### PR TITLE
DM-13349: Define storage classes in config yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 version.py
+_build.*
 .cache
 tests/.tests
 tests/test_input_datastore/
@@ -8,3 +9,4 @@ tests/test_output_datastore/
 .sconsign.dblite
 config.log
 ups/*.cfgc
+pytest_session.txt

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -21,7 +21,7 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
 
-from lsst.daf.persistence import doImport
+from lsst.daf.butler.core.utils import doImport
 
 from abc import ABCMeta, abstractmethod
 from .config import Config

--- a/python/lsst/daf/butler/core/fileDescriptor.py
+++ b/python/lsst/daf/butler/core/fileDescriptor.py
@@ -25,32 +25,20 @@
 class FileDescriptor(object):
     """Describes a particular file.
 
-    Attributes
+    Parameters
     ----------
     location : `Location`
         Storage location.
     type : `cls`
         Type the object will have after reading in Python (typically
-        `StorageClass.type`).
+        `StorageClass.pytype`).
     parameters : `dict`
         Additional parameters that can be used for reading and writing.
     """
 
-    __slots__ = ('location', 'type', 'parameters')
+    __slots__ = ('location', 'pytype', 'parameters')
 
-    def __init__(self, location, type=None, parameters=None):
-        """Constructor
-
-        Parameters
-        ----------
-        location : `Location`
-            Storage location.
-        type : `cls`
-            Type the object will have after reading in Python (typically
-            `StorageClass.type`).
-        parameters : `dict`
-            Additional parameters that can be used for reading and writing.
-        """
+    def __init__(self, location, pytype=None, parameters=None):
         self.location = location
-        self.type = type
+        self.pytype = pytype
         self.parameters = parameters

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -70,10 +70,12 @@ class Formatter(object, metaclass=ABCMeta):
         raise NotImplementedError("Type does not support writing")
 
 
-class FormatterFactory(MappingFactory):
+class FormatterFactory:
     """Factory for `Formatter` instances.
     """
-    refType = Formatter
+
+    def __init__(self):
+        self._mappingFactory = MappingFactory(Formatter)
 
     def getFormatter(self, storageClass, datasetType=None):
         """Get a new formatter instance.
@@ -86,7 +88,7 @@ class FormatterFactory(MappingFactory):
             If given, look if an override has been specified for this `DatasetType` and,
             if so return that instead.
         """
-        return self.getFromRegistry(storageClass, override=datasetType)
+        return self._mappingFactory.getFromRegistry(storageClass, override=datasetType)
 
     def registerFormatter(self, type_, formatter):
         """Register a Formatter.
@@ -103,4 +105,4 @@ class FormatterFactory(MappingFactory):
         e : `ValueError`
             If formatter does not name a valid formatter type.
         """
-        self.placeInRegistry(type_, formatter)
+        self._mappingFactory.placeInRegistry(type_, formatter)

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -88,7 +88,7 @@ class FormatterFactory:
             If given, look if an override has been specified for this `DatasetType` and,
             if so return that instead.
         """
-        return self._mappingFactory.getFromRegistry(storageClass, override=datasetType)
+        return self._mappingFactory.getFromRegistry(datasetType, storageClass)
 
     def registerFormatter(self, type_, formatter):
         """Register a Formatter.

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -23,7 +23,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from lsst.daf.persistence import doImport
+from .mappingFactory import MappingFactory
 
 
 class Formatter(object, metaclass=ABCMeta):
@@ -70,14 +70,10 @@ class Formatter(object, metaclass=ABCMeta):
         raise NotImplementedError("Type does not support writing")
 
 
-class FormatterFactory(object):
+class FormatterFactory(MappingFactory):
     """Factory for `Formatter` instances.
     """
-
-    def __init__(self):
-        """Constructor.
-        """
-        self._registry = {}
+    refType = Formatter
 
     def getFormatter(self, storageClass, datasetType=None):
         """Get a new formatter instance.
@@ -86,24 +82,18 @@ class FormatterFactory(object):
         ----------
         storageClass : `StorageClass`
             Get `Formatter` associated with this `StorageClass`, unless.
-        datasetType : `DatasetType` or `str, optional
+        datasetType : `DatasetType` or `str`, optional
             If given, look if an override has been specified for this `DatasetType` and,
             if so return that instead.
         """
-        if datasetType:
-            try:
-                typeName = self._registry[self._getName(datasetType)]()
-            except KeyError:
-                pass
-        typeName = self._registry[self._getName(storageClass)]
-        return self._getInstanceOf(typeName)
+        return self.getFromRegistry(storageClass, override=datasetType)
 
     def registerFormatter(self, type_, formatter):
         """Register a Formatter.
 
         Parameters
         ----------
-        type : `str` or `StorageClass` or `DatasetType`
+        type_ : `str` or `StorageClass` or `DatasetType`
             Type for which this formatter is to be used.
         formatter : `str`
             Identifies a `Formatter` subclass to use for reading and writing `Dataset`s of this type.
@@ -113,30 +103,4 @@ class FormatterFactory(object):
         e : `ValueError`
             If formatter does not name a valid formatter type.
         """
-        if not self._isValidFormatterStr(formatter):
-            raise ValueError("Not a valid Formatter: {0}".format(formatter))
-        self._registry[self._getName(type_)] = formatter
-
-    @staticmethod
-    def _getName(typeOrName):
-        """Extract name of `DatasetType` or `StorageClass` as string.
-        """
-        if isinstance(typeOrName, str):
-            return typeOrName
-        elif hasattr(typeOrName, 'name'):
-            return typeOrName.name
-        else:
-            raise ValueError("Cannot extract name from type")
-
-    @staticmethod
-    def _getInstanceOf(typeName):
-        cls = doImport(typeName)
-        return cls()
-
-    @staticmethod
-    def _isValidFormatterStr(formatter):
-        try:
-            f = FormatterFactory._getInstanceOf(formatter)
-            return isinstance(f, Formatter)
-        except ImportError:
-            return False
+        self.placeInRegistry(type_, formatter)

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -1,0 +1,144 @@
+#
+# LSST Data Management System
+#
+# Copyright 2008-2018  AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+from lsst.daf.persistence import doImport
+
+
+class MappingFactory:
+    """
+    Register the mapping of some key to a python type and retrieve instances.
+
+    Enables instances of these classes to be retrieved from the factory later.
+    The class can be specified as an object, class or string.
+    If the key is an object it is converted to a string by accessing
+    a `name` attribute.
+    """
+
+    refType = None
+    """Type of instances expected to be returned from factory."""
+
+    def __init__(self):
+        self._registry = {}
+
+    def getFromRegistry(self, targetClass, override=None):
+        """Get a new instance of the object stored in the registry.
+
+        Parameters
+        ----------
+        targetClass : `str` or object supporting `.name` attribute
+            Get item from registry associated with this target class, unless
+        override : `str` or object supporting `.name` attribute, optional
+            If given, look if an override has been specified for this and,
+            if so return that instead.
+
+        Returns
+        -------
+        instance : `object`
+            Instance of class stored in registry associated with the target.
+        """
+        for t in (override, targetClass):
+            if t is not None:
+                try:
+                    typeName = self._registry[self._getName(t)]
+                except KeyError:
+                    pass
+                else:
+                    return self._getInstanceOf(typeName)
+        raise KeyError("Unable to find item in registry with keys {} or {}".format(targetClass, override))
+
+    def placeInRegistry(self, registryKey, typeName):
+        """Register a class name with the associated type.
+        The type name provided is validated against the reference
+        class, `refType`, if defined.
+
+        Parameters
+        ----------
+        registryKey : `str` or object supporting `.name` attribute.
+            Item to associate with the provided type.
+        typeName : `str` or Python type
+            Identifies a class to associate with the provided key.
+
+        Raises
+        ------
+        e : `ValueError`
+            If instance of class is not of the expected type.
+        """
+        if not self._isValidStr(typeName):
+            raise ValueError("Not a valid class string: {}".format(typeName))
+        keyString = self._getName(registryKey)
+        if keyString in self._registry:
+            raise ValueError("Item with key {} already registered".format(keyString))
+
+        self._registry[keyString] = typeName
+
+    @staticmethod
+    def _getName(typeOrName):
+        """Extract name of supplied object as string.
+
+        Parameters
+        ----------
+        typeOrName : `str` or object supporting `.name` attribute.
+            Item from which to extract a name.
+
+        Returns
+        -------
+        name : `str`
+            Extracted name as a string.
+        """
+        if isinstance(typeOrName, str):
+            return typeOrName
+        elif hasattr(typeOrName, 'name'):
+            return typeOrName.name
+        else:
+            raise ValueError("Cannot extract name from type")
+
+    @staticmethod
+    def _getInstanceOf(typeOrName):
+        """Given the type name or a type, instantiate an object of that type.
+
+        If a type name is given, an attempt will be made to import the type.
+
+        Parameters
+        ----------
+        typeOrName : `str` or Python class
+            A string describing the Python class to load or a Python type.
+        """
+        if isinstance(typeOrName, str):
+            cls = doImport(typeOrName)
+        else:
+            cls = typeOrName
+        return cls()
+
+    @classmethod
+    def _isValidStr(cls, typeName):
+        """Validate that the class name provided does create instances of
+        objects that are of the expected type, as stored in the class
+        `refType` attribute.
+        """
+        if cls.refType is None:
+            return True
+        try:
+            c = cls._getInstanceOf(typeName)
+        except (ImportError, TypeError, AttributeError):
+            return False
+        else:
+            return isinstance(c, cls.refType)

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -31,13 +31,19 @@ class MappingFactory:
     The class can be specified as an object, class or string.
     If the key is an object it is converted to a string by accessing
     a `name` attribute.
+
+    Parameters
+    ----------
+    refType : `type`
+        Python reference `type` to use to ensure that items stored in the
+        registry create instance objects of the correct class. Subclasses
+        of this type are allowed. Using `None` disables the check.
+
     """
 
-    refType = None
-    """Type of instances expected to be returned from factory."""
-
-    def __init__(self):
+    def __init__(self, refType):
         self._registry = {}
+        self.refType = refType
 
     def getFromRegistry(self, targetClass, override=None):
         """Get a new instance of the object stored in the registry.
@@ -68,7 +74,7 @@ class MappingFactory:
     def placeInRegistry(self, registryKey, typeName):
         """Register a class name with the associated type.
         The type name provided is validated against the reference
-        class, `refType`, if defined.
+        class, `refType` attribute, if defined.
 
         Parameters
         ----------
@@ -128,17 +134,16 @@ class MappingFactory:
             cls = typeOrName
         return cls()
 
-    @classmethod
-    def _isValidStr(cls, typeName):
-        """Validate that the class name provided does create instances of
-        objects that are of the expected type, as stored in the class
+    def _isValidStr(self, typeName):
+        """Validate that the class type name provided does create instances of
+        objects that are of the expected type, as stored in the
         `refType` attribute.
         """
-        if cls.refType is None:
+        if self.refType is None:
             return True
         try:
-            c = cls._getInstanceOf(typeName)
+            c = self._getInstanceOf(typeName)
         except (ImportError, TypeError, AttributeError):
             return False
         else:
-            return isinstance(c, cls.refType)
+            return isinstance(c, self.refType)

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -20,7 +20,7 @@
 # the GNU General Public License along with this program.  If not,
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
-from lsst.daf.persistence import doImport
+from lsst.daf.butler.core.utils import doImport
 
 
 class MappingFactory:

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -45,31 +45,40 @@ class MappingFactory:
         self._registry = {}
         self.refType = refType
 
-    def getFromRegistry(self, targetClass, override=None):
+    def getFromRegistry(self, *targetClasses):
         """Get a new instance of the object stored in the registry.
 
         Parameters
         ----------
-        targetClass : `str` or object supporting `.name` attribute
-            Get item from registry associated with this target class, unless
-        override : `str` or object supporting `.name` attribute, optional
-            If given, look if an override has been specified for this and,
-            if so return that instead.
+        *targetClasses : `str` or objects supporting `.name` attribute
+            Each item is tested in turn until a match is found in the registry.
+            Items with `None` value are skipped.
 
         Returns
         -------
         instance : `object`
-            Instance of class stored in registry associated with the target.
+            Instance of class stored in registry associated with the first
+            matching target class.
+
+        Raises
+        ------
+        e : KeyError
+            None of the supplied target classes match an item in the registry.
         """
-        for t in (override, targetClass):
-            if t is not None:
+        attempts = []
+        for t in (targetClasses):
+            if t is None:
+                attempts.append(t)
+            else:
+                key = self._getName(t)
+                attempts.append(key)
                 try:
-                    typeName = self._registry[self._getName(t)]
+                    typeName = self._registry[key]
                 except KeyError:
                     pass
                 else:
                     return self._getInstanceOf(typeName)
-        raise KeyError("Unable to find item in registry with keys {} or {}".format(targetClass, override))
+        raise KeyError("Unable to find item in registry with keys: {}".format(attempts))
 
     def placeInRegistry(self, registryKey, typeName):
         """Register a class name with the associated type.

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -23,7 +23,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from lsst.daf.persistence import doImport
+from lsst.daf.butler.core.utils import doImport
 
 from .config import Config
 

--- a/python/lsst/daf/butler/core/safeFileIo.py
+++ b/python/lsst/daf/butler/core/safeFileIo.py
@@ -1,0 +1,229 @@
+#
+# LSST Data Management System
+#
+# Copyright 2008-2015 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+"""
+Utilities for safe file IO
+"""
+from contextlib import contextmanager
+import errno
+import fcntl
+import filecmp
+import os
+import tempfile
+from lsst.log import Log
+
+
+class DoNotWrite(RuntimeError):
+    pass
+
+
+def safeMakeDir(directory):
+    """Make a directory in a manner avoiding race conditions"""
+    if directory != "" and not os.path.exists(directory):
+        try:
+            os.makedirs(directory)
+        except OSError as e:
+            # Don't fail if directory exists due to race
+            if e.errno != errno.EEXIST:
+                raise e
+
+
+def setFileMode(filename):
+    """Set a file mode according to the user's umask"""
+    # Get the current umask, which we can only do by setting it and then reverting to the original.
+    umask = os.umask(0o077)
+    os.umask(umask)
+    # chmod the new file to match what it would have been if it hadn't started life as a temporary
+    # file (which have more restricted permissions).
+    os.chmod(filename, (~umask & 0o666))
+
+
+class FileForWriteOnceCompareSameFailure(RuntimeError):
+    pass
+
+
+@contextmanager
+def FileForWriteOnceCompareSame(name):
+    """Context manager to get a file that can be written only once and all other writes will succeed only if
+    they match the initial write.
+
+    The context manager provides a temporary file object. After the user is done, the temporary file becomes
+    the permanent file if the file at name does not already exist. If the file at name does exist the
+    temporary file is compared to the file at name. If they are the same then this is good and the temp file
+    is silently thrown away. If they are not the same then a runtime error is raised.
+    """
+    outDir, outName = os.path.split(name)
+    safeMakeDir(outDir)
+    temp = tempfile.NamedTemporaryFile(mode="w", dir=outDir, prefix=outName, delete=False)
+    try:
+        yield temp
+    finally:
+        try:
+            temp.close()
+            # If the symlink cannot be created then it will raise. If it can't be created because a file at
+            # 'name' already exists then we'll do a compare-same check.
+            os.symlink(temp.name, name)
+            # If the symlink was created then this is the process that created the first instance of the
+            # file, and we know its contents match. Move the temp file over the symlink.
+            os.rename(temp.name, name)
+            # At this point, we know the file has just been created. Set permissions according to the
+            # current umask.
+            setFileMode(name)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise e
+            filesMatch = filecmp.cmp(temp.name, name, shallow=False)
+            os.remove(temp.name)
+            if filesMatch:
+                # if the files match then the compare-same check succeeded and we can silently return.
+                return
+            else:
+                # if the files do not match then the calling code was trying to write a non-matching file over
+                # the previous file, maybe it's a race condition? In any event, raise a runtime error.
+                raise FileForWriteOnceCompareSameFailure("Written file does not match existing file.")
+
+
+@contextmanager
+def SafeFile(name):
+    """Context manager to create a file in a manner avoiding race conditions
+
+    The context manager provides a temporary file object. After the user is done,
+    we move that file into the desired place and close the fd to avoid resource
+    leakage.
+    """
+    outDir, outName = os.path.split(name)
+    safeMakeDir(outDir)
+    doWrite = True
+    with tempfile.NamedTemporaryFile(mode="w", dir=outDir, prefix=outName, delete=False) as temp:
+        try:
+            yield temp
+        except DoNotWrite:
+            doWrite = False
+        finally:
+            if doWrite:
+                os.rename(temp.name, name)
+                setFileMode(name)
+
+
+@contextmanager
+def SafeFilename(name):
+    """Context manager for creating a file in a manner avoiding race conditions
+
+    The context manager provides a temporary filename with no open file descriptors
+    (as this can cause trouble on some systems). After the user is done, we move the
+    file into the desired place.
+    """
+    outDir, outName = os.path.split(name)
+    safeMakeDir(outDir)
+    temp = tempfile.NamedTemporaryFile(mode="w", dir=outDir, prefix=outName, delete=False)
+    tempName = temp.name
+    temp.close()  # We don't use the fd, just want a filename
+    try:
+        yield tempName
+    finally:
+        os.rename(tempName, name)
+        setFileMode(name)
+
+
+@contextmanager
+def SafeLockedFileForRead(name):
+    """Context manager for reading a file that may be locked with an exclusive lock via
+    SafeLockedFileForWrite. This will first acquire a shared lock before returning the file. When the file is
+    closed the shared lock will be unlocked.
+
+    Parameters
+    ----------
+    name : string
+        The file name to be opened, may include path.
+
+    Yields
+    ------
+    file object
+        The file to be read from.
+    """
+    log = Log.getLogger("daf.persistence.butler")
+    try:
+        with open(name, 'r') as f:
+            log.debug("Acquiring shared lock on {}".format(name))
+            fcntl.flock(f, fcntl.LOCK_SH)
+            log.debug("Acquired shared lock on {}".format(name))
+            yield f
+    finally:
+        log.debug("Releasing shared lock on {}".format(name))
+
+
+class SafeLockedFileForWrite:
+    """File-like object that is used to create a file if needed, lock it with an exclusive lock, and contain
+    file descriptors to readable and writable versions of the file.
+
+    This will only open a file descriptor in 'write' mode if a write operation is performed. If no write
+    operation is performed, the existing file (if there is one) will not be overwritten.
+
+    Contains __enter__ and __exit__ functions so this can be used by a context manager.
+    """
+    def __init__(self, name):
+        self.log = Log.getLogger("daf.persistence.butler")
+        self.name = name
+        self._readable = None
+        self._writeable = None
+        safeMakeDir(os.path.split(name)[0])
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def open(self):
+        self._fileHandle = open(self.name, 'a')
+        self.log.debug("Acquiring exclusive lock on {}".format(self.name))
+        fcntl.flock(self._fileHandle, fcntl.LOCK_EX)
+        self.log.debug("Acquired exclusive lock on {}".format(self.name))
+
+    def close(self):
+        self.log.debug("Releasing exclusive lock on {}".format(self.name))
+        if self._writeable is not None:
+            self._writeable.close()
+        if self._readable is not None:
+            self._readable.close()
+        self._fileHandle.close()
+
+    @property
+    def readable(self):
+        if self._readable is None:
+            self._readable = open(self.name, 'r')
+        return self._readable
+
+    @property
+    def writeable(self):
+        if self._writeable is None:
+            self._writeable = open(self.name, 'w')
+        return self._writeable
+
+    def read(self, size=None):
+        if size is not None:
+            return self.readable.read(size)
+        return self.readable.read()
+
+    def write(self, str):
+        self.writeable.write(str)

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -35,6 +35,16 @@ class StorageClassMeta(type):
 
 
 class StorageClass(metaclass=StorageClassMeta):
+    """Class describing how a label maps to a particular Python type.
+
+    Attributes
+    ----------
+    name : `str`
+        Name associated with the StorageClass.
+    pytype : `type`
+        Python type associated with this name.
+
+    """
 
     subclasses = dict()
 
@@ -69,7 +79,7 @@ def makeNewStorageClass(name, pytype, components=None):
         else:
             pytype = doImport(pytype)
     return type(name, (StorageClass,), {"name": name,
-                                        "type": pytype,
+                                        "pytype": pytype,
                                         "components": components})
 
 

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -21,7 +21,7 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
 
-from lsst.daf.persistence import doImport
+from lsst.daf.butler.core.utils import doImport
 
 from .mappingFactory import MappingFactory
 

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -73,10 +73,12 @@ def makeNewStorageClass(name, pytype, components=None):
                                         "components": components})
 
 
-class StorageClassFactory(MappingFactory):
+class StorageClassFactory:
     """Factory for `StorageClass` instances.
     """
-    refType = StorageClass
+
+    def __init__(self):
+        self._mappingFactory = MappingFactory(StorageClass)
 
     def getStorageClass(self, storageClassName):
         """Get a StorageClass instance associated with the supplied name.
@@ -91,7 +93,7 @@ class StorageClassFactory(MappingFactory):
         instance : `StorageClass`
             Instance of the correct `StorageClass`.
         """
-        return self.getFromRegistry(storageClassName)
+        return self._mappingFactory.getFromRegistry(storageClassName)
 
     def registerStorageClass(self, storageClassName, pytype, components=None):
         """Create a `StorageClass` subclass with the supplied properties
@@ -113,4 +115,4 @@ class StorageClassFactory(MappingFactory):
             storageClassName.
         """
         newtype = makeNewStorageClass(storageClassName, pytype, components)
-        self.placeInRegistry(storageClassName, newtype)
+        self._mappingFactory.placeInRegistry(storageClassName, newtype)

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -21,7 +21,9 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 #
 
-import lsst.afw.table
+from lsst.daf.persistence import doImport
+
+from .mappingFactory import MappingFactory
 
 
 class StorageClassMeta(type):
@@ -43,38 +45,72 @@ class StorageClass(metaclass=StorageClassMeta):
         return parent
 
 
-class TablePersistable(StorageClass):
-    name = "TablePersistable"
+def makeNewStorageClass(name, pytype, components=None):
+    """Create a new Python class as a subclass of `StorageClass`.
+
+    parameters
+    ----------
+    name : `str`
+        Name to use for this class.
+    pytype : `type`
+        Python type (or name of type) to associate with the `StorageClass`
+    components : `dict`, optional
+        `dict` mapping name of a component to another `StorageClass`.
+
+    Returns
+    -------
+    newtype : `StorageClass`
+        Newly created Python type.
+    """
+    if isinstance(pytype, str):
+        # Special case Python native dict type for testing
+        if pytype == "dict":
+            pytype = dict
+        else:
+            pytype = doImport(pytype)
+    return type(name, (StorageClass,), {"name": name,
+                                        "type": pytype,
+                                        "components": components})
 
 
-class Image(StorageClass):
-    name = "Image"
+class StorageClassFactory(MappingFactory):
+    """Factory for `StorageClass` instances.
+    """
+    refType = StorageClass
 
+    def getStorageClass(self, storageClassName):
+        """Get a StorageClass instance associated with the supplied name.
 
-class Exposure(StorageClass):
-    name = "Exposure"
-    components = {
-        "image": Image,
-        "mask": Image,
-        "variance": Image,
-        "wcs": TablePersistable,
-        "psf": TablePersistable,
-        "photoCalib": TablePersistable,
-        "visitInfo": TablePersistable,
-        "apCorr": TablePersistable,
-        "coaddInputs": TablePersistable,
-    }
+        Parameter
+        ---------
+        storageClassName : `str`
+            Name of the storage class to retrieve.
 
-    @classmethod
-    def assemble(cls, parent, components):
-        raise NotImplementedError("TODO")
+        Returns
+        -------
+        instance : `StorageClass`
+            Instance of the correct `StorageClass`.
+        """
+        return self.getFromRegistry(storageClassName)
 
+    def registerStorageClass(self, storageClassName, pytype, components=None):
+        """Create a `StorageClass` subclass with the supplied properties
+        and associate it with the storageClassName in the registry.
 
-class Catalog(StorageClass):
-    name = "Catalog"
-    type = None  # Catalog is abstract (I think)
+        Parameters
+        ----------
+        storageClassName : `str`
+            Name of new storage class to be created.
+        pytype : `str` or Python class.
+            Python type to be associated with this storage class.
+        components : `dict`
+            Map of storageClassName to `storageClass` for components.
 
-
-class SourceCatalog(StorageClass):
-    name = "SourceCatalog"
-    type = lsst.afw.table.SourceCatalog
+        Raises
+        ------
+        e : `KeyError`
+            If a storage class has already been registered with
+            storageClassName.
+        """
+        newtype = makeNewStorageClass(storageClassName, pytype, components)
+        self.placeInRegistry(storageClassName, newtype)

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -46,10 +46,32 @@ def slotValuesToHash(self):
 
 
 def doImport(pythonType):
-    """Import a python object given an importable string"""
+    """Import a python object given an importable string and return the
+    type object
+
+    Parameters
+    ----------
+    pythonType : `str`
+        String containing dot-separated path of a Python class, module,
+        or member function.
+
+    Returns
+    -------
+    type : `type`
+        Type object. Either a module or class or a function.
+
+    Raises
+    ------
+    e : `TypeError`
+        pythonType is not a `str`.
+    e : `ValueError`
+        pythonType can not be imported.
+    e : `AttributeError`
+        pythonType can be partially imported.
+    """
+    if not isinstance(pythonType, str):
+        raise TypeError("Unhandled type of pythonType, val:%s" % pythonType)
     try:
-        if not isinstance(pythonType, str):
-            raise TypeError("Unhandled type of pythonType, val:%s" % pythonType)
         # import this pythonType dynamically
         # pythonType is sometimes unicode with Python 2 and pybind11; this breaks the interpreter
         pythonTypeTokenList = str(pythonType).split('.')

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -73,8 +73,7 @@ def doImport(pythonType):
         raise TypeError("Unhandled type of pythonType, val:%s" % pythonType)
     try:
         # import this pythonType dynamically
-        # pythonType is sometimes unicode with Python 2 and pybind11; this breaks the interpreter
-        pythonTypeTokenList = str(pythonType).split('.')
+        pythonTypeTokenList = pythonType.split('.')
         importClassString = pythonTypeTokenList.pop()
         importClassString = importClassString.strip()
         importPackage = ".".join(pythonTypeTokenList)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -23,8 +23,7 @@
 
 import os
 
-from lsst.daf.persistence.safeFileIo import safeMakeDir
-
+from lsst.daf.butler.core.safeFileIo import safeMakeDir
 from lsst.daf.butler.core.datastore import Datastore
 from lsst.daf.butler.core.datastore import DatastoreConfig  # noqa F401
 from lsst.daf.butler.core.location import LocationFactory

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -97,7 +97,7 @@ class PosixDatastore(Datastore):
         location = self.locationFactory.fromUri(uri)
         if not os.path.exists(location.path):
             raise ValueError("No such file: {0}".format(location.uri))
-        return formatter.read(FileDescriptor(location, storageClass.type, parameters))
+        return formatter.read(FileDescriptor(location, storageClass.pytype, parameters))
 
     def put(self, inMemoryDataset, storageClass, storageHint, typeName=None):
         """Write a `InMemoryDataset` with a given `StorageClass` to the store.
@@ -127,7 +127,7 @@ class PosixDatastore(Datastore):
         storageDir = os.path.dirname(location.path)
         if not os.path.isdir(storageDir):
             safeMakeDir(storageDir)
-        return formatter.write(inMemoryDataset, FileDescriptor(location, storageClass.type))
+        return formatter.write(inMemoryDataset, FileDescriptor(location, storageClass.pytype))
 
     def remove(self, uri):
         """Indicate to the Datastore that a `Dataset` can be removed.

--- a/python/lsst/daf/butler/formatters/fitsCatalogFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsCatalogFormatter.py
@@ -44,7 +44,7 @@ class FitsCatalogFormatter(Formatter):
             The actual returned type will be a derived class
             (e.g. `SourceCatalog` or `ExposureCatalog`).
         """
-        return fileDescriptor.type.readFits(fileDescriptor.location.path)
+        return fileDescriptor.pytype.readFits(fileDescriptor.location.path)
 
     def write(self, inMemoryDataset, fileDescriptor):
         """Write a `Catalog` to a FITS file.

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -1,35 +1,35 @@
-run: "ingest"
+run: ingest
 datastore:
-  cls: 'lsst.daf.butler.datastores.posixDatastore.PosixDatastore'
-  root: './butler_test_repository'
+  cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
+  root: ./butler_test_repository
   create: true
   storageClasses:
     StructuredData:
       # Data from a JSON or YAML file
-      type: "dict"
+      type: dict
       # formatter: "lsst.daf.butler.formatters.structuredDataFormatter.YAMLFormatter"
     TablePersistable:
-      type: "lsst.afw.table"
+      type: lsst.afw.table
     Image:
-      type: "lsst.afw.image.MaskedImage"
+      type: lsst.afw.image.MaskedImage
     Catalog:
-      type: "lsst.afw.table.BaseCatalog"
+      type: lsst.afw.table.BaseCatalog
     SourceCatalog:
-      type: "lsst.afw.table.SourceCatalog"
-      formatter: "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
+      type: lsst.afw.table.SourceCatalog
+      formatter: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     Exposure:
-      type: "lsst.afw.image.Exposure"
+      type: lsst.afw.image.Exposure
       components:
-        image: "Image"
-        mask: "Image"
-        variance: "Image"
-        wcs: "TablePersistable"
-        psf: "TablePersistable"
-        photoCalib: "TablePersistable"
-        visitInfo: "TablePersistable"
-        apCorr: "TablePersistable"
-        coaddInputs: "TablePersistable"
+        image: Image
+        mask: Image
+        variance: Image
+        wcs: TablePersistable
+        psf: TablePersistable
+        photoCalib: TablePersistable
+        visitInfo: TablePersistable
+        apCorr: TablePersistable
+        coaddInputs: TablePersistable
 registry:
-  cls: 'lsst.daf.butler.registries.sqlRegistry.SqlRegistry'
+  cls: lsst.daf.butler.registries.sqlRegistry.SqlRegistry
   dbname: 'sqlite:///:memory:'
   id: 0

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -3,8 +3,32 @@ datastore:
   cls: 'lsst.daf.butler.datastores.posixDatastore.PosixDatastore'
   root: './butler_test_repository'
   create: true
-  formatters:
-    SourceCatalog: "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
+  storageClasses:
+    StructuredData:
+      # Data from a JSON or YAML file
+      type: "dict"
+      # formatter: "lsst.daf.butler.formatters.structuredDataFormatter.YAMLFormatter"
+    TablePersistable:
+      type: "lsst.afw.table"
+    Image:
+      type: "lsst.afw.image.MaskedImage"
+    Catalog:
+      type: "lsst.afw.table.BaseCatalog"
+    SourceCatalog:
+      type: "lsst.afw.table.SourceCatalog"
+      formatter: "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
+    Exposure:
+      type: "lsst.afw.image.Exposure"
+      components:
+        image: "Image"
+        mask: "Image"
+        variance: "Image"
+        wcs: "TablePersistable"
+        psf: "TablePersistable"
+        photoCalib: "TablePersistable"
+        visitInfo: "TablePersistable"
+        apCorr: "TablePersistable"
+        coaddInputs: "TablePersistable"
 registry:
   cls: 'lsst.daf.butler.registries.sqlRegistry.SqlRegistry'
   dbname: 'sqlite:///:memory:'

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,97 @@
+#
+# LSST Data Management System
+#
+# Copyright 2018  AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import lsst.utils.tests
+
+import lsst.daf.butler.core.formatter as formatter
+import lsst.daf.butler.core.storageClass as storageClass
+
+"""Tests related to the formatter infrastructure.
+"""
+
+
+class FormatterFactoryTestCase(lsst.utils.tests.TestCase):
+    """Tests of the formatter factory infrastructure.
+    """
+    def setUp(self):
+        self.factory = formatter.FormatterFactory()
+
+    def testRegistry(self):
+        """Check that formatters can be stored in the registry.
+        """
+        formatterName = "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
+        storageClassName = "Image"
+        self.factory.registerFormatter(storageClassName, formatterName)
+        f = self.factory.getFormatter(storageClassName)
+        self.assertIsInstance(f, formatter.Formatter)
+
+        with self.assertRaises(ValueError):
+            # Try to store something that is not a Formatter but is a class
+            self.factory.registerFormatter("NotFormatter", "lsst.daf.butler.core.formatter.FormatterFactory")
+
+        with self.assertRaises(ValueError):
+            # Try to store something that is not a Formatter but is a module
+            self.factory.registerFormatter("NotFormatter", "lsst.daf.butler")
+
+        with self.assertRaises(ValueError):
+            # Try to store something that is not a Formatter but does not exist
+            self.factory.registerFormatter("NotFormatter", "lsst.daf.butler.x")
+
+        with self.assertRaises(ValueError):
+            # Try to store something that is not importable
+            self.factory.registerFormatter("NotImportable", "not a thing")
+
+        with self.assertRaises(KeyError):
+            f = self.factory.getFormatter("Missing")
+
+    def testRegistryWithStorageClass(self):
+        """Test that the registry can be given a StorageClass object.
+        """
+        formatterName = "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
+        storageClassName = "TestClass"
+        sc = storageClass.makeNewStorageClass(storageClassName, dict, None)
+
+        # Store using an instance
+        self.factory.registerFormatter(sc(), formatterName)
+
+        # Retrieve using the class
+        f = self.factory.getFormatter(sc)
+        self.assertIsInstance(f, formatter.Formatter)
+
+        with self.assertRaises(ValueError):
+            # Attempt to overwrite using the name as a simple str
+            self.factory.registerFormatter(storageClassName, formatterName)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_posixDatastore.py
+++ b/tests/test_posixDatastore.py
@@ -28,7 +28,6 @@ import lsst.utils.tests
 import lsst.afw.table
 
 from lsst.daf.butler.datastores.posixDatastore import PosixDatastore, DatastoreConfig
-from lsst.daf.butler.core.storageClass import SourceCatalog
 
 import datasetsHelper
 
@@ -75,7 +74,7 @@ class PosixDatastoreTestCase(lsst.utils.tests.TestCase):
         catalog = datasetsHelper.makeExampleCatalog()
         datastore = PosixDatastore(config=self.configFile)
         # Put
-        storageClass = SourceCatalog
+        storageClass = datastore.storageClassFactory.getStorageClass("SourceCatalog")
         uri, _ = datastore.put(catalog, storageClass=storageClass, storageHint="tester.fits", typeName=None)
         # Get
         catalogOut = datastore.get(uri, storageClass=storageClass, parameters=None)
@@ -92,7 +91,7 @@ class PosixDatastoreTestCase(lsst.utils.tests.TestCase):
         catalog = datasetsHelper.makeExampleCatalog()
         datastore = PosixDatastore(config=self.configFile)
         # Put
-        storageClass = SourceCatalog
+        storageClass = datastore.storageClassFactory.getStorageClass("SourceCatalog")
         uri, _ = datastore.put(catalog, storageClass=storageClass, storageHint="tester.fits", typeName=None)
         # Get
         catalogOut = datastore.get(uri, storageClass=storageClass, parameters=None)
@@ -115,7 +114,7 @@ class PosixDatastoreTestCase(lsst.utils.tests.TestCase):
         outputConfig = inputConfig.copy()
         outputConfig['datastore.root'] = os.path.join(self.testDir, "./test_output_datastore")
         outputPosixDatastore = PosixDatastore(config=outputConfig)
-        storageClass = SourceCatalog
+        storageClass = outputPosixDatastore.storageClassFactory.getStorageClass("SourceCatalog")
         inputUri, _ = inputPosixDatastore.put(catalog, storageClass, path)
         outputUri, _ = outputPosixDatastore.transfer(inputPosixDatastore, inputUri, storageClass, path)
         catalogOut = outputPosixDatastore.get(outputUri, storageClass)

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -31,7 +31,7 @@ import lsst.daf.butler.core.storageClass as storageClass
 
 
 class PythonType:
-    """A dummy class to test the registory of Python types."""
+    """A dummy class to test the registry of Python types."""
     pass
 
 

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -1,0 +1,86 @@
+#
+# LSST Data Management System
+#
+# Copyright 2018  AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import lsst.utils.tests
+
+import lsst.daf.butler.core.storageClass as storageClass
+
+"""Tests related to the StorageClass infrastructure.
+"""
+
+
+class PythonType:
+    """A dummy class to test the registory of Python types."""
+    pass
+
+
+class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
+    """Tests of the storage class infrastructure.
+    """
+
+    def testCreation(self):
+        """Test that we can dynamically create storage class subclasses.
+
+        This is critical for testing the factory functions."""
+        className = "TestImage"
+        newclass = storageClass.makeNewStorageClass(className, dict, None)
+        sc = newclass()
+        self.assertIsInstance(sc, storageClass.StorageClass)
+        self.assertEqual(sc.name, className)
+        self.assertIsNone(sc.components)
+        self.assertEqual(sc.type, dict)
+
+        # Check that this class is listed in the subclasses
+        self.assertIn(className, newclass.subclasses)
+
+        # Check we can create a storageClass using the name of an importable
+        # type.
+        newclass = storageClass.makeNewStorageClass("TestImage2",
+                                                    "lsst.daf.butler.core.storageClass.StorageClassFactory")
+        self.assertIsInstance(newclass.type(), storageClass.StorageClassFactory)
+
+    def testRegistry(self):
+        """Check that storage classes can be created on the fly and stored
+        in a registry."""
+        className = "TestImage"
+        factory = storageClass.StorageClassFactory()
+        factory.registerStorageClass(className, PythonType)
+        sc = factory.getStorageClass(className)
+        self.assertIsInstance(sc, storageClass.StorageClass)
+        self.assertEqual(sc.name, className)
+        self.assertIsNone(sc.components)
+        self.assertEqual(sc.type, PythonType)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -49,7 +49,7 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(sc, storageClass.StorageClass)
         self.assertEqual(sc.name, className)
         self.assertIsNone(sc.components)
-        self.assertEqual(sc.type, dict)
+        self.assertEqual(sc.pytype, dict)
 
         # Check that this class is listed in the subclasses
         self.assertIn(className, newclass.subclasses)
@@ -58,7 +58,7 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         # type.
         newclass = storageClass.makeNewStorageClass("TestImage2",
                                                     "lsst.daf.butler.core.storageClass.StorageClassFactory")
-        self.assertIsInstance(newclass.type(), storageClass.StorageClassFactory)
+        self.assertIsInstance(newclass.pytype(), storageClass.StorageClassFactory)
 
     def testRegistry(self):
         """Check that storage classes can be created on the fly and stored
@@ -70,7 +70,7 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(sc, storageClass.StorageClass)
         self.assertEqual(sc.name, className)
         self.assertIsNone(sc.components)
-        self.assertEqual(sc.type, PythonType)
+        self.assertEqual(sc.pytype, PythonType)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,6 +42,9 @@ class ImportTestCase(unittest.TestCase):
         c = doImport("lsst.daf.butler")
         self.assertTrue(inspect.ismodule(c))
 
+        c = doImport("lsst.daf.butler.core.config.Config.ppprint")
+        self.assertTrue(inspect.isfunction(c))
+
         with self.assertRaises(AttributeError):
             doImport("lsst.daf.butler.nothere")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+#
+# LSST Data Management System
+#
+# Copyright 2018  AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import inspect
+
+from lsst.daf.butler.core.utils import doImport
+from lsst.daf.butler.core.formatter import Formatter
+
+
+class ImportTestCase(unittest.TestCase):
+    """Basic tests of doImport."""
+
+    def testDoImport(self):
+        c = doImport("lsst.daf.butler.core.formatter.Formatter")
+        self.assertEqual(c, Formatter)
+
+        c = doImport("lsst.daf.butler.core.utils.doImport")
+        self.assertEqual(type(c), type(doImport))
+        self.assertTrue(inspect.isfunction(c))
+
+        c = doImport("lsst.daf.butler")
+        self.assertTrue(inspect.ismodule(c))
+
+        with self.assertRaises(AttributeError):
+            doImport("lsst.daf.butler.nothere")
+
+        with self.assertRaises(ValueError):
+            doImport("missing module")
+
+        with self.assertRaises(TypeError):
+            doImport([])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ups/daf_butler.table
+++ b/ups/daf_butler.table
@@ -3,6 +3,10 @@ setupRequired(sqlalchemy)
 setupRequired(numpy)
 setupRequired(scons)
 setupRequired(sconsUtils)
+setupRequired(log)
+setupRequired(utils)
+
+setupRequired(daf_persistence)
 setupRequired(afw)
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
* Moved the formatter factory registry to a new class MappingFactory.
* Allow the factory registry to take classes as well as string definitions.
* Replace StorageClass definitions in code with a new registry and ability to dynamically create them from strings.
* Update posix data store to dynamically generate storage classes from the YAML.
* Update tests to read storage classes from factory.
