### PR TITLE
DM-13350: Use templates to work out file names from data units

### DIFF
--- a/python/lsst/daf/butler/core/dataUnits.py
+++ b/python/lsst/daf/butler/core/dataUnits.py
@@ -1,0 +1,39 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Code relating to DataUnits."""
+
+
+class DataUnits:
+    """Represent DataUnits specification.
+
+    Parameters
+    ----------
+    units : `dict`
+        Dictionary of data units keys and values.
+    """
+
+    def __init__(self, units):
+        self.units = units.copy()
+
+    def definedUnits(self):
+        """DataUnits with non-None values."""
+        return {k: v for k, v in self.units.items() if v is not None}

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -1,0 +1,137 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for file template string expansion."""
+
+import os.path
+import string
+
+
+class FileTemplate:
+    """Format a path template into a fully expanded path.
+
+    Parameters
+    ----------
+    template : `str`
+        Template string.
+
+    Notes
+    -----
+    The templates use the standard Format Specification Mini-Language
+    with the caveat that only named fields can be used. The field names
+    are taken from the DataUnits along with two additional fields:
+    "datasettype" will be replaced with the DataSetType and "component"
+    will be replaced with the component name of a composite.
+
+    The mini-language is extended to understand a "?" in the format
+    specification. This indicates that a field is optional. If that
+    DataUnit is missing the field, along with the text before the field,
+    unless it is a path separator, will be removed from the output path.
+    """
+
+    def __init__(self, template):
+        self.template = template
+
+    def format(self, dataunits, datasettype=None, component=None):
+        """Format a template string into a full path.
+
+        Parameters
+        ----------
+        dataunits : `DataUnits`
+            DataUnits and the corresponding values.
+        datasettype : `str`, optional.
+            DataSetType name to use if needed. If it contains a "." separator
+            the type name will be split up into the main DataSetType and a
+            component.
+        component : `str`, optional
+            Component of a composite. If `datasettype` defines a component
+            this parameter will be ignored.
+
+        Returns
+        -------
+        path : `str`
+            Expanded path.
+
+        Raises
+        ------
+        KeyError
+            Requested field is not defined and the field is not optional.
+            Or, `component` is specified but "component" was not part of
+            the template.
+        """
+        units = dataunits.definedUnits()
+
+        if datasettype is not None:
+            # calexp.wcs means wcs component of a calexp
+            if "." in datasettype:
+                datasettype, component = datasettype.split(".", maxsplit=1)
+            units["datasettype"] = datasettype
+
+        usedComponent = False
+        if component is not None:
+            units["component"] = component
+
+        fmt = string.Formatter()
+        parts = fmt.parse(self.template)
+        output = ""
+
+        for literal, field_name, format_spec, conversion in parts:
+
+            if field_name == "component":
+                usedComponent = True
+
+            if "?" in format_spec:
+                optional = True
+                # Remove the non-standard character from the spec
+                format_spec = format_spec.replace("?", "")
+            else:
+                optional = False
+
+            if field_name in units:
+                value = units[field_name]
+            elif optional:
+                # If this is optional ignore the format spec
+                # and do not include the literal text prior to the optional
+                # field unless it contains a "/" path separator
+                format_spec = ""
+                value = ""
+                if "/" not in literal:
+                    literal = ""
+            else:
+                raise KeyError("{} requested in template but not defined and not optional".format(field_name))
+
+            # Now use standard formatting
+            output = output + literal + format(value, format_spec)
+
+        # Complain if we were meant to use a component
+        if component is not None and not usedComponent:
+            raise KeyError("Component {} specified but template {} did not use it".format(component,
+                                                                                          self.template))
+
+        # Since this is known to be a path, normalize it in case some double
+        # slashes have crept in
+        path = os.path.normpath(output)
+
+        # It should not be an absolute path (may happen with optionals)
+        if os.path.isabs(path):
+            path = os.path.relpath(path, start="/")
+
+        return path

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -38,7 +38,7 @@ class FileTemplate:
     The templates use the standard Format Specification Mini-Language
     with the caveat that only named fields can be used. The field names
     are taken from the DataUnits along with two additional fields:
-    "datasettype" will be replaced with the DataSetType and "component"
+    "datasetType" will be replaced with the DatasetType and "component"
     will be replaced with the component name of a composite.
 
     The mini-language is extended to understand a "?" in the format
@@ -50,19 +50,19 @@ class FileTemplate:
     def __init__(self, template):
         self.template = template
 
-    def format(self, dataunits, datasettype=None, component=None):
+    def format(self, dataUnits, datasetType=None, component=None):
         """Format a template string into a full path.
 
         Parameters
         ----------
-        dataunits : `DataUnits`
+        dataUnits : `DataUnits`
             DataUnits and the corresponding values.
-        datasettype : `str`, optional.
-            DataSetType name to use if needed. If it contains a "." separator
-            the type name will be split up into the main DataSetType and a
+        datasetType : `str`, optional.
+            DatasetType name to use if needed. If it contains a "." separator
+            the type name will be split up into the main DatasetType and a
             component.
         component : `str`, optional
-            Component of a composite. If `datasettype` defines a component
+            Component of a composite. If `datasetType` defines a component
             this parameter will be ignored.
 
         Returns
@@ -77,17 +77,17 @@ class FileTemplate:
             Or, `component` is specified but "component" was not part of
             the template.
         """
-        units = dataunits.definedUnits()
+        fields = dataUnits.definedUnits()
 
-        if datasettype is not None:
+        if datasetType is not None:
             # calexp.wcs means wcs component of a calexp
-            if "." in datasettype:
-                datasettype, component = datasettype.split(".", maxsplit=1)
-            units["datasettype"] = datasettype
+            if "." in datasetType:
+                datasetType, component = datasetType.split(".", maxsplit=1)
+            fields["datasetType"] = datasetType
 
         usedComponent = False
         if component is not None:
-            units["component"] = component
+            fields["component"] = component
 
         fmt = string.Formatter()
         parts = fmt.parse(self.template)
@@ -105,8 +105,8 @@ class FileTemplate:
             else:
                 optional = False
 
-            if field_name in units:
-                value = units[field_name]
+            if field_name in fields:
+                value = fields[field_name]
             elif optional:
                 # If this is optional ignore the format spec
                 # and do not include the literal text prior to the optional

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -24,6 +24,61 @@
 import os.path
 import string
 
+from .config import Config
+
+
+class FileTemplatesConfig(Config):
+    pass
+
+
+class FileTemplates:
+    """Collection of `FileTemplate` templates.
+
+    Parameters
+    ----------
+    config : `FileTemplatesConfig` or `str`
+        Load configuration.
+    """
+    def __init__(self, config, default=None):
+        self.config = FileTemplatesConfig(config)
+        self.templates = {}
+        for name, info in self.config.items():
+            self.templates[name] = FileTemplate(info)
+
+    def getTemplate(self, datasetType):
+        """Retrieve the `FileTemplate` associated with the dataset type.
+
+        Parameters
+        ----------
+        datasetType : `str`
+            Dataset type.
+
+        Returns
+        -------
+        template : `FileTemplate`
+            Template instance to use with that dataset type.
+        """
+        # Get a location from the templates
+        template = None
+        component = None
+        if datasetType is not None:
+            if datasetType in self.templates:
+                template = self.templates[datasetType]
+            elif "." in datasetType:
+                baseType, component = datasetType.split(".", maxsplit=1)
+                if baseType in self.templates:
+                    template = self.templates[baseType]
+
+        if template is None:
+            if "default" in self.templates:
+                template = self.templates["default"]
+
+        # if still not template give up for now.
+        if template is None:
+            raise TypeError("Unable to determine file template from supplied type [{}]".format(datasetType))
+
+        return template
+
 
 class FileTemplate:
     """Format a path template into a fully expanded path.

--- a/python/lsst/daf/butler/core/schema.py
+++ b/python/lsst/daf/butler/core/schema.py
@@ -143,6 +143,6 @@ class Schema:
                 - src, list of source column names
                 - tgt, list of target column names
         """
-        src = iterable(constraintDescription["src"])
-        tgt = iterable(constraintDescription["tgt"])
+        src = tuple(iterable(constraintDescription["src"]))
+        tgt = tuple(iterable(constraintDescription["tgt"]))
         return ForeignKeyConstraint(src, tgt)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -197,7 +197,7 @@ class PosixDatastore(Datastore):
             raise TypeError("Unable to determine file template from supplied type [{}]".format(typeName))
 
         location = self.locationFactory.fromPath(template.format(dataUnits,
-                                                                 datasettype=typeName))
+                                                                 datasetType=typeName))
 
         # Write a single component
         formatter = self.formatterFactory.getFormatter(storageClass, typeName)

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -4,9 +4,9 @@ datastore:
   root: ./butler_test_repository
   create: true
   templates:
-    default: "{datasettype}/{tract:?}/{patch:?}/{filter:?}/{visit:?}"
-    calexp: "{datasettype}.{component:?}/{datasettype}_v{visit}_f{filter}_{component:?}"
-    metric: "{datasettype}.{component:?}/{datasettype}_v{visit:08d}_f{filter}_{component:?}"
+    default: "{datasetType}/{tract:?}/{patch:?}/{filter:?}/{visit:?}"
+    calexp: "{datasetType}.{component:?}/{datasetType}_v{visit}_f{filter}_{component:?}"
+    metric: "{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{filter}_{component:?}"
   storageClasses:
     StructuredDataDictYaml:
       pytype: dict

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -68,7 +68,7 @@ datastore:
       pytype: lsst.afw.table.io.persistable.Persistable
       formatter: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     TablePersistableWcs:
-      pytype: lsst.afw.image.wcs.wcs.Wcs
+      pytype: lsst.afw.geom.skyWcs.skyWcs.SkyWcs
       formatter: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     TablePersistablePsf:
       pytype: lsst.afw.detection.Psf

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -3,6 +3,10 @@ datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
   root: ./butler_test_repository
   create: true
+  templates:
+    default: "{datasettype}/{tract:?}/{patch:?}/{filter:?}/{visit:?}"
+    calexp: "{datasettype}.{component:?}/{datasettype}_v{visit}_f{filter}_{component:?}"
+    metric: "{datasettype}.{component:?}/{datasettype}_v{visit:08d}_f{filter}_{component:?}"
   storageClasses:
     StructuredDataDictYaml:
       pytype: dict

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,74 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test file name templating."""
+
+import unittest
+
+from lsst.daf.butler.core.fileTemplates import FileTemplate
+from lsst.daf.butler.core.dataUnits import DataUnits
+
+
+class TestFileTemplates(unittest.TestCase):
+    """Test creation of paths from templates."""
+    def setUp(self):
+        self.du = DataUnits({"visit": 52, "filter": "U"})
+
+    def assertTemplate(self, template, answer, dataUnits, **kwargs):
+        fileTmpl = FileTemplate(template)
+        path = fileTmpl.format(dataUnits, **kwargs)
+        self.assertEqual(path, answer)
+
+    def testBasic(self):
+        tmplstr = "{datasettype}/{visit:05d}/{filter}"
+        self.assertTemplate(tmplstr,
+                            tmplstr.format(datasettype="calexp", **self.du.units),
+                            self.du, datasettype="calexp")
+
+    def testOptional(self):
+        tmplstr = "{datasettype}.{component:?}/v{visit:05d}_f{filter}"
+        self.assertTemplate(tmplstr, "calexp.wcs/v00052_fU",
+                            self.du, datasettype="calexp.wcs")
+        self.assertTemplate(tmplstr, "calexp.psf/v00052_fU",
+                            self.du, datasettype="calexp", component="psf")
+
+        with self.assertRaises(KeyError):
+            self.assertTemplate(tmplstr, "", self.du, component="wcs")
+
+        # Ensure that this returns a relative path even if the first field
+        # is optional
+        tmplstr = "{datasettype:?}/{visit:?}/f{filter}"
+        self.assertTemplate(tmplstr, "52/fU", self.du)
+
+    def testComponent(self):
+        tmplstr = "{datasettype}/v{visit:05d}"
+        self.assertTemplate(tmplstr, "calexp/v00052", self.du, datasettype="calexp")
+
+        with self.assertRaises(KeyError):
+            self.assertTemplate(tmplstr, "", self.du, datasettype="calexp", component="wcs")
+
+        tmplstr = "{component:?}_{visit}"
+        self.assertTemplate(tmplstr, "_52", self.du)
+        self.assertTemplate(tmplstr, "output_52", self.du, datasettype="metric.output")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -38,56 +38,56 @@ class TestFileTemplates(unittest.TestCase):
         self.assertEqual(path, answer)
 
     def testBasic(self):
-        tmplstr = "{datasettype}/{visit:05d}/{filter}"
+        tmplstr = "{datasetType}/{visit:05d}/{filter}"
         self.assertTemplate(tmplstr,
-                            tmplstr.format(datasettype="calexp", **self.du.units),
-                            self.du, datasettype="calexp")
+                            tmplstr.format(datasetType="calexp", **self.du.units),
+                            self.du, datasetType="calexp")
 
     def testOptional(self):
         """Optional units in templates."""
-        tmplstr = "{datasettype}/v{visit:05d}_f{filter:?}"
+        tmplstr = "{datasetType}/v{visit:05d}_f{filter:?}"
         self.assertTemplate(tmplstr, "calexp/v00052_fU",
-                            self.du, datasettype="calexp")
+                            self.du, datasetType="calexp")
 
         du = DataUnits({"visit": 48, "tract": 265})
         self.assertTemplate(tmplstr, "calexp/v00048",
-                            du, datasettype="calexp")
+                            du, datasetType="calexp")
 
         # Ensure that this returns a relative path even if the first field
         # is optional
-        tmplstr = "{datasettype:?}/{visit:?}/f{filter}"
+        tmplstr = "{datasetType:?}/{visit:?}/f{filter}"
         self.assertTemplate(tmplstr, "52/fU", self.du)
 
         # Ensure that // from optionals are converted to singles
-        tmplstr = "{datasettype}/{patch:?}/{tract:?}/f{filter}"
-        self.assertTemplate(tmplstr, "calexp/fU", self.du, datasettype="calexp")
+        tmplstr = "{datasetType}/{patch:?}/{tract:?}/f{filter}"
+        self.assertTemplate(tmplstr, "calexp/fU", self.du, datasetType="calexp")
 
         # Optionals with some text between fields
-        tmplstr = "{datasettype}/p{patch:?}_t{tract:?}/f{filter}"
-        self.assertTemplate(tmplstr, "calexp/p/fU", self.du, datasettype="calexp")
-        tmplstr = "{datasettype}/p{patch:?}_t{visit:04d?}/f{filter}"
-        self.assertTemplate(tmplstr, "calexp/p_t0052/fU", self.du, datasettype="calexp")
+        tmplstr = "{datasetType}/p{patch:?}_t{tract:?}/f{filter}"
+        self.assertTemplate(tmplstr, "calexp/p/fU", self.du, datasetType="calexp")
+        tmplstr = "{datasetType}/p{patch:?}_t{visit:04d?}/f{filter}"
+        self.assertTemplate(tmplstr, "calexp/p_t0052/fU", self.du, datasetType="calexp")
 
     def testComponent(self):
         """Test handling of components in templates."""
 
         tmplstr = "c_{component}_v{visit}"
-        self.assertTemplate(tmplstr, "c_output_v52", self.du, datasettype="metric.output")
+        self.assertTemplate(tmplstr, "c_output_v52", self.du, datasetType="metric.output")
         self.assertTemplate(tmplstr, "c_output_v52", self.du, component="output")
 
         tmplstr = "{component:?}_{visit}"
         self.assertTemplate(tmplstr, "_52", self.du)
-        self.assertTemplate(tmplstr, "output_52", self.du, datasettype="metric.output")
+        self.assertTemplate(tmplstr, "output_52", self.du, datasetType="metric.output")
         self.assertTemplate(tmplstr, "maskedimage.variance_52", self.du,
-                            datasettype="calexp.maskedimage.variance")
+                            datasetType="calexp.maskedimage.variance")
         self.assertTemplate(tmplstr, "output_52", self.du, component="output")
 
         # Providing a component but not using it
-        tmplstr = "{datasettype}/v{visit:05d}"
+        tmplstr = "{datasetType}/v{visit:05d}"
         with self.assertRaises(KeyError):
-            self.assertTemplate(tmplstr, "", self.du, datasettype="calexp", component="wcs")
+            self.assertTemplate(tmplstr, "", self.du, datasetType="calexp", component="wcs")
         with self.assertRaises(KeyError):
-            self.assertTemplate(tmplstr, "", self.du, datasettype="calexp.wcs")
+            self.assertTemplate(tmplstr, "", self.du, datasetType="calexp.wcs")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Templates are specified in the YAML configuration file and indexed
by dataset type.

Needs some clean up but fundamentally seems sound. Doesn't yet support fallback to a user function and I haven't got standalone tests for the template formatting.