### PR TITLE
DM-13753: Add Sphinx documentation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ tests/test_output_datastore/
 config.log
 ups/*.cfgc
 pytest_session.txt
+doc/_build
+doc/py-api

--- a/doc/_static/README
+++ b/doc/_static/README
@@ -1,0 +1,1 @@
+Images for the documentation go here.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,14 @@
+"""Sphinx configuration file for an LSST stack package.
+
+This configuration only affects single-package Sphinx documenation builds.
+"""
+
+from documenteer.sphinxconfig.stackconf import build_package_configs
+import lsst.daf.butler
+import lsst.daf.butler.version
+
+
+_g = globals()
+_g.update(build_package_configs(
+    project_name='daf_butler',
+    version=lsst.daf.butler.version.__version__))

--- a/doc/daf_butler/index.rst
+++ b/doc/daf_butler/index.rst
@@ -1,0 +1,28 @@
+.. _daf_butler-package:
+
+.. Title is the EUPS package name
+
+##########
+daf_butler
+##########
+
+.. Sentence/short paragraph describing what the package is for.
+
+The ``daf_butler`` package provides data access facilities for LSST data.
+It can be used to read and write data without having to know the details of file formats or locations.
+
+Project info
+============
+
+Repository
+   https://github.com/lsst/daf_butler
+
+JIRA component
+   ``daf_butler``
+
+Modules
+=======
+
+.. Link to Python module landing pages (same as in manifest.yaml)
+
+- :ref:`lsst.daf.butler <lsst.daf.butler>`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,13 @@
+################################
+daf_butler documentation preview
+################################
+
+.. This page is for local development only. It isn't published to pipelines.lsst.io.
+
+.. Link the index pages of package and module documentation directions (listed in manifest.yaml).
+
+.. toctree::
+   :maxdepth: 1
+
+   daf_butler/index
+   lsst.daf.butler/index

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -4,7 +4,7 @@
 lsst.daf.butler
 ###############
 
-.. Paragraph that describes what this Python module does and links to related modules and frameworks.
+This module provides an abstracted data access interface.
 
 .. Add subsections with toctree to individual topic pages.
 
@@ -12,8 +12,27 @@ Python API reference
 ====================
 
 .. automodapi:: lsst.daf.butler
-.. automodapi:: lsst.daf.butler.core
-.. automodapi:: lsst.daf.butler.ci_hsc
-.. automodapi:: lsst.daf.butler.datastores
-.. automodapi:: lsst.daf.butler.formatters
-.. automodapi:: lsst.daf.butler.registries
+
+Example Datastores
+==================
+
+.. automodapi:: lsst.daf.butler.datastores.posixDatastore
+
+Example Registries
+==================
+
+.. automodapi:: lsst.daf.butler.registries.sqlRegistry
+
+Example Formatters
+==================
+
+.. automodapi:: lsst.daf.butler.formatters.fileFormatter
+.. automodapi:: lsst.daf.butler.formatters.jsonFormatter
+.. automodapi:: lsst.daf.butler.formatters.yamlFormatter
+.. automodapi:: lsst.daf.butler.formatters.pickleFormatter
+
+Support API
+===========
+
+.. automodapi:: lsst.daf.butler.core.safeFileIo
+.. automodapi:: lsst.daf.butler.core.utils

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -1,0 +1,19 @@
+.. _lsst.daf.butler:
+
+###############
+lsst.daf.butler
+###############
+
+.. Paragraph that describes what this Python module does and links to related modules and frameworks.
+
+.. Add subsections with toctree to individual topic pages.
+
+Python API reference
+====================
+
+.. automodapi:: lsst.daf.butler
+.. automodapi:: lsst.daf.butler.core
+.. automodapi:: lsst.daf.butler.ci_hsc
+.. automodapi:: lsst.daf.butler.datastores
+.. automodapi:: lsst.daf.butler.formatters
+.. automodapi:: lsst.daf.butler.registries

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -1,0 +1,20 @@
+# Documentation manifest.
+
+# Name of this package
+# Also the name of the package documentation subdirectory.
+package: "daf_butler"
+
+# List of names of Python modules in this package.
+# For each module there is a corresponding module doc subdirectory.
+modules:
+  - "lsst.daf.butler"
+  - "lsst.daf.butler.core"
+  - "lsst.daf.butler.ci_hsc"
+  - "lsst.daf.butler.datastores"
+  - "lsst.daf.butler.formatters"
+  - "lsst.daf.butler.registries"
+
+# Name of the static content directories (subdirectories of `_static`).
+# Static content directories are usually named after the package.
+statics:
+  - "_static/daf_butler"

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -2,10 +2,12 @@
 Data Access Butler
 """
 
-from .assemblers import *
-from .ci_hsc import *
+# Formatters and assemblers are not auto-imported since they can have
+# additional runtime dependencies.
+
+# from .ci_hsc import *
 from .core import *
-from .datastores import *
-from .registries import *
+# from .datastores import *
+# from .registries import *
 from .butler import *
 from .version import *

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -1,0 +1,11 @@
+"""
+Data Access Butler
+"""
+
+from .assemblers import *
+from .ci_hsc import *
+from .core import *
+from .datastores import *
+from .registries import *
+from .butler import *
+from .version import *

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -19,9 +19,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Butler top level classes.
+"""
+
 from .core.config import Config
 from .core.datastore import Datastore
 from .core.registry import Registry
+
+__all__ = ("ButlerConfig", "Butler")
 
 
 class ButlerConfig(Config):
@@ -42,22 +48,20 @@ class Butler(object):
 
     Attributes
     ----------
-    config : `str` or `ButlerConfiguration`
+    config : `str` or `Config`
         (filename to) configuration.
     datastore : `Datastore`
         Datastore to use for storage.
     registry : `Registry`
         Registry to use for lookups.
+
+    Parameters
+    ----------
+    config : `Config`
+        Configuration.
     """
 
     def __init__(self, config):
-        """Constructor.
-
-        Parameters
-        ----------
-        config : `ButlerConfiguration`
-            Configuration.
-        """
         self.config = ButlerConfig(config)
         self.datastore = Datastore.fromConfig(self.config)
         self.registry = Registry.fromConfig(self.config)
@@ -120,7 +124,8 @@ class Butler(object):
         inMemoryDataset : `InMemoryDataset`
             The `Dataset` to store.
         producer : `Quantum`
-            The producer of this `Dataset`.  May be ``None`` for some `Registries`.
+            The producer of this `Dataset`.  May be ``None`` for some
+            `Registry` instances.
             ``producer.run`` must match ``self.config['run']``.
 
         Returns
@@ -137,7 +142,8 @@ class Butler(object):
         return self.registry.addDataset(ref, uri, components, producer=producer, run=run)
 
     def markInputUsed(self, quantum, ref):
-        """Mark a `Dataset` as having been "actually" (not just predicted-to-be) used by a `Quantum`.
+        """Mark a `Dataset` as having been "actually" (not just
+        predicted-to-be) used by a `Quantum`.
 
         Parameters
         ----------
@@ -150,13 +156,16 @@ class Butler(object):
         self.registry.markInputUsed(ref, quantum)
 
     def unlink(self, *refs):
-        """Remove the `Dataset`s associated with the given `DatasetRef`s from the Butler's `Collection`,
-        and signal that they may be deleted from storage if they are not referenced by any other `Collection`.
+        """Remove dataset from collection.
+
+        Remove the `Dataset`\ s associated with the given `DatasetRef`\ s
+        from the `Butler`\ 's collection, and signal that they may be deleted
+        from storage if they are not referenced by any other collection.
 
         Parameters
         ----------
-        refs : [`DatasetRef`]
-            List of refs for `Dataset`s to unlink.
+        refs : `list` of `DatasetRef`
+            List of refs for `Dataset`\ s to unlink.
         """
         refs = [self.registry.find(self.run.collection, ref) for ref in refs]
         for ref in self.registry.disassociate(self.run.collection, refs, remove=True):

--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -2,11 +2,15 @@
 Core code for butler.
 """
 
+# Do not export the utility routines from safeFileIo and utils
+
 from .composites import *
 from .config import *
 from .datasets import *
 from .datastore import *
+from .dataUnits import *
 from .fileDescriptor import *
+from .fileTemplates import *
 from .formatter import *
 from .location import *
 from .mappingFactory import *
@@ -14,8 +18,6 @@ from .quantum import *
 from .regions import *
 from .registry import *
 from .run import *
-from .safeFileIo import *
 from .schema import *
 from .storageClass import *
 from .units import *
-from .utils import *

--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -1,0 +1,21 @@
+"""
+Core code for butler.
+"""
+
+from .composites import *
+from .config import *
+from .datasets import *
+from .datastore import *
+from .fileDescriptor import *
+from .formatter import *
+from .location import *
+from .mappingFactory import *
+from .quantum import *
+from .regions import *
+from .registry import *
+from .run import *
+from .safeFileIo import *
+from .schema import *
+from .storageClass import *
+from .units import *
+from .utils import *

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""Configuration control."""
+
 import collections
 import copy
 import yaml
@@ -26,6 +28,8 @@ import pprint
 
 from yaml.representer import Representer
 yaml.add_representer(collections.defaultdict, Representer.represent_dict)
+
+__all__ = ("Config",)
 
 
 # UserDict and yaml have defined metaclasses and Python 3 does not allow multiple
@@ -42,29 +46,35 @@ class _ConfigBase(collections.UserDict, yaml.YAMLObject, metaclass=_ConfigMeta):
 
 
 class Config(_ConfigBase):
-    """Config implements a datatype that is used by Butler for configuration parameters.
-    It is essentially a dict with key/value pairs, including nested dicts (as values). In fact, it can be
-    initialized with a dict. The only caveat is that keys may NOT contain dots ('.'). This is explained next:
-    Config extends the dict api so that hierarchical values may be accessed with dot-delimited notation.
-    That is, foo.getValue('a.b.c') is the same as foo['a']['b']['c'] is the same as foo['a.b.c'], and either
+    """Implements a datatype that is used by `Butler` for configuration
+    parameters.
+
+    It is essentially a `dict` with key/value pairs, including nested dicts
+    (as values). In fact, it can be initialized with a `dict`. The only caveat
+    is that keys may **not** contain dots (``.``). This is explained next:
+
+    Config extends the `dict` api so that hierarchical values may be accessed
+    with dot-delimited notation. That is, ``foo.getValue('a.b.c')`` is the
+    same as ``foo['a']['b']['c']`` is the same as ``foo['a.b.c']``, and either
     of these syntaxes may be used.
 
     Storage formats supported:
+
     - yaml: read and write is supported.
+
+
+    Parameters
+    ----------
+    other : `str` or `Config` or `dict`
+        Other source of configuration, can be:
+
+        - (`str`) Treated as a path to a config file on disk. Must end with '.yaml'.
+        - (`Config`) Copies the other Config's values into this one.
+        - (`dict`) Copies the values from the dict into this Config.
     """
 
     def __init__(self, other=None):
-        """Initialize the Config. Other can be used to initialize the Config in a variety of ways.
 
-        Parameters
-        ----------
-        other: `str` or `Config` or `dict`
-            Other source of configuration, can be:
-
-            - (`str`) Treated as a path to a config file on disk. Must end with '.yaml'.
-            - (`Config`) Copies the other Config's values into this one.
-            - (`dict`) Copies the values from the dict into this Config.
-        """
         collections.UserDict.__init__(self)
 
         if other is None:
@@ -88,7 +98,7 @@ class Config(_ConfigBase):
 
         Returns
         -------
-        s: `str`
+        s : `str`
             A prettyprint formatted string representing the config
         """
         return pprint.pformat(self.data, indent=2, width=1)
@@ -101,7 +111,7 @@ class Config(_ConfigBase):
 
         Parameters
         ----------
-        path: `str`
+        path : `str`
             To a persisted config file.
         """
         if path.endswith('yaml'):
@@ -114,7 +124,7 @@ class Config(_ConfigBase):
 
         Parameters
         ----------
-        path: `str`
+        path : `str`
             To a persisted config file in YAML format.
         """
         with open(path, 'r') as f:
@@ -130,7 +140,7 @@ class Config(_ConfigBase):
 
         Raises
         ------
-        e: `yaml.YAMLError`
+        yaml.YAMLError
             If there is an error loading the file.
         """
         self.data = yaml.safe_load(stream)
@@ -186,7 +196,7 @@ class Config(_ConfigBase):
 
         Parameters
         ----------
-        other: `dict` or `Config`
+        other : `dict` or `Config`
             Source of configuration:
 
             - If foo is a dict, then after the update foo == {'a': {'c': 2}}
@@ -211,7 +221,7 @@ class Config(_ConfigBase):
 
         Parameters
         ----------
-        other: `dict` or `Config`
+        other : `dict` or `Config`
             Source of configuration:
         """
         otherCopy = copy.deepcopy(other)
@@ -242,7 +252,7 @@ class Config(_ConfigBase):
 
         Parameters
         ----------
-        name: `str`
+        name : `str`
             Key
         """
         val = self.get(name)
@@ -313,7 +323,7 @@ class Config(_ConfigBase):
 
         Parameters
         ----------
-        path: `str`
+        path : `str`
             Path to the file to use for output.
         """
         with open(path, 'w') as f:

--- a/python/lsst/daf/butler/core/dataUnits.py
+++ b/python/lsst/daf/butler/core/dataUnits.py
@@ -21,6 +21,8 @@
 
 """Code relating to DataUnits."""
 
+__all__ = ("DataUnits",)
+
 
 class DataUnits:
     """Represent DataUnits specification.

--- a/python/lsst/daf/butler/core/datasets.py
+++ b/python/lsst/daf/butler/core/datasets.py
@@ -23,6 +23,8 @@ from types import MappingProxyType
 from .utils import slotValuesAreEqual, slotValuesToHash
 from .units import DataUnitSet
 
+__all__ = ("DatasetType", "DatasetRef")
+
 
 def _safeMakeMappingProxyType(data):
     if data is None:
@@ -34,12 +36,14 @@ class DatasetType(object):
     """A named category of Datasets that defines how they are organized,
     related, and stored.
 
-    A concrete, final class whose instances represent `DatasetType`s.
+    A concrete, final class whose instances represent `DatasetType`\ s.
     `DatasetType` instances may be constructed without a `Registry`,
     but they must be registered
-    via `Registry.registerDatasetType()` before corresponding `Datasets`
+    via `Registry.registerDatasetType()` before corresponding `Dataset`\ s
     may be added.
     `DatasetType` instances are immutable.
+
+    All arguments correspond directly to instance attributes.
     """
 
     __slots__ = ("_name", "_template", "_units", "_storageClass")
@@ -55,7 +59,7 @@ class DatasetType(object):
 
     @property
     def template(self):
-        """A string with `str.format`-style replacement patterns that can be
+        """A string with `str`.format-style replacement patterns that can be
         used to create a path from a `Run`
         (and optionally its associated Collection) and a `DatasetRef`.
 
@@ -66,7 +70,7 @@ class DatasetType(object):
 
     @property
     def units(self):
-        """A `DataUnitSet` that defines the `DatasetRef`s corresponding
+        """A `DataUnitSet` that defines the `DatasetRef`\ s corresponding
         to this `DatasetType`.
         """
         return self._units
@@ -78,10 +82,6 @@ class DatasetType(object):
         return self._storageClass
 
     def __init__(self, name, template, units, storageClass):
-        """Constructor.
-
-        All arguments correspond directly to instance attributes.
-        """
         self._name = name
         self._template = template
         self._units = DataUnitSet(units)
@@ -91,8 +91,16 @@ class DatasetType(object):
 class DatasetRef(object):
     """Reference to a `Dataset` in a `Registry`.
 
-    A `DatasetRef` may point to a `Dataset`s that currently does not yet exist
-    (e.g. because it is a predicted input for provenance).
+    A `DatasetRef` may point to a `Dataset` that currently does not yet exist
+    (e.g., because it is a predicted input for provenance).
+
+    Parameters
+    ----------
+    datasetType : `DatasetType`
+        The `DatasetType` for this `Dataset`.
+    units : `dict`
+        Dictionary where the keys are `DataUnit` names and the values are
+        `DataUnit` instances.
     """
 
     __slots__ = ("_type", "_producer", "_predictedConsumers", "_actualConsumers")
@@ -111,17 +119,6 @@ class DatasetRef(object):
         return cls._currentId
 
     def __init__(self, datasetType, units):
-        """Construct a DatasetRef from a DatasetType and a complete tuple
-        of DataUnits.
-
-        Parameters
-        ----------
-        datasetType: `DatasetType`
-            The `DatasetType` for this `Dataset`.
-        units: `dict`
-            Dictionary where the keys are `DataUnit` names and the values are
-            `DataUnit` instances.
-        """
         units = datasetType.units.conform(units)
         super().__init__(
             datasetType.name,
@@ -160,7 +157,8 @@ class DatasetRef(object):
 
     @property
     def predictedConsumers(self):
-        """A sequence of `Quantum` instances that list this `Dataset` in their `predictedInputs` attributes.
+        """A sequence of `Quantum` instances that list this `Dataset` in their
+        `predictedInputs` attributes.
 
         Read-only; update via `Quantum.addPredictedInput()`.
         May be an empty list if no provenance information is available.

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -19,10 +19,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+Support for generic data stores.
+"""
+
+
 from lsst.daf.butler.core.utils import doImport
 
 from abc import ABCMeta, abstractmethod
 from .config import Config
+
+__all__ = ("DatastoreConfig", "Datastore")
 
 
 class DatastoreConfig(Config):
@@ -105,14 +112,15 @@ class Datastore(metaclass=ABCMeta):
             a Universal Resource Identifier that specifies the location of the
             stored `Dataset`.
 
-        .. note::
-            Some Datastores may implement this method as a silent no-op to
-            disable `Dataset` deletion through standard interfaces.
-
         Raises
         ------
-        e : `FileNotFoundError`
+        FileNotFoundError
             When `Dataset` does not exist.
+
+        Notes
+        -----
+        Some Datastores may implement this method as a silent no-op to
+        disable `Dataset` deletion through standard interfaces.
         """
         raise NotImplementedError("Must be implemented by subclass")
 

--- a/python/lsst/daf/butler/core/fileDescriptor.py
+++ b/python/lsst/daf/butler/core/fileDescriptor.py
@@ -27,12 +27,12 @@ class FileDescriptor(object):
     ----------
     location : `Location`
         Storage location.
-    type : `cls`
+    pytype : `type`, optional
         Type the object will have after reading in Python (typically
         `StorageClass.pytype` but can be overridden).
-    storageClass : `StorageClass`
+    storageClass : `StorageClass`, optional
         `StorageClass` associated with this file.
-    parameters : `dict`
+    parameters : `dict`, optional
         Additional parameters that can be used for reading and writing.
     """
 

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -23,9 +23,11 @@ from abc import ABCMeta, abstractmethod
 
 from .mappingFactory import MappingFactory
 
+__all__ = ("Formatter", "FormatterFactory")
+
 
 class Formatter(metaclass=ABCMeta):
-    """Interface for reading and writing `Dataset`s with a particular
+    """Interface for reading and writing `Dataset`\ s with a particular
     `StorageClass`.
     """
     @abstractmethod
@@ -62,7 +64,7 @@ class Formatter(metaclass=ABCMeta):
         uri : `str`
             The `URI` where the primary `Dataset` is stored.
         components : `dict`, optional
-            A dictionary of URIs for the `Dataset`' components.
+            A dictionary of URIs for the `Dataset`'s components.
             The latter will be empty if the `Dataset` is not a composite.
         """
         raise NotImplementedError("Type does not support writing")
@@ -89,18 +91,19 @@ class FormatterFactory:
         return self._mappingFactory.getFromRegistry(datasetType, storageClass)
 
     def registerFormatter(self, type_, formatter):
-        """Register a Formatter.
+        """Register a `Formatter`.
 
         Parameters
         ----------
         type_ : `str` or `StorageClass` or `DatasetType`
             Type for which this formatter is to be used.
         formatter : `str`
-            Identifies a `Formatter` subclass to use for reading and writing `Dataset`s of this type.
+            Identifies a `Formatter` subclass to use for reading and writing
+            `Dataset`\ s of this type.
 
         Raises
         ------
-        e : `ValueError`
+        ValueError
             If formatter does not name a valid formatter type.
         """
         self._mappingFactory.placeInRegistry(type_, formatter)

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -23,14 +23,11 @@ import os
 import os.path
 import urllib
 
+__all__ = ("Location", "LocationFactory")
+
 
 class Location(object):
     """Identifies a location in the `Datastore`.
-
-    Attributes
-    ----------
-    uri
-    path
     """
 
     __slots__ = ("_datastoreRoot", "_uri")

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -21,6 +21,8 @@
 
 from lsst.daf.butler.core.utils import doImport
 
+__all__ = ("MappingFactory", )
+
 
 class MappingFactory:
     """
@@ -61,7 +63,7 @@ class MappingFactory:
 
         Raises
         ------
-        e : KeyError
+        KeyError
             None of the supplied target classes match an item in the registry.
         """
         attempts = []
@@ -93,7 +95,7 @@ class MappingFactory:
 
         Raises
         ------
-        e : `ValueError`
+        ValueError
             If instance of class is not of the expected type.
         """
         if not self._isValidStr(typeName):

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -19,13 +19,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+__all__ = ("Quantum",)
 
-class Quantum(object):
-    """A discrete unit of work that may depend on one or more Datasets and produces one or more `Dataset`s.
 
-    Most Quanta will be executions of a particular `SuperTask`’s `runQuantum` method,
-    but they can also be used to represent discrete units of work performed manually
-    by human operators or other software agents.
+class Quantum:
+    """A discrete unit of work that may depend on one or more Datasets and
+    produces one or more `Dataset`\ s.
+
+    Most Quanta will be executions of a particular `SuperTask`’s `runQuantum`
+    method, but they can also be used to represent discrete units of work
+    performed manually by human operators or other software agents.
+
+    Parameters
+    ----------
+    run : `Run`
+        Run this quantum is part of.
+    task : `SuperTask` or `str`, optional
+        Associated task information.
+    quantumId : ??, optional
+        ???
+    registryId : ??, optional
+        ???
     """
 
     __slots__ = ("_quantumId", "_registryId", "_run", "_task", "_predictedInputs", "_actualInputs")
@@ -37,17 +51,14 @@ class Quantum(object):
         """Generate a new Quantum ID number.
 
         ..todo::
-            This is a temporary workaround that will probably disapear in the future,
-            when a solution is found to the problem of autoincrement compound primary keys in SQLite.
+            This is a temporary workaround that will probably disapear in the
+            future, when a solution is found to the problem of autoincrement
+            compound primary keys in SQLite.
         """
         cls._currentId += 1
         return cls._currentId
 
     def __init__(self, run, task=None, quantumId=None, registryId=None):
-        """Constructor.
-
-        Parameters correspond directly to attributes.
-        """
         self._quantumId = quantumId
         self._registryId = registryId
         self._run = run
@@ -57,7 +68,9 @@ class Quantum(object):
 
     @property
     def pkey(self):
-        """The `(quantum_id, registry_id)` `tuple` used to uniquely identify this `Run`,
+        """Primary keys used to uniquely identify this `Run`.
+
+        Represented as a `tuple` of ``(quantum_id, registry_id)``,
         or `None` if it has not yet been inserted into a `Registry`.
         """
         if self._quantumId is not None and self._registryId is not None:
@@ -67,10 +80,12 @@ class Quantum(object):
 
     @property
     def quantumId(self):
+        """Quantum identifier."""
         return self._quantumId
 
     @property
     def registryId(self):
+        """Registry identifier."""
         return self._registryId
 
     @property
@@ -81,7 +96,9 @@ class Quantum(object):
 
     @property
     def task(self):
-        """If the `Quantum` is associated with a `SuperTask`, this is the
+        """Task associated with this `Quantum`.
+
+        If the `Quantum` is associated with a `SuperTask`, this is the
         `SuperTask` instance that produced and should execute this set of
         inputs and outputs. If not, a human-readable string identifier
         for the operation. Some Registries may permit the value to be
@@ -91,20 +108,20 @@ class Quantum(object):
 
     @property
     def predictedInputs(self):
-        """A dictionary of input datasets that were expected to be used,
+        """A `dict` of input datasets that were expected to be used,
         with `DatasetType` names as keys and a set of `DatasetRef` instances
         as values.
 
         Input `Datasets` that have already been stored may be
-        `DatasetRef`s, and in many contexts may be guaranteed to be.
-        Read-only; update via `addPredictedInput()`.
+        `DatasetRef`\s, and in many contexts may be guaranteed to be.
+        Read-only; update via `Quantum.addPredictedInput()`.
         """
         return self._predictedInputs
 
     @property
     def actualInputs(self):
         """A `dict` of input datasets that were actually used, with the same
-        form as `predictedInputs`.
+        form as `Quantum.predictedInputs`.
 
         All returned sets must be subsets of those in `predictedInputs`.
 

--- a/python/lsst/daf/butler/core/regions.py
+++ b/python/lsst/daf/butler/core/regions.py
@@ -22,21 +22,26 @@
 import lsst.sphgeom
 import lsst.afw.geom
 
+__all__ = ("makeBoxWcsRegion", )
+
 
 def makeBoxWcsRegion(box, wcs, margin):
     """Construct a spherical ConvexPolygon from a WCS and a bounding box.
 
-    Parameters:
-    -----------
-    box : afw.geom.Box2I or afw.geom.Box2D
+    Parameters
+    ----------
+    box : lsst.afw.geom.Box2I or lsst.afw.geom.Box2D
         A box in the pixel coordinate system defined by the WCS.
-    wcs : afw.image.Wcs
+    wcs : lsst.afw.image.Wcs
         A mapping from a pixel coordinate system to the sky.
     margin : float
         A buffer in pixels to grow the box by (in all directions) before
         transforming it to sky coordinates.
 
-    Returns a sphgeom.ConvexPolygon.
+    Returns
+    -------
+    polygon : `lsst.sphgeom.ConvexPolygon`
+        A convex polygon.
     """
     box = lsst.afw.geom.Box2D(box)
     box.grow(margin)

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -25,6 +25,8 @@ from lsst.daf.butler.core.utils import doImport
 
 from .config import Config
 
+__all__ = ("RegistryConfig", "Registry")
+
 
 class RegistryConfig(Config):
     pass
@@ -37,6 +39,7 @@ class Registry(metaclass=ABCMeta):
     ----------
     config : `RegistryConfig`
     """
+
     @staticmethod
     def fromConfig(config):
         """Create `Registry` subclass instance from `config`.
@@ -70,11 +73,11 @@ class Registry(metaclass=ABCMeta):
     @abstractmethod
     def registerDatasetType(self, datasetType):
         """
-        Add a new :ref:`DatasetType` to the Registry.
+        Add a new `DatasetType` to the `Registry`.
 
         Parameters
         ----------
-        datasetType: `DatasetType`
+        datasetType : `DatasetType`
             The `DatasetType` to be added.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -85,12 +88,12 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        name: `str`
+        name : `str`
             Name of the type.
 
         Returns
         -------
-        datasetType: `DatasetType`
+        datasetType : `DatasetType`
             The `DatasetType` associated with the given name.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -104,31 +107,31 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             Identifies the `Dataset` and contains its `DatasetType`.
-        uri: `str`
+        uri : `str`
             The URI that has been associated with the `Dataset` by a
             `Datastore`.
-        components: `dict`
+        components : `dict`
             If the `Dataset` is a composite, a ``{name : URI}`` dictionary of
             its named components and storage locations.
-        run: `Run`
+        run : `Run`
             The `Run` instance that produced the Dataset.  Ignored if
             ``producer`` is passed (`producer.run` is then used instead).
             A Run must be provided by one of the two arguments.
-        producer: `Quantum`
+        producer : `Quantum`
             Unit of work that produced the Dataset.  May be ``None`` to store
             no provenance information, but if present the `Quantum` must
             already have been added to the Registry.
 
         Returns
         -------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             A newly-created `DatasetRef` instance.
 
         Raises
         ------
-        e: `Exception`
+        Exception
             If a `Dataset` with the given `DatasetRef` already exists in the
             given Collection.
         """
@@ -136,14 +139,14 @@ class Registry(metaclass=ABCMeta):
 
     @abstractmethod
     def associate(self, collection, refs):
-        """Add existing `Dataset`s to a Collection, possibly creating the
+        """Add existing `Dataset`\ s to a Collection, possibly creating the
         Collection in the process.
 
         Parameters
         ----------
-        collection: `str`
-            Indicates the Collection the `Dataset`s should be associated with.
-        refs: `[DatasetRef]`
+        collection : `str`
+            Indicates the Collection the `Dataset`\ s should be associated with.
+        refs : `list` of `DatasetRef`
             A `list` of `DatasetRef` instances that already exist in this
             `Registry`.
         """
@@ -151,26 +154,27 @@ class Registry(metaclass=ABCMeta):
 
     @abstractmethod
     def disassociate(self, collection, refs, remove=True):
-        """Remove existing `Dataset`s from a Collection.
+        """Remove existing `Dataset`\ s from a Collection.
 
         ``collection`` and ``ref`` combinations that are not currently
         associated are silently ignored.
 
         Parameters
         ----------
-        collection: `str`
-            The Collection the `Dataset`s should no longer be associated with.
-        refs: `[DatasetRef]`
+        collection : `str`
+            The Collection the `Dataset`\ s should no longer be associated
+            with.
+        refs : `list` of `DatasetRef`
             A `list` of `DatasetRef` instances that already exist in this
             `Registry`.
-        remove: `bool`
-            If `True`, remove `Dataset`s from the `Registry` if they are not
+        remove : `bool`
+            If `True`, remove `Dataset`\s from the `Registry` if they are not
             associated with any Collection (including via any composites).
 
         Returns
         -------
-        removed: `[DatasetRef]`
-            If `remove` is `True`, the `list` of `DatasetRef`s that were
+        removed : `list` of `DatasetRef`
+            If `remove` is `True`, the `list` of `DatasetRef`\ s that were
             removed.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -181,13 +185,13 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        collection: `str`
+        collection : `str`
             The Collection collection used to identify all inputs and outputs
             of the `Run`.
 
         Returns
         -------
-        run: `Run`
+        run : `Run`
             A new `Run` instance.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -200,7 +204,7 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        run: `Run`
+        run : `Run`
             The `Run` to update with the new values filled in.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -208,7 +212,7 @@ class Registry(metaclass=ABCMeta):
     @abstractmethod
     def getRun(self, collection=None, id=None):
         """
-        Get a :ref:`Run` corresponding to it's collection or id
+        Get a `Run` corresponding to its collection or id
 
         Parameters
         ----------
@@ -225,13 +229,14 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        quantum: `Quantum`
+        quantum : `Quantum`
             Instance to add to the `Registry`.
             The given `Quantum` must not already be present in the `Registry`
             (or any other), therefore its:
+
             - `pkey` attribute must be `None`.
-            - `predictedInputs` attribute must be fully populated with
-               `DatasetRef`s, and its.
+            - `Quantum.predictedInputs` attribute must be fully populated with
+              `DatasetRef`\ s, and its.
             - `actualInputs` and `outputs` will be ignored.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -241,19 +246,20 @@ class Registry(metaclass=ABCMeta):
         """Record the given `DatasetRef` as an actual (not just predicted)
         input of the given `Quantum`.
 
-        This updates both the `Registry`'s `Quantum` table and the Python `Quantum.actualInputs` attribute.
+        This updates both the `Registry`'s `Quantum` table and the Python
+        `Quantum.actualInputs` attribute.
 
         Parameters
         ----------
-        quantum: `Quantum`
+        quantum : `Quantum`
             Producer to update.
             Will be updated in this call.
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             To set as actually used input.
 
         Raises
         ------
-        e: `Exception`
+        Exception
             If `ref` is not already in the predicted inputs list.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -263,9 +269,9 @@ class Registry(metaclass=ABCMeta):
         """Add a new `DataUnit`, optionally replacing an existing one
         (for updates).
 
-        unit: `DataUnit`
+        unit : `DataUnit`
             The `DataUnit` to add or replace.
-        replace: `bool`
+        replace : `bool`
             If `True`, replace any matching `DataUnit` that already exists
             (updating its non-unique fields) instead of raising an exception.
         """
@@ -277,14 +283,14 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        cls: `type`
+        cls : `type`
             A class that inherits from `DataUnit`.
-        values: `dict`
+        values : `dict`
             A dictionary of values that uniquely identify the `DataUnit`.
 
         Returns
         -------
-        unit: `DataUnit`
+        unit : `DataUnit`
             Instance of type `cls`, or `None` if no matching unit is found.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -295,12 +301,12 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             The `DatasetRef` to expand.
 
         Returns
         -------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             The expanded reference.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -315,14 +321,14 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        collection: `str`
+        collection : `str`
             Identifies the Collection to search.
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             Identifies the `Dataset`.
 
         Returns
         -------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             A ref to the `Dataset`, or `None` if no matching `Dataset`
             was found.
         """
@@ -334,18 +340,18 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        collection: `str`
+        collection : `str`
             Indicates the input Collection to subset.
-        expr: `str`
-            An expression that limits the `DataUnit`s and (indirectly)
-            `Dataset`s in the subset.
-        datasetTypes: `[DatasetType]`
-            The `list` of `DatasetType`s whose instances should be included
+        expr : `str`
+            An expression that limits the `DataUnit`\ s and (indirectly)
+            `Dataset`\ s in the subset.
+        datasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetType`\ s whose instances should be included
             in the subset.
 
         Returns
         -------
-        collection: `str`
+        collection : `str`
             The newly created collection.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -356,41 +362,41 @@ class Registry(metaclass=ABCMeta):
 
         Entries earlier in the list will be used in preference to later
         entries when both contain
-        `Dataset`s with the same `DatasetRef`.
+        `Dataset`\ s with the same `DatasetRef`.
 
         Parameters
         ----------
-        outputCollection: `str`
+        outputCollection : `str`
             collection to use for the new Collection.
-        inputCollections: `[str]`
+        inputCollections : `list` or `str`
             A `list` of Collections to combine.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
     def makeDataGraph(self, collections, expr, neededDatasetTypes, futureDatasetTypes):
-        """Evaluate a filter expression and lists of `DatasetType`s and
+        """Evaluate a filter expression and lists of `DatasetType`\ s and
         return a `QuantumGraph`.
 
         Parameters
         ----------
-        collections: `[str]`
+        collections : `list` of `str`
             An ordered `list` of collections indicating the Collections to
-            search for `Dataset`s.
-        expr: `str`
-            An expression that limits the `DataUnit`s and (indirectly) the
-            `Dataset`s returned.
-        neededDatasetTypes: `[DatasetType]`
-            The `list` of `DatasetType`s whose instances should be included
+            search for `Dataset`\ s.
+        expr : `str`
+            An expression that limits the `DataUnit`\ s and (indirectly) the
+            `Dataset`\ s returned.
+        neededDatasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetType`\ s whose instances should be included
             in the graph and limit its extent.
-        futureDatasetTypes: `[DatasetType]`
-            The `list` of `DatasetType`s whose instances may be added to the
+        futureDatasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetType`\ s whose instances may be added to the
             graph later, which requires that their `DataUnit` types must be
             present in the graph.
 
         Returns
         -------
-        graph: `QuantumGraph`
+        graph : `QuantumGraph`
             A `QuantumGraph` instance with a `QuantumGraph.units` attribute
             that is not `None`.
         """
@@ -399,39 +405,39 @@ class Registry(metaclass=ABCMeta):
     @abstractmethod
     def makeProvenanceGraph(self, expr, types=None):
         """Make a `QuantumGraph` that contains the full provenance of all
-        `Dataset`s matching an expression.
+        `Dataset`\ s matching an expression.
 
         Parameters
         ----------
-        expr: `str`
+        expr : `str`
             An expression (SQL query that evaluates to a list of `Dataset`
-            primary keys) that selects the `Dataset`s.
+            primary keys) that selects the `Dataset`\ s.
 
         Returns
         -------
-        graph: `QuantumGraph`
-            Instance (with `units` set to `None`).
+        graph : `QuantumGraph`
+            Instance (with `QuantumGraph.units` set to `None`).
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
     def export(self, expr):
         """Export contents of the `Registry`, limited to those reachable from
-        the `Dataset`s identified by the expression `expr`, into a `TableSet`
+        the `Dataset`\ s identified by the expression `expr`, into a `TableSet`
         format such that it can be imported into a different database.
 
         Parameters
         ----------
-        expr: `str`
+        expr : `str`
             An expression (SQL query that evaluates to a list of `Dataset`
-            primary keys) that selects the `Datasets, or a `QuantumGraph`
+            primary keys) that selects the `Dataset`\ s, or a `QuantumGraph`
             that can be similarly interpreted.
 
         Returns
         -------
-        ts: `TableSet`
+        ts : `TableSet`
             Containing all rows, from all tables in the `Registry` that
-            are reachable from the selected `Dataset`s.
+            are reachable from the selected `Dataset`\ s.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
@@ -442,29 +448,29 @@ class Registry(metaclass=ABCMeta):
 
         Parameters
         ----------
-        ts: `TableSet`
+        ts : `TableSet`
             Contains the previously exported content.
-        collection: `str`
+        collection : `str`
             An additional Collection collection assigned to the newly
-            imported `Dataset`s.
+            imported `Dataset`\ s.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
     def transfer(self, src, expr, collection):
         """Transfer contents from a source `Registry`, limited to those
-        reachable from the `Dataset`s identified by the expression `expr`,
+        reachable from the `Dataset`\ s identified by the expression `expr`,
         into this `Registry` and collection them with a Collection.
 
         Parameters
         ----------
-        src: `Registry`
+        src : `Registry`
             The source `Registry`.
-        expr: `str`
-            An expression that limits the `DataUnit`s and (indirectly)
-            the `Dataset`s transferred.
-        collection: `str`
+        expr : `str`
+            An expression that limits the `DataUnit`\ s and (indirectly)
+            the `Dataset`\ s transferred.
+        collection : `str`
             An additional Collection collection assigned to the newly
-            imported `Dataset`s.
+            imported `Dataset`\ s.
         """
         self.import_(src.export(expr), collection)

--- a/python/lsst/daf/butler/core/run.py
+++ b/python/lsst/daf/butler/core/run.py
@@ -21,8 +21,25 @@
 
 from .utils import slotValuesAreEqual, slotValuesToHash
 
+__all__ = ("Run", )
+
 
 class Run(object):
+    """Represent a processing run.
+
+    Parameters
+    ----------
+    runId : `int`
+        ID to associate with this run.
+    registryId : `int`
+        ID associated with this `Registry`.
+    collection : `str`
+        Collection to use for this run.
+    environment : `str`
+        Something about the environment.
+    pipeline : `str`
+        Something about the pipeline.
+    """
     _currentId = 0
 
     @classmethod

--- a/python/lsst/daf/butler/core/safeFileIo.py
+++ b/python/lsst/daf/butler/core/safeFileIo.py
@@ -30,6 +30,16 @@ import os
 import tempfile
 from lsst.log import Log
 
+__all__ = ("DoNotWrite",
+           "safeMakeDir",
+           "setFileMode",
+           "FileForWriteOnceCompareSameFailure",
+           "FileForWriteOnceCompareSame",
+           "SafeFile",
+           "SafeFilename",
+           "SafeLockedFileForRead",
+           "SafeLockedFileForWrite")
+
 
 class DoNotWrite(RuntimeError):
     pass

--- a/python/lsst/daf/butler/core/schema.py
+++ b/python/lsst/daf/butler/core/schema.py
@@ -26,6 +26,8 @@ from sqlalchemy import Column, String, Integer, Boolean, LargeBinary, DateTime,\
 
 metadata = None  # Needed to make disabled test_hsc not fail on import
 
+__all__ = ("SchemaConfig", "Schema")
+
 
 class SchemaConfig(Config):
     """Schema configuration.
@@ -97,13 +99,13 @@ class Schema:
         columnDescription : `dict`
             Description of the column to be created.
             Should always contain:
-                - name, descriptive name
-                - type, valid column type
+            - name, descriptive name
+            - type, valid column type
             May contain:
-                - nullable, entry can be null
-                - primary_key, mark this column as primary key
-                - foreign_key, link to other table
-                - doc, docstring
+            - nullable, entry can be null
+            - primary_key, mark this column as primary key
+            - foreign_key, link to other table
+            - doc, docstring
 
         Returns
         -------
@@ -140,8 +142,8 @@ class Schema:
         constraintDescription : `dict`
             Description of the ForeignKeyConstraint to be created.
             Should always contain:
-                - src, list of source column names
-                - tgt, list of target column names
+            - src, list of source column names
+            - tgt, list of target column names
         """
         src = tuple(iterable(constraintDescription["src"]))
         tgt = tuple(iterable(constraintDescription["tgt"]))

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -28,6 +28,8 @@ from lsst.daf.butler.core.composites import CompositeAssembler
 
 from .mappingFactory import MappingFactory
 
+__all__ = ("StorageClass", "StorageClassFactory")
+
 
 class StorageClass:
     """Class describing how a label maps to a particular Python type.
@@ -155,8 +157,8 @@ class StorageClassFactory:
     def getStorageClass(self, storageClassName):
         """Get a StorageClass instance associated with the supplied name.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         storageClassName : `str`
             Name of the storage class to retrieve.
 
@@ -175,12 +177,12 @@ class StorageClassFactory:
 
         Parameters
         ----------
-        storageClass: `StorageClass`
+        storageClass : `StorageClass`
             Type of the Python `StorageClass` to register.
 
         Raises
         ------
-        e : `KeyError`
+        KeyError
             If a storage class has already been registered with
             storageClassName.
         """

--- a/python/lsst/daf/butler/core/units.py
+++ b/python/lsst/daf/butler/core/units.py
@@ -22,6 +22,21 @@
 from collections import OrderedDict
 from hashlib import sha512
 
+__all__ = ("DataUnitMeta",
+           "DataUnit",
+           "DataUnitSet",
+           "Camera",
+           "AbstractFilter",
+           "PhysicalFilter",
+           "PhysicalSensor",
+           "Visit",
+           "ObservedSensor",
+           "Snap",
+           "VisitRange",
+           "SkyMap",
+           "Tract",
+           "Patch")
+
 
 class DataUnitMeta(type):
     """
@@ -50,6 +65,11 @@ class DataUnit(metaclass=DataUnitMeta):
         """
         Compute a hash that is invariant across Python sessions, and hence
         can be stored in a database.
+
+        Returns
+        -------
+        h : `sha512`
+            Invariant hash of this instance.
         """
         return sha512(b''.join(str(v).encode('utf-8') for v in self.pkey)).digest()
 
@@ -60,7 +80,7 @@ class DataUnit(metaclass=DataUnitMeta):
     @classmethod
     def getType(cls, name):
         """
-        Get type object for DataUnit subclass by *name*
+        Get type object for `DataUnit` subclass by *name*
         """
         if name not in cls._subclasses:
             raise ValueError("Unknown DataUnit: {}".format(name))

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -24,9 +24,21 @@ def iterable(a):
     """Make input iterable.
 
     There are three cases, when the input is:
-    - iterable, but not a string -> iterate over elements (e.g. [i for i in a])
-    - a string -> return single element iterable (e.g. [a])
-    - not iterable -> return single elment iterable (e.g. [a]).
+
+    - iterable, but not a `str` -> iterate over elements
+      (e.g. ``[i for i in a]``)
+    - a `str` -> return single element iterable (e.g. ``[a]``)
+    - not iterable -> return single elment iterable (e.g. ``[a]``).
+
+    Parameters
+    ----------
+    a : iterable or `str` or not iterable
+        Argument to be converted to an iterable.
+
+    Returns
+    -------
+    i : `generator`
+        Iterable version of the input value.
     """
     if isinstance(a, str):
         yield a
@@ -39,7 +51,17 @@ def iterable(a):
 
 def allSlots(self):
     """
-    Return combined __slots__ for all classes in objects mro.
+    Return combined ``__slots__`` for all classes in objects mro.
+
+    Parameters
+    ----------
+    self : `object`
+        Instance to be inspected.
+
+    Returns
+    -------
+    slots : `itertools.chain`
+        All the slots as an iterable.
     """
     from itertools import chain
     return chain.from_iterable(getattr(cls, '__slots__', []) for cls in self.__class__.__mro__)
@@ -49,6 +71,18 @@ def slotValuesAreEqual(self, other):
     """
     Test for equality by the contents of all slots, including those of its
     parents.
+
+    Parameters
+    ----------
+    self : `object`
+        Reference instance.
+    other : `object`
+        Comparison instance.
+
+    Returns
+    -------
+    equal : `bool`
+        Returns True if all the slots are equal in both arguments.
     """
     return all((getattr(self, slot) == getattr(other, slot) for slot in allSlots(self)))
 
@@ -56,6 +90,16 @@ def slotValuesAreEqual(self, other):
 def slotValuesToHash(self):
     """
     Generate a hash from slot values.
+
+    Parameters
+    ----------
+    self : `object`
+        Instance to be hashed.
+
+    Returns
+    -------
+    h : `int`
+        Hashed value generated from the slot values.
     """
     return hash(tuple(getattr(self, slot) for slot in allSlots(self)))
 
@@ -77,11 +121,11 @@ def doImport(pythonType):
 
     Raises
     ------
-    e : `TypeError`
+    TypeError
         pythonType is not a `str`.
-    e : `ValueError`
+    ValueError
         pythonType can not be imported.
-    e : `AttributeError`
+    AttributeError
         pythonType can be partially imported.
     """
     if not isinstance(pythonType, str):

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -30,23 +30,24 @@ from lsst.daf.butler.core.formatter import FormatterFactory
 from lsst.daf.butler.core.storageClass import StorageClassFactory, makeNewStorageClass
 from lsst.daf.butler.core.fileTemplates import FileTemplates
 
+__all__ = ("PosixDatastore", )
+
 
 class PosixDatastore(Datastore):
     """Basic POSIX filesystem backed Datastore.
+
+    Parameters
+    ----------
+    config : `DatastoreConfig` or `str`
+        Configuration.
+
+    Raises
+    ------
+    ValueError
+        If root location does not exist and `create` is `False`.
     """
 
     def __init__(self, config):
-        """Construct a Datastore backed by a POSIX filesystem.
-
-        Parameters
-        ----------
-        config : `DatastoreConfig` or `str`
-            Configuration.
-
-        Raises
-        ------
-        `ValueError` : If root location does not exist and `create` is `False`.
-        """
         super().__init__(config)
         self.root = self.config['root']
         if not os.path.isdir(self.root):
@@ -106,9 +107,9 @@ class PosixDatastore(Datastore):
 
         Raises
         ------
-        e : ValueError
+        ValueError
             Requested URI can not be retrieved.
-        e : TypeError
+        TypeError
             Return value from formatter has unexpected type.
         """
         formatter = self.formatterFactory.getFormatter(storageClass)
@@ -156,7 +157,7 @@ class PosixDatastore(Datastore):
         uri : `str`
             The `URI` where the primary `Dataset` is stored.
         components : `dict`, optional
-            A dictionary of URIs for the `Dataset`' components.
+            A dictionary of URIs for the `Dataset` components.
             The latter will be empty if the `Dataset` is not a composite.
         """
 
@@ -196,9 +197,10 @@ class PosixDatastore(Datastore):
             A Universal Resource Identifier that specifies the location of the
             stored `Dataset`.
 
-        .. note::
-            Some Datastores may implement this method as a silent no-op to
-            disable `Dataset` deletion through standard interfaces.
+        Notes
+        -----
+        Some Datastores may implement this method as a silent no-op to
+        disable `Dataset` deletion through standard interfaces.
         """
         location = self.locationFactory.fromUri(uri)
         if not os.path.exists(location.preferredPath()):

--- a/python/lsst/daf/butler/formatters/fileFormatter.py
+++ b/python/lsst/daf/butler/formatters/fileFormatter.py
@@ -25,6 +25,8 @@ from abc import abstractmethod
 
 from lsst.daf.butler.core.formatter import Formatter
 
+__all__ = ("FileFormatter", )
+
 
 class FileFormatter(Formatter):
     """Interface for reading and writing files on a POSIX file system.

--- a/python/lsst/daf/butler/formatters/fitsCatalogFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsCatalogFormatter.py
@@ -23,6 +23,8 @@ import os.path
 
 from lsst.daf.butler.formatters.fileFormatter import FileFormatter
 
+__all__ = ("FitsCatalogFormatter", )
+
 
 class FitsCatalogFormatter(FileFormatter):
     """Interface for reading and writing catalogs to and from FITS files.

--- a/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
@@ -23,6 +23,8 @@ import os.path
 
 from lsst.daf.butler.formatters.fileFormatter import FileFormatter
 
+__all__ = ("FitsExposureFormatter", )
+
 
 class FitsExposureFormatter(FileFormatter):
     """Interface for reading and writing Exposures to and from FITS files.

--- a/python/lsst/daf/butler/formatters/jsonFormatter.py
+++ b/python/lsst/daf/butler/formatters/jsonFormatter.py
@@ -24,6 +24,8 @@ import json
 
 from lsst.daf.butler.formatters.fileFormatter import FileFormatter
 
+__all__ = ("JsonFormatter", )
+
 
 class JsonFormatter(FileFormatter):
     """Interface for reading and writing Python objects to and from JSON files.

--- a/python/lsst/daf/butler/formatters/pickleFormatter.py
+++ b/python/lsst/daf/butler/formatters/pickleFormatter.py
@@ -25,6 +25,8 @@ import pickle
 
 from lsst.daf.butler.formatters.fileFormatter import FileFormatter
 
+__all__ = ("PickleFormatter", )
+
 
 class PickleFormatter(FileFormatter):
     """Interface for reading and writing Python objects to and from pickle files.

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -24,6 +24,8 @@ import yaml
 
 from lsst.daf.butler.formatters.fileFormatter import FileFormatter
 
+__all__ = ("YamlFormatter", )
+
 
 class YamlFormatter(FileFormatter):
     """Interface for reading and writing Python objects to and from YAML files.

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -24,6 +24,8 @@ from sqlalchemy import create_engine
 from ..core.registry import RegistryConfig, Registry
 from ..core.schema import Schema
 
+__all__ = ("SqlRegistryConfig", "SqlRegistry")
+
 
 class SqlRegistryConfig(RegistryConfig):
     pass
@@ -47,11 +49,11 @@ class SqlRegistry(Registry):
 
     def registerDatasetType(self, datasetType):
         """
-        Add a new :ref:`DatasetType` to the SqlRegistry.
+        Add a new `DatasetType` to the SqlRegistry.
 
         Parameters
         ----------
-        datasetType: `DatasetType`
+        datasetType : `DatasetType`
             The `DatasetType` to be added.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -61,12 +63,12 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        name: `str`
+        name : `str`
             Name of the type.
 
         Returns
         -------
-        type: `DatasetType`
+        type : `DatasetType`
             The `DatasetType` associated with the given name.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -79,26 +81,26 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             Identifies the `Dataset` and contains its `DatasetType`.
-        uri: `str`
+        uri : `str`
             The URI that has been associated with the `Dataset` by a
             `Datastore`.
-        components: `dict`
+        components : `dict`
             If the `Dataset` is a composite, a ``{name : URI}`` dictionary of
             its named components and storage locations.
-        run: `Run`
+        run : `Run`
             The `Run` instance that produced the Dataset.  Ignored if
             ``producer`` is passed (`producer.run` is then used instead).
             A Run must be provided by one of the two arguments.
-        producer: `Quantum`
+        producer : `Quantum`
             Unit of work that produced the Dataset.  May be ``None`` to store
             no provenance information, but if present the `Quantum` must
             already have been added to the SqlRegistry.
 
         Returns
         -------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             A newly-created `DatasetRef` instance.
 
         Raises
@@ -110,40 +112,40 @@ class SqlRegistry(Registry):
         raise NotImplementedError("Must be implemented by subclass")
 
     def associate(self, collection, refs):
-        """Add existing `Dataset`s to a Collection, possibly creating the
+        """Add existing `Dataset`\ s to a Collection, possibly creating the
         Collection in the process.
 
         Parameters
         ----------
-        collection: `str`
-            Indicates the Collection the `Dataset`s should be associated with.
-        refs: `[DatasetRef]`
+        collection : `str`
+            Indicates the Collection the `Dataset`\ s should be associated with.
+        refs : `list` of `DatasetRef`
             A `list` of `DatasetRef` instances that already exist in this
             `SqlRegistry`.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     def disassociate(self, collection, refs, remove=True):
-        """Remove existing `Dataset`s from a Collection.
+        """Remove existing `Dataset`\ s from a Collection.
 
         ``collection`` and ``ref`` combinations that are not currently
         associated are silently ignored.
 
         Parameters
         ----------
-        collection: `str`
-            The Collection the `Dataset`s should no longer be associated with.
-        refs: `[DatasetRef]`
+        collection : `str`
+            The Collection the `Dataset`\ s should no longer be associated with.
+        refs : `list` of `DatasetRef`
             A `list` of `DatasetRef` instances that already exist in this
             `SqlRegistry`.
-        remove: `bool`
-            If `True`, remove `Dataset`s from the `SqlRegistry` if they are not
+        remove : `bool`
+            If `True`, remove `Dataset`\ s from the `SqlRegistry` if they are not
             associated with any Collection (including via any composites).
 
         Returns
         -------
-        removed: `[DatasetRef]`
-            If `remove` is `True`, the `list` of `DatasetRef`s that were
+        removed : `list` of `DatasetRef`
+            If `remove` is `True`, the `list` of `DatasetRef`\ s that were
             removed.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -153,13 +155,13 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        collection: `str`
+        collection : `str`
             The Collection collection used to identify all inputs and outputs
             of the `Run`.
 
         Returns
         -------
-        run: `Run`
+        run : `Run`
             A new `Run` instance.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -171,14 +173,14 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        run: `Run`
+        run : `Run`
             The `Run` to update with the new values filled in.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     def getRun(self, collection=None, id=None):
         """
-        Get a :ref:`Run` corresponding to it's collection or id
+        Get a `Run` corresponding to it's collection or id
 
         Parameters
         ----------
@@ -194,13 +196,14 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        quantum: `Quantum`
+        quantum : `Quantum`
             Instance to add to the `SqlRegistry`.
             The given `Quantum` must not already be present in the `SqlRegistry`
             (or any other), therefore its:
+
             - `pkey` attribute must be `None`.
             - `predictedInputs` attribute must be fully populated with
-               `DatasetRef`s, and its.
+              `DatasetRef`\ s, and its.
             - `actualInputs` and `outputs` will be ignored.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -209,14 +212,15 @@ class SqlRegistry(Registry):
         """Record the given `DatasetRef` as an actual (not just predicted)
         input of the given `Quantum`.
 
-        This updates both the `SqlRegistry`'s `Quantum` table and the Python `Quantum.actualInputs` attribute.
+        This updates both the `SqlRegistry`'s `Quantum` table and the Python
+        `Quantum.actualInputs` attribute.
 
         Parameters
         ----------
-        quantum: `Quantum`
+        quantum : `Quantum`
             Producer to update.
             Will be updated in this call.
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             To set as actually used input.
 
         Raises
@@ -230,9 +234,9 @@ class SqlRegistry(Registry):
         """Add a new `DataUnit`, optionally replacing an existing one
         (for updates).
 
-        unit: `DataUnit`
+        unit : `DataUnit`
             The `DataUnit` to add or replace.
-        replace: `bool`
+        replace : `bool`
             If `True`, replace any matching `DataUnit` that already exists
             (updating its non-unique fields) instead of raising an exception.
         """
@@ -243,14 +247,14 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        cls: `type`
+        cls : `type`
             A class that inherits from `DataUnit`.
-        values: `dict`
+        values : `dict`
             A dictionary of values that uniquely identify the `DataUnit`.
 
         Returns
         -------
-        unit: `DataUnit`
+        unit : `DataUnit`
             Instance of type `cls`, or `None` if no matching unit is found.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -260,12 +264,12 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             The `DatasetRef` to expand.
 
         Returns
         -------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             The expanded reference.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -279,14 +283,14 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        collection: `str`
+        collection : `str`
             Identifies the Collection to search.
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             Identifies the `Dataset`.
 
         Returns
         -------
-        ref: `DatasetRef`
+        ref : `DatasetRef`
             A ref to the `Dataset`, or `None` if no matching `Dataset`
             was found.
         """
@@ -297,18 +301,18 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        collection: `str`
+        collection : `str`
             Indicates the input Collection to subset.
-        expr: `str`
-            An expression that limits the `DataUnit`s and (indirectly)
-            `Dataset`s in the subset.
-        datasetTypes: `[DatasetType]`
-            The `list` of `DatasetType`s whose instances should be included
+        expr : `str`
+            An expression that limits the `DataUnit`\ s and (indirectly)
+            `Dataset`\ s in the subset.
+        datasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetType`\ s whose instances should be included
             in the subset.
 
         Returns
         -------
-        collection: `str`
+        collection : `str`
             The newly created collection.
         """
         raise NotImplementedError("Must be implemented by subclass")
@@ -318,40 +322,40 @@ class SqlRegistry(Registry):
 
         Entries earlier in the list will be used in preference to later
         entries when both contain
-        `Dataset`s with the same `DatasetRef`.
+        `Dataset`\ s with the same `DatasetRef`.
 
         Parameters
         ----------
-        outputCollection: `str`
+        outputCollection : `str`
             collection to use for the new Collection.
-        inputCollections: `[str]`
+        inputCollections : `list` of `str`
             A `list` of Collections to combine.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     def makeDataGraph(self, collections, expr, neededDatasetTypes, futureDatasetTypes):
-        """Evaluate a filter expression and lists of `DatasetType`s and
+        """Evaluate a filter expression and lists of `DatasetType`\ s and
         return a `QuantumGraph`.
 
         Parameters
         ----------
-        collections: `[str]`
+        collections : `list` of `str`
             An ordered `list` of collections indicating the Collections to
-            search for `Dataset`s.
-        expr: `str`
-            An expression that limits the `DataUnit`s and (indirectly) the
-            `Dataset`s returned.
-        neededDatasetTypes: `[DatasetType]`
-            The `list` of `DatasetType`s whose instances should be included
+            search for `Dataset`\ s.
+        expr : `str`
+            An expression that limits the `DataUnit`\ s and (indirectly) the
+            `Dataset`\ s returned.
+        neededDatasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetType`\ s whose instances should be included
             in the graph and limit its extent.
-        futureDatasetTypes: `[DatasetType]`
-            The `list` of `DatasetType`s whose instances may be added to the
+        futureDatasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetType`\ s whose instances may be added to the
             graph later, which requires that their `DataUnit` types must be
             present in the graph.
 
         Returns
         -------
-        graph: `QuantumGraph`
+        graph : `QuantumGraph`
             A `QuantumGraph` instance with a `QuantumGraph.units` attribute
             that is not `None`.
         """
@@ -359,38 +363,38 @@ class SqlRegistry(Registry):
 
     def makeProvenanceGraph(self, expr, types=None):
         """Make a `QuantumGraph` that contains the full provenance of all
-        `Dataset`s matching an expression.
+        `Dataset`\ s matching an expression.
 
         Parameters
         ----------
-        expr: `str`
+        expr : `str`
             An expression (SQL query that evaluates to a list of `Dataset`
-            primary keys) that selects the `Dataset`s.
+            primary keys) that selects the `Dataset`\ s.
 
         Returns
         -------
-        graph: `QuantumGraph`
+        graph : `QuantumGraph`
             Instance (with `units` set to `None`).
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     def export(self, expr):
         """Export contents of the `SqlRegistry`, limited to those reachable from
-        the `Dataset`s identified by the expression `expr`, into a `TableSet`
+        the `Dataset`\ s identified by the expression `expr`, into a `TableSet`
         format such that it can be imported into a different database.
 
         Parameters
         ----------
-        expr: `str`
+        expr : `str`
             An expression (SQL query that evaluates to a list of `Dataset`
             primary keys) that selects the `Datasets, or a `QuantumGraph`
             that can be similarly interpreted.
 
         Returns
         -------
-        ts: `TableSet`
+        ts : `TableSet`
             Containing all rows, from all tables in the `SqlRegistry` that
-            are reachable from the selected `Dataset`s.
+            are reachable from the selected `Dataset`\ s.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
@@ -400,28 +404,28 @@ class SqlRegistry(Registry):
 
         Parameters
         ----------
-        ts: `TableSet`
+        ts : `TableSet`
             Contains the previously exported content.
-        collection: `str`
+        collection : `str`
             An additional Collection collection assigned to the newly
-            imported `Dataset`s.
+            imported `Dataset`\ s.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
     def transfer(self, src, expr, collection):
         """Transfer contents from a source `SqlRegistry`, limited to those
-        reachable from the `Dataset`s identified by the expression `expr`,
+        reachable from the `Dataset`\ s identified by the expression `expr`,
         into this `SqlRegistry` and collection them with a Collection.
 
         Parameters
         ----------
-        src: `SqlRegistry`
+        src : `SqlRegistry`
             The source `SqlRegistry`.
-        expr: `str`
-            An expression that limits the `DataUnit`s and (indirectly)
-            the `Dataset`s transferred.
-        collection: `str`
+        expr : `str`
+            An expression that limits the `DataUnit`\ s and (indirectly)
+            the `Dataset`\ s transferred.
+        collection : `str`
             An additional Collection collection assigned to the newly
-            imported `Dataset`s.
+            imported `Dataset`\ s.
         """
         self.import_(src.export(expr), collection)


### PR DESCRIPTION
* Enable Sphinx in docs/ subdirectory
* Fix numpydoc documentation problems in the Python code
* Establish a public API by adding `__init__.py` modifications.

Not perfect yet since, for example, `Quantum` does not show any methods. Also, currently every mention of `Dataset` is magically converted to a link to the h5py documentation stack. Probably still worth merging as is. Note that assemblers and formatters that depend on `afw` are not included in the documentation tree because they are effectively optional dependencies on `afw` for runtime usage but the sphinx system has to be able to import everything.

I'm not sure how we stop drift in the docs over time again as all the subtle numpydoc problems creep back.

@jonathansick can you take a look please?