### PR TITLE
DM-13452: Few small fixes needed for SuperTask/QuantumGraph

### DIFF
--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -42,7 +42,7 @@ class Quantum(Execution):
         The Run this Quantum is a part of.
     """
 
-    __slots__ = ("_task", "_run", "_predictedInputs", "_actualInputs")
+    __slots__ = ("_task", "_run", "_predictedInputs", "_actualInputs", "_outputs")
     __eq__ = slotValuesAreEqual
 
     def __init__(self, task, run, *args, **kwargs):
@@ -51,6 +51,7 @@ class Quantum(Execution):
         self._run = run
         self._predictedInputs = {}
         self._actualInputs = {}
+        self._outputs = {}
 
     @property
     def task(self):
@@ -93,11 +94,25 @@ class Quantum(Execution):
         """
         return self._actualInputs
 
+    @property
+    def outputs(self):
+        """A `dict` of output datasets (to be) generated for this quantum,
+        with the same form as `predictedInputs`.
+
+        Read-only; update via `addOutput()`.
+        """
+        return self._outputs
+
     def addPredictedInput(self, ref):
         """Add an input `DatasetRef` to the `Quantum`.
 
         This does not automatically update a `Registry`; all `predictedInputs`
         must be present before a `Registry.addQuantum()` is called.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            Reference for a Dataset to add to the Quantum's predicted inputs.
         """
         datasetTypeName = ref.datasetType.name
         if datasetTypeName not in self._actualInputs:
@@ -122,3 +137,17 @@ class Quantum(Execution):
             self._actualInputs[datasetTypeName] = [ref, ]
         else:
             self._actualInputs[datasetTypeName].append(ref)
+
+    def addOutput(self, ref):
+        """Add an output `DatasetRef` to the `Quantum`.
+
+        This does not automatically update a `Registry`; all `outputs`
+        must be present before a `Registry.addQuantum()` is called.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            Reference for a Dataset to add to the Quantum's outputs.
+        """
+        datasetTypeName = ref.datasetType.name
+        self._outputs.setdefault(datasetTypeName, []).append(ref)

--- a/python/lsst/daf/butler/core/units.py
+++ b/python/lsst/daf/butler/core/units.py
@@ -226,6 +226,13 @@ class Visit(DataUnit):
 
     dependencies = (Camera, PhysicalFilter)
 
+    def __init__(self, visitId):
+        self._visitId = visitId
+
+    @property
+    def visitId(self):
+        return self._visitId
+
 
 class ObservedSensor(DataUnit):
 
@@ -246,12 +253,33 @@ class SkyMap(DataUnit):
 
     dependencies = ()
 
+    def __init__(self, skyMapId):
+        self._skyMapId = skyMapId
+
+    @property
+    def skyMapId(self):
+        return self._skyMapId
+
 
 class Tract(DataUnit):
 
     dependencies = (SkyMap,)
 
+    def __init__(self, tractId):
+        self._tractId = tractId
+
+    @property
+    def tractId(self):
+        return self._tractId
+
 
 class Patch(DataUnit):
 
     dependencies = (SkyMap, Tract)
+
+    def __init__(self, patchId):
+        self._patchId = patchId
+
+    @property
+    def patchId(self):
+        return self._patchId


### PR DESCRIPTION
Small fixes for things that I discovered while trying to implement
trivial tests on SuperTask side that depend on gen3 butler interfaces.

Note for reviewers: I'm not quite sure I did the right thing extending DataUnit classes with data/methods. So I did not update all DataUnit classes but only those that I needed for my SuperTask examples.