### PR TITLE
DM-12635: Subpackage for converting Gen2->Gen3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ups/*.cfgc
 pytest_session.txt
 doc/_build
 doc/py-api
+butler_test_repository

--- a/config/gen2convert.yaml
+++ b/config/gen2convert.yaml
@@ -1,0 +1,51 @@
+mappers:
+  HscMapper:
+    # Gen3 Camera name associated with this Gen2 Mapper
+    camera: HSC
+    # VisitInfo objects are used to populate Gen3 Visit and Exposure DataUnit
+    # entries; options here say how to get those from a Gen2 repo.
+    VisitInfo:
+      # The Gen2 DatasetType to read when trying to create a VisitInfo.
+      # (we actually add a "_md" suffix, because we just read the metadata).
+      DatasetType: raw
+      # Gen2 Data ID keys for the above DatasetType that are used
+      # to construct Gen3 Exposure/Visit identifiers.
+      # At present, only one key can be provided and this is used directly
+      # as the Gen3 value.
+      uniqueKeys:
+        - visit
+collections:
+  substitutions:
+    # Regular expression patterns and replacement strings (passed directly
+    # to Python's re.sub) applied in order to all Gen2 absolute repository
+    # paths in order to construct names for the Collections they go into.
+    # This can be used to merge Gen2 repositories into a single Collection
+    # by making them reduce to the same name.
+    -
+      pattern: "^(.+)/rerun/private/"
+      repl: "u/"
+    -
+      pattern: "^(.+)/rerun/"
+      repl: "shared/"
+  overrides:
+    # A dictionary of DatasetType -> Collection mappings that force all
+    # Datasets with that DatasetType into a particular Collection.
+    # Collection names can be str.format patterns that utilize any of
+    # the Gen3 DataUnits or Gen2 DataIds associated with the Dataset.
+    raw: raw/{camera}
+    ref_cat: ref/{name}
+    ref_cat_config: ref/{name}
+runs:
+  # Names of Collections (after processing via the above section)
+  # that should be assigned to a particular Run.
+  # Note that the *first* Collection a Dataset is added to determines
+  # its Run; this will be the one corresponding to the Gen2 repository
+  # that originally contained the file, unless that has been overridden.
+  raw/HSC: 1
+  ref/ps1_pv3_3pi_20170110: 2
+
+skymaps: {}  # dictionary mapping repository roots to Gen3 SkyMap names
+
+storageClasses:
+  # dictionary mapping Gen2 Mapping.persistable to Gen3 StorageClass name
+  {}

--- a/config/registry/default_schema.yaml
+++ b/config/registry/default_schema.yaml
@@ -262,6 +262,12 @@ dataUnits:
             Local sideral time on the meridian (equivalent, but not
             equal, to Local Mean Sidereal Time).
         -
+          name: seeing
+          type: float
+          doc: >
+            Average seeing, measured as the FWHM of the Gaussian with the same
+            effective area (arcsec).
+        -
           name: region
           type: blob
           doc: >

--- a/config/registry/default_schema.yaml
+++ b/config/registry/default_schema.yaml
@@ -31,19 +31,6 @@ dataUnits:
     -
       name: abstract_filter
       type: string
-      #foreign_key: AbstractFilter.abstract_filter
-    tables:
-      AbstractFilter:
-        doc: >
-          A definition table containing recognized AbstractFilter names.
-        columns:
-        -
-          name: abstract_filter
-          type: string
-          primary_key: true
-          doc: >
-            The name of the filter, typically a single letter
-            (e.g. "r" or "i").
 
   PhysicalFilter:
     dependencies:
@@ -88,9 +75,6 @@ dataUnits:
         -
           src: camera
           tgt: Camera.camera
-        -
-          src: abstract_filter
-          tgt: AbstractFilter.abstract_filter
 
   Sensor:
     dependencies:

--- a/config/registry/default_schema.yaml
+++ b/config/registry/default_schema.yaml
@@ -330,6 +330,12 @@ dataUnits:
           doc: >
             The bandpass filter used for all exposures in this Visit.
         -
+          name: physical_filter
+          type: string
+          nullable: false
+          doc: >
+            The bandpass filter used for all exposures in this Visit.
+        -
           name: snap
           type: int
           doc: >

--- a/config/registry/default_schema.yaml
+++ b/config/registry/default_schema.yaml
@@ -196,13 +196,20 @@ dataUnits:
             same as the datetime_begin of the first Exposure associated
             with this Visit.
         -
+          name: datetime_end
+          type: datetime
+          doc: >
+            Timestamp of the end of the Visit.  This should be the
+            same as the datetime_end of the last Exposure associated
+            with this Visit.
+        -
           name: exposure_time
           type: float
           doc: >
             The total exposure time of the Visit in seconds.  This should
             be equal to the sum of the exposure_time values for all
-            constituent Exposures (i.e. it should not include time with
-            the shutter closed).
+            constituent Exposures (i.e. it should not include time between
+            Exposures).
         -
           name: region
           type: blob

--- a/config/registry/default_schema.yaml
+++ b/config/registry/default_schema.yaml
@@ -600,7 +600,8 @@ dataunit_joins:
     rhs:
     - ExposureRange
     sql:
-      where: (lhs.camera = rhs.camera) AND (lhs.exposure BETWEEN rhs.valid_first AND rhs.valid_last)
+      (lhs.camera = rhs.camera) AND
+      (lhs.exposure BETWEEN rhs.valid_first AND rhs.valid_last)
   MultiCameraExposureJoin:
     doc: >
       A join table that relates Exposures from different Cameras, with
@@ -680,6 +681,7 @@ dataunit_joins:
         -
           name: sensor
           type: int
+          nullable: false
           doc: Sensor ID
         -
           name: skypix

--- a/config/registry/default_schema.yaml
+++ b/config/registry/default_schema.yaml
@@ -157,6 +157,8 @@ dataUnits:
       A sequence of observations processed together, comprised of one or
       more Exposures from the same Camera with the same pointing and
       PhysicalFilter.
+      The Visit table contains metadata that is both meaningful only for
+      science Exposures and the same for all Exposures in a Visit.
     link:
     -
       name: visit
@@ -210,6 +212,55 @@ dataUnits:
             be equal to the sum of the exposure_time values for all
             constituent Exposures (i.e. it should not include time between
             Exposures).
+        -
+          name: earth_rotation_angle
+          type: float
+          doc: Earth rotation angle in degrees.
+        -
+          name: boresight_ra
+          type: float
+          doc: Position of the boresight in right ascension (decimal degrees).
+        -
+          name: boresight_dec
+          type: float
+          doc: Position of the boresight in declination (decimal degrees).
+        -
+          name: boresight_alt
+          type: float
+          doc: Position of the boresight in altitude (decimal degrees).
+        -
+          name: boresight_az
+          type: float
+          doc: Position of the boresight in azimuth (decimal degrees).
+        -
+          name: boresight_hour_angle
+          type: float
+          doc: Hour angle at the boresight.
+        -
+          name: boresight_parallactic_angle
+          type: float
+          doc: >
+            Equal to the angle between the North celestial pole and Zenith at
+            the boresight. Or, the angular separation between two great circle
+            arcs that meet at the object, one passing through the North
+            celestial pole, and the other through zenith. For an object on the
+            meridian the angle is zero if it is South of zenith and pi if it is
+            North of zenith The angle is positive for objects East of the
+            meridian, and negative for objects to the West.
+        -
+          name: boresight_airmass
+          type: float
+          doc: Airmass at the boresight, relative to zenith at sea level.
+        -
+          name: rot_angle
+          type: float
+          doc: Rotation angle of the focal plane w.r.t. nominal.
+        -
+          name: local_era
+          type: float
+          doc: >
+            Local sideral time on the meridian (equivalent, but not
+            equal, to Local Mean Sidereal Time).
         -
           name: region
           type: blob
@@ -299,6 +350,10 @@ dataUnits:
       don't have multiple Exposures per Visit.  As a result, Cameras that
       don't have multiple Exposures per Visit will typically have Visit
       entries that are essentially duplicates of their Exposure entries.
+
+      The Exposure table contains metadata entries that are relevant for
+      calibration Exposures, and does not duplicate entries in Visit that
+      would be the same for all Exposures within a Visit.
     link:
     -
       name: exposure
@@ -356,8 +411,23 @@ dataUnits:
         -
           name: exposure_time
           type: float
-          doc: >
-            Duration of the Exposure in seconds.
+          doc: Duration of the Exposure with shutter open (seconds).
+        -
+          name: dark_time
+          type: float
+          doc: Duration of the Exposure with shutter closed (seconds).
+        -
+          name: rot_angle
+          type: float
+          doc: Rotation angle of the focal plane w.r.t. nominal
+        -
+          name: boresight_alt
+          type: float
+          doc: Position of the boresight in altitude (decimal degrees).
+        -
+          name: boresight_az
+          type: float
+          doc: Position of the boresight in azimuth (decimal degrees).        
         foreignKeys:
         -
           src: camera

--- a/python/lsst/daf/butler/core/run.py
+++ b/python/lsst/daf/butler/core/run.py
@@ -50,6 +50,9 @@ class Run(Execution):
         self._environment = environment
         self._pipeline = pipeline
 
+    def __repr__(self):
+        return "Run(collection='{}', id={})".format(self.collection, self.id)
+
     @property
     def collection(self):
         return self._collection

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -283,6 +283,23 @@ class PosixDatastore(Datastore):
         path = formatter.write(inMemoryDataset, FileDescriptor(location,
                                                                storageClass=storageClass))
 
+        self.ingest(path, ref, formatter=formatter)
+
+    def ingest(self, path, ref, formatter=None):
+        """Record that a Dataset with the given `DatasetRef` exists in the store.
+
+        Parameters
+        ----------
+        path : `str`
+            File path, relative to the repository root.
+        ref : `DatasetRef`
+            Reference to the associated Dataset.
+        formatter : `Formatter` (optional)
+            Formatter that should be used to retreive the Dataset.
+        """
+        if formatter is None:
+            formatter = self.formatterFactory.getFormatter(ref.datasetType.storageClass,
+                                                           ref.datasetType.name)
         # Create Storage information in the registry
         ospath = os.path.join(self.root, path)
         checksum = self.computeChecksum(ospath)
@@ -292,7 +309,7 @@ class PosixDatastore(Datastore):
         self.registry.addStorageInfo(ref, info)
 
         # Associate this dataset with the formatter for later read.
-        fileInfo = StoredFileInfo(formatter, path, storageClass)
+        fileInfo = StoredFileInfo(formatter, path, ref.datasetType.storageClass)
         self.addStoredFileInfo(ref, fileInfo)
 
         # Register all components with same information

--- a/python/lsst/daf/butler/gen2convert/__init__.py
+++ b/python/lsst/daf/butler/gen2convert/__init__.py
@@ -1,0 +1,24 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .walker import ConversionWalker
+from .writer import ConversionWriter
+from .translators import *

--- a/python/lsst/daf/butler/gen2convert/extractor.py
+++ b/python/lsst/daf/butler/gen2convert/extractor.py
@@ -1,0 +1,165 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import re
+from collections import OrderedDict
+
+from .structures import Gen2Dataset, Gen2DatasetType
+
+__all__ = ("Extractor",)
+
+# Regular expression that matches a single substitution in
+# Gen2 CameraMapper template, such as "%(tract)04d".
+TEMPLATE_RE = re.compile(r'\%\((?P<name>\w+)\)[^\%]*?(?P<type>[idrs])')
+
+
+class FilePathParser:
+    """A callable object that extracts Gen2Dataset instances from filenames
+    corresponding to a particular Gen2 DatasetType.
+
+    External code should use the `fromMapping` method to construct instances.
+
+    Parameters
+    ----------
+    datasetType : `Gen2DatasetType`
+        Information about the DatasetType this parser processes.
+    regex : regular expression object
+        Regular expression pattern with named groups for all data ID keys.
+    """
+
+    @classmethod
+    def fromMapping(cls, mapping):
+        """Construct a FilePathParser instance from a Gen2
+        `lsst.obs.base.Mapping` instance.
+        """
+        try:
+            template = mapping.template
+        except RuntimeError:
+            return None
+        datasetType = Gen2DatasetType(name=mapping.datasetType,
+                                      keys={},
+                                      persistable=mapping.persistable,
+                                      python=mapping.python)
+        # The template string is something like
+        # "deepCoadd/%(tract)04d-%(patch)s/%(filter)s"; each step of this
+        # iterator corresponds to a %-tagged substitution string.
+        # Our goal in all of this parsing is to turn the template into a regex
+        # we can use to extract the associated values when matching strings
+        # generated with the template.
+        last = 0
+        terms = []
+        allKeys = mapping.keys()
+        for match in TEMPLATE_RE.finditer(template):
+            # Copy the (escaped) regular string between the last substitution
+            # and this one to the terms that will form the regex.
+            terms.append(re.escape(template[last:match.start()]))
+            # Pull out the data ID key from the name used in the
+            # subistution string.  Use that and the substition
+            # type to come up with the pattern to use in the regex.
+            name = match.group("name")
+            if name == "patch":
+                pattern = r"\d+,\d+"
+            elif match.group("type") in "id":  # integers
+                pattern = r"0*\d+"
+            else:
+                pattern = ".+"
+            # only use named groups for the first occurence of a key
+            if name not in datasetType.keys:
+                terms.append(r"(?P<%s>%s)" % (name, pattern))
+                datasetType.keys[name] = allKeys[name]
+            else:
+                terms.append(r"(%s)" % pattern)
+            # Remember the end of this match
+            last = match.end()
+        # Append anything remaining after the last substitution string
+        # to the regex.
+        terms.append(re.escape(template[last:]))
+        return cls(datasetType=datasetType, regex=re.compile("".join(terms)))
+
+    def __init__(self, datasetType, regex):
+        self.datasetType = datasetType
+        self.regex = regex
+
+    def __call__(self, filePath, root):
+        """Extract a Gen2Dataset instance from the given path.
+
+        Parameters
+        ----------
+        filePath : `str`
+            Path and filename relative to `root`.
+        root : `str`
+            Absolute path to the root of the Gen2 data repository containing
+            this file.
+        """
+        m = self.regex.fullmatch(filePath)
+        if m is None:
+            return None
+        dataId = {k: v(m.group(k)) for k, v in self.datasetType.keys.items()}
+        return Gen2Dataset(datasetType=self.datasetType, dataId=dataId,
+                           filePath=filePath, root=root)
+
+
+class Extractor:
+    """A callable object that parses Gen2 paths into Gen2Dataset instances for
+    a particular Gen2 data repository.
+
+    Parameters
+    ----------
+    repo : `Gen2Repo`
+        Structure describing the repository this Extractor will process.
+    """
+
+    def __init__(self, repo):
+        self.repo = repo
+        self.parsers = OrderedDict()
+        for mapping in self.repo.mapper.mappings.values():
+            parser = FilePathParser.fromMapping(mapping)
+            if parser is not None:
+                self.parsers[parser.datasetType.name] = parser
+
+    def __call__(self, filePath):
+        """Parse a file path and return a Gen2Dataset that represents it.
+
+        Parameters
+        ----------
+        filePath : `str`
+            A path relative to the root of the data repository.
+
+        Returns
+        -------
+        dataset : `Gen2Dataset` or None
+            A Gen2Dataset instance, or None if the file path is not recognized
+            by this mapper.
+        """
+        for parser in self.parsers.values():
+            dataset = parser(filePath, root=self.repo.root)
+            if dataset is not None:
+                break
+        else:
+            return None
+        # Move the parser we just used to the front of the OrderedDict so we
+        # always try them in MRU order.
+        self.parsers.move_to_end(dataset.datasetType.name, last=False)
+        return dataset
+
+    def getDatasetTypes(self):
+        """Return a dict mapping DatasetType name to Gen2DatasetType instance."""
+        return {parser.datasetType.name: parser.datasetType for parser in self.parsers.values()}

--- a/python/lsst/daf/butler/gen2convert/structures.py
+++ b/python/lsst/daf/butler/gen2convert/structures.py
@@ -1,0 +1,214 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from collections import defaultdict
+
+from lsst.log import Log
+
+__all__ = ("Gen2DatasetType", "Gen2Dataset", "Gen2Repo", "ConvertedRepo")
+
+
+class Gen2DatasetType:
+    """Data structure that represents a DatasetType defined by a Gen2 Mapper.
+
+    Parameters
+    ----------
+    name : `str`
+        String name of this DatasetType.
+    keys : `dict`
+        A mapping from data ID key names to the type objects corresponding to
+        their values.
+    persistable : `str`
+        The string configured as the "persistable" type for the corresponding
+        Gen2 Mapping object.
+    python : `str`
+        String name of the fully-qualified Python type associated with this
+        DatasetType.
+    """
+
+    __slots__ = ("name", "keys", "persistable", "python")
+
+    def __init__(self, name, keys, persistable, python):
+        self.name = name
+        self.keys = keys
+        self.persistable = persistable
+        self.python = python
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return "Gen2DatasetType(%r, %s, %r, %r)" % (self.name, self.keys, self.persistable, self.python)
+
+
+class Gen2Dataset:
+    """Data structure that represents a Dataset in a Gen2 Data Repository.
+
+    Parameters
+    ----------
+    datasetType : `Gen2DatasetType`
+        Structure describing the DatasetType of this Dataset.
+    dataId : `dict`
+        Gen2 Data ID dictionary.  Contains at least the key-value pairs that
+        are necessary to uniquely identify the Dataset, and may contain others.
+    filePath : `str`
+        Path and filename of the Dataset relative to its repository.
+    root : `str`
+        Root of the repository in which this Dataset exists.
+    """
+
+    __slots__ = ("datasetType", "dataId", "filePath", "root")
+
+    def __init__(self, datasetType, dataId, filePath, root):
+        self.datasetType = datasetType
+        self.dataId = dataId
+        self.filePath = filePath
+        self.root = root
+
+    def __str__(self):
+        return "%s at %s" % (self.datasetType, self.dataId)
+
+    def __repr__(self):
+        return "Gen2Dataset(%s, %s, %s, %s)" % (self.datasetType, self.dataId, self.filePath, self.root)
+
+    @property
+    def fullPath(self):
+        """Full path to this dataset, combining `root` and `filePath` (`str`)."""
+        return os.path.join(self.root, self.filePath)
+
+
+class Gen2Repo:
+    """Data structure that represents the contents of a Gen2 Data Repository.
+
+    Gen2Repo instances should *only* be constructed by calling
+    `ConversionWalker.tryRoot`.
+    """
+
+    __slots__ = ("_root", "_MapperClass", "_mapper", "_parents", "_skyMaps", "_datasetTypes",
+                 "_datasets", "_unrecognized")
+
+    def __init__(self, root, MapperClass):
+        self._root = root
+        self._MapperClass = MapperClass
+        self._mapper = None
+        self._parents = []
+        self._skyMaps = {}
+        self._datasetTypes = {}
+        self._datasets = defaultdict(dict)
+        self._unrecognized = []
+
+    @property
+    def mapper(self):
+        """Gen2 Mapper that organizes this repository (`obs.base.CameraMapper)."""
+        if self._mapper is None:
+            mapperLog = Log.getLogger("CameraMapper")
+            mapperLogLevel = mapperLog.getLevel()
+            mapperLog.setLevel(mapperLog.ERROR)
+            self._mapper = self.MapperClass(root=self.root)
+            mapperLog.setLevel(mapperLogLevel)
+        return self._mapper
+
+    @property
+    def root(self):
+        """Absolute path to the root of the repository (`str`)."""
+        return self._root
+
+    @property
+    def MapperClass(self):
+        """Gen2 Mapper type responsible for organizing this repository (`type`)."""
+        return self._MapperClass
+
+    @property
+    def parents(self):
+        """A list of parent repositories (`list` of `Gen2Repo`)."""
+        return self._parents
+
+    @property
+    def skyMaps(self):
+        """SkyMaps used by this repository (`dict`).
+
+        Keys are coaddNames (`str`) and values are `Gen2SkyMap` instances.
+        """
+        return self._skyMaps
+
+    @property
+    def datasetTypes(self):
+        """Information associated with the DatasetTypes in the repo (`dict`).
+
+        A mapping from DatasetType name to Gen2DatasetType instance.
+        """
+        return self._datasetTypes
+
+    @property
+    def datasets(self):
+        """Datasets found directly in this repository, not a parent (`defaultdict`).
+
+        This is a two-level nested dictionary; outer keys are
+        datasetType (`str`), inner keys are filePath (`str`), values are
+        `Gen2Dataset`.
+        """
+        return self._datasets
+
+    @property
+    def unrecognized(self):
+        """A list of filePaths that were not recognized as datasets (`str`)."""
+        return self._unrecognized
+
+    def _findCycles(self, seen=None):
+        """Look for cycles in the parents graph.
+
+        Raises ValueError if a cycle is found.
+
+        Assumes all parent repositories objects have been fully initialized.
+        """
+        if seen is None:
+            seen = set()
+        if self.root in seen:
+            raise ValueError("Cycle detected for repository at %s" % self.root)
+        seen.add(self.root)
+        for parent in self.parents:
+            parent._findCycles(seen)
+
+
+class ConvertedRepo:
+    """Representation of a Gen2 repository that is being converted to Gen3.
+
+    Parameters
+    ----------
+    gen2 : `Gen2Repo`
+        Structure describing the Gen2 data repository.
+    camera : `str`
+        Gen3 Camera DataUnit name.
+    run : `Run`
+        Gen3 Run instance Datasets will be added to (unless overridden) at
+        the DatasetType or Dataset level.
+    translators : `dict`
+        Dictionary mapping DatasetType name to `Translator` instance.
+    """
+
+    __slots__ = ("gen2", "camera", "run", "translators")
+
+    def __init__(self, gen2, camera, run, translators):
+        self.gen2 = gen2
+        self.camera = camera
+        self.run = run
+        self.translators = translators

--- a/python/lsst/daf/butler/gen2convert/translators.py
+++ b/python/lsst/daf/butler/gen2convert/translators.py
@@ -1,0 +1,276 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import itertools
+from abc import ABCMeta, abstractmethod
+
+__all__ = ("Translator", "NoSkyMapError", "KeyHandler", "CopyKeyHandler", "ConstantKeyHandler")
+
+
+class NoSkyMapError(LookupError):
+    """Exception thrown when a Translator cannot be created because it needs
+    a nonexistent SkyMap.
+    """
+    pass
+
+
+class KeyHandler(metaclass=ABCMeta):
+    """Base class for Translator helpers that each handle just one Gen3 Data ID key.
+
+    Parameters
+    ----------
+    gen3key : `str`
+        Name of the Gen3 Data ID key (DataUnit link field name) populated by this
+        handler (e.g. "visit" or "abstract_filter")
+    gen3unit : `str`
+        Name of the Gen3 DataUnit associated with `gen3key` (e.g. "Visit" or
+        "AbstractFilter").
+    """
+
+    __slots__ = ("gen3key", "gen3unit")
+
+    def __init__(self, gen3key, gen3unit):
+        self.gen3key = gen3key
+        self.gen3unit = gen3unit
+
+    def translate(self, gen2id, gen3id, skyMap, skyMapName):
+        gen3id[self.gen3key] = self.extract(gen2id, skyMap=skyMap, skyMapName=skyMapName)
+
+    @abstractmethod
+    def extract(self, gen2id, skyMap, skyMapName):
+        raise NotImplementedError()
+
+
+class ConstantKeyHandler(KeyHandler):
+    """A KeyHandler that adds a constant key-value pair to the Gen3 data ID."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, gen3key, gen3unit, value):
+        super().__init__(gen3key, gen3unit)
+        self.value = value
+
+    def extract(self, gen2id, skyMap, skyMapName):
+        return self.value
+
+
+class CopyKeyHandler(KeyHandler):
+    """A KeyHandler that simply copies a value from a Gen3 data ID."""
+
+    __slots__ = ("gen2key",)
+
+    def __init__(self, gen3key, gen3unit, gen2key=None):
+        super().__init__(gen3key, gen3unit)
+        self.gen2key = gen2key if gen2key is not None else gen3key
+
+    def extract(self, gen2id, skyMap, skyMapName):
+        return gen2id[self.gen2key]
+
+
+class PatchKeyHandler(KeyHandler):
+    """A KeyHandler for Patches."""
+
+    __slots__ = ()
+
+    def __init__(self):
+        super().__init__("patch", "Patch")
+
+    def extract(self, gen2id, skyMap, skyMapName):
+        tract = gen2id["tract"]
+        tractInfo = skyMap[tract]
+        x, y = gen2id["patch"].split(",")
+        patchInfo = tractInfo[int(x), int(y)]
+        return tractInfo.getSequentialPatchIndex(patchInfo)
+
+
+class SkyMapKeyHandler(KeyHandler):
+    """A KeyHandler for SkyMaps."""
+
+    __slots__ = ()
+
+    def __init__(self):
+        super().__init__("skymap", "SkyMap")
+
+    def extract(self, gen2id, skyMap, skyMapName):
+        return skyMapName
+
+
+class Translator:
+    """Callable object that translates Gen2 Data IDs to Gen3 Data IDs for a
+    particular DatasetType.
+
+    Translators should usually be constructed via the `makeMatching` method.
+
+    Parameters
+    ----------
+    handlers : `list`
+        A list of KeyHandlers this Translator should use.
+    skyMap : `BaseSkyMap`
+        SkyMap instance used to define any Tract or Patch DataUnits.
+    skyMapName : `str`
+        Gen3 SkyMap DataUnit name to be associated with any Tract or Patch
+        DataUnits.
+    """
+
+    __slots__ = ("handlers", "skyMap", "skyMapName")
+
+    # Rules used to match Handlers when constring a Translator.
+    # outer key is camera name, or None for any
+    # inner key is DatasetType name, or None for any
+    # values are 3-tuples of (frozenset(gen2keys), handler, consume)
+    _rules = {
+        None: {
+            None: []
+        }
+    }
+
+    @classmethod
+    def addRule(cls, handler, camera=None, datasetTypeName=None, gen2keys=(), consume=True):
+        """Add a KeyHandler and an associated matching rule.
+
+        Parameters
+        ----------
+        handler : `KeyHandler`
+            A KeyHandler instance to add to a Translator when this rule matches.
+        camera : `str`
+            Gen3 camera name the Gen2 repository must be associated with for
+            this rule to match, or None to match any camera.
+        datasetTypeName : `str`
+            Name of the DatasetType this rule matches, or None to match any
+            DatasetType.
+        gen2Keys : sequence
+            Sequence of Gen2 data ID keys that must all be present for this
+            rule to match.
+        consume : `bool` or `tuple`
+            If True (default), remove all entries in gen2keys from the set of
+            keys being matched to in order to prevent less-specific handlers
+            from matching them.
+            May also be a `tuple` listing only the keys to consume.
+        """
+        # Ensure consume is always a frozenset, so we can process it uniformly
+        # from here on.
+        if consume is True:
+            consume = frozenset(gen2keys)
+        elif consume:
+            consume = frozenset(consume)
+        else:
+            consume = frozenset()
+        # find the rules for this camera, or if we haven't seen it before,
+        # add a nested dictionary that matches any DatasetType name and then
+        # append this rule.
+        rulesForCamera = cls._rules.setdefault(camera, {None: []})
+        rulesForCameraAndDatasetType = rulesForCamera.setdefault(datasetTypeName, [])
+        rulesForCameraAndDatasetType.append((frozenset(gen2keys), handler, consume))
+
+    @classmethod
+    def makeMatching(cls, camera, datasetType, skyMapNames, skyMaps):
+        """Construct a Translator appropriate for instances of the given dataset.
+
+        Parameters
+        ----------
+        camera : `str`
+            String name of the Gen3 camera associated with the Gen2 repository
+            this dataset is being translated from.
+        datasetType : `Gen2DatasetType`
+            A structure containing information about the Gen2 DatasetType,
+            including its name and data ID keys.
+        skyMaps: `dict`
+            A dictionary mapping "coaddName" strings to Gen2SkyMap instances.
+        skyMapNames : `dict`
+            A dictionary mapping "coaddName" strings to Gen3 SkyMap names.
+
+        Returns
+        -------
+        translator : `Translator`
+            A translator whose translate() method can be used to transform Gen2
+            data IDs to Gen3 dataIds.
+
+        Raises
+        ------
+        NoSkyMapError
+            Raised when the given skyMaps and/or skyMapNames dicts do not
+            contain a entry with the "coaddName" associated with this Dataset.
+        """
+        rulesForCamera = cls._rules.get(camera, {None: []})
+        rulesForAnyCamera = cls._rules[None]
+        candidateRules = itertools.chain(
+            rulesForCamera.get(datasetType.name, []),     # this camera, this DatasetType
+            rulesForCamera[None],                         # this camera, any DatasetType
+            rulesForAnyCamera.get(datasetType.name, []),  # any camera, this DatasetType
+            rulesForAnyCamera[None],                      # any camera, any DatasetType
+        )
+        matchedHandlers = []
+        targetKeys = set(datasetType.keys)
+        for ruleKeys, ruleHandlers, consume in candidateRules:
+            if ruleKeys.issubset(targetKeys):
+                matchedHandlers.append(ruleHandlers)
+                targetKeys -= consume
+        i = datasetType.name.find("Coadd")
+        if ("tract" in datasetType.keys or i > 0):
+            if len(skyMaps) == 1:
+                skyMap, = skyMaps.values()
+                skyMapName, = skyMapNames.values()
+            elif i > 0:
+                coaddName = datasetType.name[:i]
+                try:
+                    skyMap = skyMaps[coaddName]
+                    skyMapName = skyMapNames[coaddName]
+                except KeyError:
+                    raise NoSkyMapError("No skymap found for {}.".format(datasetType.name))
+            else:
+                raise NoSkyMapError("No skymap found for {}.".format(datasetType.name))
+        else:
+            skyMap = None
+            skyMapName = None
+        return Translator(matchedHandlers, skyMap=skyMap, skyMapName=skyMapName)
+
+    def __init__(self, handlers, skyMap, skyMapName):
+        self.handlers = handlers
+        self.skyMap = skyMap
+        self.skyMapName = skyMapName
+
+    def __call__(self, gen2id):
+        """Return a Gen3 data ID that corresponds to the given Gen2 data ID.
+        """
+        gen3id = {}
+        for handler in self.handlers:
+            handler.translate(gen2id, gen3id, skyMap=self.skyMap, skyMapName=self.skyMapName)
+        return gen3id
+
+    @property
+    def gen3keys(self):
+        """The Gen3 data ID keys populated by this Translator (`frozenset`)."""
+        return frozenset(h.gen3key for h in self.handlers)
+
+    @property
+    def gen3units(self):
+        """The Gen3 DataUnit (names) populated by this Translator (`frozenset`)."""
+        return frozenset(h.gen3unit for h in self.handlers)
+
+
+# Add "skymap" to Gen3 ID if Gen2 ID has a 'tract' key.
+Translator.addRule(SkyMapKeyHandler(), gen2keys=("tract",), consume=False)
+
+# Translate Gen2 str patch IDs to Gen3 sequential integers.
+Translator.addRule(PatchKeyHandler(), gen2keys=("patch",))
+
+# Copy Gen2 'tract' to Gen3 'tract'.
+Translator.addRule(CopyKeyHandler("tract", "Tract"), gen2keys=("tract",))

--- a/python/lsst/daf/butler/gen2convert/walker.py
+++ b/python/lsst/daf/butler/gen2convert/walker.py
@@ -1,0 +1,335 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import pickle
+
+import yaml
+
+# register YAML loader for repositoryCfg.yaml files.
+import lsst.daf.persistence.repositoryCfg   # noqa F401
+from lsst.log import Log
+from lsst.afw.image import readMetadata
+
+from ..core import Config
+from ..core.utils import doImport
+
+from .structures import Gen2Repo
+from .extractor import Extractor
+
+__all__ = ("ConversionWalker",)
+
+
+class ConversionWalker:
+    """A class that walks Gen2 Data Repositories to extract the information
+    necessary to create a Gen3 'snapshot' view to them.
+
+    ConversionWalkers attempt to only include state that does not involve any
+    user choices about how to perform the conversion; anything that does is
+    handled by ConversionWriter instead.
+
+    Parameters
+    ----------
+    config : Config
+        Configuration used by both ConversionWalkers and ConversionWriters.
+        Defaults are maintained in daf_base/config/gen2convert.yaml.
+    """
+
+    def __init__(self, config):
+        self.config = Config(config)
+        self._found = {}
+        self._scanned = {}
+        self._ignored = set()
+        self._skyMaps = dict()
+        self._skyMapRoots = dict()
+        self._visitInfo = dict()
+
+    def scanAll(self):
+        """Recursively inspect and scan Gen2 data repositories.
+
+        This calls `scanRepo` repeatedly until all repositories in `self.found`
+        are in either `self.ignored` or `self.scanned`.
+        """
+        todo = self.found.keys() - self.scanned.keys() - self.ignored
+        while todo:
+            for root in todo:
+                self.scanRepo(self.found[root])
+            todo = self.found.keys() - self.scanned.keys() - self.ignored
+
+    def tryRoot(self, root):
+        """Attempt to identify a Gen2 Data Repository at the given root path.
+
+        If the path appears to be a Gen2 Data Repository, a Gen2Data instance
+        representing it will be added to `self.found` (unless it is already
+        there) and returned.  `tryRoot()` will also be called recursively on
+        all parent repositories, with all processed repositories added
+        `self.found` and their `.parents` and `.MapperClass` attributes
+        populated.
+
+        Returns `None` if the path does not appear to be the root of a Gen2 Data
+        Repository.
+
+        Returns `True` if the path does appear to be a Gen2 Data Repository but
+        it is in `self.ignored`.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        root = os.path.abspath(root)
+        repo = self.found.get(root, None)
+        if repo is not None:
+            return repo
+        if root in self.ignored:
+            return True
+
+        MapperClass = None
+        parentPaths = []
+        repoCfgPath = os.path.join(root, "repositoryCfg.yaml")
+        if os.path.exists(repoCfgPath):
+            with open(repoCfgPath, 'r') as f:
+                repoCfg = yaml.load(f)
+            parentPaths = [parent.root for parent in repoCfg.parents]
+            MapperClass = repoCfg.mapper
+        else:
+            parentLinkPath = os.path.join(root, "_parent")
+            if os.path.exists(parentLinkPath):
+                parentPaths.append(os.readlink(parentLinkPath))
+            mapperFilePath = os.path.join(root, "_mapper")
+            if os.path.exists(mapperFilePath):
+                with open(mapperFilePath, 'r') as f:
+                    mapperClassPath = f.read().strip()
+                MapperClass = doImport(mapperClassPath)
+
+        # This directory has no _mapper, no _parent, and no repositoryCfg.yaml.
+        # It probably just isn't a repository root.
+        if not (parentPaths or MapperClass):
+            log.debug("%s: not a data repository.", root)
+            return None
+
+        # We now have either a MapperClass or a non-zero parents list, so
+        # it's likely this is a valid repository.  We'll add it to self.found
+        # before we recurse into parents to make sure we short-cut any cycles
+        # (which shouldn't exist, but better to detect that later rather than
+        # recurse infinitely).
+        repo = Gen2Repo(root, MapperClass)
+        self.found[root] = repo
+
+        try:
+            # Recursively construct (or look up) Gen2Repo objects for parents.
+            for path in parentPaths:
+                parent = self.tryRoot(path)
+                if parent is None:
+                    raise ValueError("%s is a parent of %s, but is not a repository." % (parent, root))
+                if parent is True:  # parent has already been marked as ignored
+                    continue
+                repo.parents.append(parent)
+            # Make sure there are no cycles in the graph of parents.
+            repo._findCycles()
+            # Make sure we can find a MapperClass in parents if we don't have one already.
+            self._ensureMapperClass(repo)
+            # Make sure we have all the SkyMaps we need.
+            self._ensureSkyMaps(repo)
+        except Exception:
+            # Unwind changes to self if something goes wrong.
+            del self.found[root]
+            raise
+
+        log.info("%s: identified as a data repository with mapper=%s.", root, repo.MapperClass.__name__)
+        return repo
+
+    def scanRepo(self, repo):
+        """Scan an already-found Gen2 data repository for datasets.
+
+        Parameters
+        ----------
+        repo : `Gen2Repo`
+            A Gen2Repo instance that must already present in `self.found`.
+
+        Returns
+        -------
+        repo : `Gen2Repo`
+            The same repository object passed as an argument.
+
+        On return, the scanned repo will be added to `self.scanned`, and
+        its `datasetTypes`, `datasets`, and `unrecognized` attributes will be
+        populated.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        assert(repo.root in self.found)
+        assert(repo.root not in self.ignored)
+        # Short-circuit if we've already scanned this path.
+        existing = self.scanned.setdefault(repo.root, repo)
+        if existing is not repo:
+            return existing
+
+        log.info("%s: making extractor.", repo.root)
+        extractor = Extractor(repo)
+        repo.datasetTypes.update(extractor.getDatasetTypes())
+
+        log.info("%s: walking datasets.", repo.root)
+        for dirPath, dirNames, fileNames in os.walk(repo.root):
+            dirNames[:] = [dirName for dirName in dirNames
+                           if not self.tryRoot(os.path.join(dirPath, dirName))]
+            relative = dirPath[len(repo.root) + 1:]
+            for fileName in fileNames:
+                if fileName in ("registry.sqlite3", "_mapper", "repositoryCfg.yaml"):
+                    continue
+                filePath = os.path.join(relative, fileName)
+                dataset = extractor(filePath)
+                if dataset is None:
+                    log.debug("%s: %s unrecognized.", repo.root, filePath)
+                    repo.unrecognized.append(filePath)
+                else:
+                    log.debug("%s: found %s with %s", repo.root, dataset.datasetType.name, dataset.dataId)
+                    repo.datasets[dataset.datasetType.name][filePath] = dataset
+
+    def readVisitInfo(self):
+        """Load unique VisitInfo objects and filter associations from all scanned repositories.
+        """
+        for repo in self.scanned.values():
+            config = self.config['mappers'][repo.MapperClass.__name__]["VisitInfo"]
+            cameraVisitInfo = self.visitInfo.setdefault(repo.MapperClass.__name__, {})
+            datasets = repo.datasets.get(config["DatasetType"], {})
+            for dataset in datasets.values():
+                visitInfoId = tuple(dataset.dataId[k] for k in config["uniqueKeys"])
+                if visitInfoId in cameraVisitInfo:
+                    continue
+                md = readMetadata(dataset.fullPath)
+                filt = repo.mapper.queryMetadata(config["DatasetType"], ("filter",), dataset.dataId)[0][0]
+                cameraVisitInfo[visitInfoId] = (repo.mapper.makeRawVisitInfo(md, exposureId=0), filt)
+
+    @property
+    def found(self):
+        """All known Gen2 data repositories (`dict` of `{abspath: Gen2Repo}`).
+
+        Found repos will always have a root, MapperClass, and a set of SkyMaps.
+        """
+        return self._found
+
+    @property
+    def scanned(self):
+        """Gen2 data repositories that have been scanned for Datasets (`dict`
+        of `{abspath: Gen2Repo}`).
+
+        Scanned repos will have populated `datasets` and `unrecognized`
+        attributes in addition to the attributes guaranteed by `found`.
+        """
+        return self._scanned
+
+    @property
+    def ignored(self):
+        """Gen2 data repository roots that should be ignored (`set` of `str`).
+
+        Entries are absolute paths.  Any path in `ignored` will never be
+        included in `found` or `processed`.
+
+        TODO: Provide a way to ignore repositories via the config file.
+        """
+        return self._ignored
+
+    @property
+    def skyMaps(self):
+        """All SkyMaps found in any repository (`dict` of `{sha1: BaseSkyMap}`).
+
+        The SkyMaps here are a superset of those actually used by scanned
+        Datasets; some may be used by Datasets in data repositories that were
+        ignored after the SkyMap was found.
+        """
+        return self._skyMaps
+
+    @property
+    def skyMapRoots(self):
+        """Repository roots in which each SkyMap was found
+        (`dict` of `{sha1: list}`).
+        """
+        return self._skyMapRoots
+
+    @property
+    def visitInfo(self):
+        """All unique VisitInfo objects and visit-filter associations
+        found in any repository (`dict`, nested).
+
+        This is a nested dictionary, with mapper class names as outer keys and
+        the inner keys a tuple of mapper-specific data ID values determined from
+        configuration.  Values are a tuple of `(lsst.afw.image.VisitInfo, str)`,
+        with the latter a Gen2 filter name.
+        """
+        return self._visitInfo
+
+    def _ensureMapperClass(self, repo):
+        """Make sure self.MapperClass is defined.
+
+        If self.MapperClass is None, set it from the MapperClass used by
+        parent repositories.
+
+        Assumes all parent repositories objects have been fully initialized.
+
+        Raises
+        ------
+        ValueError
+            Raisedif this is there is no single MapperClass used by all parents.
+        """
+        if repo.MapperClass is None:
+            parentMapperClasses = set(type(p.MapperClass) for p in repo.parents)
+            if len(parentMapperClasses) != 1:
+                raise ValueError("Could not determine mapper for %s." % repo.root)
+            repo.MapperClass = parentMapperClasses.pop()
+
+    def _ensureSkyMaps(self, repo):
+        """Make sure any SkyMaps we can use are present.
+
+        Loops over all SkyMap datasets defined by the mapper and tries to load
+        them.  When we can't find one, we look to see if there's a unique
+        skymap to inherit from the parent repos (for each coaddName).
+
+        Assumes all parent repository objects have been fully initialized.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        for datasetTypeName, mapping in repo.mapper.mappings.items():
+            if not datasetTypeName.endswith("_skyMap"):
+                continue
+            coaddName = datasetTypeName[:-len("Coadd_skyMap")]
+            filePath = mapping.template  # SkyMaps should never need a dataId for lookup
+            fullPath = os.path.join(repo.root, filePath)
+            if os.path.exists(fullPath):
+                with open(fullPath, 'rb') as f:
+                    skyMap = pickle.load(f, encoding='latin1')
+                # If we have already loaded an equivalent SkyMap, use that.
+                skyMap = self.skyMaps.setdefault(skyMap.getSha1(), skyMap)
+                self.skyMapRoots.setdefault(skyMap.getSha1(), []).append(repo.root)
+                log.debug("%s: using %s directly from repo.", repo.root, datasetTypeName)
+            else:
+                # No SkyMap for this coaddName found in this repo; see if
+                # we can inherit one from parent repos (requires that any
+                # that define a SkyMap for this coaddName agree).
+                parentSkyMaps = set(pd.skyMaps.get(coaddName, None) for pd in repo.parents)
+                parentSkyMaps.discard(None)
+                if len(parentSkyMaps) == 1:
+                    skyMap = parentSkyMaps.pop()
+                    log.debug("%s: using %s from parents.", repo.root, datasetTypeName)
+                else:
+                    # No SkyMap for this coaddName.  This is not necessarily an
+                    # error, because the repo may not have any datasets with
+                    # that coaddName.
+                    skyMap = None
+                    log.debug("%s: no %s found.", repo.root, datasetTypeName)
+            # Remember that this is the SkyMap associated with this
+            # coaddName in this repo.
+            if skyMap is not None:
+                repo.skyMaps[coaddName] = skyMap

--- a/python/lsst/daf/butler/gen2convert/writer.py
+++ b/python/lsst/daf/butler/gen2convert/writer.py
@@ -1,0 +1,316 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import re
+import datetime
+from collections import OrderedDict
+
+from lsst.log import Log
+
+from ..core import Config, Run, DatasetType, StorageClassFactory
+from .structures import ConvertedRepo
+from .translators import Translator, NoSkyMapError
+
+
+__all__ = ("ConversionWriter,")
+
+
+class ConversionWriter:
+    """A class that creates a Gen3 snapshot view into one or more Gen2
+    repositories already scanned by a ConversionWalker.
+
+    ConversionWriter is designed to avoid actually having to inspect the
+    filesystem where a Gen2 Data Repository exists or instantiate its mapper
+    (all of that is done by ConversionWalker).  It does handle any state that
+    involves user choices about how to perform the conversion.
+
+    Parameters
+    ----------
+    config : Config
+        Configuration used by both ConversionWalkers and ConversionWriters.
+        Defaults are maintained in daf_base/config/gen2convert.yaml.
+    gen2repos : dict
+        A dictionary with absolute paths as keys and `Gen2Repo` objects as
+        values, usually obtained from the `scanned` attribute of a
+        `ConversionWalker`.
+    skyMaps : dict
+        A dictionary with sha1 hashes as keys and `BaseSkyMap` instances as
+        values, usually obtained from the `skyMaps` attribute of a
+        `ConversionWalker`.
+    skyMapRoots : dict
+        A dictionary with sha1 hashes as keys and lists of repository roots as
+        values, usually obtained from the `skyMapRoots` attribute of a
+        `ConversionWalker`.
+    visitInfo: dict
+        A nested dictionary of afw.image.VisitInfo objects, with MapperClass
+        names as outer keys and tuples of camera-dependent Gen2 visit/exposure
+        identifiers as inner keys.  Usually obtained from
+        `ConversionWalker.visitInfo`.
+    """
+
+    @classmethod
+    def fromWalker(cls, walker):
+        """Construct a ConversionWriter from a ConversionWalker."""
+        return cls(config=walker.config, gen2repos=walker.scanned,
+                   skyMaps=walker.skyMaps, skyMapRoots=walker.skyMapRoots,
+                   visitInfo=walker.visitInfo)
+
+    def __init__(self, config, gen2repos, skyMaps, skyMapRoots, visitInfo):
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        self.config = Config(config)
+        self.skyMaps = skyMaps
+        self.visitInfo = visitInfo
+        self.repos = OrderedDict()
+        self.datasetTypes = dict()
+        self.runs = {k: Run(id=v, collection=k) for k, v in self.config["runs"].items()}
+        self.skyMapNames = {}  # mapping from sha1 to Gen3 SkyMap name
+        skyMapConfig = self.config.get("skymaps", {})
+        for sha1, skyMap in self.skyMaps.items():
+            for root in skyMapRoots[sha1]:
+                skyMapName = skyMapConfig.get(root, None)
+                if skyMapName is not None:
+                    log.debug("Using '%s' for SkyMap with sha1=%s", skyMapName, skyMap.getSha1().hex())
+                    self.skyMapNames[skyMap.getSha1()] = skyMapName
+                    break
+        for gen2repo in gen2repos.values():
+            self._addConvertedRepoSorted(gen2repo)
+
+    def _addConvertedRepoSorted(self, gen2repo):
+        """Recursively create ConvertedRepo objects from Gen2Repo objects,
+        adding them to self.repos in a way that sorts them such that parents
+        always precede their children.
+
+        Also constructs all Translators and populates self.skyMapNames and
+        self.datasetTypes.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        log.info("Preparing writing for repo at '%s'", gen2repo.root)
+        converted = self.repos.get(gen2repo.root, None)
+        if converted is not None:
+            return
+        # Determine the SkyMaps, Collections, and Runs for this repo.
+        collection = gen2repo.root
+        for sub in self.config["collections.substitutions"]:
+            collection = re.sub(sub["pattern"], sub["repl"], collection)
+        log.debug("Using collection '%s' for root '%s'", collection, gen2repo.root)
+        run = self.runs.setdefault(collection, Run(collection=collection))
+        camera = self.config["mappers"][gen2repo.MapperClass.__name__]["camera"]
+        skyMapNamesByCoaddName = {}
+        for coaddName, skyMap in gen2repo.skyMaps.items():
+            log.debug("Using SkyMap with sha1=%s for '%s' in '%s'",
+                      skyMap.getSha1().hex(), coaddName, gen2repo.root)
+            skyMapNamesByCoaddName[coaddName] = self.skyMapNames[skyMap.getSha1()]
+        # Create translators and Gen3 DatasetType objects from Gen2DatasetType objects, but
+        # only if we actually use them for Datasets in this repo.
+        translators = {}
+        scFactory = StorageClassFactory()
+        scConfig = self.config["storageClasses"]
+        for datasetTypeName in gen2repo.datasets.keys():
+            gen2dst = gen2repo.datasetTypes[datasetTypeName]
+            try:
+                translators[datasetTypeName] = Translator.makeMatching(camera=camera, datasetType=gen2dst,
+                                                                       skyMaps=gen2repo.skyMaps,
+                                                                       skyMapNames=skyMapNamesByCoaddName)
+            except NoSkyMapError:
+                log.warn("No SkyMap associated with DatasetType %s in %s; skipping.",
+                         datasetTypeName, gen2repo.root)
+                continue
+            if datasetTypeName in self.datasetTypes:
+                continue
+            storageClassName = scConfig.get(gen2dst.python, None)
+            if storageClassName is not None:
+                storageClass = scFactory.getStorageClass(storageClassName)
+            else:
+                log.debug("No StorageClass name configured for %s; trying persistable '%s'",
+                          gen2dst.name, gen2dst.persistable)
+                try:
+                    storageClass = scFactory.getStorageClass(gen2dst.persistable)
+                except KeyError:
+                    storageClass = None
+                if storageClass is None:
+                    unqualified = gen2dst.python.split(".")[-1]
+                    log.debug("No StorageClass name configured for %s; trying unqualified python type '%s'",
+                              gen2dst.name, unqualified)
+                    try:
+                        storageClass = scFactory.getStorageClass(unqualified)
+                    except KeyError:
+                        log.warn("No StorageClass found for %s; skipping.", gen2dst.name)
+                        continue
+            log.debug("Using StorageClass %s for %s", storageClass.name, gen2dst.name)
+            self.datasetTypes[datasetTypeName] = DatasetType(
+                name=datasetTypeName,
+                storageClass=storageClass,
+                dataUnits=translators[datasetTypeName].gen3units
+            )
+        converted = ConvertedRepo(gen2repo, camera=camera, run=run, translators=translators)
+        # Add parent repositories first, so self.repos is sorted topologically.
+        for parent in gen2repo.parents:
+            self._addConvertedRepoSorted(parent)
+        # Now we can finally add the current repo to self.repos.
+        self.repos[gen2repo.root] = converted
+        return converted
+
+    def run(self, registry, datastore):
+        """Main driver for ConversionWriter.
+
+        Runs all steps to create a Gen3 Repo, aside from Camera registration
+        (we merely check that the needed Cameras, Sensors, and PhysicalFilters
+        have already been registered).
+        """
+        self.checkCameras(registry)
+        self.insertSkyMaps(registry)
+        self.insertObservations(registry)
+        self.insertDatasetTypes(registry)
+        self.insertDatasets(registry, datastore)
+        # TODO: associate parent repo datasets with child repo Collections
+
+    def checkCameras(self, registry):
+        """Check that all necessary Cameras are already present in the
+        Registry.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        cameras = set()
+        for repo in self.repos.values():
+            cameras.add(self.config["mappers"][repo.gen2.MapperClass.__name__]["camera"])
+        for camera in cameras:
+            log.debug("Looking for preexisting Camera '%s'.", camera)
+            if registry.findDataUnitEntry("Camera", {"camera": camera}) is None:
+                raise LookupError(
+                    "Camera '{}' has not been registered with the given Registry.".format(camera)
+                )
+
+    def insertSkyMaps(self, registry):
+        """Add all necessary SkyMap DataUnits (and associated Tracts and
+        Patches) to the Registry.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        for sha1, skyMap in self.skyMaps.items():
+            skyMapName = self.skyMapNames.get(sha1, None)
+            try:
+                existing, = registry.query("SELECT skymap FROM SkyMap WHERE sha1=:sha1",
+                                           sha1=sha1)
+                if skyMapName is None:
+                    skyMapName = existing["skymap"]
+                    self.skyMapNames[sha1] = skyMapName
+                    log.debug("Using preexisting SkyMap '%s' with sha1=%s", skyMapName, sha1.hex())
+                if skyMapName != existing["skymap"]:
+                    raise ValueError(
+                        ("SkyMap with new name={} and sha1={} already exists in the Registry "
+                         "with name={}".format(skyMapName, sha1.hex(), existing["skymap"]))
+                    )
+                continue
+            except ValueError:
+                # No SkyMap with this sha1 exists, so we need to insert it.
+                pass
+            if skyMapName is None:
+                raise LookupError(
+                    ("SkyMap with sha1={} has no name "
+                     "and does not already exist in the Registry.").format(sha1.hex())
+                )
+            log.info("Inserting SkyMap '%s' with sha1=%s", skyMapName, sha1.hex())
+            skyMap.register(skyMapName, registry)
+
+    def insertObservations(self, registry):
+        """Add all necessary Visit and Exposure DataUnits to the Registry.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        for mapperName, nested in self.visitInfo.items():
+            camera = self.config["mappers"][mapperName]["camera"]
+            log.info("Inserting Exposure and Visit DataUnits for Camera '%s'", camera)
+            for visitInfoId, (visitInfo, filt) in nested.items():
+                # TODO: generalize this to cameras with snaps and/or compound gen2 visit/exposure IDs
+                visitId, = visitInfoId
+                exposureId, = visitInfoId
+                # TODO: skip insertion if DataUnits already exist.
+                mid = visitInfo.getDate().toPython()
+                offset = datetime.timedelta(seconds=0.5*visitInfo.getExposureTime())
+                commonValues = {
+                    "camera": camera,
+                    "visit": visitId,
+                    "physical_filter": filt,
+                    "datetime_begin": mid - offset,
+                    "exposure_time": visitInfo.getExposureTime(),
+                    "boresight_az": visitInfo.getBoresightAzAlt().getLongitude().asDegrees(),
+                    "boresight_alt": visitInfo.getBoresightAzAlt().getLatitude().asDegrees(),
+                    "rot_angle": visitInfo.getBoresightRotAngle().asDegrees(),
+
+                }
+                exposureValues = commonValues.copy()
+                exposureValues.update({
+                    "exposure": exposureId,
+                    "snap": 0,
+                    "dark_time": visitInfo.getDarkTime()
+                })
+                visitValues = commonValues.copy()
+                visitValues.update({
+                    "datetime_end": mid + offset,
+                    "earth_rotation_angle": visitInfo.getEra().asDegrees(),
+                    "boresight_ra": visitInfo.getBoresightRaDec().getLongitude().asDegrees(),
+                    "boresight_dec": visitInfo.getBoresightRaDec().getLatitude().asDegrees(),
+                    "boresight_parallactic_angle": visitInfo.getBoresightParAngle().asDegrees(),
+                    "local_era": visitInfo.getLocalEra().asDegrees(),
+                })
+                log.debug("Inserting Exposure %d and Visit %d.", exposureId, visitId)
+                registry.addDataUnitEntry("Visit", visitValues)
+                registry.addDataUnitEntry("Exposure", exposureValues)
+
+    def insertDatasetTypes(self, registry):
+        """Add all necessary DatasetType registrations to the Registry.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        for datasetType in self.datasetTypes.values():
+            # TODO: should put this "just make sure it exists" logic
+            # into registerDatasetType itself, and make it a bit more careful.
+            try:
+                registry.registerDatasetType(datasetType)
+                log.debug("Registered DatasetType '%s'." % datasetType.name)
+            except KeyError:
+                log.debug("DatasetType '%s' already registered." % datasetType.name)
+
+    def insertDatasets(self, registry, datastore):
+        """Add all Dataset entries to the given Registry and Datastore.
+        """
+        log = Log.getLogger("lsst.daf.butler.gen2convert")
+        for repo in self.repos.values():
+            for datasetTypeName, datasets in repo.gen2.datasets.items():
+                datasetType = self.datasetTypes.get(datasetTypeName, None)
+                if datasetType is None:
+                    log.debug("Skipping insertion of '%s' from %s", datasetTypeName, repo.gen2.root)
+                    continue
+                log.info("Inserting '%s' from %s", datasetTypeName, repo.gen2.root)
+                collectionTemplate = self.config["collections.overrides"].get(datasetTypeName, None)
+                if collectionTemplate is None:
+                    collection = repo.run.collection
+                    registry.ensureRun(repo.run)
+                    run = repo.run
+                translator = repo.translators[datasetTypeName]
+                for dataset in datasets.values():
+                    gen3id = translator(dataset.dataId)
+                    if collectionTemplate is not None:
+                        allIds = dataset.dataId.copy()
+                        allIds.update(gen3id)
+                        collection = collectionTemplate.format(**allIds)
+                        run = self.runs.setdefault(collection, Run(collection=collection))
+                        registry.ensureRun(run)
+                    log.debug("Adding Dataset %s as %s in %s", dataset.filePath, gen3id, repo.run)
+                    ref = registry.addDataset(datasetType, gen3id, run)
+                    datastore.ingest(path=os.path.relpath(dataset.fullPath, start=datastore.root), ref=ref)

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -707,6 +707,9 @@ class SqlRegistry(Registry):
 
         Raises
         ------
+        TypeError
+            If the given `DataUnit` does not have explicit entries in the
+            registry.
         ValueError
             If an entry with the primary-key defined in `values` is already
             present.
@@ -714,6 +717,8 @@ class SqlRegistry(Registry):
         dataUnit = self._schema.dataUnits[dataUnitName]
         dataUnit.validateId(values)
         dataUnitTable = dataUnit.table
+        if dataUnitTable is None:
+            raise TypeError("DataUnit '{}' has no table.".format(dataUnitName))
         with self._engine.begin() as connection:
             try:
                 connection.execute(dataUnitTable.insert().values(**values))

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -557,6 +557,8 @@ class SqlRegistry(Registry):
         """
         runTable = self._schema.metadata.tables['Run']
         with self._engine.begin() as connection:
+            # TODO: this check is probably undesirable, as we may want to have multiple Runs output
+            # to the same collection.  Fixing this requires (at least) modifying getRun() accordingly.
             if connection.execute(select([exists().where(runTable.c.collection == run.collection)])).scalar():
                 raise ValueError("A run already exists with this collection: {}".format(run.collection))
             # First add the Execution part
@@ -566,6 +568,7 @@ class SqlRegistry(Registry):
                                                         collection=run.collection,
                                                         environment_id=None,  # TODO add environment
                                                         pipeline_id=None))    # TODO add pipeline
+        # TODO: set given Run's 'id' attribute.
 
     def getRun(self, id=None, collection=None):
         """

--- a/tests/test_sqlRegistry.py
+++ b/tests/test_sqlRegistry.py
@@ -285,7 +285,9 @@ class SqlRegistryTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(registry.findDataUnitEntry(dataUnitName, dataUnitValue), dataUnitValue)
         # Find on a non-existant value should return None
         self.assertIsNone(registry.findDataUnitEntry(dataUnitName, {'camera': 'Unknown'}))
-        registry.addDataUnitEntry('AbstractFilter', {'abstract_filter': 'i'})
+        # AbstractFilter doesn't have a table; should fail.
+        with self.assertRaises(TypeError):
+            registry.addDataUnitEntry('AbstractFilter', {'abstract_filter': 'i'})
         dataUnitName2 = 'PhysicalFilter'
         dataUnitValue2 = {'physical_filter': 'DummyCam_i', 'abstract_filter': 'i'}
         # Missing required dependency ('camera') should fail


### PR DESCRIPTION
The conversion code here has two high-level drivers:
 - The `ConversionWalker` class (`walker.py`) extracts everything we'll need for the conversion from a Gen2 repo.  It's basically complete, and I've done some one-off testing it on `ci_hsc` (check out `ci_hsc`, setup and build, and start by calling `ConversionWalker.tryRoot` on `$CI_HSC_DIR/DATA`).
 - The `ConversionWriter` class (`writer.py`) adds entries to a `Registry` and `Datastore` - or it would if all of the actual calls to do so weren't just "TODO" comment placeholders

As for those TODO placeholders, there are a ton of them, and I think they cover most of what needs to be done to get things working.  Beyond that, we'll also eventually need a high-level driver that can be run easily from the command-line, but that doesn't necessarily need to be done right now.
