### PR TITLE
DM-14225: Make PosixDatastore's internal records persistent

### DIFF
--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -3,6 +3,7 @@ Core code for butler.
 """
 
 # Do not export the utility routines from safeFileIo and utils
+# Do not export SqlDatabaseDict (should be constructed by other classes).
 
 from .composites import *
 from .config import *
@@ -22,3 +23,4 @@ from .storageClass import *
 from .storageInfo import *
 from .storedFileInfo import *
 from .dataUnit import *
+from .databaseDict import *

--- a/python/lsst/daf/butler/core/databaseDict.py
+++ b/python/lsst/daf/butler/core/databaseDict.py
@@ -1,0 +1,105 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import MutableMapping
+
+from .utils import doImport
+
+
+class DatabaseDict(MutableMapping):
+    """An abstract base class for dict-like objects with a specific key type
+    and namedtuple values, backed by a database.
+
+    DatabaseDict subclasses must implement the abstract ``__getitem__``,
+    ``__setitem__``, ``__delitem__`, ``__iter__``, and ``__len__`` abstract
+    methods defined by `MutableMapping`.
+
+    They must also provide a constructor that takes the same arguments as that
+    of `DatabaseDict` itself, *unless* they are constructed solely by
+    `Registry.makeDatabaseDict` (in which case any constructor arguments are
+    permitted).
+
+    Parameters
+    ----------
+    config : `Config`
+        Configuration used to identify and construct a subclass.
+    types : `dict`
+        A dictionary mapping `str` field names to type objects, containing
+        all fields to be held in the database.
+    key : `str`
+        The name of the field to be used as the dictionary key.  Must not be
+        present in ``value._fields``.
+    value : `type`
+        The type used for the dictionary's values, typically a `namedtuple`.
+        Must have a ``_fields`` class attribute that is a tuple of field names
+        (i.e. as defined by `namedtuple`); these field names must also appear
+        in the ``types`` arg, and a `_make` attribute to construct it from a
+        sequence of values (again, as defined by `namedtuple`).
+    """
+
+    @staticmethod
+    def fromConfig(config, types, key, value, registry=None):
+        """Create a `DatabaseDict` subclass instance from `config`.
+
+        If ``config`` contains a class ``cls`` key, this will be assumed to
+        be the fully-qualified name of a DatabaseDict subclass to construct.
+        If not, ``registry.makeDatabaseDict`` will be called instead.
+
+        Parameters
+        ----------
+        config : `Config`
+            Configuration used to identify and construct a subclass.
+        types : `dict`
+            A dictionary mapping `str` field names to type objects, containing
+            all fields to be held in the database.
+        key : `str`
+            The name of the field to be used as the dictionary key.  Must not
+            be present in ``value._fields``.
+        value : `type`
+            The type used for the dictionary's values, typically a
+            `namedtuple`. Must have a ``_fields`` class attribute that is a
+            tuple of field names (i.e. as defined by `namedtuple`); these
+            field names must also appear in the ``types`` arg, and a `_make`
+            attribute to construct it from a sequence of values (again, as
+            defined by `namedtuple`).
+        registry : `Registry`
+            A registry instance from which a `DatabaseDict` subclass can be
+            obtained.  Ignored if ``config["cls"]`` exists; may be None if
+            it does.
+
+        Returns
+        -------
+        dictionary : `DatabaseDict` (subclass)
+            A new `DatabaseDict` subclass instance.
+        """
+        if 'cls' in config:
+            cls = doImport(config['cls'])
+            return cls(config=config, types=types, key=key, value=value)
+        else:
+            table = config['table']
+            if registry is None:
+                raise ValueError("Either config['cls'] or registry must be provided.")
+            return registry.makeDatabaseDict(table, types=types, key=key, value=value)
+
+    def __init__(self, config, types, key, value):
+        # This constructor is currently defined just to clearly document the
+        # interface subclasses should conform to.
+        pass

--- a/python/lsst/daf/butler/core/databaseDict.py
+++ b/python/lsst/daf/butler/core/databaseDict.py
@@ -61,7 +61,9 @@ class DatabaseDict(MutableMapping):
 
         If ``config`` contains a class ``cls`` key, this will be assumed to
         be the fully-qualified name of a DatabaseDict subclass to construct.
-        If not, ``registry.makeDatabaseDict`` will be called instead.
+        If not, ``registry.makeDatabaseDict`` will be called instead, and
+        ``config`` must contain a ``table`` key with the name of the table
+        to use.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/core/sqlDatabaseDict.py
+++ b/python/lsst/daf/butler/core/sqlDatabaseDict.py
@@ -1,0 +1,150 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime
+
+from sqlalchemy import create_engine, Table, MetaData, Column, \
+    String, Integer, Boolean, LargeBinary, DateTime, Float
+from sqlalchemy.sql import select, bindparam, func
+from sqlalchemy.exc import IntegrityError, StatementError
+
+from .databaseDict import DatabaseDict
+
+
+class SqlDatabaseDict(DatabaseDict):
+    """A DatabaseDict backed by a SQL database.
+
+    Configuration for SqlDatabaseDict must have the following entries:
+
+    ``db``
+        A database connection URI of the form accepted by SQLAlchemy.
+        Ignored if the ``engine`` argument is not None.
+    ``table``
+        Name of the database table used to store the data in the
+        dictionary.
+
+    Parameters
+    ----------
+    config : `Config`
+        Configuration used to identify this subclass and connect to a
+        database.
+    types : `dict`
+        A dictionary mapping `str` field names to type objects, containing all
+        fields to be held in the database.  The supported type objects are the
+        keys of the `COLUMN_TYPES` attribute.  SQLAlchemy column type objects
+        may also be passed directly, though of course this not portable to
+        other `DatabaseDict` subclasses.
+    key : `str`
+        The name of the field to be used as the dictionary key.  Must not be
+        present in ``value._fields``.
+    value : `type` (`namedtuple`)
+        The type used for the dictionary's values, typically a `namedtuple`.
+        Must have a ``_fields`` class attribute that is a tuple of field names
+        (i.e. as defined by `namedtuple`); these field names must also appear
+        in the ``types`` arg, and a `_make` attribute to construct it from a
+        sequence of values (again, as defined by `namedtuple`).
+    engine : `sqlalchemy.engine.Engine`
+        A SQLAlchemy connection object.  If not None, ``config["db"]`` is
+        ignored.
+    """
+
+    COLUMN_TYPES = {str: String, int: Integer, float: Float,
+                    bool: Boolean, bytes: LargeBinary, datetime: DateTime}
+
+    def __init__(self, config, types, key, value, engine=None):
+        allColumns = []
+        for name, type_ in types.items():
+            column = Column(name, self.COLUMN_TYPES.get(type_, type_), primary_key=(name == key))
+            allColumns.append(column)
+        if engine is None:
+            engine = create_engine(config['db'])
+        if key in value._fields:
+            raise ValueError("DatabaseDict's key field may not be a part of the value tuple")
+        if key not in types.keys():
+            raise TypeError("No type provided for key {}".format(key))
+        if not types.keys() >= frozenset(value._fields):
+            raise TypeError("No type(s) provided for field(s) {}".format(set(value._fields) - types.keys()))
+        self._key = key
+        self._value = value
+        self._engine = engine
+        metadata = MetaData()
+        self._table = Table(config["table"], metadata, *allColumns)
+        metadata.create_all(self._engine)
+        valueColumns = [getattr(self._table.columns, name) for name in self._value._fields]
+        keyColumn = getattr(self._table.columns, key)
+        self._getSql = select(valueColumns).where(keyColumn == bindparam("key"))
+        self._updateSql = self._table.update().where(keyColumn == bindparam("key"))
+        self._delSql = self._table.delete().where(keyColumn == bindparam("key"))
+        self._keysSql = select([keyColumn])
+        self._lenSql = select([func.count(keyColumn)])
+
+    def __getitem__(self, key):
+        with self._engine.begin() as connection:
+            row = connection.execute(self._getSql, key=key).fetchone()
+            if row is None:
+                raise KeyError("{} not found".format(key))
+            return self._value._make(row)
+
+    def __setitem__(self, key, value):
+        assert isinstance(value, self._value)
+        # Try insert first, as we expect that to be the most commmon usage
+        # pattern.
+        kwds = value._asdict()
+        kwds[self._key] = key
+        with self._engine.begin() as connection:
+            try:
+                connection.execute(self._table.insert(), **kwds)
+                return
+            except IntegrityError:
+                pass
+            except StatementError as err:
+                raise TypeError("Bad data types in value: {}".format(err))
+
+        # If we fail due to an IntegrityError (i.e. duplicate primary key values),
+        # try to do an update instead.
+        kwds.pop(self._key, None)
+        with self._engine.begin() as connection:
+            try:
+                connection.execute(self._updateSql, key=key, **kwds)
+            except StatementError as err:
+                # n.b. we can't rely on a failure in the insert attempt above
+                # to have caught this case, because we trap for IntegrityError
+                # first.  And we have to do that because IntegrityError is a
+                # StatementError.
+                raise TypeError("Bad data types in value: {}".format(err))
+
+    def __delitem__(self, key):
+        with self._engine.begin() as connection:
+            result = connection.execute(self._delSql, key=key)
+            if result.rowcount == 0:
+                raise KeyError("{} not found".format(key))
+
+    def __iter__(self):
+        with self._engine.begin() as connection:
+            for row in connection.execute(self._keysSql).fetchall():
+                yield row[0]
+
+    def __len__(self):
+        with self._engine.begin() as connection:
+            return connection.execute(self._lenSql).scalar()
+
+    # TODO: add custom view objects for at views() and items(), so we don't
+    # invoke a __getitem__ call for every key.

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -1,6 +1,8 @@
 run: ingest
 datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
+  records:
+    table: PosixDatastoreRecords
   root: ./butler_test_repository
   create: true
   templates:

--- a/tests/dummyRegistry.py
+++ b/tests/dummyRegistry.py
@@ -40,3 +40,6 @@ class DummyRegistry:
 
     def removeStorageInfo(self, datastoreName, ref):
         del self._entries[ref.id]
+
+    def makeDatabaseDict(self, table, types, key, value):
+        return dict()

--- a/tests/test_sqlDatabaseDict.py
+++ b/tests/test_sqlDatabaseDict.py
@@ -1,0 +1,143 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from collections import namedtuple
+
+import lsst.utils.tests
+
+from lsst.daf.butler.core import Config, DatabaseDict, Registry
+
+"""Tests for SqlDatabaseDict.
+"""
+
+
+class SqlDatabaseDictTestCase(lsst.utils.tests.TestCase):
+    """Test for SqlDatabaseDict.
+    """
+
+    def setUp(self):
+        self.config = Config()
+        self.config["cls"] = "lsst.daf.butler.core.sqlDatabaseDict.SqlDatabaseDict"
+        self.config["db"] = "sqlite:///:memory:"
+        self.config["table"] = "TestTable"
+        self.types = {"x": int, "y": str, "z": float}
+        self.key = "x"
+
+    def checkDatabaseDict(self, d, data):
+        self.assertEqual(len(d), 0)
+        self.assertFalse(d)
+        d[0] = data[0]
+        self.assertEqual(len(d), 1)
+        self.assertTrue(d)
+        self.assertIn(0, d)
+        self.assertEqual(d[0], data[0])
+        d[1] = data[1]
+        self.assertEqual(len(d), 2)
+        self.assertTrue(d)
+        self.assertIn(1, d)
+        self.assertEqual(d[1], data[1])
+        self.assertCountEqual(d.keys(), data.keys())
+        self.assertCountEqual(d.values(), data.values())
+        self.assertCountEqual(d.items(), data.items())
+        del d[0]
+        self.assertNotIn(0, d)
+        self.assertEqual(len(d), 1)
+        with self.assertRaises(KeyError):
+            del d[0]
+        with self.assertRaises(KeyError):
+            d[0]
+        # Test that we can update an existing key
+        d[1] = data[0]
+        self.assertEqual(len(d), 1)
+        self.assertEqual(d[1], data[0])
+
+    def testKeyInValue(self):
+        """Test that the key is not permitted to be part of the value."""
+        value = namedtuple("TestValue", ["x", "y", "z"])
+        with self.assertRaises(ValueError):
+            DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
+
+    def testKeyNotInValue(self):
+        """Test when the value does not include the key."""
+        value = namedtuple("TestValue", ["y", "z"])
+        data = {
+            0: value(y="zero", z=0.0),
+            1: value(y="one", z=0.1),
+        }
+        d = DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
+        self.checkDatabaseDict(d, data)
+
+    def testBadValueTypes(self):
+        """Test that we cannot insert value tuples with the wrong types."""
+        value = namedtuple("TestValue", ["y", "z"])
+        data = {
+            0: value(y=0, z="zero"),
+        }
+        d = DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
+        with self.assertRaises(TypeError):
+            d[0] = data[0]
+
+    def testBadKeyTypes(self):
+        """Test that we cannot insert with the wrong key type."""
+        value = namedtuple("TestValue", ["y", "z"])
+        data = {
+            0: value(y="zero", z=0.0),
+        }
+        d = DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
+        d["zero"] = data[0]
+
+    def testExtraFieldsInTable(self):
+        """Test when there are fields in the table that not in the value or the key.
+
+        These should be completely ignored by the DatabaseDict after the table
+        is created (which implies that they must be nullable if __setitem__ is
+        expected to work."""
+        value = namedtuple("TestValue", ["y"])
+        data = {
+            0: value(y="zero"),
+            1: value(y="one"),
+        }
+        d = DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
+        self.checkDatabaseDict(d, data)
+
+    def testExtraFieldsInValue(self):
+        """Test that we don't permit the value tuple to have ._fields entries
+        that are not in the types argument itself (since we need to know
+        their types).
+        """
+        value = namedtuple("TestValue", ["y", "a"])
+        with self.assertRaises(TypeError):
+            DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_sqlDatabaseDict.py
+++ b/tests/test_sqlDatabaseDict.py
@@ -129,6 +129,20 @@ class SqlDatabaseDictTestCase(lsst.utils.tests.TestCase):
         with self.assertRaises(TypeError):
             DatabaseDict.fromConfig(self.config, key=self.key, types=self.types, value=value)
 
+    def testFromRegistry(self):
+        """Test that we can obtain a DatabaseDict from a SqlRegistry."""
+        testDir = os.path.dirname(__file__)
+        configFile = os.path.join(testDir, "config/basic/butler.yaml")
+        registry = Registry.fromConfig(configFile)
+        value = namedtuple("TestValue", ["y", "z"])
+        data = {
+            0: value(y="zero", z=0.0),
+            1: value(y="one", z=0.1),
+        }
+        d = registry.makeDatabaseDict(table="TestRegistryTable", key=self.key, types=self.types,
+                                      value=value)
+        self.checkDatabaseDict(d, data)
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
The approach I've taken here is:
 - Add a `DatabaseDict` ABC that just provides a mechanism for constructing persistent dict-like objects from Config.
 - Add a SQL implementation thereof, and a way to get an instance of that SQL-backed dict from a Registry.
 - Replace the `internalRegistry` in PosixDatastore with DatabaseDict it constructs from config.

Because `DatabaseDict` uses `namedtuple` objects for its value type (since, being backed by a database, that needs to be known up front), there's a bit of redundancy between `StoredFileInfo` and the new `namedtuple` `PosixDatastore.RecordTuple` (basically, they only differ on whether to hold a `StorageClass` instance or name).  I imagine we'll want to address that eventually, but just letting them both exist for now minimizes the changes to `PosixDatastore`, and I think that's a good thing.