### PR TITLE
DM-14334: Add initial implementation of preflight solver.

### DIFF
--- a/python/lsst/daf/butler/registries/sqlPreFlight.py
+++ b/python/lsst/daf/butler/registries/sqlPreFlight.py
@@ -1,0 +1,188 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ("SqlPreFlight")
+
+import itertools
+import copy
+
+from sqlalchemy.sql import select, and_, text
+
+import lsst.log as lsstLog
+
+
+_LOG = lsstLog.Log.getLogger(__name__)
+
+
+class SqlPreFlight:
+    """Class implementing part of preflight solver which extracts
+    units data from registry.
+
+    This is an implementation detail only to be used by SqlRegistry class,
+    not supposed to be used anywhere else.
+
+    Parameters
+    ----------
+    schema : `Schema`
+        Schema instance
+    connection : `sqlalchmey.Connection`
+        Connection to use for database access.
+    """
+    def __init__(self, schema, connection):
+        self._schema = schema
+        self._connection = connection
+
+    def selectDataUnits(self, collections, expr, neededDatasetTypes, futureDatasetTypes):
+        """Evaluate a filter expression and lists of
+        `DatasetTypes <DatasetType>` and return a set of data unit values.
+
+        Returned set consists of combinations of units participating in data
+        transformation from ``neededDatasetTypes`` to ``futureDatasetTypes``,
+        restricted by existing data and filter expression.
+
+        Parameters
+        ----------
+        collections : `list` of `str`
+            An ordered `list` of collections indicating the Collections to
+            search for Datasets.
+        expr : `str`
+            An expression that limits the `DataUnits <DataUnit>` and
+            (indirectly) the Datasets returned.
+        neededDatasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetTypes <DatasetType>` whose DataUnits will
+            be included in the returned column set. Output is limited by the
+            the Datasets of these DatasetTypes which already exist in the
+            registry.
+        futureDatasetTypes : `list` of `DatasetType`
+            The `list` of `DatasetTypes <DatasetType>` whose DataUnits will
+            be included in the returned column set. It is expected that
+            Datasets for these DatasetTypes do not exist in the registry,
+            but presently this is not checked.
+
+        Returns
+        -------
+        header : `tuple` of `tuple`
+            Length of tuple equals the number of columns in the returned
+            result set. Each item is a tuple with two elements - DataUnit
+            name (e.g. "Visit") and unit value name (e.g. "visit").
+        rows : iterable of `tuple`
+            Result set, this can be a single-pass iterator. Each tuple
+            contains unit values corresponding to units in a header.
+        """
+
+        # for now only a single collection is supported
+        if len(collections) != 1:
+            raise ValueError("Only single collection is supported by makeDataGraph()")
+        collection = collections[0]
+
+        # Collect unit names in both input and output dataset types
+        allUnits = set(itertools.chain.from_iterable(dsType.dataUnits for dsType in neededDatasetTypes))
+        allUnits.update(itertools.chain.from_iterable(dsType.dataUnits for dsType in futureDatasetTypes))
+        _LOG.debug("allUnits: %s", allUnits)
+
+        # All DataUnit instances in a subset that we need
+        allDataUnits = {unitName: self._schema.dataUnits[unitName] for unitName in allUnits}
+
+        # potentially we have to extend units set with the "required" superset
+        # from schema, for now just assume that set is full.
+
+        # Temporary workaround for AbstractFilter "view" which is not defined in schema yet,
+        # make a subquery for it and use it as an alias for that sub-query
+        dataUnit = allDataUnits.get("AbstractFilter")
+        if dataUnit and dataUnit.table is None:
+            # make a copy, do not change object in schema
+            dataUnit = copy.copy(dataUnit)
+            filterTable = self._schema.dataUnits["PhysicalFilter"].table
+            subquery = select([filterTable.c["abstract_filter"]]).distinct()
+            dataUnit._table = subquery.alias("AbstractFilter")
+            allDataUnits["AbstractFilter"] = dataUnit
+
+        # Build select column list
+        selectColumns = []
+        header = []            # tuple (UnitName, link_name) for each returned column
+        for dataUnit in allDataUnits.values():
+            if dataUnit.table is not None:
+                # take link column names, usually there is one
+                for link in dataUnit.link:
+                    header.append((dataUnit.name, link))
+                    selectColumns.append(dataUnit.table.c[link])
+        _LOG.debug("selectColumns: %s", selectColumns)
+        _LOG.debug("header: %s", header)
+
+        # joins for all unit tables
+        where = []
+        for dataUnit in allDataUnits.values():
+            table = dataUnit.table
+            if table is None:
+                continue
+            _LOG.debug("add unit table: %s", table)
+
+            for other in dataUnit.requiredDependencies:
+                _LOG.debug("joining to: %s", other)
+                for link in other.link:
+                    _LOG.debug("joining on link: %s", link)
+                    where.append(table.c[link] == other.table.c[link])
+
+            for other in dataUnit.optionalDependencies:
+                if other.name in allDataUnits:
+                    _LOG.debug("joining to: %s", other)
+                    for link in other.link:
+                        _LOG.debug("joining on link: %s", link)
+                        where.append(table.c[link] == other.table.c[link])
+                else:
+                    _LOG.debug("not joining to: %s", other)
+                    pass
+
+        _LOG.debug("units where: %s", [str(x) for x in where])
+
+        # join with input datasets to restrict to existing inputs
+        dsTable = self._schema._metadata.tables['Dataset']
+        dsCollTable = self._schema._metadata.tables['DatasetCollection']
+        for dsType in neededDatasetTypes:
+            _LOG.debug("joining dataset: %s", dsType.name)
+            dsAlias = dsTable.alias("ds" + dsType.name)
+            dsCollAlias = dsCollTable.alias("dsColl" + dsType.name)
+
+            for unitName in dsType.dataUnits:
+                dataUnit = allDataUnits[unitName]
+                for link in dataUnit.link:
+                    _LOG.debug("joining on link: %s", link)
+                    where.append(dsAlias.c[link] == dataUnit.table.c[link])
+
+            where += [dsAlias.c['dataset_id'] == dsCollAlias.c['dataset_id'],
+                      dsAlias.c['dataset_type_name'] == dsType.name,
+                      dsCollAlias.c['collection'] == collection]
+        _LOG.debug("datasets where: %s", [str(x) for x in where])
+
+        # build full query
+        q = select(selectColumns)
+        if expr:
+            # TODO: potentially transform query from user-friendly expression
+            where += [text(expr)]
+        if where:
+            where = and_(*where)
+            _LOG.debug("full where: %s", where)
+            q = q.where(where)
+        _LOG.debug("full query: %s", q)
+
+        # execute and return header and result iterator
+        rows = self._connection.execute(q).fetchall()
+        return tuple(header), (tuple(row) for row in rows)

--- a/tests/test_sqlPreFlight.py
+++ b/tests/test_sqlPreFlight.py
@@ -1,0 +1,239 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+import lsst.utils.tests
+
+from lsst.daf.butler.core.butlerConfig import ButlerConfig
+from lsst.daf.butler.core.datasets import DatasetType
+from lsst.daf.butler.core.registry import Registry
+from lsst.daf.butler.core.storageClass import StorageClass
+from lsst.sphgeom import Angle, Box, LonLat, NormalizedAngle
+
+
+class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
+    """Test for SqlPreFlight.
+    """
+
+    def setUp(self):
+        self.testDir = os.path.dirname(__file__)
+        self.configFile = os.path.join(self.testDir, "config/basic/butler.yaml")
+        # easiest way to make SqlPreFlight instance is to ask SqlRegistry to do it
+        self.butlerConfig = ButlerConfig(self.configFile)
+        self.registry = Registry.fromConfig(self.butlerConfig)
+        self.preFlight = self.registry._preFlight
+
+    def testPreFlightCameraUnits(self):
+        """Test involving only Camera units, no joins to SkyMap"""
+        registry = self.registry
+
+        # need a bunch of units and datasets for test
+        registry.addDataUnitEntry('Camera', dict(camera='DummyCam'))
+        registry.addDataUnitEntry('PhysicalFilter', dict(camera='DummyCam',
+                                                         physical_filter='dummy_r',
+                                                         abstract_filter='r'))
+        registry.addDataUnitEntry('PhysicalFilter', dict(camera='DummyCam',
+                                                         physical_filter='dummy_i',
+                                                         abstract_filter='i'))
+        for sensor in (1, 2, 3, 4, 5):
+            registry.addDataUnitEntry('Sensor', dict(camera='DummyCam', sensor=sensor))
+        registry.addDataUnitEntry('Visit', dict(camera='DummyCam', visit=10, physical_filter='dummy_i'))
+        registry.addDataUnitEntry('Visit', dict(camera='DummyCam', visit=11, physical_filter='dummy_r'))
+        registry.addDataUnitEntry('Exposure', dict(camera='DummyCam', exposure=100, visit=10,
+                                                   physical_filter='dummy_i'))
+        registry.addDataUnitEntry('Exposure', dict(camera='DummyCam', exposure=101, visit=10,
+                                                   physical_filter='dummy_i'))
+        registry.addDataUnitEntry('Exposure', dict(camera='DummyCam', exposure=110, visit=11,
+                                                   physical_filter='dummy_r'))
+        registry.addDataUnitEntry('Exposure', dict(camera='DummyCam', exposure=111, visit=11,
+                                                   physical_filter='dummy_r'))
+
+        # dataset types
+        run = registry.makeRun(collection="test")
+        storageClass = StorageClass("testDataset")
+        registry.storageClasses.registerStorageClass(storageClass)
+        rawType = DatasetType(name="RAW", dataUnits=("Camera", "Exposure", "Sensor"),
+                              storageClass=storageClass)
+        registry.registerDatasetType(rawType)
+        calexpType = DatasetType(name="CALEXP", dataUnits=("Camera", "Visit", "Sensor"),
+                                 storageClass=storageClass)
+        registry.registerDatasetType(calexpType)
+
+        # add pre-existing datasets
+        for exposure in (100, 101, 110, 111):
+            for sensor in (1, 2, 3):
+                # note that only 3 of 5 sensors have datasets
+                dataId = dict(camera='DummyCam', exposure=exposure, sensor=sensor)
+                registry.addDataset(rawType, dataId=dataId, run=run)
+
+        # with empty expression
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"], expr="",
+                                                       neededDatasetTypes=[rawType],
+                                                       futureDatasetTypes=[calexpType])
+        # order of columns is not defined
+        self.assertCountEqual(headers, (('Camera', 'camera'),
+                                        ('Sensor', 'sensor'),
+                                        ('Exposure', 'exposure'),
+                                        ('Visit', 'visit')))
+        rows = list(rows)
+        self.assertEqual(len(rows), 4*3)   # 4 exposures times 3 sensors
+
+        # limit to single visit
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="Visit.visit = 10",
+                                                       neededDatasetTypes=[rawType],
+                                                       futureDatasetTypes=[calexpType])
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 2*3)   # 2 exposures times 3 sensors
+
+        # expression excludes everyhting
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="Visit.visit = 10 and Sensor.sensor > 1",
+                                                       neededDatasetTypes=[rawType],
+                                                       futureDatasetTypes=[calexpType])
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 2*2)   # 2 exposures times 2 sensors
+
+        # expression excludes everyhting
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="Visit.visit > 1000",
+                                                       neededDatasetTypes=[rawType],
+                                                       futureDatasetTypes=[calexpType])
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 0)
+
+        # Selecting by PhysicalFilter, this should be done via
+        # PhysicalFilter.physical_filter but that is not supported currently,
+        # instead we can do Visit.physical_filter (or Exposure.physical_filter)
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="Visit.physical_filter = 'dummy_r'",
+                                                       neededDatasetTypes=[rawType],
+                                                       futureDatasetTypes=[calexpType])
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 2*3)   # 2 exposures times 3 sensors
+
+    def testPreFlightSkyMapUnits(self):
+        """Test involving only SkyMap units, no joins to Camera"""
+        registry = self.registry
+
+        # need a bunch of units and datasets for test, we want 'AbstractFilter'
+        # in the test so also have to add PhysicalFilter units
+        registry.addDataUnitEntry('Camera', dict(camera='DummyCam'))
+        registry.addDataUnitEntry('PhysicalFilter', dict(camera='DummyCam',
+                                                         physical_filter='dummy_r',
+                                                         abstract_filter='r'))
+        registry.addDataUnitEntry('PhysicalFilter', dict(camera='DummyCam',
+                                                         physical_filter='dummy_i',
+                                                         abstract_filter='i'))
+        registry.addDataUnitEntry('SkyMap', dict(skymap='DummyMap', sha1="sha!"))
+        for tract in range(10):
+            registry.addDataUnitEntry('Tract', dict(skymap='DummyMap', tract=tract))
+            for patch in range(10):
+                registry.addDataUnitEntry('Patch', dict(skymap='DummyMap', tract=tract, patch=patch,
+                                                        cell_x=0, cell_y=0,
+                                                        region=Box(LonLat(NormalizedAngle(0.), Angle(0.)))))
+
+        # dataset types
+        run = registry.makeRun(collection="test")
+        storageClass = StorageClass("testDataset")
+        registry.storageClasses.registerStorageClass(storageClass)
+        calexpType = DatasetType(name="deepCoadd_calexp", dataUnits=("SkyMap", "Tract", "Patch",
+                                                                     "AbstractFilter"),
+                                 storageClass=storageClass)
+        registry.registerDatasetType(calexpType)
+        mergeType = DatasetType(name="deepCoadd_mergeDet", dataUnits=("SkyMap", "Tract", "Patch"),
+                                storageClass=storageClass)
+        registry.registerDatasetType(mergeType)
+        measType = DatasetType(name="deepCoadd_meas", dataUnits=("SkyMap", "Tract", "Patch",
+                                                                 "AbstractFilter"),
+                               storageClass=storageClass)
+        registry.registerDatasetType(measType)
+
+        # add pre-existing datasets
+        for tract in (1, 3, 5):
+            for patch in (2, 4, 6, 7):
+                dataId = dict(skymap='DummyMap', tract=tract, patch=patch)
+                registry.addDataset(mergeType, dataId=dataId, run=run)
+                for aFilter in ('i', 'r'):
+                    dataId = dict(skymap='DummyMap', tract=tract, patch=patch, abstract_filter=aFilter)
+                    registry.addDataset(calexpType, dataId=dataId, run=run)
+
+        # with empty expression
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"], expr="",
+                                                       neededDatasetTypes=[calexpType, mergeType],
+                                                       futureDatasetTypes=[measType])
+        # order of columns is not defined
+        self.assertCountEqual(headers, (('SkyMap', 'skymap'),
+                                        ('Tract', 'tract'),
+                                        ('Patch', 'patch'),
+                                        ('AbstractFilter', 'abstract_filter')))
+        rows = list(rows)
+        self.assertEqual(len(rows), 3*4*2)   # 4 tracts x 4 patches x 2 filters
+
+        # limit to 2 tracts and 2 patches
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="Tract.tract IN (1, 5) AND Patch.patch IN (2, 7)",
+                                                       neededDatasetTypes=[calexpType, mergeType],
+                                                       futureDatasetTypes=[measType])
+        # order of columns is not defined
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 2*2*2)   # 4 tracts x 4 patches x 2 filters
+
+        # limit to single filter
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="AbstractFilter.abstract_filter = 'i'",
+                                                       neededDatasetTypes=[calexpType, mergeType],
+                                                       futureDatasetTypes=[measType])
+        # order of columns is not defined
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 3*4*1)   # 4 tracts x 4 patches x 2 filters
+
+        # expression excludes everyhting, specifying non-existing skymap is not a
+        # fatal error, it's operator error
+        headers, rows = self.preFlight.selectDataUnits(collections=["test"],
+                                                       expr="SkyMap.skymap = 'Mars'",
+                                                       neededDatasetTypes=[calexpType, mergeType],
+                                                       futureDatasetTypes=[measType])
+        # order of columns is not defined
+        self.assertEqual(len(headers), 4)  # headers must be the same
+        rows = list(rows)
+        self.assertEqual(len(rows), 0)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This is an incomlpete implementation, it only works on either camera
utits or skymap units but does not know how to join two groups together
(and join tabes/views are missing from registry so I cannot yet start
implementing joins). Renamed makeDataGraph() method into selectDataUnits()
to reflect better what it does. Combining units into quanta is done in
pipe_supertask as it needs to know about pipeline tasks.