### PR TITLE
Revamp equality test for StorageClass and add tests

### DIFF
--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -237,7 +237,7 @@ class Butler:
         storageClass = datasetType.storageClass
 
         # Check to see if this storage class has a disassembler
-        if storageClass.assemblerClass.disassemble is not None and storageClass.components:
+        if storageClass.components and storageClass.assemblerClass.disassemble is not None:
             components = storageClass.assembler().disassemble(obj)
             for component, info in components.items():
                 compTypeName = datasetType.componentTypeName(component)

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -23,10 +23,13 @@
 
 import builtins
 import itertools
+import logging
 
 from .utils import doImport, Singleton, getFullTypeName
 from .composites import CompositeAssembler
 from .config import ConfigSubset
+
+log = logging.getLogger(__name__)
 
 __all__ = ("StorageClass", "StorageClassFactory", "StorageClassConfig")
 
@@ -66,11 +69,15 @@ class StorageClass:
         if assembler is not None:
             self._assemblerClassName = assembler
             self._assembler = None
-        else:
-            # We set a default assembler so that a class is guaranteed to
-            # support something.
+        elif components is not None:
+            # We set a default assembler for composites so that a class is
+            # guaranteed to support something if it is a composite.
+            log.debug("Setting default assembler for %s", self.name)
             self._assembler = self.defaultAssembler
             self._assemblerClassName = self.defaultAssemblerName
+        else:
+            self._assembler = None
+            self._assemblerClassName = None
         # The types are created on demand and cached
         self._pytype = None
 

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -58,7 +58,8 @@ class StorageClass:
         self.name = name
         self._pytypeName = pytype
         if pytype is None:
-            raise ValueError("All StorageClass definitions require a Python type")
+            self._pytypeName = "object"
+            self._pytype = object
         self._components = components if components is not None else {}
         # if the assembler is not None also set it and clear the default
         # assembler

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -316,7 +316,7 @@ class StorageClassFactory(metaclass=Singleton):
         else:
             self._storageClasses[storageClass.name] = storageClass
 
-    def unregisterStorageClass(self, storageClassName):
+    def _unregisterStorageClass(self, storageClassName):
         """Remove the named StorageClass from the factory.
 
         Parameters

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -217,6 +217,13 @@ class StorageClassFactory(metaclass=Singleton):
         in : `bool`
             True if the supplied string is present, or if the supplied
             `StorageClass` is present and identical.
+
+        Notes
+        -----
+        The two different checks (one for "key" and one for "value") based on
+        the type of the given argument mean that it is possible for
+        StorageClass.name to be in the factory but StorageClass to not be
+        in the factory.
         """
         if isinstance(storageClassOrName, str):
             return storageClassOrName in self._storageClasses
@@ -321,5 +328,10 @@ class StorageClassFactory(metaclass=Singleton):
         ------
         KeyError
             The named storage class is not registered.
+
+        Notes
+        -----
+        This method is intended to simplify testing of StorageClassFactory
+        functionality and it is not expected to be required for normal usage.
         """
         del self._storageClasses[storageClassName]

--- a/tests/config/basic/chainedDatastore2.yaml
+++ b/tests/config/basic/chainedDatastore2.yaml
@@ -1,0 +1,5 @@
+datastore:
+  cls: lsst.daf.butler.datastores.chainedDatastore.ChainedDatastore
+  datastores:
+  - !include inMemoryDatastore.yaml
+  - !include inMemoryDatastore.yaml

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -123,7 +123,7 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         with self.assertRaises(ValueError):
             factory.registerStorageClass(newclass3)
 
-        factory.unregisterStorageClass(newclass3.name)
+        factory._unregisterStorageClass(newclass3.name)
         self.assertNotIn(newclass3, factory)
         self.assertNotIn(newclass3.name, factory)
         factory.registerStorageClass(newclass3)

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -50,8 +50,9 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(sc.validateInstance({}))
         self.assertFalse(sc.validateInstance(""))
 
-        with self.assertRaises(ValueError):
-            storageClass.StorageClass(className)
+        # Allow no definition of python type
+        scn = storageClass.StorageClass(className)
+        self.assertIs(scn.pytype, object)
 
         # Include some components
         scc = storageClass.StorageClass(className, pytype=PythonType, components={"comp1": sc})

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -47,11 +47,53 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(sc, storageClass.StorageClass)
         self.assertEqual(sc.name, className)
         self.assertFalse(sc.components)
+        self.assertTrue(sc.validateInstance({}))
+        self.assertFalse(sc.validateInstance(""))
+
+        with self.assertRaises(ValueError):
+            storageClass.StorageClass(className)
+
+        # Include some components
+        scc = storageClass.StorageClass(className, pytype=PythonType, components={"comp1": sc})
+        self.assertIn("comp1", scc.components)
+        self.assertIn("comp1", repr(scc))
+
         # Check we can create a storageClass using the name of an importable
         # type.
         sc2 = storageClass.StorageClass("TestImage2",
                                         "lsst.daf.butler.core.storageClass.StorageClassFactory")
         self.assertIsInstance(sc2.pytype(), storageClass.StorageClassFactory)
+        self.assertIn("butler.core", repr(sc2))
+
+    def testEquality(self):
+        """Test that StorageClass equality works"""
+        className = "TestImage"
+        sc1 = storageClass.StorageClass(className, pytype=dict)
+        sc2 = storageClass.StorageClass(className, pytype=dict)
+        self.assertEqual(sc1, sc2)
+        sc3 = storageClass.StorageClass(className + "2", pytype=str)
+        self.assertNotEqual(sc1, sc3)
+
+        # Same StorageClass name but different python type
+        sc4 = storageClass.StorageClass(className, pytype=str)
+        self.assertNotEqual(sc1, sc4)
+
+        # Now with components
+        sc5 = storageClass.StorageClass("Composite", pytype=PythonType,
+                                        components={"comp1": sc1, "comp2": sc3})
+        sc6 = storageClass.StorageClass("Composite", pytype=PythonType,
+                                        components={"comp1": sc1, "comp2": sc3})
+        self.assertEqual(sc5, sc6)
+        self.assertNotEqual(sc5, sc3)
+        sc7 = storageClass.StorageClass("Composite", pytype=PythonType,
+                                        components={"comp1": sc4, "comp2": sc3})
+        self.assertNotEqual(sc5, sc7)
+        sc8 = storageClass.StorageClass("Composite", pytype=PythonType,
+                                        components={"comp2": sc3})
+        self.assertNotEqual(sc5, sc8)
+        sc9 = storageClass.StorageClass("Composite", pytype=PythonType,
+                                        components={"comp2": sc3}, assembler="lsst.daf.butler.Butler")
+        self.assertNotEqual(sc5, sc9)
 
     def testRegistry(self):
         """Check that storage classes can be created on the fly and stored
@@ -65,6 +107,30 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(sc.name, className)
         self.assertFalse(sc.components)
         self.assertEqual(sc.pytype, PythonType)
+        self.assertIn(sc, factory)
+        newclass2 = storageClass.StorageClass("Temporary2", pytype=str)
+        self.assertNotIn(newclass2, factory)
+        factory.registerStorageClass(newclass2)
+        self.assertIn(newclass2, factory)
+        self.assertIn("Temporary2", factory)
+        self.assertNotIn("Temporary3", factory)
+        self.assertNotIn({}, factory)
+
+        # Make sure we can't register a storage class with the same name
+        # but different values
+        newclass3 = storageClass.StorageClass("Temporary2", pytype=dict)
+        with self.assertRaises(ValueError):
+            factory.registerStorageClass(newclass3)
+
+        factory.unregisterStorageClass(newclass3.name)
+        self.assertNotIn(newclass3, factory)
+        self.assertNotIn(newclass3.name, factory)
+        factory.registerStorageClass(newclass3)
+        self.assertIn(newclass3, factory)
+        self.assertIn(newclass3.name, factory)
+
+        # Check you can silently insert something that is already there
+        factory.registerStorageClass(newclass3)
 
     def testPickle(self):
         """Test that we can pickle storageclasses.


### PR DESCRIPTION
* Add proper `__eq__` method that tests the full definition of a StorageClass
* Add extensive tests of equality and factory inserts.
* Add ability to unregister a storage class from the factory