### PR TITLE
DM-15372: Use temp directories for datastores

### DIFF
--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -107,11 +107,11 @@ class DatastoreTests(DatasetTestHelper):
 
         # Some subclasses override the working root directory
         if self.root is not None:
-            def cleanup(path):
-                if path is not None and os.path.exists(path):
-                    shutil.rmtree(path)
-            self.addCleanup(cleanup, self.root)
             self.datastoreType.setConfigRoot(self.root, self.config, self.config.copy())
+
+    def tearDown(self):
+        if self.root is not None and os.path.exists(self.root):
+            shutil.rmtree(self.root, ignore_errors=True)
 
     def testConstructor(self):
         datastore = self.makeDatastore()

--- a/tests/test_datastoreFits.py
+++ b/tests/test_datastoreFits.py
@@ -160,10 +160,12 @@ class DatastoreFitsTests(FitsCatalogDatasetsHelper, DatasetTestHelper):
         ref = self.makeDatasetRef("calexp", dataUnits, storageClass, dataId)
 
         inputConfig = DatastoreConfig(self.configFile)
-        inputConfig["root"] = os.path.join(self.testDir, "./test_input_datastore")
+        self.datastoreType.setConfigRoot(os.path.join(self.testDir, "test_input_datastore"),
+                                         inputConfig, inputConfig.copy())
         inputPosixDatastore = self.datastoreType(config=inputConfig, registry=self.registry)
         outputConfig = inputConfig.copy()
-        outputConfig["root"] = os.path.join(self.testDir, "./test_output_datastore")
+        self.datastoreType.setConfigRoot(os.path.join(self.testDir, "test_output_datastore"),
+                                         outputConfig, outputConfig.copy())
         outputPosixDatastore = self.datastoreType(config=outputConfig,
                                                   registry=DummyRegistry())
 


### PR DESCRIPTION
Using fixed names causes name collisions when tests run in parallel. Current status is that this fixes the problem, although there's a bit too much code duplication for my liking.