### PR TITLE
DM-15447: Fix for registry setDataUnitRegion() method

### DIFF
--- a/python/lsst/daf/butler/core/dataUnit.py
+++ b/python/lsst/daf/butler/core/dataUnit.py
@@ -414,7 +414,7 @@ class DataUnitRegistry:
             requiredDependencies = ()
             optionalDependencies = ()
             table = None
-            spatial = False
+            spatial = dataUnitDescription.get("spatial", False)
             link = ()
             if "dependencies" in dataUnitDescription:
                 dependencies = dataUnitDescription["dependencies"]
@@ -439,7 +439,6 @@ class DataUnitRegistry:
                         if tableName == dataUnitName:
                             # Primary table for this DataUnit
                             table = builder.addTable(tableName, tableDescription)
-                            spatial = dataUnitDescription.get("spatial", False)
                         else:
                             # Secondary table
                             builder.addTable(tableName, tableDescription)
@@ -452,7 +451,7 @@ class DataUnitRegistry:
             self[dataUnitName] = dataUnit
             for linkColumnName in link:
                 self._dataUnitsByLinkColumnName[linkColumnName] = dataUnit
-            if spatial is not None:
+            if spatial:
                 self._spatialDataUnits |= frozenset((dataUnitName, ))
                 # The DataUnit (or DataUnitJoin) instance that can be used
                 # to retreive the region is keyed based on the union

--- a/tests/test_dataUnit.py
+++ b/tests/test_dataUnit.py
@@ -44,6 +44,30 @@ class DataUnitRegistryTestCase(lsst.utils.tests.TestCase):
             for d in dataUnit.dependencies:
                 self.assertIsInstance(d, DataUnit)
 
+        # Tests below depend on the schema.yaml definitions as well
+
+        # check all spatial data units names, Sensor is there because
+        # pair (Visit, Sensor) is a spatial entity
+        self.assertCountEqual(dataUnitRegistry._spatialDataUnits,
+                              ["Tract", "Patch", "Visit", "Sensor", "SkyPix"])
+        self.assertCountEqual(dataUnitRegistry._dataUnitRegions.keys(),
+                              [{'Visit'}, {'SkyPix'}, {'Tract'},
+                               {'Patch', 'Tract'}, {'Sensor', 'Visit'}])
+        self.assertEqual(len(dataUnitRegistry.joins), 11)
+        joins = ((['Exposure'], ['Exposure']),
+                 (['Exposure'], ['ExposureRange']),
+                 (['Patch'], ['SkyPix']),
+                 (['Sensor', 'Visit'], ['Patch']),
+                 (['Sensor', 'Visit'], ['SkyPix']),
+                 (['Sensor', 'Visit'], ['Tract']),
+                 (['Tract'], ['SkyPix']),
+                 (['Visit'], ['Patch']),
+                 (['Visit'], ['Sensor']),
+                 (['Visit'], ['SkyPix']))
+        for lhs, rhs in joins:
+            self.assertIsNotNone(dataUnitRegistry.getJoin(lhs, rhs))
+            self.assertIsNotNone(dataUnitRegistry.getJoin(rhs, lhs))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sqlRegistry.py
+++ b/tests/test_sqlRegistry.py
@@ -379,6 +379,11 @@ class SqlRegistryTestCase(lsst.utils.tests.TestCase):
                                                         lsst.sphgeom.UnitVector3d(0, 1, 1)))
         for a, b in combinations((regionTract, regionPatch, regionVisit, regionVisitSensor), 2):
             self.assertNotEqual(a, b)
+
+        # This depends on current schema.yaml definitions
+        rows = list(registry.query('select count(*) as "cnt" from "PatchSkyPixJoin"'))
+        self.assertEqual(rows[0]["cnt"], 0)
+
         # Add some dataunits
         registry.addDataUnitEntry("Camera", {"camera": "DummyCam"})
         registry.addDataUnitEntry("PhysicalFilter", {"camera": "DummyCam",
@@ -437,6 +442,9 @@ class SqlRegistryTestCase(lsst.utils.tests.TestCase):
                                 "tract": 1})
         # Check if we can get the region for a skypix
         self.assertIsInstance(registry.getRegion({"skypix": 1000}), lsst.sphgeom.ConvexPolygon)
+        # PatchSkyPixJoin should not be empty
+        rows = list(registry.query('select count(*) as "cnt" from "PatchSkyPixJoin"'))
+        self.assertNotEqual(rows[0]["cnt"], 0)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
DataUnitRegistry uses different keys for different mappings, need to
take care of passing correct set of units to each method. Also added
trivial unit tests for this issue and for DataUnitRegistry, these tests
depend on current schema.yaml definitions.