### PR TITLE
DM-15471: Control disassembly at butler config level not storage class

### DIFF
--- a/config/composites.yaml
+++ b/config/composites.yaml
@@ -1,0 +1,17 @@
+composites:
+  # True: concrete composite (composites are disassembled);
+  # False: virtual composite (composites are written monolithically).
+  # default applies to all composites that are not explicitly mentioned
+  # elsewhere.
+  default: False
+  storageClasses:
+    # Use a dict rather than a list to allow easy merging of user config
+    # into default config. Config class has no way of merging lists.
+    ExposureI: False
+    ExposureF: False
+    ExposureCompositeF: True
+    ExposureCompositeF: True
+  datasetTypes:
+    # Same definition as for storage classes, but dataset type explicitly
+    # overrides a storage class definition.
+    calexp: False

--- a/config/composites.yaml
+++ b/config/composites.yaml
@@ -9,7 +9,7 @@ composites:
     # into default config. Config class has no way of merging lists.
     ExposureI: False
     ExposureF: False
-    ExposureCompositeF: True
+    ExposureCompositeI: True
     ExposureCompositeF: True
   datasetTypes:
     # Same definition as for storage classes, but dataset type explicitly

--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -35,3 +35,5 @@ datastore:
     Background: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     Config: lsst.daf.butler.formatters.pexConfigFormatter.PexConfigFormatter
     Packages: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
+    PropertyList: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
+    PropertySet: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -1274,13 +1274,6 @@ schema:
           The ID of the Quantum that produced this Dataset, providing access
           to fine-grained provenance information.
           May be null for Datasets not produced by running a SuperTask.
-      -
-        name: assembler
-        type: string
-        doc: >
-          Fully-qualified name of an importable Assembler object that can be
-          used to construct this Dataset from its components.  Null for
-          datasets that are not virtual composites.
 
       foreignKeys:
       -

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -39,7 +39,7 @@ storageClasses:
     pytype: lsst.daf.base.PropertyList
   Exposure: &Exposure
     pytype: lsst.afw.image.Exposure
-    assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssemblerMonolithic
+    assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
     components:
       image: ImageF
       mask: MaskX
@@ -51,21 +51,16 @@ storageClasses:
       apCorrMap: TablePersistableApCorr
       coaddInputs: TablePersistableCoaddInputs
       metadata: PropertyList
-  ExposureF:
+  ExposureF: &ExposureF
     <<: *Exposure
     pytype: lsst.afw.image.ExposureF
-  ExposureI:
+  ExposureI: &ExposureI
     <<: *Exposure
     pytype: lsst.afw.image.ExposureI
-  ExposureComposite: &ExposureComposite
-    <<: *Exposure
-    assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
   ExposureCompositeF:
-    <<: *ExposureComposite
-    pytype: lsst.afw.image.ExposureF
+    <<: *ExposureF
   ExposureCompositeI:
-    <<: *ExposureComposite
-    pytype: lsst.afw.image.ExposureI
+    <<: *ExposureI
   Background:
     pytype: lsst.afw.math.BackgroundList
   Config:

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -63,7 +63,7 @@ storageClasses:
   ExposureCompositeF:
     <<: *ExposureComposite
     pytype: lsst.afw.image.ExposureF
-  ExposureI:
+  ExposureCompositeI:
     <<: *ExposureComposite
     pytype: lsst.afw.image.ExposureI
   Background:

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -37,6 +37,8 @@ storageClasses:
     pytype: lsst.skymap.BaseSkyMap
   PropertyList:
     pytype: lsst.daf.base.PropertyList
+  PropertySet:
+    pytype: lsst.daf.base.PropertySet
   Exposure: &Exposure
     pytype: lsst.afw.image.Exposure
     assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler

--- a/python/lsst/daf/butler/assemblers/exposureAssembler.py
+++ b/python/lsst/daf/butler/assemblers/exposureAssembler.py
@@ -218,6 +218,7 @@ class ExposureAssembler(CompositeAssembler):
             info.setVisitInfo(components.pop("visitInfo"))
         info.setApCorrMap(components.pop("apCorrMap", None))
         info.setCoaddInputs(components.pop("coaddInputs", None))
+        info.setMetadata(components.pop("metadata", None))
 
         # If we have some components left over that is a problem
         if components:

--- a/python/lsst/daf/butler/assemblers/exposureAssembler.py
+++ b/python/lsst/daf/butler/assemblers/exposureAssembler.py
@@ -25,7 +25,7 @@
 import lsst.afw.detection  # noqa F401
 from lsst.afw.image import makeExposure, makeMaskedImage
 
-from lsst.daf.butler.core.composites import CompositeAssembler
+from lsst.daf.butler import CompositeAssembler
 
 
 class ExposureAssembler(CompositeAssembler):

--- a/python/lsst/daf/butler/assemblers/exposureAssembler.py
+++ b/python/lsst/daf/butler/assemblers/exposureAssembler.py
@@ -225,8 +225,3 @@ class ExposureAssembler(CompositeAssembler):
                              " {}".format(list(components.keys())))
 
         return exposure
-
-
-class ExposureAssemblerMonolithic(ExposureAssembler):
-    """Exposure assembler with disassembly disabled."""
-    disassemble = None

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -34,6 +34,7 @@ from .core.run import Run
 from .core.storageClass import StorageClassFactory
 from .core.config import Config, ConfigSubset
 from .core.butlerConfig import ButlerConfig
+from .core.composites import CompositesMap
 
 
 __all__ = ("Butler",)
@@ -143,6 +144,7 @@ class Butler:
         self.datastore = Datastore.fromConfig(self.config, self.registry)
         self.storageClasses = StorageClassFactory()
         self.storageClasses.addFromConfig(self.config)
+        self.composites = CompositesMap(self.config)
         if run is None:
             runCollection = self.config.get("run", None)
             self.run = None
@@ -240,8 +242,8 @@ class Butler:
         # Look up storage class to see if this is a composite
         storageClass = datasetType.storageClass
 
-        # Check to see if this storage class has a disassembler
-        if storageClass.components and storageClass.assemblerClass.disassemble is not None:
+        # Check to see if this datasetType requires disassembly
+        if self.composites.doDisassembly(datasetType):
             components = storageClass.assembler().disassemble(obj)
             for component, info in components.items():
                 compTypeName = datasetType.componentTypeName(component)

--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -5,8 +5,8 @@ Core code for butler.
 # Do not export the utility routines from safeFileIo and utils
 # Do not export SqlDatabaseDict (should be constructed by other classes).
 
+from .assembler import *
 from .butlerConfig import *
-from .composites import *
 from .config import *
 from .datasets import *
 from .datastore import *

--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -8,6 +8,7 @@ Core code for butler.
 from .assembler import *
 from .butlerConfig import *
 from .config import *
+from .composites import *
 from .datasets import *
 from .datastore import *
 from .exceptions import *

--- a/python/lsst/daf/butler/core/assembler.py
+++ b/python/lsst/daf/butler/core/assembler.py
@@ -21,7 +21,7 @@
 
 """Support for reading and writing composite objects."""
 
-__all__ = ("DatasetComponent", "CompositeAssembler", "CompositeAssemblerMonolithic")
+__all__ = ("DatasetComponent", "CompositeAssembler")
 
 import collections
 import logging
@@ -309,8 +309,3 @@ class CompositeAssembler:
             raise ValueError("Unhandled components during disassembly ({})".format(requested))
 
         return components
-
-
-class CompositeAssemblerMonolithic(CompositeAssembler):
-    """Generic assembler class that disables disassembly."""
-    disassemble = None

--- a/python/lsst/daf/butler/core/assembler.py
+++ b/python/lsst/daf/butler/core/assembler.py
@@ -21,7 +21,12 @@
 
 """Support for reading and writing composite objects."""
 
+__all__ = ("DatasetComponent", "CompositeAssembler", "CompositeAssemblerMonolithic")
+
 import collections
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class DatasetComponent:

--- a/python/lsst/daf/butler/core/butlerConfig.py
+++ b/python/lsst/daf/butler/core/butlerConfig.py
@@ -30,10 +30,12 @@ from .datastore import DatastoreConfig
 from .schema import SchemaConfig
 from .registry import RegistryConfig
 from .storageClass import StorageClassConfig
+from .composites import CompositesConfig
 
 __all__ = ("ButlerConfig",)
 
-CONFIG_COMPONENT_CLASSES = (SchemaConfig, RegistryConfig, StorageClassConfig, DatastoreConfig)
+CONFIG_COMPONENT_CLASSES = (SchemaConfig, RegistryConfig, StorageClassConfig,
+                            DatastoreConfig, CompositesConfig)
 
 
 class ButlerConfig(Config):

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -1,0 +1,113 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for reading and writing composite objects."""
+
+__all__ = ("CompositesConfig", "CompositesMap")
+
+import logging
+
+from .config import ConfigSubset
+from .datasets import DatasetType
+from .storageClass import StorageClass
+
+log = logging.getLogger(__name__)
+
+
+class CompositesConfig(ConfigSubset):
+    component = "composites"
+    requiredKeys = ("default", "storageClasses")
+    defaultConfigFile = "composites.yaml"
+
+    def validate(self):
+        """Validate entries have the correct type."""
+        super().validate()
+        for n in ("storageClasses", "datasetTypes"):
+            for k in self[n]:
+                key = f"{n}.{k}"
+                if not isinstance(self[key], bool):
+                    raise ValueError(f"CompositesConfig: Key {key} is not a Boolean")
+
+
+class CompositesMap:
+    """Determine whether a specific datasetType or StorageClass should be
+    disassembled.
+
+    Parameters
+    ----------
+    config : `str`, `ButlerConfig`, or `CompositesConfig`
+        Configuration to control composites disassembly.
+    """
+
+    def __init__(self, config):
+        if not isinstance(config, type(self)):
+            config = CompositesConfig(config)
+        assert isinstance(config, CompositesConfig)
+        self.config = config
+
+    def doDisassembly(self, entity):
+        """Given some choices, indicate whether the entity should be
+        disassembled.
+
+        Parameters
+        ----------
+        entity : `StorageClass` or `DatasetType`
+            Thing to test against the configuration. The ``name`` property
+            is used to determine a match.  A `DatasetType` will first check
+            its name, before checking its `StorageClass`.  If there are no
+            matches the default will be returned. If the associated
+            `StorageClass` is not a composite, will always return `False`.
+
+        Returns
+        -------
+        disassemble : `bool`
+            Returns `True` if disassembly should occur; `False` otherwise.
+        """
+        components = None
+        datasetTypeName = None
+        storageClassName = None
+        if isinstance(entity, DatasetType):
+            datasetTypeName = entity.name
+            storageClassName = entity.storageClass.name
+            components = entity.storageClass.components
+        elif isinstance(entity, StorageClass):
+            storageClassName = entity.name
+            components = entity.components
+        else:
+            raise ValueError(f"Unexpected argument: {entity:!r}")
+
+        # We know for a fact this is not a composite
+        if not components:
+            log.debug("%s will not be disassembled (not a composite)", entity)
+            return False
+
+        matchName = "{} (via default)".format(entity)
+        disassemble = self.config["default"]
+
+        if datasetTypeName is not None and datasetTypeName in self.config["datasetTypes"]:
+            disassemble = self.config[f"datasetTypes.{datasetTypeName}"]
+            matchName = datasetTypeName
+        elif storageClassName is not None and storageClassName in self.config["storageClasses"]:
+            disassemble = self.config[f"storageClasses.{storageClassName}"]
+            matchName = storageClassName
+
+        log.debug("%s will%s be disassembled", matchName, "" if disassemble else " not")
+        return disassemble

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -23,6 +23,7 @@
 
 import collections
 import copy
+import logging
 import pprint
 import os
 import yaml
@@ -36,6 +37,9 @@ from .utils import doImport
 yaml.add_representer(collections.defaultdict, Representer.represent_dict)
 
 __all__ = ("Config", "ConfigSubset")
+
+# Config module logger
+log = logging.getLogger(__name__)
 
 # PATH-like environment variable to use for defaults.
 CONFIG_PATH = "DAF_BUTLER_CONFIG_PATH"
@@ -100,6 +104,7 @@ class Loader(yaml.CLoader):
 
     def extractFile(self, filename):
         filepath = os.path.join(self._root, filename)
+        log.debug("Opening YAML file via !include: %s", filepath)
         with open(filepath, "r") as f:
             return yaml.load(f, Loader)
 
@@ -190,6 +195,7 @@ class Config(_ConfigBase):
         path : `str`
             To a persisted config file in YAML format.
         """
+        log.debug("Opening YAML config file: %s", path)
         with open(path, "r") as f:
             self.__initFromYaml(f)
 

--- a/python/lsst/daf/butler/core/datasets.py
+++ b/python/lsst/daf/butler/core/datasets.py
@@ -168,8 +168,7 @@ class DatasetRef:
     """
 
     __slots__ = ("_id", "_datasetType", "_dataId", "_producer",
-                 "_predictedConsumers", "_actualConsumers", "_components",
-                 "_assembler")
+                 "_predictedConsumers", "_actualConsumers", "_components")
     __eq__ = slotValuesAreEqual
 
     def __init__(self, datasetType, dataId, id=None):
@@ -181,7 +180,6 @@ class DatasetRef:
         self._predictedConsumers = dict()
         self._actualConsumers = dict()
         self._components = dict()
-        self._assembler = None
 
     @property
     def id(self):
@@ -243,15 +241,6 @@ class DatasetRef:
         Read-only; update via `Registry.attachComponent()`.
         """
         return _safeMakeMappingProxyType(self._components)
-
-    @property
-    def assembler(self):
-        """Fully-qualified name of an importable Assembler object that can be
-        used to construct this Dataset from its components.
-
-        `None` for datasets that are not virtual composites.
-        """
-        return self._assembler
 
     def __str__(self):
         components = ""

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -172,11 +172,10 @@ class StorageClass:
         return hash(self.name)
 
     def __repr__(self):
-        components = list(self.components.keys() if self.components else "[]")
         return "{}({}, pytype={}, components={})".format(type(self).__qualname__,
                                                          self.name,
                                                          self.pytype,
-                                                         components)
+                                                         list(self.components.keys()))
 
 
 class StorageClassFactory(metaclass=Singleton):

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -26,7 +26,7 @@ import itertools
 import logging
 
 from .utils import doImport, Singleton, getFullTypeName
-from .composites import CompositeAssembler
+from .assembler import CompositeAssembler
 from .config import ConfigSubset
 
 log = logging.getLogger(__name__)

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -149,11 +149,9 @@ class ChainedDatastore(Datastore):
         # they are ephemeral
         isEphemeral = True
         for d in self.datastores:
-            log.debug("Child: %s", d.isEphemeral)
             if not d.isEphemeral:
                 isEphemeral = False
                 break
-        log.debug("Ephmeral: %s", isEphemeral)
         self.isEphemeral = isEphemeral
 
         log.debug("Created %s (%s)", self.name, ("ephemeral" if self.isEphemeral else "permanent"))

--- a/tests/config/basic/butler-chained.yaml
+++ b/tests/config/basic/butler-chained.yaml
@@ -1,3 +1,4 @@
 run: ingest
 datastore: !include chainedDatastore.yaml
 storageClasses: !include storageClasses.yaml
+composites: !include composites.yaml

--- a/tests/config/basic/butler-inmemory.yaml
+++ b/tests/config/basic/butler-inmemory.yaml
@@ -1,3 +1,4 @@
 run: ingest
 datastore: !include inMemoryDatastore.yaml
 storageClasses: !include storageClasses.yaml
+composites: !include composites.yaml

--- a/tests/config/basic/butler.yaml
+++ b/tests/config/basic/butler.yaml
@@ -1,3 +1,4 @@
 run: ingest
 datastore: !include posixDatastore.yaml
 storageClasses: !include storageClasses.yaml
+composites: !include composites.yaml

--- a/tests/config/basic/composites-bad.yaml
+++ b/tests/config/basic/composites-bad.yaml
@@ -1,0 +1,11 @@
+composites:
+  storageClasses:
+    # This will fail since a str is not a bool
+    StructuredData: "False"
+    StructuredDataJson: False
+    StructuredDataPickle: False
+    StructuredComposite: True
+    StructuredCompositeTestA: True
+    StructuredCompositeTestB: True
+  datasetTypes:
+    dummyTest: True

--- a/tests/config/basic/composites.yaml
+++ b/tests/config/basic/composites.yaml
@@ -1,0 +1,11 @@
+composites:
+  storageClasses:
+    StructuredData: False
+    StructuredDataJson: False
+    StructuredDataPickle: False
+    StructuredComposite: True
+    StructuredCompositeTestA: True
+    StructuredCompositeTestB: True
+  datasetTypes:
+    dummyTrue: True
+    dummyFalse: False

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -15,7 +15,7 @@ storageClasses:
   StructuredData: &StructuredData
     # Data from a simple Python class
     pytype: examplePythonTypes.MetricsExample
-    assembler: lsst.daf.butler.CompositeAssemblerMonolithic
+    assembler: lsst.daf.butler.CompositeAssembler
     # Use YAML formatter by default
     components:
       # Components are those supported by get.

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -15,7 +15,7 @@ storageClasses:
   StructuredData: &StructuredData
     # Data from a simple Python class
     pytype: examplePythonTypes.MetricsExample
-    assembler: lsst.daf.butler.core.composites.CompositeAssemblerMonolithic
+    assembler: lsst.daf.butler.CompositeAssemblerMonolithic
     # Use YAML formatter by default
     components:
       # Components are those supported by get.
@@ -28,7 +28,7 @@ storageClasses:
     <<: *StructuredData
   StructuredComposite: &StructuredComposite
     pytype: examplePythonTypes.MetricsExample
-    assembler: lsst.daf.butler.core.composites.CompositeAssembler
+    assembler: lsst.daf.butler.CompositeAssembler
     components:
       summary: StructuredDataDictYaml
       output: StructuredDataDictYaml

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -1,0 +1,91 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from lsst.daf.butler import CompositesConfig, CompositesMap, StorageClass, DatasetType
+
+TESTDIR = os.path.dirname(__file__)
+
+
+class TestCompositesConfig(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.configFile = os.path.join(TESTDIR, "config", "basic", "composites.yaml")
+
+    def testBadConfig(self):
+        """Config with bad values in it"""
+        with self.assertRaises(ValueError):
+            CompositesConfig(os.path.join(TESTDIR, "config", "basic", "composites-bad.yaml"))
+
+    def testConfig(self):
+        c = CompositesConfig(self.configFile)
+        self.assertIn("default", c)
+        # Check merging has worked
+        self.assertIn("datasetTypes.calexp", c)
+        self.assertIn("datasetTypes.dummyTrue", c)
+        self.assertIn("storageClasses.StructuredComposite", c)
+        self.assertIn("storageClasses.ExposureF", c)
+
+        # Check that all entries are booleans (this is meant to be enforced
+        # internally)
+        for n in ("storageClasses", "datasetTypes"):
+            for k in c[n]:
+                self.assertIsInstance(c[f"{n}.{k}"], bool, f"Testing {n}.{k}")
+
+    def testMap(self):
+        c = CompositesMap(self.configFile)
+
+        # Check that a str is not supported
+        with self.assertRaises(ValueError):
+            c.doDisassembly("fred")
+
+        # These will fail (not a composite)
+        sc = StorageClass("StructuredDataJson")
+        d = DatasetType("dummyTrue", ("a", "b"), sc)
+        self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
+        self.assertFalse(c.doDisassembly(sc), f"Test with StorageClass: {sc}")
+
+        # Repeat but this time use a composite storage class
+        sccomp = StorageClass("Dummy")
+        sc = StorageClass("StructuredDataJson", components={"dummy": sccomp})
+        d = DatasetType("dummyTrue", ("a", "b"), sc)
+        self.assertTrue(c.doDisassembly(d), f"Test with DatasetType: {d}")
+        self.assertFalse(c.doDisassembly(sc), f"Test with StorageClass: {sc}")
+
+        # Override with False
+        d = DatasetType("dummyFalse", ("a", "b"), sc)
+        self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
+
+        # DatasetType that has no explicit entry
+        d = DatasetType("dummyFred", ("a", "b"), sc)
+        self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
+
+        # StorageClass that will be disassembled
+        sc = StorageClass("StructuredComposite", components={"dummy": sccomp})
+        d = DatasetType("dummyFred", ("a", "b"), sc)
+        self.assertTrue(c.doDisassembly(d), f"Test with DatasetType: {d}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously StorageClasses defined how to disassembly, but if we want per-datasetType control over disassembly we have to move them into their own configuration area.