### PR TITLE
DM-15533: Python inheritance for StorageClass

### DIFF
--- a/config/composites.yaml
+++ b/config/composites.yaml
@@ -9,8 +9,6 @@ composites:
     # into default config. Config class has no way of merging lists.
     ExposureI: False
     ExposureF: False
-    ExposureCompositeI: True
-    ExposureCompositeF: True
   datasetTypes:
     # Same definition as for storage classes, but dataset type explicitly
     # overrides a storage class definition.

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -22,22 +22,23 @@ storageClasses:
   Image: &Image
     pytype: lsst.afw.image.Image
   ImageF:
-    <<: *Image
+    inheritsFrom: Image
     pytype: lsst.afw.image.ImageF
   ImageI:
-    <<: *Image
+    inheritsFrom: Image
     pytype: lsst.afw.image.ImageI
   ImageU:
-    <<: *Image
+    inheritsFrom: Image
     pytype: lsst.afw.image.ImageU
   DecoratedImage: &DecoratedImage
     pytype: lsst.afw.image.DecoratedImage
   DecoratedImageU:
-    <<: *DecoratedImage
+    inheritsFrom: DecoratedImage
     pytype: lsst.afw.image.DecoratedImageU
   Mask:
     pytype: lsst.afw.image.Mask
   MaskX:
+    inheritsFrom: Mask
     pytype: lsst.afw.image.MaskX
   Catalog:
     pytype: lsst.afw.table.BaseCatalog
@@ -69,41 +70,23 @@ storageClasses:
       transmissionCurve: TablePersistableTransmissionCurve
       metadata: PropertyList
   ExposureF: &ExposureF
-    <<: *Exposure
+    inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF
     components:
       image: ImageF
       mask: MaskX
       variance: ImageF
-      wcs: TablePersistableWcs
-      psf: TablePersistablePsf
-      calib: TablePersistableCalib
-      visitInfo: TablePersistableVisitInfo
-      apCorrMap: TablePersistableApCorr
-      coaddInputs: TablePersistableCoaddInputs
-      transmissionCurve: TablePersistableTransmissionCurve
-      metadata: PropertyList
   ExposureI: &ExposureI
-    <<: *Exposure
+    inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureI
     components:
       image: ImageI
       mask: MaskX
       variance: ImageF
-      wcs: TablePersistableWcs
-      psf: TablePersistablePsf
-      calib: TablePersistableCalib
-      visitInfo: TablePersistableVisitInfo
-      apCorrMap: TablePersistableApCorr
-      coaddInputs: TablePersistableCoaddInputs
-      transmissionCurve: TablePersistableTransmissionCurve
-      metadata: PropertyList
-  ExposureComposite:
-    <<: *Exposure
   ExposureCompositeF:
-    <<: *ExposureF
+    inheritsFrom: ExposureF
   ExposureCompositeI:
-    <<: *ExposureI
+    inheritsFrom: ExposureI
   Background:
     pytype: lsst.afw.math.BackgroundList
   Config:

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -83,10 +83,6 @@ storageClasses:
       image: ImageI
       mask: MaskX
       variance: ImageF
-  ExposureCompositeF:
-    inheritsFrom: ExposureF
-  ExposureCompositeI:
-    inheritsFrom: ExposureI
   Background:
     pytype: lsst.afw.math.BackgroundList
   Config:

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -30,7 +30,7 @@ storageClasses:
   ImageU:
     inheritsFrom: Image
     pytype: lsst.afw.image.ImageU
-  DecoratedImage: &DecoratedImage
+  DecoratedImage:
     pytype: lsst.afw.image.DecoratedImage
   DecoratedImageU:
     inheritsFrom: DecoratedImage
@@ -54,7 +54,7 @@ storageClasses:
     pytype: lsst.daf.base.PropertyList
   PropertySet:
     pytype: lsst.daf.base.PropertySet
-  Exposure: &Exposure
+  Exposure:
     pytype: lsst.afw.image.Exposure
     assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
     components:
@@ -69,14 +69,14 @@ storageClasses:
       coaddInputs: TablePersistableCoaddInputs
       transmissionCurve: TablePersistableTransmissionCurve
       metadata: PropertyList
-  ExposureF: &ExposureF
+  ExposureF:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF
     components:
       image: ImageF
       mask: MaskX
       variance: ImageF
-  ExposureI: &ExposureI
+  ExposureI:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureI
     components:

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -25,6 +25,7 @@ Butler top level classes.
 
 import os
 import contextlib
+import logging
 
 from .core.utils import doImport, transactional
 from .core.datasets import DatasetRef
@@ -38,6 +39,8 @@ from .core.composites import CompositesMap
 
 
 __all__ = ("Butler",)
+
+log = logging.getLogger(__name__)
 
 
 class Butler:
@@ -224,6 +227,7 @@ class Butler:
             Raised if the butler was not constructed with a Run, and is hence
             read-only.
         """
+        log.debug("Butler put: %s, dataId=%s, producer=%s", datasetRefOrType, dataId, producer)
         if self.run is None:
             raise TypeError("Butler is read-only.")
         if isinstance(datasetRefOrType, DatasetRef):
@@ -322,6 +326,7 @@ class Butler:
         obj : `object`
             The dataset.
         """
+        log.debug("Butler get: %s, dataId=%s, parameters=%s", datasetRefOrType, dataId, parameters)
         if isinstance(datasetRefOrType, DatasetRef):
             if dataId is not None:
                 raise ValueError("DatasetRef given, cannot use dataId as well")

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -318,6 +318,19 @@ class StorageClassFactory(metaclass=Singleton):
         clsargs = {f"_cls_{k}": v for k, v in kwargs.items() if v is not None}
         clsargs["_cls_name"] = name
 
+        # Components are a special case because we want to be able to
+        # combine components here with components in the parent
+        # so the parent can define a component of class Image but the child
+        # can override with ImageF.
+        compKey = "_cls_components"
+        if compKey in clsargs:
+            components = getattr(baseClass, compKey, None)
+            if components is not None:
+                components = components.copy()
+                # Merge with the supplied values
+                components.update(clsargs[compKey])
+                clsargs[compKey] = components
+
         return type(f"StorageClass{name}", (baseClass,), clsargs)
 
     def getStorageClass(self, storageClassName):

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -289,7 +289,7 @@ class StorageClassFactory(metaclass=Singleton):
             storageClassKwargs["components"] = components
 
             # Create the new storage class and register it
-            baseClass = StorageClass
+            baseClass = None
             if "inheritsFrom" in info:
                 baseName = info["inheritsFrom"]
                 if baseName not in self:
@@ -304,21 +304,28 @@ class StorageClassFactory(metaclass=Singleton):
             processStorageClass(name, sconfig)
 
     @staticmethod
-    def makeNewStorageClass(name, baseClass, **kwargs):
+    def makeNewStorageClass(name, baseClass=StorageClass, **kwargs):
         """Create a new Python class as a subclass of `StorageClass`.
 
         Parameters
         ----------
         name : `str`
             Name to use for this class.
-        baseClass : `type`
-            Base class for this `StorageClass`.
+        baseClass : `type`, optional
+            Base class for this `StorageClass`. Must be either `StorageClass`
+            or a subclass of `StorageClass`. If `None`, `StorageClass` will
+            be used.
 
         Returns
         -------
         newtype : `type` subclass of `StorageClass`
             Newly created Python type.
         """
+
+        if baseClass is None:
+            baseClass = StorageClass
+        if not issubclass(baseClass, StorageClass):
+            raise ValueError(f"Base class must be a StorageClass not {baseClass}")
 
         # convert the arguments to use different internal names
         clsargs = {f"_cls_{k}": v for k, v in kwargs.items() if v is not None}

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -132,8 +132,15 @@ class StorageClass:
         assembler : `CompositeAssembler`
             Instance of the assembler associated with this `StorageClass`.
             Assembler is constructed with this `StorageClass`.
+
+        Raises
+        ------
+        TypeError
+            This StorageClass has no associated assembler.
         """
         cls = self.assemblerClass
+        if cls is None:
+            raise TypeError(f"No assembler class is associated with StorageClass {self.name}")
         return cls(storageClass=self)
 
     def validateInstance(self, instance):

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -291,7 +291,6 @@ class StorageClassFactory(metaclass=Singleton):
 
             newStorageClassType = self.makeNewStorageClass(name, baseClass, **storageClassKwargs)
             newStorageClass = newStorageClassType()
-            print("Registering {}".format(newStorageClass))
             self.registerStorageClass(newStorageClass)
 
         for name in list(sconfig.keys()):

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -172,10 +172,11 @@ class StorageClass:
         return hash(self.name)
 
     def __repr__(self):
-        return "{}({}, pytype={}, components={})".format(type(self).__qualname__,
-                                                         self.name,
-                                                         self.pytype,
-                                                         list(self.components.keys()))
+        return "{}({}, pytype={}, assembler={}, components={})".format(type(self).__qualname__,
+                                                                       self.name,
+                                                                       self._pytypeName,
+                                                                       self._assemblerClassName,
+                                                                       list(self.components.keys()))
 
 
 class StorageClassFactory(metaclass=Singleton):

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -95,5 +95,9 @@ class YamlFormatter(FileFormatter):
             Object of expected type `pytype`.
         """
         if not hasattr(builtins, pytype.__name__):
-            inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
+            if storageClass.components:
+                inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
+            else:
+                # Hope that we can pass the arguments in directly
+                inMemoryDataset = pytype(inMemoryDataset)
         return inMemoryDataset

--- a/tests/config/basic/composites.yaml
+++ b/tests/config/basic/composites.yaml
@@ -6,6 +6,8 @@ composites:
     StructuredComposite: True
     StructuredCompositeTestA: True
     StructuredCompositeTestB: True
+    ExposureCompositeI: True
+    ExposureCompositeF: True
   datasetTypes:
     dummyTrue: True
     dummyFalse: False

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -14,6 +14,7 @@ datastore:
     StructuredDataDictPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     StructuredDataListPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     StructuredData: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
+    StructuredDataNoComponents: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     StructuredDataJson: lsst.daf.butler.formatters.jsonFormatter.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -2,7 +2,7 @@ datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
   root: ./butler_test_repository
   templates:
-    default: "{collection}/{datasetType}/{tract:?}/{patch:?}/{filter:?}/{camera:?}_{visit:?}"
+    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{filter:?}/{camera:?}_{visit:?}"
     calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{filter:?}_{component:?}"
     metric: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{filter}_{component:?}"
     test_metric_comp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{camera}_{component:?}"
@@ -16,3 +16,4 @@ datastore:
     StructuredData: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataJson: lsst.daf.butler.formatters.jsonFormatter.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
+    ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -4,7 +4,7 @@ datastore:
   records:
     table: PosixDatastoreRecords2
   templates:
-    default: "{run:02d}/{datasetType}/{tract:?}/{patch:?}/{filter:?}/{camera:?}_{visit:?}"
+    default: "{run:02d}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{filter:?}/{camera:?}_{visit:?}"
     calexp: "{run:02d}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{filter:?}_{component:?}"
     metric: "{run:02d}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{filter}_{component:?}"
     test_metric_comp: "{run:02d}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{camera}_{component:?}"
@@ -18,3 +18,4 @@ datastore:
     StructuredData: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataJson: lsst.daf.butler.formatters.jsonFormatter.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
+    ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -16,6 +16,7 @@ datastore:
     StructuredDataDictPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     StructuredDataListPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     StructuredData: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
+    StructuredDataNoComponents: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataJson: lsst.daf.butler.formatters.jsonFormatter.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -12,7 +12,7 @@ storageClasses:
     pytype: dict
   StructuredDataListPickle:
     pytype: list
-  StructuredData: &StructuredData
+  StructuredData:
     # Data from a simple Python class
     pytype: examplePythonTypes.MetricsExample
     assembler: lsst.daf.butler.CompositeAssembler
@@ -23,24 +23,19 @@ storageClasses:
       output: StructuredDataDictYaml
       data: StructuredDataListYaml
   StructuredDataJson:
-    <<: *StructuredData
+    inheritsFrom: StructuredData
   StructuredDataPickle:
-    <<: *StructuredData
-  StructuredComposite: &StructuredComposite
-    pytype: examplePythonTypes.MetricsExample
-    assembler: lsst.daf.butler.CompositeAssembler
-    components:
-      summary: StructuredDataDictYaml
-      output: StructuredDataDictYaml
-      data: StructuredDataListYaml
+    inheritsFrom: StructuredData
+  StructuredComposite:
+    inheritsFrom: StructuredData
   StructuredCompositeTestA:
-    <<: *StructuredComposite
+    inheritsFrom: StructuredComposite
     components:
       summary: StructuredDataDictJson
       output: StructuredDataDictJson
       data: StructuredDataListJson
   StructuredCompositeTestB:
-    <<: *StructuredComposite
+    inheritsFrom: StructuredComposite
     components:
       summary: StructuredDataDictPickle
       output: StructuredDataDictJson

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -12,6 +12,9 @@ storageClasses:
     pytype: dict
   StructuredDataListPickle:
     pytype: list
+  StructuredDataNoComponents:
+    # Reading and writing a blob and no components known
+    pytype: examplePythonTypes.MetricsExample
   StructuredData:
     # Data from a simple Python class
     pytype: examplePythonTypes.MetricsExample

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -45,3 +45,7 @@ storageClasses:
       summary: StructuredDataDictPickle
       output: StructuredDataDictJson
       data: StructuredDataListYaml
+  ExposureCompositeF:
+    inheritsFrom: ExposureF
+  ExposureCompositeI:
+    inheritsFrom: ExposureI

--- a/tests/datasetsHelper.py
+++ b/tests/datasetsHelper.py
@@ -111,5 +111,4 @@ class DatastoreTestHelper:
         config = self.config.copy()
         if sub is not None and self.root is not None:
             self.datastoreType.setConfigRoot(os.path.join(self.root, sub), config, self.config)
-            print(config)
         return self.datastoreType(config=config, registry=self.registry)

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -74,13 +74,19 @@ class ButlerFitsTests(FitsCatalogDatasetsHelper, DatasetTestHelper):
         if self.root is not None and os.path.exists(self.root):
             shutil.rmtree(self.root, ignore_errors=True)
 
-    def testExposureCompositePutGet(self):
+    def testExposureCompositePutGetConcrete(self):
+        storageClass = self.storageClassFactory.getStorageClass("ExposureF")
+        self.runExposureCompositePutGetTest(storageClass, "calexp")
+
+    def testExposureCompositePutGetVirtual(self):
+        storageClass = self.storageClassFactory.getStorageClass("ExposureCompositeF")
+        self.runExposureCompositePutGetTest(storageClass, "unknown")
+
+    def runExposureCompositePutGetTest(self, storageClass, datasetTypeName):
         example = os.path.join(TESTDIR, "data", "basic", "small.fits")
         exposure = lsst.afw.image.ExposureF(example)
         butler = Butler(self.tmpConfigFile)
-        datasetTypeName = "calexp"
         dataUnits = ("Camera", "Visit")
-        storageClass = self.storageClassFactory.getStorageClass("ExposureF")
         self.registerDatasetTypes(datasetTypeName, dataUnits, storageClass, butler.registry)
         dataId = {"visit": 42, "camera": "DummyCam", "physical_filter": "d-r"}
         # Add needed DataUnits
@@ -88,9 +94,9 @@ class ButlerFitsTests(FitsCatalogDatasetsHelper, DatasetTestHelper):
         butler.registry.addDataUnitEntry("PhysicalFilter", {"camera": "DummyCam", "physical_filter": "d-r"})
         butler.registry.addDataUnitEntry("Visit", {"camera": "DummyCam", "visit": 42,
                                                    "physical_filter": "d-r"})
-        butler.put(exposure, "calexp", dataId)
+        butler.put(exposure, datasetTypeName, dataId)
         # Get the full thing
-        full = butler.get("calexp", dataId)  # noqa F841
+        full = butler.get(datasetTypeName, dataId)  # noqa F841
         # TODO enable check for equality (fix for Exposure type)
         # self.assertEqual(full, exposure)
         # Get a component

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -23,7 +23,7 @@ import pickle
 import unittest
 import lsst.utils.tests
 
-import lsst.daf.butler.core.storageClass as storageClass
+from lsst.daf.butler import StorageClass, StorageClassFactory, StorageClassConfig
 
 """Tests related to the StorageClass infrastructure.
 """
@@ -43,73 +43,73 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
 
         This is critical for testing the factory functions."""
         className = "TestImage"
-        sc = storageClass.StorageClass(className, pytype=dict)
-        self.assertIsInstance(sc, storageClass.StorageClass)
+        sc = StorageClass(className, pytype=dict)
+        self.assertIsInstance(sc, StorageClass)
         self.assertEqual(sc.name, className)
         self.assertFalse(sc.components)
         self.assertTrue(sc.validateInstance({}))
         self.assertFalse(sc.validateInstance(""))
 
         # Allow no definition of python type
-        scn = storageClass.StorageClass(className)
+        scn = StorageClass(className)
         self.assertIs(scn.pytype, object)
 
         # Include some components
-        scc = storageClass.StorageClass(className, pytype=PythonType, components={"comp1": sc})
+        scc = StorageClass(className, pytype=PythonType, components={"comp1": sc})
         self.assertIn("comp1", scc.components)
         self.assertIn("comp1", repr(scc))
 
         # Check we can create a storageClass using the name of an importable
         # type.
-        sc2 = storageClass.StorageClass("TestImage2",
-                                        "lsst.daf.butler.core.storageClass.StorageClassFactory")
-        self.assertIsInstance(sc2.pytype(), storageClass.StorageClassFactory)
+        sc2 = StorageClass("TestImage2",
+                           "lsst.daf.butler.core.storageClass.StorageClassFactory")
+        self.assertIsInstance(sc2.pytype(), StorageClassFactory)
         self.assertIn("butler.core", repr(sc2))
 
     def testEquality(self):
         """Test that StorageClass equality works"""
         className = "TestImage"
-        sc1 = storageClass.StorageClass(className, pytype=dict)
-        sc2 = storageClass.StorageClass(className, pytype=dict)
+        sc1 = StorageClass(className, pytype=dict)
+        sc2 = StorageClass(className, pytype=dict)
         self.assertEqual(sc1, sc2)
-        sc3 = storageClass.StorageClass(className + "2", pytype=str)
+        sc3 = StorageClass(className + "2", pytype=str)
         self.assertNotEqual(sc1, sc3)
 
         # Same StorageClass name but different python type
-        sc4 = storageClass.StorageClass(className, pytype=str)
+        sc4 = StorageClass(className, pytype=str)
         self.assertNotEqual(sc1, sc4)
 
         # Now with components
-        sc5 = storageClass.StorageClass("Composite", pytype=PythonType,
-                                        components={"comp1": sc1, "comp2": sc3})
-        sc6 = storageClass.StorageClass("Composite", pytype=PythonType,
-                                        components={"comp1": sc1, "comp2": sc3})
+        sc5 = StorageClass("Composite", pytype=PythonType,
+                           components={"comp1": sc1, "comp2": sc3})
+        sc6 = StorageClass("Composite", pytype=PythonType,
+                           components={"comp1": sc1, "comp2": sc3})
         self.assertEqual(sc5, sc6)
         self.assertNotEqual(sc5, sc3)
-        sc7 = storageClass.StorageClass("Composite", pytype=PythonType,
-                                        components={"comp1": sc4, "comp2": sc3})
+        sc7 = StorageClass("Composite", pytype=PythonType,
+                           components={"comp1": sc4, "comp2": sc3})
         self.assertNotEqual(sc5, sc7)
-        sc8 = storageClass.StorageClass("Composite", pytype=PythonType,
-                                        components={"comp2": sc3})
+        sc8 = StorageClass("Composite", pytype=PythonType,
+                           components={"comp2": sc3})
         self.assertNotEqual(sc5, sc8)
-        sc9 = storageClass.StorageClass("Composite", pytype=PythonType,
-                                        components={"comp2": sc3}, assembler="lsst.daf.butler.Butler")
+        sc9 = StorageClass("Composite", pytype=PythonType,
+                           components={"comp2": sc3}, assembler="lsst.daf.butler.Butler")
         self.assertNotEqual(sc5, sc9)
 
     def testRegistry(self):
         """Check that storage classes can be created on the fly and stored
         in a registry."""
         className = "TestImage"
-        factory = storageClass.StorageClassFactory()
-        newclass = storageClass.StorageClass(className, pytype=PythonType)
+        factory = StorageClassFactory()
+        newclass = StorageClass(className, pytype=PythonType)
         factory.registerStorageClass(newclass)
         sc = factory.getStorageClass(className)
-        self.assertIsInstance(sc, storageClass.StorageClass)
+        self.assertIsInstance(sc, StorageClass)
         self.assertEqual(sc.name, className)
         self.assertFalse(sc.components)
         self.assertEqual(sc.pytype, PythonType)
         self.assertIn(sc, factory)
-        newclass2 = storageClass.StorageClass("Temporary2", pytype=str)
+        newclass2 = StorageClass("Temporary2", pytype=str)
         self.assertNotIn(newclass2, factory)
         factory.registerStorageClass(newclass2)
         self.assertIn(newclass2, factory)
@@ -119,7 +119,7 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
 
         # Make sure we can't register a storage class with the same name
         # but different values
-        newclass3 = storageClass.StorageClass("Temporary2", pytype=dict)
+        newclass3 = StorageClass("Temporary2", pytype=dict)
         with self.assertRaises(ValueError):
             factory.registerStorageClass(newclass3)
 
@@ -137,8 +137,8 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         """Test that we can pickle storageclasses.
         """
         className = "TestImage"
-        sc = storageClass.StorageClass(className, pytype=dict)
-        self.assertIsInstance(sc, storageClass.StorageClass)
+        sc = StorageClass(className, pytype=dict)
+        self.assertIsInstance(sc, StorageClass)
         self.assertEqual(sc.name, className)
         self.assertFalse(sc.components)
         sc2 = pickle.loads(pickle.dumps(sc))

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -159,6 +159,14 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertIn("wcs", exposure.components)
         self.assertIn("wcs", exposureF.components)
 
+        # Check that we can't have a new StorageClass that does not
+        # inherit from StorageClass
+        with self.assertRaises(ValueError):
+            factory.makeNewStorageClass("ClassName", baseClass=StorageClassFactory)
+
+        sc = factory.makeNewStorageClass("ClassName")
+        self.assertIsInstance(sc(), StorageClass)
+
     def testPickle(self):
         """Test that we can pickle storageclasses.
         """

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -23,7 +23,7 @@ import pickle
 import unittest
 import lsst.utils.tests
 
-from lsst.daf.butler import StorageClass, StorageClassFactory, StorageClassConfig
+from lsst.daf.butler import StorageClass, StorageClassFactory, StorageClassConfig, CompositeAssembler
 
 """Tests related to the StorageClass infrastructure.
 """
@@ -50,6 +50,10 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(sc.validateInstance({}))
         self.assertFalse(sc.validateInstance(""))
 
+        # Ensure we do not have an assembler
+        with self.assertRaises(TypeError):
+            sc.assembler()
+
         # Allow no definition of python type
         scn = StorageClass(className)
         self.assertIs(scn.pytype, object)
@@ -58,6 +62,9 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         scc = StorageClass(className, pytype=PythonType, components={"comp1": sc})
         self.assertIn("comp1", scc.components)
         self.assertIn("comp1", repr(scc))
+
+        # Ensure that we have an assembler
+        self.assertIsInstance(scc.assembler(), CompositeAssembler)
 
         # Check we can create a storageClass using the name of an importable
         # type.

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -141,6 +141,17 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(imageF, type(image))
         self.assertNotEqual(imageF, image)
 
+        # Check component inheritance
+        exposure = factory.getStorageClass("Exposure")
+        exposureF = factory.getStorageClass("ExposureF")
+        self.assertIsInstance(exposureF, type(exposure))
+        self.assertIsInstance(exposure.components["image"], type(image))
+        self.assertNotIsInstance(exposure.components["image"], type(imageF))
+        self.assertIsInstance(exposureF.components["image"], type(image))
+        self.assertIsInstance(exposureF.components["image"], type(imageF))
+        self.assertIn("wcs", exposure.components)
+        self.assertIn("wcs", exposureF.components)
+
     def testPickle(self):
         """Test that we can pickle storageclasses.
         """

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -133,6 +133,14 @@ class StorageClassFactoryTestCase(lsst.utils.tests.TestCase):
         # Check you can silently insert something that is already there
         factory.registerStorageClass(newclass3)
 
+    def testFactoryConfig(self):
+        factory = StorageClassFactory()
+        factory.addFromConfig(StorageClassConfig())
+        image = factory.getStorageClass("Image")
+        imageF = factory.getStorageClass("ImageF")
+        self.assertIsInstance(imageF, type(image))
+        self.assertNotEqual(imageF, image)
+
     def testPickle(self):
         """Test that we can pickle storageclasses.
         """


### PR DESCRIPTION
@TallJimbo here's a proof of concept for StorageClass inheritance. I think if I add support for overriding of components (so ExposureF.components.image can override Exposure.components.image -- could check the child `ImageF` is-a `Image` for example) then storage class definitions suddenly become much much simpler since all the Exposure F/I duplication disappears with the only differences being the actual F and I.