### PR TITLE
DM-15561: Allow templates to be retrieved by DatasetRef and other cleanups

### DIFF
--- a/config/composites.yaml
+++ b/config/composites.yaml
@@ -7,7 +7,7 @@ composites:
   # Use a dict rather than a list to allow easy merging of user config
   # into default config. Config class has no way of merging lists.
   # Types can be StorageClass names or DatasetType names
-  names:
+  disassembled:
     ExposureI: False
     ExposureF: False
     calexp: False

--- a/config/composites.yaml
+++ b/config/composites.yaml
@@ -4,12 +4,10 @@ composites:
   # default applies to all composites that are not explicitly mentioned
   # elsewhere.
   default: False
-  storageClasses:
-    # Use a dict rather than a list to allow easy merging of user config
-    # into default config. Config class has no way of merging lists.
+  # Use a dict rather than a list to allow easy merging of user config
+  # into default config. Config class has no way of merging lists.
+  # Types can be StorageClass names or DatasetType names
+  names:
     ExposureI: False
     ExposureF: False
-  datasetTypes:
-    # Same definition as for storage classes, but dataset type explicitly
-    # overrides a storage class definition.
     calexp: False

--- a/config/composites.yaml
+++ b/config/composites.yaml
@@ -6,7 +6,8 @@ composites:
   default: False
   # Use a dict rather than a list to allow easy merging of user config
   # into default config. Config class has no way of merging lists.
-  # Types can be StorageClass names or DatasetType names
+  # Types can be StorageClass names or DatasetType names, with DatasetType
+  # name always taking preference over StorageClass name.
   disassembled:
     ExposureI: False
     ExposureF: False

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -285,7 +285,7 @@ class Butler:
         # if the ref exists in the store we return it directly
         if self.datastore.exists(ref):
             return self.datastore.get(ref, parameters=parameters)
-        elif ref.components:
+        elif ref.isComposite():
             # Reconstruct the composite
             components = {}
             for compName, compRef in ref.components.items():

--- a/python/lsst/daf/butler/core/assembler.py
+++ b/python/lsst/daf/butler/core/assembler.py
@@ -180,7 +180,7 @@ class CompositeAssembler:
             `CompositeAssembler.storageClass`.
         """
         components = {}
-        if self.storageClass is not None and self.storageClass.components:
+        if self.storageClass is not None and self.storageClass.isComposite():
             for c in self.storageClass.components:
                 if isinstance(composite, collections.Mapping):
                     comp = composite[c]

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -95,7 +95,7 @@ class CompositesMap:
         matchName = "{} (via default)".format(entity)
         disassemble = self.config["default"]
 
-        for name in (entity.lookupNames()):
+        for name in (entity._lookupNames()):
             if name is not None and name in self.config["disassembled"]:
                 disassemble = self.config[f"disassembled.{name}"]
                 matchName = name

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -26,8 +26,6 @@ __all__ = ("CompositesConfig", "CompositesMap")
 import logging
 
 from .config import ConfigSubset
-from .datasets import DatasetType, DatasetRef
-from .storageClass import StorageClass
 
 log = logging.getLogger(__name__)
 
@@ -79,31 +77,25 @@ class CompositesMap:
         -------
         disassemble : `bool`
             Returns `True` if disassembly should occur; `False` otherwise.
-        """
-        components = None
-        datasetTypeName = None
-        storageClassName = None
-        if isinstance(entity, DatasetRef):
-            entity = entity.datasetType
-        if isinstance(entity, DatasetType):
-            datasetTypeName = entity.name
-            storageClassName = entity.storageClass.name
-            components = entity.storageClass.components
-        elif isinstance(entity, StorageClass):
-            storageClassName = entity.name
-            components = entity.components
-        else:
-            raise ValueError(f"Unexpected argument: {entity:!r}")
 
-        # We know for a fact this is not a composite
-        if not components:
+        Raises
+        ------
+        ValueError
+            The supplied argument is not understood.
+        """
+
+        if not hasattr(entity, "isComposite"):
+            raise ValueError(f"Supplied entity ({entity}) is not understood.")
+
+        # If this is not a composite there is nothing to disassemble.
+        if not entity.isComposite():
             log.debug("%s will not be disassembled (not a composite)", entity)
             return False
 
         matchName = "{} (via default)".format(entity)
         disassemble = self.config["default"]
 
-        for name in (datasetTypeName, storageClassName):
+        for name in (entity.lookupNames()):
             if name is not None and name in self.config["names"]:
                 disassemble = self.config[f"names.{name}"]
                 matchName = name

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -32,14 +32,14 @@ log = logging.getLogger(__name__)
 
 class CompositesConfig(ConfigSubset):
     component = "composites"
-    requiredKeys = ("default", "names")
+    requiredKeys = ("default", "disassembled")
     defaultConfigFile = "composites.yaml"
 
     def validate(self):
         """Validate entries have the correct type."""
         super().validate()
-        for k in self["names"]:
-            key = f"names.{k}"
+        for k in self["disassembled"]:
+            key = f"disassembled.{k}"
             if not isinstance(self[key], bool):
                 raise ValueError(f"CompositesConfig: Key {key} is not a Boolean")
 
@@ -96,8 +96,8 @@ class CompositesMap:
         disassemble = self.config["default"]
 
         for name in (entity.lookupNames()):
-            if name is not None and name in self.config["names"]:
-                disassemble = self.config[f"names.{name}"]
+            if name is not None and name in self.config["disassembled"]:
+                disassemble = self.config[f"disassembled.{name}"]
                 matchName = name
                 break
 

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -220,7 +220,12 @@ class Config(_ConfigBase):
 
     def __getitem__(self, name):
         data = self.data
-        for key in name.split("."):
+        # Override the split for the simple case
+        if name in data:
+            keys = (name,)
+        else:
+            keys = name.split(".")
+        for key in keys:
             if data is None:
                 return None
             if key in data and isinstance(data, collections.Mapping):

--- a/python/lsst/daf/butler/core/datasets.py
+++ b/python/lsst/daf/butler/core/datasets.py
@@ -148,6 +148,17 @@ class DatasetType:
             return self.nameWithComponent(self.name, component)
         raise KeyError("Requested component ({}) not understood by this DatasetType".format(component))
 
+    def isComposite(self):
+        """Boolean indicating whether this `DatasetType` is a composite type.
+
+        Returns
+        -------
+        isComposite : `bool`
+            `True` if this `DatasetType` is a composite type, `False`
+            otherwise.
+        """
+        return self.storageClass.isComposite()
+
     def lookupNames(self):
         """Names to use when looking up this datasetType in a configuration.
 
@@ -281,6 +292,17 @@ class DatasetRef:
         ref = deepcopy(self)
         ref._id = None
         return ref
+
+    def isComposite(self):
+        """Boolean indicating whether this `DatasetRef` is a composite type.
+
+        Returns
+        -------
+        isComposite : `bool`
+            `True` if this `DatasetRef` is a composite type, `False`
+            otherwise.
+        """
+        return self.datasetType.isComposite()
 
     def lookupNames(self):
         """Names to use when looking up this DatasetRef in a configuration.

--- a/python/lsst/daf/butler/core/datasets.py
+++ b/python/lsst/daf/butler/core/datasets.py
@@ -159,7 +159,7 @@ class DatasetType:
         """
         return self.storageClass.isComposite()
 
-    def lookupNames(self):
+    def _lookupNames(self):
         """Names to use when looking up this datasetType in a configuration.
 
         The names are returned in order of priority.
@@ -169,7 +169,7 @@ class DatasetType:
         names : `tuple` of `str`
             Tuple of the `DatasetType` name and the `StorageClass` name.
         """
-        return (self.name, *self.storageClass.lookupNames())
+        return (self.name, *self.storageClass._lookupNames())
 
 
 class DatasetRef:
@@ -304,7 +304,7 @@ class DatasetRef:
         """
         return self.datasetType.isComposite()
 
-    def lookupNames(self):
+    def _lookupNames(self):
         """Names to use when looking up this DatasetRef in a configuration.
 
         The names are returned in order of priority.
@@ -314,4 +314,4 @@ class DatasetRef:
         names : `tuple` of `str`
             Tuple of the `DatasetType` name and the `StorageClass` name.
         """
-        return self.datasetType.lookupNames()
+        return self.datasetType._lookupNames()

--- a/python/lsst/daf/butler/core/datasets.py
+++ b/python/lsst/daf/butler/core/datasets.py
@@ -148,6 +148,18 @@ class DatasetType:
             return self.nameWithComponent(self.name, component)
         raise KeyError("Requested component ({}) not understood by this DatasetType".format(component))
 
+    def lookupNames(self):
+        """Names to use when looking up this datasetType in a configuration.
+
+        The names are returned in order of priority.
+
+        Returns
+        -------
+        names : `tuple` of `str`
+            Tuple of the `DatasetType` name and the `StorageClass` name.
+        """
+        return (self.name, *self.storageClass.lookupNames())
+
 
 class DatasetRef:
     """Reference to a Dataset in a `Registry`.
@@ -269,3 +281,15 @@ class DatasetRef:
         ref = deepcopy(self)
         ref._id = None
         return ref
+
+    def lookupNames(self):
+        """Names to use when looking up this DatasetRef in a configuration.
+
+        The names are returned in order of priority.
+
+        Returns
+        -------
+        names : `tuple` of `str`
+            Tuple of the `DatasetType` name and the `StorageClass` name.
+        """
+        return self.datasetType.lookupNames()

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -88,7 +88,7 @@ class FileTemplates:
         """
 
         # Get the names to use for lookup
-        names = entity.lookupNames()
+        names = entity._lookupNames()
 
         # Get a location from the templates
         template = None

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -61,13 +61,20 @@ class FileTemplates:
             else:
                 self.templates[name] = FileTemplate(templateStr)
 
-    def getTemplate(self, datasetTypeName):
+    def getTemplate(self, entity):
         """Retrieve the `FileTemplate` associated with the dataset type.
+
+        If the lookup name corresponds to a component the base name for
+        the component will be examined if the full component name does
+        not match.
 
         Parameters
         ----------
-        datasetTypeName : `str`
-            Dataset type name.
+        entity : `DatasetType`, `DatasetRef`, or `StorageClass`
+            Instance to use to look for a corresponding template.
+            A `DatasetType` name or a `StorageClass` name will be used
+            depending on the supplied entity. Priority is given to a
+            `DatasetType` name.
 
         Returns
         -------
@@ -79,23 +86,28 @@ class FileTemplates:
         KeyError
             No template could be located for this Dataset type.
         """
+
+        # Get the names to use for lookup
+        names = entity.lookupNames()
+
         # Get a location from the templates
         template = None
-        component = None
-        if datasetTypeName is not None:
-            if datasetTypeName in self.templates:
-                template = self.templates[datasetTypeName]
-            elif "." in datasetTypeName:
-                baseType, component = datasetTypeName.split(".", maxsplit=1)
+        for name in names:
+            if name in self.templates:
+                template = self.templates[name]
+            elif "." in name:
+                baseType, component = name.split(".", maxsplit=1)
                 if baseType in self.templates:
                     template = self.templates[baseType]
+            if template is not None:
+                break
 
         if template is None and self.default is not None:
             template = self.default
 
         # if still not template give up for now.
         if template is None:
-            raise KeyError(f"Unable to determine file template from supplied type [{datasetTypeName}]")
+            raise KeyError(f"Unable to determine file template from supplied argument [{entity}]")
 
         return template
 

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -95,18 +95,21 @@ class FormatterFactory:
     def __init__(self):
         self._mappingFactory = MappingFactory(Formatter)
 
-    def getFormatter(self, storageClass, datasetType=None):
+    def getFormatter(self, entity):
         """Get a new formatter instance.
 
         Parameters
         ----------
-        storageClass : `StorageClass`
-            Get `Formatter` associated with this `StorageClass`, unless.
-        datasetType : `DatasetType` or `str`, optional
-            If given, look if an override has been specified for this
-            `DatasetType` and, if so return that instead.
+        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+            Entity to use to determine the formatter to return.
+            `StorageClass` will be used as a last resort if `DatasetRef`
+            or `DatasetType` instance is provided.
         """
-        return self._mappingFactory.getFromRegistry(datasetType, storageClass)
+        if isinstance(entity, str):
+            names = (entity,)
+        else:
+            names = entity.lookupNames()
+        return self._mappingFactory.getFromRegistry(*names)
 
     def registerFormatter(self, type_, formatter):
         """Register a `Formatter`.

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -108,7 +108,7 @@ class FormatterFactory:
         if isinstance(entity, str):
             names = (entity,)
         else:
-            names = entity.lookupNames()
+            names = entity._lookupNames()
         return self._mappingFactory.getFromRegistry(*names)
 
     def registerFormatter(self, type_, formatter):

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -157,7 +157,7 @@ class StorageClass:
             return True
         return False
 
-    def lookupNames(self):
+    def _lookupNames(self):
         """Names to use when looking up this DatasetRef in a configuration.
 
         The names are returned in order of priority.

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -143,6 +143,20 @@ class StorageClass:
             raise TypeError(f"No assembler class is associated with StorageClass {self.name}")
         return cls(storageClass=self)
 
+    def isComposite(self):
+        """Boolean indicating whether this `StorageClass` is a composite
+        or not.
+
+        Returns
+        -------
+        isComposite : `bool`
+            `True` if this `StorageClass` is a composite, `False`
+            otherwise.
+        """
+        if self.components:
+            return True
+        return False
+
     def lookupNames(self):
         """Names to use when looking up this DatasetRef in a configuration.
 

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -143,6 +143,18 @@ class StorageClass:
             raise TypeError(f"No assembler class is associated with StorageClass {self.name}")
         return cls(storageClass=self)
 
+    def lookupNames(self):
+        """Names to use when looking up this DatasetRef in a configuration.
+
+        The names are returned in order of priority.
+
+        Returns
+        -------
+        names : `tuple` of `str`
+            Tuple of solely the `StorageClass` name.
+        """
+        return (self.name, )
+
     def validateInstance(self, instance):
         """Check that the supplied Python object has the expected Python type
 

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -321,9 +321,9 @@ class PosixDatastore(Datastore):
 
         # Work out output file name
         try:
-            template = self.templates.getTemplate(typeName)
+            template = self.templates.getTemplate(datasetType)
         except KeyError as e:
-            raise DatasetTypeNotSupportedError(f"Unable to find template for {typeName}") from e
+            raise DatasetTypeNotSupportedError(f"Unable to find template for {datasetType}") from e
 
         location = self.locationFactory.fromPath(template.format(ref))
 
@@ -406,7 +406,7 @@ class PosixDatastore(Datastore):
                     raise RuntimeError("'{}' is not inside repository root '{}'".format(path, self.root))
                 path = os.path.relpath(path, absRoot)
         else:
-            template = self.templates.getTemplate(ref.datasetType.name)
+            template = self.templates.getTemplate(ref)
             location = self.locationFactory.fromPath(template.format(ref))
             newPath = formatter.predictPath(location)
             newFullPath = os.path.join(self.root, newPath)
@@ -487,9 +487,7 @@ class PosixDatastore(Datastore):
             if not predict:
                 raise FileNotFoundError("Dataset {} not in this datastore".format(ref))
 
-            datasetType = ref.datasetType
-            typeName = datasetType.name
-            template = self.templates.getTemplate(typeName)
+            template = self.templates.getTemplate(ref)
             location = self.locationFactory.fromPath(template.format(ref) + "#predicted")
         else:
             # If this is a ref that we have written we can get the path.

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -329,7 +329,7 @@ class PosixDatastore(Datastore):
 
         # Get the formatter based on the storage class
         try:
-            formatter = self.formatterFactory.getFormatter(datasetType.storageClass, typeName)
+            formatter = self.formatterFactory.getFormatter(datasetType)
         except KeyError as e:
             raise DatasetTypeNotSupportedError("Unable to find formatter for StorageClass "
                                                f"{datasetType.storageClass.name} or "
@@ -390,8 +390,7 @@ class PosixDatastore(Datastore):
             location computed from the template.
         """
         if formatter is None:
-            formatter = self.formatterFactory.getFormatter(ref.datasetType.storageClass,
-                                                           ref.datasetType.name)
+            formatter = self.formatterFactory.getFormatter(ref)
 
         fullPath = os.path.join(self.root, path)
         if not os.path.exists(fullPath):

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -95,7 +95,7 @@ class YamlFormatter(FileFormatter):
             Object of expected type `pytype`.
         """
         if not hasattr(builtins, pytype.__name__):
-            if storageClass.components:
+            if storageClass.isComposite():
                 inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
             else:
                 # Hope that we can pass the arguments in directly

--- a/tests/config/basic/composites-bad.yaml
+++ b/tests/config/basic/composites-bad.yaml
@@ -1,5 +1,5 @@
 composites:
-  names:
+  disassembled:
     # This will fail since a str is not a bool
     StructuredData: "False"
     StructuredDataJson: False

--- a/tests/config/basic/composites-bad.yaml
+++ b/tests/config/basic/composites-bad.yaml
@@ -1,5 +1,5 @@
 composites:
-  storageClasses:
+  names:
     # This will fail since a str is not a bool
     StructuredData: "False"
     StructuredDataJson: False
@@ -7,5 +7,4 @@ composites:
     StructuredComposite: True
     StructuredCompositeTestA: True
     StructuredCompositeTestB: True
-  datasetTypes:
     dummyTest: True

--- a/tests/config/basic/composites.yaml
+++ b/tests/config/basic/composites.yaml
@@ -1,5 +1,5 @@
 composites:
-  storageClasses:
+  names:
     StructuredData: False
     StructuredDataJson: False
     StructuredDataPickle: False
@@ -8,6 +8,5 @@ composites:
     StructuredCompositeTestB: True
     ExposureCompositeI: True
     ExposureCompositeF: True
-  datasetTypes:
     dummyTrue: True
     dummyFalse: False

--- a/tests/config/basic/composites.yaml
+++ b/tests/config/basic/composites.yaml
@@ -1,5 +1,5 @@
 composites:
-  names:
+  disassembled:
     StructuredData: False
     StructuredDataJson: False
     StructuredDataPickle: False

--- a/tests/config/templates/templates-nodefault.yaml
+++ b/tests/config/templates/templates-nodefault.yaml
@@ -1,3 +1,4 @@
 # This file disables defaulting
 default: False
 calexp: "{datasetType}.{component:?}/{datasetType}_v{visit}_f{filter:?}_{component:?}"
+StorageClassX: "StorageClass/{datasetType}"

--- a/tests/config/templates/templates-nodefault.yaml
+++ b/tests/config/templates/templates-nodefault.yaml
@@ -1,4 +1,5 @@
 # This file disables defaulting
 default: False
 calexp: "{datasetType}.{component:?}/{datasetType}_v{visit}_f{filter:?}_{component:?}"
+calexp.wcs: "{datasetType}.{component}-a-wcs-{visit}-{filter}"
 StorageClassX: "StorageClass/{datasetType}"

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -42,16 +42,15 @@ class TestCompositesConfig(unittest.TestCase):
         c = CompositesConfig(self.configFile)
         self.assertIn("default", c)
         # Check merging has worked
-        self.assertIn("datasetTypes.calexp", c)
-        self.assertIn("datasetTypes.dummyTrue", c)
-        self.assertIn("storageClasses.StructuredComposite", c)
-        self.assertIn("storageClasses.ExposureF", c)
+        self.assertIn("names.calexp", c)
+        self.assertIn("names.dummyTrue", c)
+        self.assertIn("names.StructuredComposite", c)
+        self.assertIn("names.ExposureF", c)
 
         # Check that all entries are booleans (this is meant to be enforced
         # internally)
-        for n in ("storageClasses", "datasetTypes"):
-            for k in c[n]:
-                self.assertIsInstance(c[f"{n}.{k}"], bool, f"Testing {n}.{k}")
+        for k in c["names"]:
+            self.assertIsInstance(c[f"names.{k}"], bool, f"Testing names.{k}")
 
     def testMap(self):
         c = CompositesMap(self.configFile)

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -62,6 +62,8 @@ class TestCompositesConfig(unittest.TestCase):
         # These will fail (not a composite)
         sc = StorageClass("StructuredDataJson")
         d = DatasetType("dummyTrue", ("a", "b"), sc)
+        self.assertFalse(sc.isComposite())
+        self.assertFalse(d.isComposite())
         self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
         self.assertFalse(c.doDisassembly(sc), f"Test with StorageClass: {sc}")
 
@@ -69,6 +71,8 @@ class TestCompositesConfig(unittest.TestCase):
         sccomp = StorageClass("Dummy")
         sc = StorageClass("StructuredDataJson", components={"dummy": sccomp})
         d = DatasetType("dummyTrue", ("a", "b"), sc)
+        self.assertTrue(sc.isComposite())
+        self.assertTrue(d.isComposite())
         self.assertTrue(c.doDisassembly(d), f"Test with DatasetType: {d}")
         self.assertFalse(c.doDisassembly(sc), f"Test with StorageClass: {sc}")
 

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -42,15 +42,16 @@ class TestCompositesConfig(unittest.TestCase):
         c = CompositesConfig(self.configFile)
         self.assertIn("default", c)
         # Check merging has worked
-        self.assertIn("names.calexp", c)
-        self.assertIn("names.dummyTrue", c)
-        self.assertIn("names.StructuredComposite", c)
-        self.assertIn("names.ExposureF", c)
+        rootKey = "disassembled"
+        self.assertIn(f"{rootKey}.calexp", c)
+        self.assertIn(f"{rootKey}.dummyTrue", c)
+        self.assertIn(f"{rootKey}.StructuredComposite", c)
+        self.assertIn(f"{rootKey}.ExposureF", c)
 
         # Check that all entries are booleans (this is meant to be enforced
         # internally)
-        for k in c["names"]:
-            self.assertIsInstance(c[f"names.{k}"], bool, f"Testing names.{k}")
+        for k in c[rootKey]:
+            self.assertIsInstance(c[f"{rootKey}.{k}"], bool, f"Testing {rootKey}.{k}")
 
     def testMap(self):
         c = CompositesMap(self.configFile)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -33,13 +33,13 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 class TestFileTemplates(unittest.TestCase):
     """Test creation of paths from templates."""
 
-    def makeDatasetRef(self, datasetTypeName, dataId=None):
+    def makeDatasetRef(self, datasetTypeName, dataId=None, storageClassName="DefaultStorageClass"):
         """Make a simple DatasetRef"""
         if dataId is None:
             dataId = self.dataId
         if datasetTypeName not in self.datasetTypes:
             self.datasetTypes[datasetTypeName] = DatasetType(datasetTypeName, list(dataId.keys()),
-                                                             StorageClass(None))
+                                                             StorageClass(storageClassName))
         datasetType = self.datasetTypes[datasetTypeName]
         return DatasetRef(datasetType, dataId, run=Run(id=2, collection="run2"))
 
@@ -122,18 +122,24 @@ class TestFileTemplates(unittest.TestCase):
         config1 = FileTemplatesConfig(os.path.join(configRoot, "templates-nodefault.yaml"))
         templates = FileTemplates(config1)
         ref = self.makeDatasetRef("calexp")
-        tmpl = templates.getTemplate(ref.datasetType.name)
+        tmpl = templates.getTemplate(ref)
         self.assertIsInstance(tmpl, FileTemplate)
 
         # This config file should not allow defaulting
         ref2 = self.makeDatasetRef("unknown")
         with self.assertRaises(KeyError):
-            templates.getTemplate(ref2.datasetType.name)
+            templates.getTemplate(ref2)
+
+        # This should fall through the datasetTypeName check and use
+        # StorageClass instead
+        ref3 = self.makeDatasetRef("unknown2", storageClassName="StorageClassX")
+        tmpl = templates.getTemplate(ref3)
+        self.assertIsInstance(tmpl, FileTemplate)
 
         # Format config file with defaulting
         config2 = FileTemplatesConfig(os.path.join(configRoot, "templates-withdefault.yaml"))
         templates = FileTemplates(config2)
-        tmpl = templates.getTemplate(ref2.datasetType.name)
+        tmpl = templates.getTemplate(ref2)
         self.assertIsInstance(tmpl, FileTemplate)
 
         # Format config file with bad format string
@@ -144,12 +150,12 @@ class TestFileTemplates(unittest.TestCase):
         config3 = os.path.join(configRoot, "templates-nodefault2.yaml")
         templates = FileTemplates(config3)
         with self.assertRaises(KeyError):
-            templates.getTemplate(ref2.datasetType.name)
+            templates.getTemplate(ref2)
 
         # Try again but specify a default in the constructor
         default = "{datasetType}/{filter}"
         templates = FileTemplates(config3, default=default)
-        tmpl = templates.getTemplate(ref2.datasetType.name)
+        tmpl = templates.getTemplate(ref2)
         self.assertEqual(tmpl.template, default)
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -136,6 +136,18 @@ class TestFileTemplates(unittest.TestCase):
         tmpl = templates.getTemplate(ref3)
         self.assertIsInstance(tmpl, FileTemplate)
 
+        # Try with a component: one with defined formatter and one without
+        ref_wcs = self.makeDatasetRef("calexp.wcs")
+        ref_image = self.makeDatasetRef("calexp.image")
+        tmpl_calexp = templates.getTemplate(ref)
+        tmpl_wcs = templates.getTemplate(ref_wcs)  # Should be special
+        tmpl_image = templates.getTemplate(ref_image)
+        self.assertIsInstance(tmpl_calexp, FileTemplate)
+        self.assertIsInstance(tmpl_image, FileTemplate)
+        self.assertIsInstance(tmpl_wcs, FileTemplate)
+        self.assertEqual(tmpl_calexp, tmpl_image)
+        self.assertNotEqual(tmpl_calexp, tmpl_wcs)
+
         # Format config file with defaulting
         config2 = FileTemplatesConfig(os.path.join(configRoot, "templates-withdefault.yaml"))
         templates = FileTemplates(config2)


### PR DESCRIPTION
* Use DatasetRef, DatasetType or StorageClass to retrieve a file template.
* Use same "give me names" code for formatter retrieval.
* Remove storageClass and datasetType distinction from composites configruation.