### PR TITLE
DM-15377: More robust parameter handling

### DIFF
--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -57,6 +57,9 @@ storageClasses:
   Exposure:
     pytype: lsst.afw.image.Exposure
     assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
+    parameters:
+      - bbox
+      - origin
     components:
       image: Image
       mask: Mask

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -21,6 +21,10 @@ storageClasses:
     pytype: lsst.afw.image.TransmissionCurve
   Image: &Image
     pytype: lsst.afw.image.Image
+    assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
+    parameters:
+      - bbox
+      - origin
   ImageF:
     inheritsFrom: Image
     pytype: lsst.afw.image.ImageF
@@ -37,6 +41,10 @@ storageClasses:
     pytype: lsst.afw.image.DecoratedImageU
   Mask:
     pytype: lsst.afw.image.Mask
+    assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
+    parameters:
+      - bbox
+      - origin
   MaskX:
     inheritsFrom: Mask
     pytype: lsst.afw.image.MaskX

--- a/python/lsst/daf/butler/assemblers/exposureAssembler.py
+++ b/python/lsst/daf/butler/assemblers/exposureAssembler.py
@@ -226,3 +226,31 @@ class ExposureAssembler(CompositeAssembler):
                              " {}".format(list(components.keys())))
 
         return exposure
+
+    def handleParameters(self, inMemoryDataset, parameters=None):
+        """Modify the in-memory dataset using the supplied parameters,
+        returning a possibly new object.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to modify based on the parameters.
+        parameters : `dict`, optional
+            Parameters to apply. Values are specific to the parameter.
+            Supported parameters are defined in the associated
+            `StorageClass`.  If no relevant parameters are specified the
+            inMemoryDataset will be return unchanged.
+
+        Returns
+        -------
+        inMemoryDataset : `object`
+            Updated form of supplied in-memory dataset, after parameters
+            have been used.
+        """
+        # Understood by *this* subset command
+        understood = ("bbox", "origin")
+        use = self.storageClass.filterParameters(parameters, subset=understood)
+        if use:
+            inMemoryDataset = inMemoryDataset.subset(**use)
+
+        return inMemoryDataset

--- a/python/lsst/daf/butler/core/assembler.py
+++ b/python/lsst/daf/butler/core/assembler.py
@@ -314,6 +314,11 @@ class CompositeAssembler:
         """Modify the in-memory dataset using the supplied parameters,
         returning a possibly new object.
 
+        For safety, if any parameters are given to this method an
+        exception will be raised.  This is to protect the user from
+        thinking that parameters have been applied when they have not been
+        applied.
+
         Parameters
         ----------
         inMemoryDataset : `object`
@@ -329,5 +334,13 @@ class CompositeAssembler:
         inMemoryDataset : `object`
             Updated form of supplied in-memory dataset, after parameters
             have been used.
+
+        Raises
+        ------
+        ValueError
+            Parameters have been provided to this default implementation.
         """
+        if parameters:
+            raise ValueError(f"Parameters ({parameters}) provided to default implementation.")
+
         return inMemoryDataset

--- a/python/lsst/daf/butler/core/assembler.py
+++ b/python/lsst/daf/butler/core/assembler.py
@@ -309,3 +309,25 @@ class CompositeAssembler:
             raise ValueError("Unhandled components during disassembly ({})".format(requested))
 
         return components
+
+    def handleParameters(self, inMemoryDataset, parameters=None):
+        """Modify the in-memory dataset using the supplied parameters,
+        returning a possibly new object.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to modify based on the parameters.
+        parameters : `dict`
+            Parameters to apply. Values are specific to the parameter.
+            Supported parameters are defined in the associated
+            `StorageClass`.  If no relevant parameters are specified the
+            inMemoryDataset will be return unchanged.
+
+        Returns
+        -------
+        inMemoryDataset : `object`
+            Updated form of supplied in-memory dataset, after parameters
+            have been used.
+        """
+        return inMemoryDataset

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -49,24 +49,29 @@ class StorageClass:
         Python type (or name of type) to associate with the `StorageClass`
     components : `dict`, optional
         `dict` mapping name of a component to another `StorageClass`.
+    parameters : `~collections.abc.Sequence` or `~collections.abc.Set`
+        Parameters understood by this `StorageClass`.
     assembler : `str`, optional
         Fully qualified name of class supporting assembly and disassembly
         of a `pytype` instance.
     """
     _cls_name = "BaseStorageClass"
     _cls_components = None
+    _cls_parameters = None
     _cls_assembler = None
     _cls_pytype = None
     defaultAssembler = CompositeAssembler
     defaultAssemblerName = getFullTypeName(defaultAssembler)
 
-    def __init__(self, name=None, pytype=None, components=None, assembler=None):
+    def __init__(self, name=None, pytype=None, components=None, parameters=None, assembler=None):
         if name is None:
             name = self._cls_name
         if pytype is None:
             pytype = self._cls_pytype
         if components is None:
             components = self._cls_components
+        if parameters is None:
+            parameters = self._cls_parameters
         if assembler is None:
             assembler = self._cls_assembler
         self.name = name
@@ -75,6 +80,7 @@ class StorageClass:
             self._pytypeName = "object"
             self._pytype = object
         self._components = components if components is not None else {}
+        self._parameters = frozenset(parameters) if parameters is not None else frozenset()
         # if the assembler is not None also set it and clear the default
         # assembler
         if assembler is not None:
@@ -97,6 +103,12 @@ class StorageClass:
         """Component names mapped to associated `StorageClass`
         """
         return self._components
+
+    @property
+    def parameters(self):
+        """`set` of names of parameters supported by this `StorageClass`
+        """
+        return set(self._parameters)
 
     @property
     def pytype(self):
@@ -169,6 +181,40 @@ class StorageClass:
         """
         return (self.name, )
 
+    def validateParameters(self, parameters=None):
+        """Check that the parameters are known to this StorageClass
+
+        Does not check the values.
+
+        Parameters
+        ----------
+        parameters : `dict`, optional
+            Collection containing the parameters. Can be `dict`-like or
+            `set`-like.  The parameter values are not checked.
+            If no parameters are defined, always returns without error.
+
+        Raises
+        ------
+        KeyError
+            Some parameters are not understood by this `StorageClass`.
+        """
+        if parameters is None:
+            return
+
+        # Extract the important information into a set. Works for dict and
+        # list.
+        external = {p for p in parameters}
+
+        # no parameters is always okay.
+        if not external:
+            return
+
+        diff = external - self._parameters
+        if diff:
+            s = "s" if len(diff) > 1 else ""
+            unknown = '\', \''.join(diff)
+            raise KeyError(f"Parameter{s} '{unknown}' not understood by StorageClass {self.name}")
+
     def validateInstance(self, instance):
         """Check that the supplied Python object has the expected Python type
 
@@ -204,6 +250,10 @@ class StorageClass:
         if set(self.components.keys()) != set(other.components.keys()):
             return False
 
+        # Same parameters
+        if self.parameters != other.parameters:
+            return False
+
         # Ensure that all the components have the same type
         for k in self.components:
             if self.components[k] != other.components[k]:
@@ -216,11 +266,13 @@ class StorageClass:
         return hash(self.name)
 
     def __repr__(self):
-        return "{}({}, pytype={}, assembler={}, components={})".format(type(self).__qualname__,
-                                                                       self.name,
-                                                                       self._pytypeName,
-                                                                       self._assemblerClassName,
-                                                                       list(self.components.keys()))
+        return "{}({}, pytype={}, assembler={}, components={}," \
+            " parameters={})".format(type(self).__qualname__,
+                                     self.name,
+                                     self._pytypeName,
+                                     self._assemblerClassName,
+                                     list(self.components.keys()),
+                                     self._parameters)
 
 
 class StorageClassFactory(metaclass=Singleton):
@@ -309,7 +361,7 @@ class StorageClassFactory(metaclass=Singleton):
                     components[cname] = self.getStorageClass(ctype)
 
             # Extract scalar items from dict that are needed for StorageClass Constructor
-            storageClassKwargs = {k: info[k] for k in ("pytype", "assembler") if k in info}
+            storageClassKwargs = {k: info[k] for k in ("pytype", "assembler", "parameters") if k in info}
 
             # Fill in other items
             storageClassKwargs["components"] = components
@@ -357,18 +409,28 @@ class StorageClassFactory(metaclass=Singleton):
         clsargs = {f"_cls_{k}": v for k, v in kwargs.items() if v is not None}
         clsargs["_cls_name"] = name
 
-        # Components are a special case because we want to be able to
-        # combine components here with components in the parent
-        # so the parent can define a component of class Image but the child
-        # can override with ImageF.
-        compKey = "_cls_components"
-        if compKey in clsargs:
-            components = getattr(baseClass, compKey, None)
-            if components is not None:
-                components = components.copy()
-                # Merge with the supplied values
-                components.update(clsargs[compKey])
-                clsargs[compKey] = components
+        # Some container items need to merge with the base class values
+        # so that a child can inherit but override one bit.
+        # lists (which you get from configs) are treated as sets for this to
+        # work consistently.
+        for k in ("components", "parameters"):
+            classKey = f"_cls_{k}"
+            if classKey in clsargs:
+                baseValue = getattr(baseClass, classKey, None)
+                if baseValue is not None:
+                    currentValue = clsargs[classKey]
+                    if isinstance(currentValue, dict):
+                        newValue = baseValue.copy()
+                    else:
+                        newValue = set(baseValue)
+                    newValue.update(currentValue)
+                    clsargs[classKey] = newValue
+
+        # If we have parameters they should be a frozen set so that the
+        # parameters in the class can not be modified.
+        pk = f"_cls_parameters"
+        if pk in clsargs:
+            clsargs[pk] = frozenset(clsargs[pk])
 
         return type(f"StorageClass{name}", (baseClass,), clsargs)
 

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -256,6 +256,9 @@ class InMemoryDatastore(Datastore):
         storedItemInfo = self.getStoredItemInfo(ref)
         writeStorageClass = storedItemInfo.storageClass
 
+        # Check that the supplied parameters are suitable for the type read
+        readStorageClass.validateParameters(parameters)
+
         # We might need a parent if we are being asked for a component
         # of a concrete composite
         thisID = ref.id

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -245,7 +245,7 @@ class InMemoryDatastore(Datastore):
             Formatter failed to process the dataset.
         """
 
-        log.debug("Retrieve %s from %s", ref, self.name)
+        log.debug("Retrieve %s from %s with parameters %s", ref, self.name, parameters)
 
         if not self.exists(ref):
             raise FileNotFoundError("Could not retrieve Dataset {}".format(ref))
@@ -278,6 +278,10 @@ class InMemoryDatastore(Datastore):
 
             # Concrete composite written as a single object (we hope)
             inMemoryDataset = writeStorageClass.assembler().getComponent(inMemoryDataset, component)
+
+        # Handle parameters
+        if parameters:
+            inMemoryDataset = readStorageClass.assembler().handleParameters(inMemoryDataset, parameters)
 
         # Validate the returned data type matches the expected data type
         pytype = readStorageClass.pytype

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -273,6 +273,9 @@ class PosixDatastore(Datastore):
         readStorageClass = ref.datasetType.storageClass
         writeStorageClass = storedFileInfo.storageClass
 
+        # Check that the supplied parameters are suitable for the type read
+        readStorageClass.validateParameters(parameters)
+
         # Is this a component request?
         component = ref.datasetType.component()
 

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -248,6 +248,8 @@ class PosixDatastore(Datastore):
             Formatter failed to process the dataset.
         """
 
+        log.debug("Retrieve %s from %s with parameters %s", ref, self.name, parameters)
+
         # Get file metadata and internal metadata
         try:
             storedFileInfo = self.getStoredFileInfo(ref)
@@ -280,12 +282,17 @@ class PosixDatastore(Datastore):
         component = ref.datasetType.component()
 
         formatter = getInstanceOf(storedFileInfo.formatter)
+        formatterParams, assemblerParams = formatter.segregateParameters(parameters)
         try:
             result = formatter.read(FileDescriptor(location, readStorageClass=readStorageClass,
                                                    storageClass=writeStorageClass, parameters=parameters),
                                     component=component)
         except Exception as e:
             raise ValueError("Failure from formatter for Dataset {}: {}".format(ref.id, e))
+
+        # Process any left over parameters
+        if parameters:
+            result = readStorageClass.assembler().handleParameters(result, assemblerParams)
 
         # Validate the returned data type matches the expected data type
         pytype = readStorageClass.pytype

--- a/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
@@ -31,8 +31,6 @@ class FitsExposureFormatter(Formatter):
     """
     extension = ".fits"
 
-    parameters = frozenset(("bbox", "origin"))
-
     def readImageComponent(self, fileDescriptor, component):
         """Read the image, mask, or variance component of an Exposure.
 
@@ -132,8 +130,7 @@ class FitsExposureFormatter(Formatter):
             parameters = fileDescriptor.parameters
         if parameters is None:
             parameters = {}
-        if not self.parameters.issuperset(parameters.keys()):
-            raise KeyError("Unrecognized parameter key(s): {}".format(parameters.keys() - self.parameters))
+        fileDescriptor.storageClass.validateParameters(parameters)
         return fileDescriptor.storageClass.pytype(fileDescriptor.location.path, **parameters)
 
     def read(self, fileDescriptor, component=None):

--- a/python/lsst/daf/butler/formatters/jsonFormatter.py
+++ b/python/lsst/daf/butler/formatters/jsonFormatter.py
@@ -32,6 +32,9 @@ class JsonFormatter(FileFormatter):
     """
     extension = ".json"
 
+    unsupportedParameters = None
+    """This formatter does not support any parameters"""
+
     def _readFile(self, path, pytype=None):
         """Read a file from the path in JSON format.
 

--- a/python/lsst/daf/butler/formatters/pickleFormatter.py
+++ b/python/lsst/daf/butler/formatters/pickleFormatter.py
@@ -34,6 +34,9 @@ class PickleFormatter(FileFormatter):
     """
     extension = ".pickle"
 
+    unsupportedParameters = None
+    """This formatter does not support any parameters"""
+
     def _readFile(self, path, pytype=None):
         """Read a file from the path in pickle format.
 

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -32,6 +32,9 @@ class YamlFormatter(FileFormatter):
     """
     extension = ".yaml"
 
+    unsupportedParameters = None
+    """This formatter does not support any parameters"""
+
     def _readFile(self, path, pytype=None):
         """Read a file from the path in YAML format.
 

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -18,3 +18,4 @@ datastore:
     StructuredDataJson: lsst.daf.butler.formatters.jsonFormatter.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
+    ThingOne: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -20,3 +20,4 @@ datastore:
     StructuredDataJson: lsst.daf.butler.formatters.jsonFormatter.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
+    ThingOne: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -4,6 +4,9 @@ storageClasses:
     pytype: dict
   StructuredDataListYaml:
     pytype: list
+    assembler: examplePythonTypes.ListAssembler
+    parameters:
+      - slice
   StructuredDataDictJson:
     pytype: dict
   StructuredDataListJson:
@@ -15,10 +18,13 @@ storageClasses:
   StructuredDataNoComponents:
     # Reading and writing a blob and no components known
     pytype: examplePythonTypes.MetricsExample
+    assembler: examplePythonTypes.MetricsAssembler
+    parameters:
+      - slice
   StructuredData:
     # Data from a simple Python class
     pytype: examplePythonTypes.MetricsExample
-    assembler: lsst.daf.butler.CompositeAssembler
+    assembler: examplePythonTypes.MetricsAssembler
     # Use YAML formatter by default
     components:
       # Components are those supported by get.

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -47,3 +47,12 @@ storageClasses:
     inheritsFrom: ExposureF
   ExposureCompositeI:
     inheritsFrom: ExposureI
+  ThingOne:
+    pytype: dict
+    parameters:
+      - param1
+      - param2
+  ThingTwo:
+    inheritsFrom: ThingOne
+    parameters:
+      - param3

--- a/tests/examplePythonTypes.py
+++ b/tests/examplePythonTypes.py
@@ -25,6 +25,9 @@ large external dependencies on python classes such as afw or serialization
 formats such as FITS or HDF5.
 """
 
+import copy
+from lsst.daf.butler import CompositeAssembler
+
 
 class MetricsExample:
     """Smorgasboard of information that might be the result of some
@@ -89,3 +92,63 @@ class MetricsExample:
         if "data" in exportDict:
             data = exportDict["data"]
         return cls(exportDict["summary"], exportDict["output"], data)
+
+
+class ListAssembler(CompositeAssembler):
+    """Parameter handler for list parameters"""
+
+    def handleParameters(self, inMemoryDataset, parameters=None):
+        """Modify the in-memory dataset using the supplied parameters,
+        returning a possibly new object.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to modify based on the parameters.
+        parameters : `dict`
+            Parameters to apply. Values are specific to the parameter.
+            Supported parameters are defined in the associated
+            `StorageClass`.  If no relevant parameters are specified the
+            inMemoryDataset will be return unchanged.
+
+        Returns
+        -------
+        inMemoryDataset : `object`
+            Updated form of supplied in-memory dataset, after parameters
+            have been used.
+        """
+        inMemoryDataset = copy.deepcopy(inMemoryDataset)
+        use = self.storageClass.filterParameters(parameters, subset={"slice"})
+        if use:
+            inMemoryDataset = inMemoryDataset[use["slice"]]
+        return inMemoryDataset
+
+
+class MetricsAssembler(CompositeAssembler):
+    """Parameter handler for parameters using Metrics"""
+
+    def handleParameters(self, inMemoryDataset, parameters=None):
+        """Modify the in-memory dataset using the supplied parameters,
+        returning a possibly new object.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to modify based on the parameters.
+        parameters : `dict`
+            Parameters to apply. Values are specific to the parameter.
+            Supported parameters are defined in the associated
+            `StorageClass`.  If no relevant parameters are specified the
+            inMemoryDataset will be return unchanged.
+
+        Returns
+        -------
+        inMemoryDataset : `object`
+            Updated form of supplied in-memory dataset, after parameters
+            have been used.
+        """
+        inMemoryDataset = copy.deepcopy(inMemoryDataset)
+        use = self.storageClass.filterParameters(parameters, subset={"slice"})
+        if use:
+            inMemoryDataset.data = inMemoryDataset.data[use["slice"]]
+        return inMemoryDataset

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -33,6 +33,8 @@ from datasetsHelper import FitsCatalogDatasetsHelper, DatasetTestHelper
 
 try:
     import lsst.afw.image
+    from lsst.afw.image import LOCAL
+    from lsst.geom import Box2I, Point2I
 except ImportError:
     lsst.afw.image = None
 
@@ -112,6 +114,13 @@ class ButlerFitsTests(FitsCatalogDatasetsHelper, DatasetTestHelper):
         bbox = lsst.afw.geom.Box2I(lsst.afw.geom.Point2I(0, 0),
                                    lsst.afw.geom.Extent2I(9, 9))
         self.assertWcsAlmostEqualOverBBox(compsRead["wcs"], exposure.getWcs(), bbox)
+
+        # With parameters
+        inBBox = Box2I(minimum=Point2I(0, 0), maximum=Point2I(3, 3))
+        parameters = dict(bbox=inBBox, origin=LOCAL)
+        subset = butler.get(datasetTypeName, dataId, parameters=parameters)
+        outBBox = subset.getBBox()
+        self.assertEqual(inBBox, outBBox)
 
 
 class PosixDatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -95,6 +95,20 @@ class DatastoreTests(DatasetTestHelper, DatastoreTestHelper):
         self.assertIsNotNone(datastore)
         self.assertIs(datastore.isEphemeral, self.isEphemeral)
 
+    def testParameterValidation(self):
+        """Check that parameters are validated"""
+        sc = self.storageClassFactory.getStorageClass("ThingOne")
+        dataUnits = frozenset(("visit", "filter"))
+        dataId = {"visit": 52, "filter": "V"}
+        ref = self.makeDatasetRef("metric", dataUnits, sc, dataId)
+        datastore = self.makeDatastore()
+        data = {1: 2, 3: 4}
+        datastore.put(data, ref)
+        newdata = datastore.get(ref)
+        self.assertEqual(data, newdata)
+        with self.assertRaises(KeyError):
+            newdata = datastore.get(ref, parameters={"missing": 5})
+
     def testBasicPutGet(self):
         metrics = makeExampleMetrics()
         datastore = self.makeDatastore()


### PR DESCRIPTION
* Parameters must be defined in a storage class
* Parameters for virtual composites are forwarded to the component
* Parameters are handled by InMemoryDatastore via assemblers.
* Assemblers are called for any parameters not supported by a formatter.