### PR TITLE
DM-15614: Allow dynamic hierarchy delimiters for configs

### DIFF
--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -130,9 +130,9 @@ class Butler:
             os.makedirs(root)
         config = Config(config)
         full = ButlerConfig(config)  # this applies defaults
-        datastoreClass = doImport(full["datastore.cls"])
+        datastoreClass = doImport(full[".datastore.cls"])
         datastoreClass.setConfigRoot(root, config, full)
-        registryClass = doImport(full["registry.cls"])
+        registryClass = doImport(full[".registry.cls"])
         registryClass.setConfigRoot(root, config, full)
         if standalone:
             config.merge(full)

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -242,7 +242,7 @@ class Butler:
                 raise ValueError("Must provide a dataId if first argument is not a DatasetRef")
             datasetType = self.registry.getDatasetType(datasetRefOrType)
 
-        isVirtualComposite = self.composites.doDisassembly(datasetType)
+        isVirtualComposite = self.composites.shouldBeDisassembled(datasetType)
 
         # Add Registry Dataset entry.  If not a virtual composite, add
         # and attach components at the same time.

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -130,9 +130,9 @@ class Butler:
             os.makedirs(root)
         config = Config(config)
         full = ButlerConfig(config)  # this applies defaults
-        datastoreClass = doImport(full[".datastore.cls"])
+        datastoreClass = doImport(full["datastore", "cls"])
         datastoreClass.setConfigRoot(root, config, full)
-        registryClass = doImport(full[".registry.cls"])
+        registryClass = doImport(full["registry", "cls"])
         registryClass.setConfigRoot(root, config, full)
         if standalone:
             config.merge(full)

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -29,16 +29,19 @@ from .config import ConfigSubset
 
 log = logging.getLogger(__name__)
 
+# Key to access disassembly information
+DISASSEMBLY_KEY = "disassembled"
+
 
 class CompositesConfig(ConfigSubset):
     component = "composites"
-    requiredKeys = ("default", "disassembled")
+    requiredKeys = ("default", DISASSEMBLY_KEY)
     defaultConfigFile = "composites.yaml"
 
     def validate(self):
         """Validate entries have the correct type."""
         super().validate()
-        for k, v in self["disassembled"].items():
+        for k, v in self[DISASSEMBLY_KEY].items():
             if not isinstance(v, bool):
                 raise ValueError(f"CompositesConfig: Key {k} is not a Boolean")
 
@@ -95,8 +98,8 @@ class CompositesMap:
         disassemble = self.config["default"]
 
         for name in (entity._lookupNames()):
-            if name is not None and name in self.config["disassembled"]:
-                disassemble = self.config[("disassembled", name)]
+            if name is not None and name in self.config[DISASSEMBLY_KEY]:
+                disassemble = self.config[(DISASSEMBLY_KEY, name)]
                 matchName = name
                 break
 

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -99,7 +99,7 @@ class CompositesMap:
 
         for name in (entity._lookupNames()):
             if name is not None and name in self.config[DISASSEMBLY_KEY]:
-                disassemble = self.config[(DISASSEMBLY_KEY, name)]
+                disassemble = self.config[DISASSEMBLY_KEY, name]
                 matchName = name
                 break
 

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -62,7 +62,7 @@ class CompositesMap:
         assert isinstance(config, CompositesConfig)
         self.config = config
 
-    def doDisassembly(self, entity):
+    def shouldBeDisassembled(self, entity):
         """Given some choices, indicate whether the entity should be
         disassembled.
 

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -39,7 +39,7 @@ class CompositesConfig(ConfigSubset):
         """Validate entries have the correct type."""
         super().validate()
         for k in self["disassembled"]:
-            key = f"disassembled.{k}"
+            key = f"disassembled{self.D}{k}"
             if not isinstance(self[key], bool):
                 raise ValueError(f"CompositesConfig: Key {key} is not a Boolean")
 
@@ -97,7 +97,7 @@ class CompositesMap:
 
         for name in (entity._lookupNames()):
             if name is not None and name in self.config["disassembled"]:
-                disassemble = self.config[f"disassembled.{name}"]
+                disassemble = self.config[f"disassembled{self.config.D}{name}"]
                 matchName = name
                 break
 

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -38,10 +38,9 @@ class CompositesConfig(ConfigSubset):
     def validate(self):
         """Validate entries have the correct type."""
         super().validate()
-        for k in self["disassembled"]:
-            key = f"disassembled{self.D}{k}"
-            if not isinstance(self[key], bool):
-                raise ValueError(f"CompositesConfig: Key {key} is not a Boolean")
+        for k, v in self["disassembled"].items():
+            if not isinstance(v, bool):
+                raise ValueError(f"CompositesConfig: Key {k} is not a Boolean")
 
 
 class CompositesMap:
@@ -97,7 +96,7 @@ class CompositesMap:
 
         for name in (entity._lookupNames()):
             if name is not None and name in self.config["disassembled"]:
-                disassemble = self.config[f"disassembled{self.config.D}{name}"]
+                disassemble = self.config[("disassembled", name)]
                 matchName = name
                 break
 

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -175,7 +175,7 @@ class Config(collections.UserDict):
         return pprint.pformat(self.data, indent=2, width=1)
 
     def __repr__(self):
-        return self.data.__repr__()
+        return f"{type(self).__name__}({self.data!r})"
 
     def __initFromFile(self, path):
         """Load a file from path.

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -255,8 +255,8 @@ class Config(collections.UserDict):
             if escaped in key:
                 # Replace with a character that won't be in the string
                 temp = "\r"
-                if temp in key or d == "\r":
-                    raise ValueError("Can not use carriage return character in hierarchical key or as"
+                if temp in key or d == temp:
+                    raise ValueError(f"Can not use character {temp!r} in hierarchical key or as"
                                      " delimiter if escaping the delimiter")
                 key = key.replace(escaped, temp)
             hierarchy = key.split(d)

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -637,7 +637,7 @@ class ConfigSubset(Config):
         # component.component (since the included files can themselves
         # include the component name)
         if self.component is not None:
-            doubled = "{0}{1}{0}".format(self.component, self.D)
+            doubled = (self.component, ) * 2
             # Must check for double depth first
             if doubled in externalConfig:
                 externalConfig = externalConfig[doubled]
@@ -701,9 +701,9 @@ class ConfigSubset(Config):
 
         if mergeDefaults and containerKey is not None and containerKey in self:
             for idx, subConfig in enumerate(self[containerKey]):
-                self[f"{containerKey}{self.D}{idx}"] = type(self)(other=subConfig, validate=validate,
-                                                                  mergeDefaults=mergeDefaults,
-                                                                  searchPaths=searchPaths)
+                self[(containerKey, idx)] = type(self)(other=subConfig, validate=validate,
+                                                       mergeDefaults=mergeDefaults,
+                                                       searchPaths=searchPaths)
 
         if validate:
             self.validate()

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -112,14 +112,15 @@ class Config(collections.UserDict):
     The default delimiter is defined in the class variable `Config.D`.
 
     The default delimiter can be overridden by specifying it as the first
-    character of the string: ``foo[".a.b.c"]`` will us ``.`` as a delimiter
+    character of the string: ``foo[".a.b.c"]`` will use ``.`` as a delimiter
     regardless of the internal default, but ``foo[":a.b.c"]`` will use ``:``
     as the delimeter resulting in a single key of ``a.b.c`` being accessed.
     Using ``foo[":a:b:c"]`` is therefore equivalent to ``foo[".a.b.c"]``.
     This requires that keys in `Config` instances do not themselves start with
-    non-alphanumeric characters.  If the hierarchy is already availabe in a
+    non-alphanumeric characters.  If the hierarchy is already available in a
     `list` or `tuple` it can be provided directly without forming it into a
-    string.
+    string, such that ``foo[("a", "b", "c")]`` is equivalent to
+    ``foot[".a.b.c"]``.
 
     Storage formats supported:
 

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -177,6 +177,9 @@ class Config(collections.UserDict):
     def __repr__(self):
         return f"{type(self).__name__}({self.data!r})"
 
+    def __str__(self):
+        return self.ppprint()
+
     def __initFromFile(self, path):
         """Load a file from path.
 

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -777,9 +777,9 @@ class ConfigSubset(Config):
 
         if mergeDefaults and containerKey is not None and containerKey in self:
             for idx, subConfig in enumerate(self[containerKey]):
-                self[(containerKey, idx)] = type(self)(other=subConfig, validate=validate,
-                                                       mergeDefaults=mergeDefaults,
-                                                       searchPaths=searchPaths)
+                self[containerKey, idx] = type(self)(other=subConfig, validate=validate,
+                                                     mergeDefaults=mergeDefaults,
+                                                     searchPaths=searchPaths)
 
         if validate:
             self.validate()

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -714,7 +714,7 @@ class ConfigSubset(Config):
         # component.component (since the included files can themselves
         # include the component name)
         if self.component is not None:
-            doubled = (self.component, ) * 2
+            doubled = (self.component, self.component)
             # Must check for double depth first
             if doubled in externalConfig:
                 externalConfig = externalConfig[doubled]

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -448,6 +448,7 @@ class Config(collections.UserDict):
             Delimiter to use when forming the keys.  If the delimiter is
             present in any of the keys, it will be escaped in the returned
             names.  If `None` given a delimiter will be automatically provided.
+            The delimiter can not be alphanumeric.
 
         Returns
         -------
@@ -458,12 +459,20 @@ class Config(collections.UserDict):
         -----
         This is different than the built-in method `dict.keys`, which will
         return only the first level keys.
+
+        Raises
+        ------
+        ValueError:
+            The supplied delimiter is alphanumeric.
         """
         if topLevelOnly:
             return list(self.keys())
 
         # Get all the tuples of hierarchical keys
         nameTuples = self.nameTuples()
+
+        if delimiter is not None and delimiter.isalnum():
+            raise ValueError(f"Supplied delimiter ({delimiter!r}) must not be alphanumeric.")
 
         if delimiter is None:
             # Start with something, and ensure it does not need to be

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -289,6 +289,9 @@ class Config(collections.UserDict):
                     return None
         if isinstance(data, collections.Mapping):
             data = Config(data)
+            # Ensure that child configs inherit the parent internal delimiter
+            if self._D != Config._D:
+                data._D = self._D
         return data
 
     def __setitem__(self, name, value):

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -142,7 +142,7 @@ class Config(_ConfigBase):
         If `None` is provided an empty `Config` will be created.
     """
 
-    D = "."
+    D = "→"
     """Delimiter to use for components in the hierarchy"""
 
     def __init__(self, other=None):

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -44,19 +44,6 @@ log = logging.getLogger(__name__)
 # PATH-like environment variable to use for defaults.
 CONFIG_PATH = "DAF_BUTLER_CONFIG_PATH"
 
-# UserDict and yaml have defined metaclasses and Python 3 does not allow
-# multiple inheritance of classes with distinct metaclasses. We therefore have
-# to create a new baseclass that Config can inherit from. This is because the
-# metaclass syntax differs between versions
-
-
-class _ConfigMeta(type(collections.UserDict), type(yaml.YAMLObject)):
-    pass
-
-
-class _ConfigBase(collections.UserDict, yaml.YAMLObject, metaclass=_ConfigMeta):
-    pass
-
 
 class Loader(yaml.CLoader):
     """YAML Loader that supports file include directives
@@ -109,7 +96,7 @@ class Loader(yaml.CLoader):
             return yaml.load(f, Loader)
 
 
-class Config(_ConfigBase):
+class Config(collections.UserDict):
     """Implements a datatype that is used by `Butler` for configuration
     parameters.
 

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -385,7 +385,10 @@ class Config(_ConfigBase):
         self.data = otherCopy.data
 
     def names(self, topLevelOnly=False):
-        """Get the dot-delimited name of all the keys in the hierarchy.
+        """Get the delimited name of all the keys in the hierarchy.
+
+        The values returned from this method are guaranteed to be usable
+        to access items in the configuration object.
 
         Parameters
         ----------
@@ -419,7 +422,9 @@ class Config(_ConfigBase):
                     getKeys(val, keys, levelKey)
         keys = []
         getKeys(self.data, keys, None)
-        return keys
+        # Prepend the delimiter so that access works even if the delimiter is
+        # changed.
+        return [f"{self.D}{k}" for k in keys]
 
     def asArray(self, name):
         """Get a value as an array.

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -226,7 +226,7 @@ class Config(collections.UserDict):
         self.data = content
         return self
 
-    def _splitKeys(self, key):
+    def _splitIntoKeys(self, key):
         """Split the argument for get/set/in into a hierarchical list.
 
         Parameters
@@ -276,7 +276,7 @@ class Config(collections.UserDict):
         if name in data:
             keys = (name,)
         else:
-            keys = self._splitKeys(name)
+            keys = self._splitIntoKeys(name)
         for key in keys:
             if data is None:
                 return None
@@ -296,7 +296,7 @@ class Config(collections.UserDict):
         return data
 
     def __setitem__(self, name, value):
-        keys = self._splitKeys(name)
+        keys = self._splitIntoKeys(name)
         last = keys.pop()
         if isinstance(value, Config):
             value = copy.deepcopy(value.data)
@@ -314,7 +314,7 @@ class Config(collections.UserDict):
 
     def __contains__(self, key):
         d = self.data
-        keys = self._splitKeys(key)
+        keys = self._splitIntoKeys(key)
         last = keys.pop()
 
         def checkNextItem(k, d):

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -257,7 +257,8 @@ class Config(collections.UserDict):
                 # Complain at the attempt to escape the escape
                 doubled = fr"\{escaped}"
                 if doubled in key:
-                    raise ValueError(f"Escaping an escaped delimiter ({doubled} in {key}) is not yet supported.")
+                    raise ValueError(f"Escaping an escaped delimiter ({doubled} in {key})"
+                                     " is not yet supported.")
                 # Replace with a character that won't be in the string
                 temp = "\r"
                 if temp in key or d == temp:

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -124,6 +124,16 @@ class Config(_ConfigBase):
 
     The default delimiter is defined in the class variable `Config.D`.
 
+    The default delimiter can be overridden by specifying it as the first
+    character of the string: ``foo[".a.b.c"]`` will us ``.`` as a delimiter
+    regardless of the internal default, but ``foo[":a.b.c"]`` will use ``:``
+    as the delimeter resulting in a single key of ``a.b.c`` being accessed.
+    Using ``foo[":a:b:c"]`` is therefore equivalent to ``foo[".a.b.c"]``.
+    This requires that keys in `Config` instances do not themselves start with
+    non-alphanumeric characters.  If the hierarchy is already availabe in a
+    `list` or `tuple` it can be provided directly without forming it into a
+    string.
+
     Storage formats supported:
 
     - yaml: read and write is supported.
@@ -247,14 +257,16 @@ class Config(_ConfigBase):
                 key = key[1:]
             else:
                 d = self.D
-            print("Result of split:", key.split(d))
             return key.split(d)
         else:
             return list(key)
 
     def __getitem__(self, name):
         data = self.data
-        # Override the split for the simple case
+        # Override the split for the simple case where there is an exact
+        # match.  This allows `Config.items()` to work since `UserDict`
+        # accesses Config.data directly to obtain the keys and every top
+        # level key should always retrieve the top level values.
         if name in data:
             keys = (name,)
         else:

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -226,7 +226,8 @@ class Config(collections.UserDict):
         self.data = content
         return self
 
-    def _splitIntoKeys(self, key):
+    @staticmethod
+    def _splitIntoKeys(key):
         """Split the argument for get/set/in into a hierarchical list.
 
         Parameters
@@ -250,10 +251,13 @@ class Config(collections.UserDict):
                 key = key[1:]
             else:
                 return [key, ]
-            # Allow escaping of the delimiter: .a.foo\.bar -> a foo.bar
             escaped = f"\\{d}"
             temp = None
             if escaped in key:
+                # Complain at the attempt to escape the escape
+                doubled = fr"\{escaped}"
+                if doubled in key:
+                    raise ValueError(f"Escaping an escaped delimiter ({doubled} in {key}) is not yet supported.")
                 # Replace with a character that won't be in the string
                 temp = "\r"
                 if temp in key or d == temp:

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -477,7 +477,7 @@ class Config(collections.UserDict):
                     for n in names:
                         for s in n:
                             if searchStr in s:
-                                return s
+                                return n
                     return None
 
                 raise ValueError(f"Specified delimiter, {delimiter!r} can not be used.  "

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -188,7 +188,7 @@ class Datastore(metaclass=ABCMeta):
         config : `Config`
             Configuration instance.
         """
-        cls = doImport(config[".datastore.cls"])
+        cls = doImport(config["datastore", "cls"])
         return cls(config=config, registry=registry)
 
     def __init__(self, config, registry):

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -188,7 +188,7 @@ class Datastore(metaclass=ABCMeta):
         config : `Config`
             Configuration instance.
         """
-        cls = doImport(config["datastore.cls"])
+        cls = doImport(config[".datastore.cls"])
         return cls(config=config, registry=registry)
 
     def __init__(self, config, registry):

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -76,7 +76,7 @@ class Registry(metaclass=ABCMeta):
             should be copied from `full` to `Config`.
         """
         Config.overrideParameters(RegistryConfig, config, full,
-                                  toCopy=(".skypix.cls", ".skypix.level"))
+                                  toCopy=(("skypix", "cls"), ("skypix", "level")))
 
     @staticmethod
     def fromConfig(registryConfig, schemaConfig=None, dataUnitRegistryConfig=None, create=False):
@@ -170,8 +170,8 @@ class Registry(metaclass=ABCMeta):
     def pixelization(self):
         """Object that interprets SkyPix DataUnit values (`sphgeom.Pixelization`)."""
         if self._pixelization is None:
-            pixelizationCls = doImport(self.config[".skypix.cls"])
-            self._pixelization = pixelizationCls(level=self.config[".skypix.level"])
+            pixelizationCls = doImport(self.config["skypix", "cls"])
+            self._pixelization = pixelizationCls(level=self.config["skypix", "level"])
         return self._pixelization
 
     @abstractmethod

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -76,7 +76,7 @@ class Registry(metaclass=ABCMeta):
             should be copied from `full` to `Config`.
         """
         Config.overrideParameters(RegistryConfig, config, full,
-                                  toCopy=("skypix.cls", "skypix.level"))
+                                  toCopy=(".skypix.cls", ".skypix.level"))
 
     @staticmethod
     def fromConfig(registryConfig, schemaConfig=None, dataUnitRegistryConfig=None, create=False):
@@ -170,8 +170,8 @@ class Registry(metaclass=ABCMeta):
     def pixelization(self):
         """Object that interprets SkyPix DataUnit values (`sphgeom.Pixelization`)."""
         if self._pixelization is None:
-            pixelizationCls = doImport(self.config["skypix.cls"])
-            self._pixelization = pixelizationCls(level=self.config["skypix.level"])
+            pixelizationCls = doImport(self.config[".skypix.cls"])
+            self._pixelization = pixelizationCls(level=self.config[".skypix.level"])
         return self._pixelization
 
     @abstractmethod

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -112,7 +112,7 @@ class ChainedDatastore(Datastore):
             datastoreClass.setConfigRoot(newroot, childConfig, fullChildConfig)
 
             # Reattach to parent
-            datastoreConfig[f"{containerKey}.{idx}"] = childConfig
+            datastoreConfig[f"{containerKey}{datastoreConfig.D}{idx}"] = childConfig
 
         # Reattach modified datastore config to parent
         # If this has a datastore key we attach there, otherwise we assume

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -112,7 +112,7 @@ class ChainedDatastore(Datastore):
             datastoreClass.setConfigRoot(newroot, childConfig, fullChildConfig)
 
             # Reattach to parent
-            datastoreConfig[f"{containerKey}{datastoreConfig.D}{idx}"] = childConfig
+            datastoreConfig[(containerKey, idx)] = childConfig
 
         # Reattach modified datastore config to parent
         # If this has a datastore key we attach there, otherwise we assume

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -112,7 +112,7 @@ class ChainedDatastore(Datastore):
             datastoreClass.setConfigRoot(newroot, childConfig, fullChildConfig)
 
             # Reattach to parent
-            datastoreConfig[(containerKey, idx)] = childConfig
+            datastoreConfig[containerKey, idx] = childConfig
 
         # Reattach modified datastore config to parent
         # If this has a datastore key we attach there, otherwise we assume

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -111,7 +111,7 @@ class PosixDatastore(Datastore):
         """
         Config.overrideParameters(DatastoreConfig, config, full,
                                   toUpdate={"root": root},
-                                  toCopy=("cls", ".records.table"))
+                                  toCopy=("cls", ("records", "table")))
 
     def __init__(self, config, registry):
         super().__init__(config, registry)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -111,7 +111,7 @@ class PosixDatastore(Datastore):
         """
         Config.overrideParameters(DatastoreConfig, config, full,
                                   toUpdate={"root": root},
-                                  toCopy=("cls", "records.table"))
+                                  toCopy=("cls", ".records.table"))
 
     def __init__(self, config, registry):
         super().__init__(config, registry)

--- a/python/lsst/daf/butler/gen2convert/walker.py
+++ b/python/lsst/daf/butler/gen2convert/walker.py
@@ -203,7 +203,7 @@ class ConversionWalker:
         """Load unique VisitInfo objects and filter associations from all scanned repositories.
         """
         for repo in self.scanned.values():
-            config = self.config["mappers"][repo.MapperClass.__name__]["VisitInfo"]
+            config = self.config["mappers", repo.MapperClass.__name__, "VisitInfo"]
             cameraVisitInfo = self.visitInfo.setdefault(repo.MapperClass.__name__, {})
             datasets = repo.datasets.get(config["DatasetType"], {})
             for dataset in datasets.values():

--- a/python/lsst/daf/butler/gen2convert/writer.py
+++ b/python/lsst/daf/butler/gen2convert/writer.py
@@ -118,11 +118,11 @@ class ConversionWriter:
             return
         # Determine the SkyMaps, Collections, and Runs for this repo.
         collection = gen2repo.root
-        for sub in self.config["collections.substitutions"]:
+        for sub in self.config["collections", "substitutions"]:
             collection = re.sub(sub["pattern"], sub["repl"], collection)
         log.debug("Using collection '%s' for root '%s'", collection, gen2repo.root)
         run = self.runs.setdefault(collection, Run(collection=collection))
-        camera = self.config["mappers"][gen2repo.MapperClass.__name__]["camera"]
+        camera = self.config["mappers", gen2repo.MapperClass.__name__, "camera"]
         skyMapNamesByCoaddName = {}
         for coaddName, skyMap in gen2repo.skyMaps.items():
             log.debug("Using SkyMap with hash=%s for '%s' in '%s'",
@@ -211,7 +211,7 @@ class ConversionWriter:
         log = Log.getLogger("lsst.daf.butler.gen2convert")
         cameras = set()
         for repo in self.repos.values():
-            cameras.add(self.config["mappers"][repo.gen2.MapperClass.__name__]["camera"])
+            cameras.add(self.config["mappers", repo.gen2.MapperClass.__name__, "camera"])
         for camera in cameras:
             log.debug("Looking for preexisting Camera '%s'.", camera)
             if registry.findDataUnitEntry("Camera", {"camera": camera}) is None:
@@ -255,7 +255,7 @@ class ConversionWriter:
         """
         log = Log.getLogger("lsst.daf.butler.gen2convert")
         for mapperName, nested in self.visitInfo.items():
-            camera = self.config["mappers"][mapperName]["camera"]
+            camera = self.config["mappers", mapperName, "camera"]
             log.info("Inserting Exposure and Visit DataUnits for Camera '%s'", camera)
             for visitInfoId, (visitInfo, filt) in nested.items():
                 # TODO: generalize this to cameras with snaps and/or compound gen2 visit/exposure IDs
@@ -295,7 +295,7 @@ class ConversionWriter:
                     log.debug("Skipping insertion of '%s' from %s", datasetTypeName, repo.gen2.root)
                     continue
                 log.info("Inserting '%s' from %s", datasetTypeName, repo.gen2.root)
-                collectionTemplate = self.config["collections.overrides"].get(datasetTypeName, None)
+                collectionTemplate = self.config["collections", "overrides"].get(datasetTypeName, None)
                 if collectionTemplate is None:
                     collection = repo.run.collection
                     registry.ensureRun(repo.run)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, E251, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806
 exclude = __init__.py
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 E251 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -19,3 +19,4 @@ datastore:
     StructuredDataPickle: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
     ExposureCompositeF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     ThingOne: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
+    datasetType.component: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -274,7 +274,7 @@ class ButlerTests:
 class PosixDatastoreButlerTestCase(ButlerTests, lsst.utils.tests.TestCase):
     """PosixDatastore specialization of a butler"""
     configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
-    fullConfigKey = "datastore.formatters"
+    fullConfigKey = ".datastore.formatters"
 
     datastoreStr = "datastore='./butler_test_repository"
     registryStr = "registry='sqlite:///:memory:'"
@@ -292,7 +292,7 @@ class InMemoryDatastoreButlerTestCase(ButlerTests, lsst.utils.tests.TestCase):
 class ChainedDatastoreButlerTestCase(ButlerTests, lsst.utils.tests.TestCase):
     """PosixDatastore specialization"""
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
-    fullConfigKey = "datastore.datastores.1.formatters"
+    fullConfigKey = ".datastore.datastores.1.formatters"
     datastoreStr = "datastore='InMemory, ./butler_test_repository, ./butler_test_repository2'"
     registryStr = "registry='sqlite:///:memory:'"
 

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -58,15 +58,15 @@ class TestCompositesConfig(unittest.TestCase):
 
         # Check that a str is not supported
         with self.assertRaises(ValueError):
-            c.doDisassembly("fred")
+            c.shouldBeDisassembled("fred")
 
         # These will fail (not a composite)
         sc = StorageClass("StructuredDataJson")
         d = DatasetType("dummyTrue", ("a", "b"), sc)
         self.assertFalse(sc.isComposite())
         self.assertFalse(d.isComposite())
-        self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
-        self.assertFalse(c.doDisassembly(sc), f"Test with StorageClass: {sc}")
+        self.assertFalse(c.shouldBeDisassembled(d), f"Test with DatasetType: {d}")
+        self.assertFalse(c.shouldBeDisassembled(sc), f"Test with StorageClass: {sc}")
 
         # Repeat but this time use a composite storage class
         sccomp = StorageClass("Dummy")
@@ -74,21 +74,21 @@ class TestCompositesConfig(unittest.TestCase):
         d = DatasetType("dummyTrue", ("a", "b"), sc)
         self.assertTrue(sc.isComposite())
         self.assertTrue(d.isComposite())
-        self.assertTrue(c.doDisassembly(d), f"Test with DatasetType: {d}")
-        self.assertFalse(c.doDisassembly(sc), f"Test with StorageClass: {sc}")
+        self.assertTrue(c.shouldBeDisassembled(d), f"Test with DatasetType: {d}")
+        self.assertFalse(c.shouldBeDisassembled(sc), f"Test with StorageClass: {sc}")
 
         # Override with False
         d = DatasetType("dummyFalse", ("a", "b"), sc)
-        self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
+        self.assertFalse(c.shouldBeDisassembled(d), f"Test with DatasetType: {d}")
 
         # DatasetType that has no explicit entry
         d = DatasetType("dummyFred", ("a", "b"), sc)
-        self.assertFalse(c.doDisassembly(d), f"Test with DatasetType: {d}")
+        self.assertFalse(c.shouldBeDisassembled(d), f"Test with DatasetType: {d}")
 
         # StorageClass that will be disassembled
         sc = StorageClass("StructuredComposite", components={"dummy": sccomp})
         d = DatasetType("dummyFred", ("a", "b"), sc)
-        self.assertTrue(c.doDisassembly(d), f"Test with DatasetType: {d}")
+        self.assertTrue(c.shouldBeDisassembled(d), f"Test with DatasetType: {d}")
 
 
 if __name__ == "__main__":

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -43,15 +43,15 @@ class TestCompositesConfig(unittest.TestCase):
         self.assertIn("default", c)
         # Check merging has worked
         rootKey = "disassembled"
-        self.assertIn(f"{rootKey}.calexp", c)
-        self.assertIn(f"{rootKey}.dummyTrue", c)
-        self.assertIn(f"{rootKey}.StructuredComposite", c)
-        self.assertIn(f"{rootKey}.ExposureF", c)
+        self.assertIn(f".{rootKey}.calexp", c)
+        self.assertIn(f".{rootKey}.dummyTrue", c)
+        self.assertIn(f".{rootKey}.StructuredComposite", c)
+        self.assertIn(f".{rootKey}.ExposureF", c)
 
         # Check that all entries are booleans (this is meant to be enforced
         # internally)
         for k in c[rootKey]:
-            self.assertIsInstance(c[f"{rootKey}.{k}"], bool, f"Testing {rootKey}.{k}")
+            self.assertIsInstance(c[f".{rootKey}.{k}"], bool, f"Testing {rootKey}.{k}")
 
     def testMap(self):
         c = CompositesMap(self.configFile)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,7 +105,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIn("key3", pretty)
         r = repr(c)
         self.assertIn("key3", r)
-        regex = "^Config\(\{.*\}\)$"
+        regex = r"^Config\(\{.*\}\)$"
         self.assertRegex(r, regex)
         s = str(c)
         self.assertIn("\n", s)
@@ -120,7 +120,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(c[r"\a\foo.bar"], 1)
         self.assertEqual(c["\ra\rfoo.bar"], 1)
         with self.assertRaises(ValueError):
-            c[".a.foo\.bar\r"]
+            c[".a.foo\\.bar\r"]
 
     def testOperators(self):
         c1 = Config({"a": {"b": 1}, "c": 2})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,14 @@ class ConfigTestCase(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 Config(badArg)
 
+    def testBasics(self):
+        c = Config({1: 2, 3: 4, "key3": 6})
+        pretty = c.ppprint()
+        self.assertIn("key3", pretty)
+        r = repr(c)
+        self.assertIn("key3", r)
+        self.assertRegex(r, "^Config\(\{.*\}\)$")
+
     def testOperators(self):
         c1 = Config({"a": {"b": 1}, "c": 2})
         c2 = c1.copy()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,7 +104,11 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIn("key3", pretty)
         r = repr(c)
         self.assertIn("key3", r)
-        self.assertRegex(r, "^Config\(\{.*\}\)$")
+        regex = "^Config\(\{.*\}\)$"
+        self.assertRegex(r, regex)
+        s = str(c)
+        self.assertIn("\n", s)
+        self.assertNotRegex(s, regex)
 
     def testOperators(self):
         c1 = Config({"a": {"b": 1}, "c": 2})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ import unittest
 import os
 import contextlib
 import collections
+import itertools
 
 from lsst.daf.butler import ConfigSubset, Config
 
@@ -218,11 +219,20 @@ class ConfigTestCase(unittest.TestCase):
 
         # Test that we can get all the listed names.
         # and also that they are marked as "in" the Config
-        # Two distinct loops
-        for n in c.names():
+        # Try delimited names and tuples
+        for n in itertools.chain(c.names(), c.nameTuples()):
             val = c[n]
             self.assertIsNotNone(val)
             self.assertIn(n, c)
+
+        names = c.names()
+        nameTuples = c.nameTuples()
+        self.assertEqual(len(names), len(nameTuples))
+        self.assertGreater(len(names), 5)
+        self.assertGreater(len(nameTuples), 5)
+
+        top = c.nameTuples(topLevelOnly=True)
+        self.assertIsInstance(top[0], tuple)
 
         # Investigate a possible delimeter in a key
         c = Config({"formatters": {"calexp.wcs": 2, "calexp": 3}})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,13 +100,17 @@ class ConfigTestCase(unittest.TestCase):
                 Config(badArg)
 
     def testBasics(self):
-        c = Config({1: 2, 3: 4, "key3": 6})
+        c = Config({1: 2, 3: 4, "key3": 6, "dict": {"a": 1, "b": 2}})
         pretty = c.ppprint()
         self.assertIn("key3", pretty)
         r = repr(c)
         self.assertIn("key3", r)
         regex = r"^Config\(\{.*\}\)$"
         self.assertRegex(r, regex)
+        c2 = eval(r)
+        for n in c.names():
+            self.assertEqual(c2[n], c[n])
+        self.assertEqual(c, c2)
         s = str(c)
         self.assertIn("\n", s)
         self.assertNotRegex(s, regex)
@@ -230,8 +234,8 @@ class ConfigTestCase(unittest.TestCase):
         names = c.names()
         nameTuples = c.nameTuples()
         self.assertEqual(len(names), len(nameTuples))
-        self.assertGreater(len(names), 5)
-        self.assertGreater(len(nameTuples), 5)
+        self.assertEqual(len(names), 11)
+        self.assertEqual(len(nameTuples), 11)
 
         with self.assertRaises(ValueError):
             names = c.names(delimiter=".")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -237,8 +237,11 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(len(names), 11)
         self.assertEqual(len(nameTuples), 11)
 
-        with self.assertRaises(ValueError):
-            names = c.names(delimiter=".")
+        # Test that delimiter escaping works
+        names = c.names(delimiter=".")
+        for n in names:
+            self.assertIn(n, c)
+        self.assertIn(".formatters.calexp\\.wcs", names)
 
         # Use a name that includes the internal default delimiter
         # to test automatic adjustment of delimiter

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,6 +210,8 @@ class ConfigTestCase(unittest.TestCase):
 
         # Check that lists still work even if assigned a dict
         c = Config({"cls": "lsst.daf.butler",
+                    "formatters": {"calexp.wcs": "{component}",
+                                   "calexp": "{datasetType}"},
                     "datastores": [{"datastore": {"cls": "datastore1"}},
                                    {"datastore": {"cls": "datastore2"}}]})
         c[".datastores.1.datastore"] = {"cls": "datastore2modified"}
@@ -230,6 +232,9 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(len(names), len(nameTuples))
         self.assertGreater(len(names), 5)
         self.assertGreater(len(nameTuples), 5)
+
+        with self.assertRaises(ValueError):
+            names = c.names(delimiter=".")
 
         top = c.nameTuples(topLevelOnly=True)
         self.assertIsInstance(top[0], tuple)
@@ -398,6 +403,11 @@ class ConfigSubsetTestCase(unittest.TestCase):
         self.assertIn(c._D.join(("", "comp3", "1", "comp", "item1")), names)
         for n in names:
             self.assertIn(n, c)
+
+        # Test that override delimiter works
+        delimiter = "-"
+        names = c.names(delimiter=delimiter)
+        self.assertIn(delimiter.join(("", "comp3", "1", "comp", "item1")), names)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -110,6 +110,17 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIn("\n", s)
         self.assertNotRegex(s, regex)
 
+    def testEscape(self):
+        c = Config({"a": {"foo.bar": 1}, "b😂c": {"bar_baz": 2}})
+        self.assertEqual(c[r".a.foo\.bar"], 1)
+        self.assertEqual(c[":a:foo.bar"], 1)
+        self.assertEqual(c[".b😂c.bar_baz"], 2)
+        self.assertEqual(c["😂b\😂c😂bar_baz"], 2)
+        self.assertEqual(c[r"\a\foo.bar"], 1)
+        self.assertEqual(c["\ra\rfoo.bar"], 1)
+        with self.assertRaises(ValueError):
+            c[".a.foo\.bar\r"]
+
     def testOperators(self):
         c1 = Config({"a": {"b": 1}, "c": 2})
         c2 = c1.copy()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,9 +158,9 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(c[".a.x"], "string")
 
         # Try different delimiters
-        self.assertEqual(c[f"a{c.D}z"], 52)
         self.assertEqual(c["⇛a⇛z"], 52)
         self.assertEqual(c[("a", "z")], 52)
+        self.assertEqual(c["a", "z"], 52)
 
         c[".b.new.thing1"] = "thing1"
         c[".b.new.thing2"] = "thing2"
@@ -229,13 +229,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(c[":formatters:calexp.wcs"], 2)
         self.assertEqual(c[":formatters:calexp"], 3)
         for k, v in c["formatters"].items():
-            self.assertEqual(c[("formatters", k)], v)
+            self.assertEqual(c["formatters", k], v)
 
         # and now try again by forcing a "." delimiter
         c2 = c["formatters"]
-        c2.D = "."
+        c2._D = "."
         for k, v in c2.items():
-            self.assertEqual(c[("formatters", k)], v)
+            self.assertEqual(c["formatters", k], v)
 
 
 class ConfigSubsetTestCase(unittest.TestCase):
@@ -385,7 +385,7 @@ class ConfigSubsetTestCase(unittest.TestCase):
         # Test a specific name and then test that all
         # returned names are "in" the config.
         names = c.names()
-        self.assertIn(c.D.join(("", "comp3", "1", "comp", "item1")), names)
+        self.assertIn(c._D.join(("", "comp3", "1", "comp", "item1")), names)
         for n in names:
             self.assertIn(n, c)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -236,6 +236,16 @@ class ConfigTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             names = c.names(delimiter=".")
 
+        # Use a name that includes the internal default delimiter
+        # to test automatic adjustment of delimiter
+        strangeKey = f"calexp{c._D}wcs"
+        c["formatters", strangeKey] = "dynamic"
+        names = c.names()
+        self.assertIn(strangeKey, "-".join(names))
+        self.assertFalse(names[0].startswith(c._D))
+        for n in names:
+            self.assertIn(n, c)
+
         top = c.nameTuples(topLevelOnly=True)
         self.assertIsInstance(top[0], tuple)
 
@@ -246,11 +256,11 @@ class ConfigTestCase(unittest.TestCase):
         for k, v in c["formatters"].items():
             self.assertEqual(c["formatters", k], v)
 
-        # and now try again by forcing a "." delimiter
+        # Check internal delimiter inheritance
+        c._D = "."
         c2 = c["formatters"]
-        c2._D = "."
-        for k, v in c2.items():
-            self.assertEqual(c["formatters", k], v)
+        self.assertEqual(c._D, c2._D)  # Check that the child inherits
+        self.assertNotEqual(c2._D, Config._D)
 
 
 class ConfigSubsetTestCase(unittest.TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -180,6 +180,10 @@ class ConfigTestCase(unittest.TestCase):
         # Check we get the same top level keys
         self.assertEqual(set(c.names(topLevelOnly=True)), set(c.data.keys()))
 
+        # Check that we can iterate through items
+        for k, v in c.items():
+            self.assertEqual(c[k], v)
+
         # Check that lists still work even if assigned a dict
         c = Config({"cls": "lsst.daf.butler",
                     "datastores": [{"datastore": {"cls": "datastore1"}},
@@ -196,6 +200,19 @@ class ConfigTestCase(unittest.TestCase):
             val = c[n]
             self.assertIsNotNone(val)
             self.assertIn(n, c)
+
+        # Investigate a possible delimeter in a key
+        c = Config({"formatters": {"calexp.wcs": 2, "calexp": 3}})
+        self.assertEqual(c[":formatters:calexp.wcs"], 2)
+        self.assertEqual(c[":formatters:calexp"], 3)
+        for k, v in c["formatters"].items():
+            self.assertEqual(c[("formatters", k)], v)
+
+        # and now try again by forcing a "." delimiter
+        c2 = c["formatters"]
+        c2.D = "."
+        for k, v in c2.items():
+            self.assertEqual(c[("formatters", k)], v)
 
 
 class ConfigSubsetTestCase(unittest.TestCase):
@@ -345,9 +362,9 @@ class ConfigSubsetTestCase(unittest.TestCase):
         # Test a specific name and then test that all
         # returned names are "in" the config.
         names = c.names()
-        self.assertIn(c.D.join(("comp3", "1", "comp", "item1")), names)
+        self.assertIn(c.D.join(("", "comp3", "1", "comp", "item1")), names)
         for n in names:
-            self.assertIn(n, names)
+            self.assertIn(n, c)
 
 
 if __name__ == "__main__":

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -445,7 +445,7 @@ class ChainedDatastoreTestCase(PosixDatastoreTestCase):
     hasUnsupportedPut = False
     ingestTransferModes = ("copy", "move", "hardlink", "symlink")
     isEphemeral = False
-    rootKeys = ("datastores.1.root", "datastores.2.root")
+    rootKeys = (".datastores.1.root", ".datastores.2.root")
 
 
 class ChainedDatastoreMemoryTestCase(InMemoryDatastoreTestCase):


### PR DESCRIPTION
The delimiter for hierarchies no longer defaults to a `.`. The delimiter is now a class variable and can be overridden by starting the string with the delimiter you wish to use.