### PR TITLE
DM-15721: Refactor config hierarchy access and add __delitem__

### DIFF
--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -269,8 +269,11 @@ class Config(collections.UserDict):
             if temp:
                 hierarchy = [h.replace(temp, d) for h in hierarchy]
             return hierarchy
-        else:
+        elif isinstance(key, collections.abc.Iterable):
             return list(key)
+        else:
+            # Not sure what this is so try it anyway
+            return [key, ]
 
     def _getKeyHierarchy(self, name):
         """Retrieve the key hierarchy for accessing the Config
@@ -395,6 +398,19 @@ class Config(collections.UserDict):
         keys = self._getKeyHierarchy(key)
         hierarchy, complete = self._findInHierarchy(keys)
         return complete
+
+    def __delitem__(self, key):
+        keys = self._getKeyHierarchy(key)
+        last = keys.pop()
+        hierarchy, complete = self._findInHierarchy(keys)
+        if complete:
+            if hierarchy:
+                data = hierarchy[-1]
+            else:
+                data = self.data
+            del data[last]
+        else:
+            raise KeyError(f"{key} not found in Config")
 
     def update(self, other):
         """Like dict.update, but will add or modify keys in nested dicts,

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -123,6 +123,15 @@ class Config(collections.UserDict):
     a two element hierarchy of ``a`` and ``b.c``.  For hard-coded strings it is
     always better to use a different delimiter in these cases.
 
+    Note that adding a multi-level key implicitly creates any nesting levels
+    that do not exist, but removing multi-level keys does not automatically
+    remove empty nesting levels.  As a result::
+        >>> c = Config()
+        >>> c[".a.b"] = 1
+        >>> del c[".a.b"]
+        >>> c["a"]
+        Config({'a': {}})
+
     Storage formats supported:
 
     - yaml: read and write is supported.

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -96,7 +96,7 @@ class Loader(yaml.CLoader):
             return yaml.load(f, Loader)
 
 
-class Config(collections.UserDict):
+class Config(collections.abc.MutableMapping):
     r"""Implements a datatype that is used by `Butler` for configuration
     parameters.
 
@@ -155,8 +155,7 @@ class Config(collections.UserDict):
     constructing keys for external use (see `Config.names()`)."""
 
     def __init__(self, other=None):
-
-        collections.UserDict.__init__(self)
+        self.data = {}
 
         if other is None:
             return
@@ -190,6 +189,15 @@ class Config(collections.UserDict):
 
     def __str__(self):
         return self.ppprint()
+
+    def __len__(self):
+        return len(self.data)
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def copy(self):
+        return type(self)(self)
 
     def __initFromFile(self, path):
         """Load a file from path.
@@ -369,9 +377,9 @@ class Config(collections.UserDict):
 
     def __getitem__(self, name):
         # Override the split for the simple case where there is an exact
-        # match.  This allows `Config.items()` to work since `UserDict`
-        # accesses Config.data directly to obtain the keys and every top
-        # level key should always retrieve the top level values.
+        # match.  This allows `Config.items()` to work via a simple
+        # __iter__ implementation that returns top level keys of
+        # self.data.
         keys = self._getKeyHierarchy(name)
 
         hierarchy, complete = self._findInHierarchy(keys)

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -97,7 +97,7 @@ class Loader(yaml.CLoader):
 
 
 class Config(collections.UserDict):
-    """Implements a datatype that is used by `Butler` for configuration
+    r"""Implements a datatype that is used by `Butler` for configuration
     parameters.
 
     It is essentially a `dict` with key/value pairs, including nested dicts
@@ -228,7 +228,7 @@ class Config(collections.UserDict):
 
     @staticmethod
     def _splitIntoKeys(key):
-        """Split the argument for get/set/in into a hierarchical list.
+        r"""Split the argument for get/set/in into a hierarchical list.
 
         Parameters
         ----------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,20 +116,55 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIn("\n", s)
         self.assertNotRegex(s, regex)
 
-        # Check deletion
+        self.assertCountEqual(c.keys(), ["1", "3", "key3", "dict"])
+        self.assertEqual(list(c), list(c.keys()))
+        self.assertEqual(list(c.values()), [c[k] for k in c.keys()])
+        self.assertEqual(list(c.items()), [(k, c[k]) for k in c.keys()])
+
+        newKeys = ("key4", ".dict.q", ("dict", "r"), "5")
+        oldKeys = ("key3", ".dict.a", ("dict", "b"), "3")
+        remainingKey = "1"
+
+        # Check get with existing key
+        for k in oldKeys:
+            self.assertEqual(c.get(k, "missing"), c[k])
+
+        # Check get, pop with nonexistent key
+        for k in newKeys:
+            self.assertEqual(c.get(k, "missing"), "missing")
+            self.assertEqual(c.pop(k, "missing"), "missing")
+
+        # Check setdefault with existing key
+        for k in oldKeys:
+            c.setdefault(k, 8)
+            self.assertNotEqual(c[k], 8)
+
+        # Check setdefault with nonexistent key (mutates c, adding newKeys)
+        for k in newKeys:
+            c.setdefault(k, 8)
+            self.assertEqual(c[k], 8)
+
+        # Check pop with existing key (mutates c, removing newKeys)
+        for k in newKeys:
+            v = c[k]
+            self.assertEqual(c.pop(k, "missing"), v)
+
+        # Check deletion (mutates c, removing oldKeys)
         for k in ("key3", ".dict.a", ("dict", "b"), "3"):
             self.assertIn(k, c)
             del c[k]
             self.assertNotIn(k, c)
 
-        # Standard dict methods
-        c["test.default.a"] = "default1"
-        self.assertEqual(c["test.default.a"], "default1")
-        self.assertEqual(c.get("test.default.a"), "default1")
-        self.assertEqual(c.get("test.default.b", "default2"), "default2")
-        self.assertEqual(c.setdefault("test.default.a"), "default1")
-        self.assertEqual(c.setdefault("test.default.b", "default2"), "default2")
-        self.assertEqual(c["test.default.b"], "default2")
+        # Check that `dict` still exists, but is now empty (then remove it, mutatic c)
+        self.assertIn("dict", c)
+        del c["dict"]
+
+        # Check popitem (mutates c, removing remainingKey)
+        v = c[remainingKey]
+        self.assertEqual(c.popitem(), (remainingKey, v))
+
+        # Check that c is now empty
+        self.assertFalse(c)
 
     def assertSplit(self, answer, *args):
         """Helper function to compare string splitting"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -122,6 +122,15 @@ class ConfigTestCase(unittest.TestCase):
             del c[k]
             self.assertNotIn(k, c)
 
+        # Standard dict methods
+        c["test.default.a"] = "default1"
+        self.assertEqual(c["test.default.a"], "default1")
+        self.assertEqual(c.get("test.default.a"), "default1")
+        self.assertEqual(c.get("test.default.b", "default2"), "default2")
+        self.assertEqual(c.setdefault("test.default.a"), "default1")
+        self.assertEqual(c.setdefault("test.default.b", "default2"), "default2")
+        self.assertEqual(c["test.default.b"], "default2")
+
     def assertSplit(self, answer, *args):
         """Helper function to compare string splitting"""
         for s in (answer, *args):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,7 +100,7 @@ class ConfigTestCase(unittest.TestCase):
                 Config(badArg)
 
     def testBasics(self):
-        c = Config({1: 2, 3: 4, "key3": 6, "dict": {"a": 1, "b": 2}})
+        c = Config({"1": 2, "3": 4, "key3": 6, "dict": {"a": 1, "b": 2}})
         pretty = c.ppprint()
         self.assertIn("key3", pretty)
         r = repr(c)
@@ -108,6 +108,7 @@ class ConfigTestCase(unittest.TestCase):
         regex = r"^Config\(\{.*\}\)$"
         self.assertRegex(r, regex)
         c2 = eval(r)
+        self.assertIn("1", c)
         for n in c.names():
             self.assertEqual(c2[n], c[n])
         self.assertEqual(c, c2)
@@ -115,12 +116,8 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIn("\n", s)
         self.assertNotRegex(s, regex)
 
-        # Try an integer key
-        self.assertIn(3, c)
-        self.assertEqual(c[3], 4)
-
         # Check deletion
-        for k in ("key3", ".dict.a", ("dict", "b"), 3):
+        for k in ("key3", ".dict.a", ("dict", "b"), "3"):
             self.assertIn(k, c)
             del c[k]
             self.assertNotIn(k, c)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -115,6 +115,16 @@ class ConfigTestCase(unittest.TestCase):
         self.assertIn("\n", s)
         self.assertNotRegex(s, regex)
 
+        # Try an integer key
+        self.assertIn(3, c)
+        self.assertEqual(c[3], 4)
+
+        # Check deletion
+        for k in ("key3", ".dict.a", ("dict", "b"), 3):
+            self.assertIn(k, c)
+            del c[k]
+            self.assertNotIn(k, c)
+
     def assertSplit(self, answer, *args):
         """Helper function to compare string splitting"""
         for s in (answer, *args):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -288,7 +288,7 @@ class ConfigTestCase(unittest.TestCase):
             self.assertIsInstance(a, list)
 
         # Check we get the same top level keys
-        self.assertEqual(set(c.names(topLevelOnly=True)), set(c.data.keys()))
+        self.assertEqual(set(c.names(topLevelOnly=True)), set(c._data.keys()))
 
         # Check that we can iterate through items
         for k, v in c.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,7 +119,6 @@ class ConfigTestCase(unittest.TestCase):
         """Helper function to compare string splitting"""
         for s in (answer, *args):
             split = Config._splitIntoKeys(s)
-            print(f"S: {s} -> {split}")
             self.assertEqual(split, answer)
 
     def testSplitting(self):
@@ -144,7 +143,7 @@ class ConfigTestCase(unittest.TestCase):
             Config._splitIntoKeys("\ra\rcalexp\\\rwcs\rb")
 
         with self.assertRaises(ValueError):
-            Config._splitIntoKeys(".a.cal\rexp\.wcs.b")
+            Config._splitIntoKeys(".a.cal\rexp\\.wcs.b")
 
     def testEscape(self):
         c = Config({"a": {"foo.bar": 1}, "b😂c": {"bar_baz": 2}})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -211,6 +211,7 @@ class ConfigTestCase(unittest.TestCase):
         c1 = Config({"a": {"b": 1}, "c": 2})
         c2 = c1.copy()
         self.assertEqual(c1, c2)
+        self.assertIsInstance(c2, Config)
         c2[".a.b"] = 5
         self.assertNotEqual(c1, c2)
 


### PR DESCRIPTION
@TallJimbo noted that `__delitem__` was missing. Rather than copy the hierarchy access code to a new method this PR factors it out so it is shared for multiple dunder methods and `__delitem__` is then implemented on top of that.