### PR TITLE
DM-15256: Include calibration repositories in Gen2->Gen3 conversion

### DIFF
--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -28,6 +28,7 @@ datastore:
     ImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     DecoratedImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     MaskX: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
+    MaskedImageF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     Exposure: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     ExposureF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     ExposureI: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -48,6 +48,17 @@ storageClasses:
   MaskX:
     inheritsFrom: Mask
     pytype: lsst.afw.image.MaskX
+  MaskedImage:
+    pytype: lsst.afw.image.MaskedImage
+  MaskedImageF:
+    inheritsFrom: MaskedImage
+    pytype: lsst.afw.image.MaskedImageF
+  MaskedImageU:
+    inheritsFrom: MaskedImage
+    pytype: lsst.afw.image.MaskedImageU
+  MaskedImageI:
+    inheritsFrom: MaskedImage
+    pytype: lsst.afw.image.MaskedImageI
   Catalog:
     pytype: lsst.afw.table.BaseCatalog
   PeakCatalog:


### PR DESCRIPTION
The Gen2->Gen3 conversion code ignored calibration repositories
entirely.  This fixes the issue, by having the gen2convert/walker.py
script directly query calibration repos as they are discovered.  As
calibRegistry.sqlite3 contains no mapper information, this is derived
by searching parent directories to find a valid mapper to use.
Matching DM-15760, this uses datetime objects for the
valid_first/valid_last entries in the Dataset table.

Information about the MaskedImageF was added to the storage
class/datastore yaml files to allow the FLAT to be handled properly.

Additional changes to support this in obs_subaru.