### PR TITLE
Convert isrTask to valid pipelineTask.

### DIFF
--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -122,3 +122,7 @@ storageClasses:
     pytype: lsst.pex.config.Config
   Packages:
     pytype: lsst.base.Packages
+  NumpyArray:
+    pytype: numpy.ndarray
+  Thumbnail:
+    pytype: numpy.ndarray


### PR DESCRIPTION
Add additional storage classes needed for ISR products.  Fix
pickleFormatter issue that prevented python2 pickle products from
being read.