### PR TITLE
DM-17300: add configuration, bugfixes to support brightObjectMask dataset

### DIFF
--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -28,6 +28,7 @@ datastore:
     PeakCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     SimpleCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     SourceCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
+    ObjectMaskCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     ImageF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     ImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     DecoratedImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -28,7 +28,7 @@ datastore:
     PeakCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     SimpleCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     SourceCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
-    ObjectMaskCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
+    ObjectMaskCatalog: lsst.pipe.tasks.objectMasks.RegionFileFormatter
     ImageF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     ImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     DecoratedImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -69,6 +69,8 @@ storageClasses:
     pytype: lsst.afw.table.SimpleCatalog
   SourceCatalog:
     pytype: lsst.afw.table.SourceCatalog
+  ObjectMaskCatalog:
+    pytype: lsst.pipe.tasks.objectMasks.ObjectMaskCatalog
   SkyMap:
     pytype: lsst.skymap.BaseSkyMap
   PropertySet:

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -84,9 +84,6 @@ class MappingFactory:
     def placeInRegistry(self, registryKey, typeName):
         """Register a class name with the associated type.
 
-        The type name provided is validated against the reference
-        class, `refType` attribute, if defined.
-
         Parameters
         ----------
         registryKey : `str` or object supporting ``name`` attribute.
@@ -96,13 +93,9 @@ class MappingFactory:
 
         Raises
         ------
-        ValueError
-            If instance of class is not of the expected type.
         KeyError
             If item is already registered and has different value.
         """
-        if not self._isValidStr(typeName):
-            raise ValueError("Not a valid class string: {}".format(typeName))
         keyString = self._getName(registryKey)
         if keyString in self._registry:
             # Compare the class strings since dynamic classes can be the
@@ -135,17 +128,3 @@ class MappingFactory:
             return typeOrName.name
         else:
             raise ValueError("Cannot extract name from type")
-
-    def _isValidStr(self, typeName):
-        """Validate that the class type name provided does create instances of
-        objects that are of the expected type, as stored in the `refType`
-        attribute.
-        """
-        if self.refType is None:
-            return True
-        try:
-            c = getInstanceOf(typeName)
-        except (ImportError, TypeError, AttributeError):
-            return False
-        else:
-            return isinstance(c, self.refType)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -47,22 +47,6 @@ class FormatterFactoryTestCase(lsst.utils.tests.TestCase):
         from lsst.daf.butler.formatters.fitsCatalogFormatter import FitsCatalogFormatter
         self.assertEqual(type(f), FitsCatalogFormatter)
 
-        with self.assertRaises(ValueError):
-            # Try to store something that is not a Formatter but is a class
-            self.factory.registerFormatter("NotFormatter", "lsst.daf.butler.core.formatter.FormatterFactory")
-
-        with self.assertRaises(ValueError):
-            # Try to store something that is not a Formatter but is a module
-            self.factory.registerFormatter("NotFormatter", "lsst.daf.butler")
-
-        with self.assertRaises(ValueError):
-            # Try to store something that is not a Formatter and does not exist
-            self.factory.registerFormatter("NotFormatter", "lsst.daf.butler.x")
-
-        with self.assertRaises(ValueError):
-            # Try to store something that is not importable
-            self.factory.registerFormatter("NotImportable", "not a thing")
-
         with self.assertRaises(KeyError):
             f = self.factory.getFormatter("Missing")
 


### PR DESCRIPTION
First commit here uses the "lying" approach of Gen2, in which we pretend the `ObjectMaskCatalog` is saved as FITS because it has a `readFits` method.

Second and third commits stop that lying by using a new formatter defined in the pipe_tasks branch for this ticket.