### PR TITLE
DM-17496: query size and data ID expansion optimizations

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -3,6 +3,7 @@ registry:
   cls: lsst.daf.butler.registries.sqliteRegistry.SqliteRegistry
   db: 'sqlite:///:memory:'
   limited: false
+  deferOutputIdQueries: true
   skypix:
     cls: lsst.sphgeom.HtmPixelization
     level: 7

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -390,13 +390,22 @@ class Registry(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def getDataset(self, id):
+    def getDataset(self, id, datasetType=None, dataId=None):
         """Retrieve a Dataset entry.
 
         Parameters
         ----------
         id : `int`
             The unique identifier for the Dataset.
+        datasetType : `DatasetType`, optional
+            The `DatasetType` of the dataset to retrieve.  This is used to
+            short-circuit retrieving the `DatasetType`, so if provided, the
+            caller is guaranteeing that it is what would have been retrieved.
+        dataId : `DataId`, optional
+            A `Dimension`-based identifier for the dataset within a
+            collection, possibly containing additional metadata. This is used
+            to short-circuit retrieving the `DataId`, so if provided, the
+            caller is guaranteeing that it is what would have been retrieved.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registries/sqlPreFlight.py
+++ b/python/lsst/daf/butler/registries/sqlPreFlight.py
@@ -628,7 +628,8 @@ class SqlPreFlight:
                     )
                     datasetRefs[dsType] = ref if ref is not None else DatasetRef(dsType, dsDataId, id=None)
                 else:
-                    datasetRefs[dsType] = self.registry.getDataset(id=row[col])
+                    datasetRefs[dsType] = self.registry.getDataset(id=row[col], datasetType=dsType,
+                                                                   dataId=dsDataId)
 
             count += 1
             yield PreFlightDimensionsRow(dataId, datasetRefs)

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -800,7 +800,9 @@ class SqlRegistry(Registry):
             return dsType
         needed = [standardize(t) for t in neededDatasetTypes]
         future = [standardize(t) for t in futureDatasetTypes]
-        preFlight = SqlPreFlight(self, originInfo, needed, future, expandDataIds=expandDataIds)
+        preFlight = SqlPreFlight(self, originInfo, needed, future,
+                                 expandDataIds=expandDataIds,
+                                 deferOutputIdQueries=self.config["deferOutputIdQueries"])
         return preFlight.selectDimensions(expression)
 
     @disableWhenLimited

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -800,9 +800,8 @@ class SqlRegistry(Registry):
             return dsType
         needed = [standardize(t) for t in neededDatasetTypes]
         future = [standardize(t) for t in futureDatasetTypes]
-        preFlight = SqlPreFlight(self)
-        return preFlight.selectDimensions(originInfo, expression, needed, future,
-                                          expandDataIds=expandDataIds)
+        preFlight = SqlPreFlight(self, originInfo, needed, future, expandDataIds=expandDataIds)
+        return preFlight.selectDimensions(expression)
 
     @disableWhenLimited
     def _queryMetadata(self, element, dataId, columns):

--- a/python/lsst/daf/butler/registries/sqliteRegistry.py
+++ b/python/lsst/daf/butler/registries/sqliteRegistry.py
@@ -85,7 +85,7 @@ class SqliteRegistry(SqlRegistry):
         super().setConfigRoot(root, config, full)
         Config.overrideParameters(RegistryConfig, config, full,
                                   toUpdate={"db": "sqlite:///{}/gen3.sqlite3".format(root)},
-                                  toCopy=("cls", ))
+                                  toCopy=("cls", "deferOutputIdQueries"))
 
     def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False):
         registryConfig = SqlRegistryConfig(registryConfig)


### PR DESCRIPTION
This change reduces the number of table clauses in the big `selectDimensions` query used in preflight, getting it below SQLite's maximum number of joins (64) in our tests (and hopefully all realistic cases).

~The remaining commits attempt to speed up some of the data ID manipulations we apply to each result row of that query, which turn out to be much slower than the query itself.  In my profiling, that brought down time spent in preflight for ci_hsc from about 12 minutes to about 5 minutes.  That's still much too slow, but my remaining plans for speedups involve some combination of more significant refactoring and lifting code to C++, and I don't think either belongs on this ticket.~