### PR TITLE
DM-17608: use transactions in gen2convert to avoid slow locking

### DIFF
--- a/python/lsst/daf/butler/gen2convert/writer.py
+++ b/python/lsst/daf/butler/gen2convert/writer.py
@@ -199,12 +199,16 @@ class ConversionWriter:
 
         Runs all steps to create a Gen3 Repo.
         """
-        self.insertInstruments(registry)
-        self.insertSkyMaps(registry)
-        self.insertObservations(registry)
-        self.insertDatasetTypes(registry)
-        self.insertDatasets(registry, datastore)
-        self.insertObservationRegions(registry, datastore)
+        # Transaction here should help with performance as well as making the
+        # conversion atomic, as it prevents each Registry.addDataset from
+        # having to grab a new lock on the database.
+        with registry.transaction():
+            self.insertInstruments(registry)
+            self.insertSkyMaps(registry)
+            self.insertObservations(registry)
+            self.insertDatasetTypes(registry)
+            self.insertDatasets(registry, datastore)
+            self.insertObservationRegions(registry, datastore)
 
     def insertInstruments(self, registry):
         """Check that all necessary Instruments are already present in the

--- a/python/lsst/daf/butler/gen2convert/writer.py
+++ b/python/lsst/daf/butler/gen2convert/writer.py
@@ -286,13 +286,8 @@ class ConversionWriter:
         """
         log = Log.getLogger("lsst.daf.butler.gen2convert")
         for datasetType in self.datasetTypes.values():
-            # TODO: should put this "just make sure it exists" logic
-            # into registerDatasetType itself, and make it a bit more careful.
-            try:
-                registry.registerDatasetType(datasetType)
-                log.debug("Registered DatasetType '%s'." % datasetType.name)
-            except KeyError:
-                log.debug("DatasetType '%s' already registered." % datasetType.name)
+            registry.registerDatasetType(datasetType)
+            log.debug("Registered DatasetType '%s'." % datasetType.name)
 
     def insertDatasets(self, registry, datastore):
         """Add all Dataset entries to the given Registry and Datastore.

--- a/python/lsst/daf/butler/registries/sqliteRegistry.py
+++ b/python/lsst/daf/butler/registries/sqliteRegistry.py
@@ -22,6 +22,8 @@
 from contextlib import closing
 
 from sqlalchemy import event
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
 
 from sqlite3 import Connection as SQLite3Connection
 
@@ -92,7 +94,8 @@ class SqliteRegistry(SqlRegistry):
         super().__init__(registryConfig, schemaConfig, dimensionConfig, create)
 
     def _createEngine(self):
-        engine = super()._createEngine()
+        engine = create_engine(self.config["db"], poolclass=NullPool,
+                               connect_args={"check_same_thread": False})
         event.listen(engine, "connect", _onSqlite3Connect)
         event.listen(engine, "begin", _onSqlite3Begin)
         return engine


### PR DESCRIPTION
These changes were originally committed to DM-17496, but are not really part of its primary goal, and are actually more important to get merged, as they fix a slowdown in ci_hsc on master.  They have been tested with the stack being used for the demo later today (via the DM-17496 branch), and while we do not plan to use this branch for the demo, it would be desirable to get this into the weekly.

See commit messages for details.