### PR TITLE
DM-17720: Improve user expression handling in preflight

### DIFF
--- a/python/lsst/daf/butler/exprParser/__init__.py
+++ b/python/lsst/daf/butler/exprParser/__init__.py
@@ -1,3 +1,4 @@
 from .exprTree import *
 from .parserLex import *
 from .parserYacc import *
+from .treeVisitor import *

--- a/python/lsst/daf/butler/exprParser/parserLex.py
+++ b/python/lsst/daf/butler/exprParser/parserLex.py
@@ -96,7 +96,6 @@ class ParserLex:
         # NULL="NULL",
         OR="OR",
         AND="AND",
-        XOR="XOR",
         NOT="NOT",
         # BETWEEN="BETWEEN",
         # LIKE="LIKE",

--- a/python/lsst/daf/butler/exprParser/parserYacc.py
+++ b/python/lsst/daf/butler/exprParser/parserYacc.py
@@ -137,7 +137,6 @@ class ParserYacc:
 
     precedence = (
         ('left', 'OR'),
-        ('left', 'XOR'),
         ('left', 'AND'),
         ('nonassoc', 'EQ', 'NE'),  # Nonassociative operators
         ('nonassoc', 'LT', 'LE', 'GT', 'GE'),  # Nonassociative operators
@@ -160,7 +159,6 @@ class ParserYacc:
 
     def p_expr(self, p):
         """ expr : expr OR expr
-                 | expr XOR expr
                  | expr AND expr
                  | NOT expr
                  | bool_primary

--- a/python/lsst/daf/butler/exprParser/treeVisitor.py
+++ b/python/lsst/daf/butler/exprParser/treeVisitor.py
@@ -1,0 +1,143 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ['TreeVisitor']
+
+from abc import ABC, abstractmethod
+
+
+class TreeVisitor(ABC):
+    """Definition of interface for visitor classes.
+
+    Visitors and tree node classes implement Visitor pattern for tree
+    traversal. Typical use case is to generate different representation
+    of the tree, e.g. transforming parsed tree into SQLAlchemy clause.
+
+    All methods of the class can (and most likely should) return the
+    "transformed" value of the visited node. This value will be returned
+    from the `Node.visit` method and it will also be passed as an argument
+    to other methods of the visitor.
+    """
+    @abstractmethod
+    def visitNumericLiteral(self, value, node):
+        """Visit NumericLiteral node.
+
+        Parameters
+        ----------
+        value : `str`
+            The value associated with the visited node, the value is string,
+            exactly as it appears in the original expression. Depending on
+            use case it may need to be converted to `int` or `float`.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitStringLiteral(self, value, node):
+        """Visit StringLiteral node.
+
+        Parameters
+        ----------
+        value : `str`
+            The value associated with the visited node.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitIdentifier(self, name, node):
+        """Visit Identifier node.
+
+        Parameters
+        ----------
+        name : `str`
+            Identifier name.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitUnaryOp(self, operator, operand, node):
+        """Visit UnaryOp node.
+
+        Parameters
+        ----------
+        operator : `str`
+            Operator name, e.g. "NOT" or "+".
+        operand : `object`
+            Operand, this object is returned by one of the methods of this
+            class as a result of transformation of some other tree node.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitBinaryOp(self, operator, lhs, rhs, node):
+        """Visit BinaryOp node.
+
+        Parameters
+        ----------
+        operator : `str`
+            Operator name, e.g. "NOT" or "+".
+        lhs : `object`
+            Left hand side operand, this object is returned by one of the
+            methods of this class as a result of transformation of some other
+            tree node.
+        rhs : `object`
+            Right hand side operand, this object is returned by one of the
+            methods of this class as a result of transformation of some other
+            tree node.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitIsIn(self, lhs, values, not_in, node):
+        """Visit IsIn node.
+
+        Parameters
+        ----------
+        lhs : `object`
+            Left hand side operand, this object is returned by one of the
+            methods of this class as a result of transformation of some other
+            tree node.
+        values : `list` of `object`
+            Right hand side operand, list of objects returned by methods of
+            this class as a result of transformation of some other tree nodes.
+        not_in : `bool`
+            `True` for "NOT IN" expression.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitParens(self, expression, node):
+        """Visit Parens node.
+
+        Parameters
+        ----------
+        expression : `object`
+            Expression inside parentheses, this object is returned by one of
+            the methods of this class as a result of transformation of some
+            other tree node.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -82,15 +82,15 @@ class ParserLexTestCase(unittest.TestCase):
         """Test for reserved words"""
         lexer = ParserLex.make_lexer()
 
-#         tokens = "IS NOT IN NULL OR XOR AND BETWEEN LIKE ESCAPE REGEXP"
-        tokens = "NOT IN OR XOR AND"
+#         tokens = "IS NOT IN NULL OR AND BETWEEN LIKE ESCAPE REGEXP"
+        tokens = "NOT IN OR AND"
         lexer.input(tokens)
         for token in tokens.split():
             self._assertToken(lexer.token(), token, token)
         self.assertIsNone(lexer.token())
 
-#         tokens = "is not in null or xor and between like escape regexp"
-        tokens = "not in or xor and"
+#         tokens = "is not in null or and between like escape regexp"
+        tokens = "not in or and"
         lexer.input(tokens)
         for token in tokens.split():
             self._assertToken(lexer.token(), token.upper(), token)

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -202,7 +202,7 @@ class ParserLexTestCase(unittest.TestCase):
         """
         parser = ParserYacc()
 
-        for op in ('OR', 'XOR', 'AND'):
+        for op in ('OR', 'AND'):
             tree = parser.parse('a {} b'.format(op))
             self.assertIsInstance(tree, exprTree.BinaryOp)
             self.assertEqual(tree.op, op)

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -24,8 +24,37 @@
 
 import unittest
 
-from lsst.daf.butler.exprParser import exprTree, ParserYacc, ParseError
+from lsst.daf.butler.exprParser import exprTree, TreeVisitor, ParserYacc, ParseError
 import lsst.utils.tests
+
+
+class _Visitor(TreeVisitor):
+    """Trivial implementation of TreeVisitor.
+    """
+    def visitNumericLiteral(self, value, node):
+        return f"N({value})"
+
+    def visitStringLiteral(self, value, node):
+        return f"S({value})"
+
+    def visitIdentifier(self, name, node):
+        return f"ID({name})"
+
+    def visitUnaryOp(self, operator, operand, node):
+        return f"U({operator} {operand})"
+
+    def visitBinaryOp(self, operator, lhs, rhs, node):
+        return f"B({lhs} {operator} {rhs})"
+
+    def visitIsIn(self, lhs, values, not_in, node):
+        values = ", ".join([str(val) for val in values])
+        if not_in:
+            return f"!IN({lhs} ({values}))"
+        else:
+            return f"IN({lhs} ({values}))"
+
+    def visitParens(self, expression, node):
+        return f"P({expression})"
 
 
 class ParserLexTestCase(unittest.TestCase):
@@ -280,34 +309,22 @@ class ParserLexTestCase(unittest.TestCase):
     def testVisit(self):
         """Test for visitor methods"""
 
-        def _visitor(node, nodes):
-            nodes.append(node)
-
+        # test should cover all visit* methods
         parser = ParserYacc()
+        visitor = _Visitor()
 
         tree = parser.parse("(a+b)")
+        result = tree.visit(visitor)
+        self.assertEqual(result, "P(B(ID(a) + ID(b)))")
 
-        # collect all nodes into a list, depth first
-        nodes = []
-        tree.visitDepthFirst(_visitor, nodes)
-        self.assertEqual(len(nodes), 4)
-        self.assertIsInstance(nodes[0], exprTree.Identifier)
-        self.assertEqual(nodes[0].name, 'a')
-        self.assertIsInstance(nodes[1], exprTree.Identifier)
-        self.assertEqual(nodes[1].name, 'b')
-        self.assertIsInstance(nodes[2], exprTree.BinaryOp)
-        self.assertIsInstance(nodes[3], exprTree.Parens)
+        tree = parser.parse("(A or B) and not (x + 3 > y)")
+        result = tree.visit(visitor)
+        self.assertEqual(result, "B(P(B(ID(A) OR ID(B))) AND U(NOT P(B(B(ID(x) + N(3)) > ID(y)))))")
 
-        # collect all nodes into a list, breadth first
-        nodes = []
-        tree.visitBreadthFirst(_visitor, nodes)
-        self.assertEqual(len(nodes), 4)
-        self.assertIsInstance(nodes[0], exprTree.Parens)
-        self.assertIsInstance(nodes[1], exprTree.BinaryOp)
-        self.assertIsInstance(nodes[2], exprTree.Identifier)
-        self.assertEqual(nodes[2].name, 'a')
-        self.assertIsInstance(nodes[3], exprTree.Identifier)
-        self.assertEqual(nodes[3].name, 'b')
+        tree = parser.parse("x in (1,2) AND y NOT IN (1.1, .25, 1e2) OR z in ('a', 'b')")
+        result = tree.visit(visitor)
+        self.assertEqual(result, "B(B(IN(ID(x) (N(1), N(2))) AND !IN(ID(y) (N(1.1), N(.25), N(1e2))))"
+                         " OR IN(ID(z) (S(a), S(b))))")
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_sqlPreFlight.py
+++ b/tests/test_sqlPreFlight.py
@@ -130,7 +130,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                 preFlight = SqlPreFlight(self.registry, neededDatasetTypes=[rawType],
                                          futureDatasetTypes=[calexpType], originInfo=originInfo,
                                          deferOutputIdQueries=deferOutputIdQueries)
-                rows = preFlight.selectDimensions(expression="")
+                rows = preFlight.selectDimensions()
                 rows = list(rows)
                 self.assertEqual(len(rows), 4*3)   # 4 exposures times 3 detectors
                 for row in rows:
@@ -152,7 +152,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
         originInfo = DatasetOriginInfoDef(defaultInputs=[collection2], defaultOutput=collection1)
         preFlight = SqlPreFlight(self.registry, originInfo=originInfo, neededDatasetTypes=[rawType],
                                  futureDatasetTypes=[calexpType])
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 4*3)   # 4 exposures times 3 detectors
         for row in rows:
@@ -168,7 +168,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
         preFlight = SqlPreFlight(self.registry, originInfo=originInfo,
                                  neededDatasetTypes=[rawType],
                                  futureDatasetTypes=[calexpType])
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 6*3)   # 6 exposures times 3 detectors
         for row in rows:
@@ -191,12 +191,12 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
         self.assertCountEqual(set(row.dataId["visit"] for row in rows), (10,))
         self.assertCountEqual(set(row.dataId["detector"] for row in rows), (1, 2, 3))
 
-        # more limiting expression
+        # more limiting expression, using link names instead of Table.column
         originInfo = DatasetOriginInfoDef(defaultInputs=[collection1], defaultOutput="")
         preFlight = SqlPreFlight(self.registry, originInfo=originInfo,
                                  neededDatasetTypes=[rawType],
                                  futureDatasetTypes=[calexpType])
-        rows = preFlight.selectDimensions(expression="Visit.visit = 10 and Detector.detector > 1")
+        rows = preFlight.selectDimensions(expression="visit = 10 and detector > 1")
         rows = list(rows)
         self.assertEqual(len(rows), 2*2)   # 2 exposures times 2 detectors
         self.assertCountEqual(set(row.dataId["exposure"] for row in rows), (100, 101))
@@ -216,7 +216,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
         preFlight = SqlPreFlight(self.registry, originInfo=originInfo,
                                  neededDatasetTypes=[rawType],
                                  futureDatasetTypes=[calexpType])
-        rows = preFlight.selectDimensions(expression="PhysicalFilter.physical_filter = 'dummy_r'")
+        rows = preFlight.selectDimensions(expression="physical_filter = 'dummy_r'")
         rows = list(rows)
         self.assertEqual(len(rows), 2*3)   # 2 exposures times 3 detectors
         self.assertCountEqual(set(row.dataId["exposure"] for row in rows), (110, 111))
@@ -314,7 +314,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[rawType],
                                  futureDatasetTypes=[calexpType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 6*5)   # 6 exposures times 5 detectors
         for row in rows:
@@ -327,7 +327,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[rawType, biasType],
                                  futureDatasetTypes=[calexpType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 6*5)  # 6 exposures times 5 detectors
         for row in rows:
@@ -340,7 +340,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[rawType, flatType],
                                  futureDatasetTypes=[calexpType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 3*3)  # 3 exposures times 3 detectors
         for row in rows:
@@ -353,7 +353,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[rawType, flatType, biasType],
                                  futureDatasetTypes=[calexpType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="Detector.detector IN (1, 3)")
+        rows = preFlight.selectDimensions(expression="detector IN (1, 3)")
         rows = list(rows)
         self.assertEqual(len(rows), 3*2)  # 3 exposures times 2 detectors
         for row in rows:
@@ -435,7 +435,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[calexpType, mergeType],
                                  futureDatasetTypes=[measType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 3*4*2)   # 4 tracts x 4 patches x 2 filters
         for row in rows:
@@ -450,7 +450,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[calexpType, mergeType],
                                  futureDatasetTypes=[measType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="Tract.tract IN (1, 5) AND Patch.patch IN (2, 7)")
+        rows = preFlight.selectDimensions(expression="tract IN (1, 5) AND Patch.patch IN (2, 7)")
         rows = list(rows)
         self.assertEqual(len(rows), 2*2*2)   # 4 tracts x 4 patches x 2 filters
         self.assertCountEqual(set(row.dataId["tract"] for row in rows), (1, 5))
@@ -462,7 +462,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[calexpType, mergeType],
                                  futureDatasetTypes=[measType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="AbstractFilter.abstract_filter = 'i'")
+        rows = preFlight.selectDimensions(expression="abstract_filter = 'i'")
         rows = list(rows)
         self.assertEqual(len(rows), 3*4*1)   # 4 tracts x 4 patches x 2 filters
         self.assertCountEqual(set(row.dataId["tract"] for row in rows), (1, 3, 5))
@@ -475,7 +475,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[calexpType, mergeType],
                                  futureDatasetTypes=[measType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="SkyMap.skymap = 'Mars'")
+        rows = preFlight.selectDimensions(expression="skymap = 'Mars'")
         rows = list(rows)
         self.assertEqual(len(rows), 0)
 
@@ -511,7 +511,7 @@ class SqlPreFlightTestCase(lsst.utils.tests.TestCase):
                                  neededDatasetTypes=[calexpType],
                                  futureDatasetTypes=[coaddType],
                                  expandDataIds=False)
-        rows = preFlight.selectDimensions(expression="")
+        rows = preFlight.selectDimensions()
         rows = list(rows)
         self.assertEqual(len(rows), 0)
 


### PR DESCRIPTION
User expression is now parsed by preflight and then translated into
sqlalchemy clause expression. It now also supports using link names
instead of table.column syntax in expressions.
