### PR TITLE
DM-18577: Support butler relocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,11 @@ version.py
 _build.*
 .cache
 tests/.tests
-tests/test_input_datastore/
-tests/test_output_datastore/
 .sconf_temp/
 .sconsign.dblite
 config.log
 ups/*.cfgc
 pytest_session.txt
-butler_test_repository
 bin/*
 .coverage
 .pytest_cache/

--- a/bin.src/validateButlerConfiguration.py
+++ b/bin.src/validateButlerConfiguration.py
@@ -64,9 +64,6 @@ if __name__ == "__main__":
                         help="DatasetType(s) to ignore for validation (can be comma-separated)")
 
     args = parser.parse_args()
-    # The collection does not matter for validation but if a run is specified
-    # in the configuration then it must be consistent with this collection
-    butler = Butler(config=args.root, collection=args.collection)
 
     logFailures = True
     if args.quiet:
@@ -76,10 +73,17 @@ if __name__ == "__main__":
     ignore = processCommas(args.ignore)
     datasetTypes = processCommas(args.datasettype)
 
-    try:
-        butler.validateConfiguration(logFailures=logFailures, datasetTypeNames=datasetTypes,
-                                     ignore=ignore)
-    except ValidationError:
-        sys.exit(1)
-    else:
-        print("No problems encountered with configuration.")
+    exitStatus = 0
+
+    # The collection does not matter for validation but if a run is specified
+    # in the configuration then it must be consistent with this collection
+    with Butler(config=args.root, collection=args.collection) as butler:
+        try:
+            butler.validateConfiguration(logFailures=logFailures, datasetTypeNames=datasetTypes,
+                                         ignore=ignore)
+        except ValidationError:
+            exitStatus = 1
+        else:
+            print("No problems encountered with configuration.")
+
+    sys.exit(exitStatus)

--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -1,6 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
-  root: default_butler_repository
+  root: <root>/datastore
   records:
     table: PosixDatastoreRecords
   create: true

--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -1,6 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
-  root: <root>/datastore
+  root: <butlerRoot>/datastore
   records:
     table: PosixDatastoreRecords
   create: true

--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -8,7 +8,7 @@ datastore:
     # valid_first and valid_last here are YYYYMMDD; we assume we'll switch to
     # MJD (DM-15890) before we need more than day resolution, since that's all
     # Gen2 has.
-    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{run}"
+    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
   formatters:
     TablePersistable: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     TablePersistableWcs: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -70,3 +70,7 @@ Support API
 .. automodapi:: lsst.daf.butler.core.utils
    :no-main-docstr:
    :headings: ^"
+.. automodapi:: lsst.daf.butler.core.repoRelocation
+   :no-main-docstr:
+   :headings: ^"
+   :include-all-objects:

--- a/python/lsst/daf/butler/assemblers/exposureAssembler.py
+++ b/python/lsst/daf/butler/assemblers/exposureAssembler.py
@@ -22,7 +22,7 @@
 """Support for assembling and disassembling afw Exposures."""
 
 # Need to enable PSFs to be instantiated
-import lsst.afw.detection  # noqa F401
+import lsst.afw.detection  # noqa: F401
 from lsst.afw.image import makeExposure, makeMaskedImage
 
 from lsst.daf.butler import CompositeAssembler

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -220,6 +220,12 @@ class Butler:
         # resort if at all possible.
         self.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
     def close(self):
         """This method should be called to properly close any resources the
         butler may have open. The instance on which this method is closed

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -42,7 +42,7 @@ from .core.butlerConfig import ButlerConfig
 from .core.composites import CompositesMap
 from .core.dimensions import DataId
 from .core.exceptions import ValidationError
-from .core.repoRelocation import ROOT_TAG
+from .core.repoRelocation import BUTLER_ROOT_TAG
 from .core.safeFileIo import safeMakeDir
 
 log = logging.getLogger(__name__)
@@ -155,9 +155,9 @@ class Butler:
 
         full = ButlerConfig(config)  # this applies defaults
         datastoreClass = doImport(full["datastore", "cls"])
-        datastoreClass.setConfigRoot(ROOT_TAG, config, full)
+        datastoreClass.setConfigRoot(BUTLER_ROOT_TAG, config, full)
         registryClass = doImport(full["registry", "cls"])
-        registryClass.setConfigRoot(ROOT_TAG, config, full)
+        registryClass.setConfigRoot(BUTLER_ROOT_TAG, config, full)
         if standalone:
             config.merge(full)
         config.dumpToFile(os.path.join(root, "butler.yaml"))

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -155,7 +155,7 @@ class Butler:
 
         full = ButlerConfig(config)  # this applies defaults
         datastoreClass = doImport(full["datastore", "cls"])
-        datastoreClass.setConfigRoot(f"{ROOT_TAG}/datastore", config, full)
+        datastoreClass.setConfigRoot(ROOT_TAG, config, full)
         registryClass = doImport(full["registry", "cls"])
         registryClass.setConfigRoot(ROOT_TAG, config, full)
         if standalone:

--- a/python/lsst/daf/butler/core/butlerConfig.py
+++ b/python/lsst/daf/butler/core/butlerConfig.py
@@ -58,6 +58,8 @@ class ButlerConfig(Config):
 
     def __init__(self, other=None):
 
+        self.configDir = None
+
         # If this is already a ButlerConfig we assume that defaults
         # have already been loaded.
         if other is not None and isinstance(other, ButlerConfig):
@@ -73,6 +75,10 @@ class ButlerConfig(Config):
         # Read the supplied config so that we can work out which other
         # defaults to use.
         butlerConfig = Config(other)
+
+        configFile = butlerConfig.configFile
+        if configFile is not None:
+            self.configDir = os.path.dirname(os.path.abspath(configFile))
 
         # A Butler config contains defaults defined by each of the component
         # configuration classes. We ask each of them to apply defaults to

--- a/python/lsst/daf/butler/core/butlerConfig.py
+++ b/python/lsst/daf/butler/core/butlerConfig.py
@@ -64,6 +64,8 @@ class ButlerConfig(Config):
         # have already been loaded.
         if other is not None and isinstance(other, ButlerConfig):
             super().__init__(other)
+            # Ensure that the configuration directory propagates
+            self.configDir = other.configDir
             return
 
         if isinstance(other, str) and os.path.isdir(other):

--- a/python/lsst/daf/butler/core/butlerConfig.py
+++ b/python/lsst/daf/butler/core/butlerConfig.py
@@ -52,11 +52,18 @@ class ButlerConfig(Config):
     other : `str`, `Config`, optional
         Path to butler configuration YAML file or a directory containing a
         "butler.yaml" file. If `None` the butler will
-        be configured based entirely on defaults read from the environment.
+        be configured based entirely on defaults read from the environment
+        or from ``searchPaths``.
         No defaults will be read if a `ButlerConfig` is supplied directly.
+    searchPaths : `list` or `tuple`, optional
+        Explicit additional paths to search for defaults. They should
+        be supplied in priority order. These paths have higher priority
+        than those read from the environment in
+        `ConfigSubset.defaultSearchPaths()`.  They are only read if ``other``
+        refers to a configuration file or directory.
     """
 
-    def __init__(self, other=None):
+    def __init__(self, other=None, searchPaths=None):
 
         self.configDir = None
 
@@ -92,7 +99,7 @@ class ButlerConfig(Config):
             localOverrides = None
             if configClass.component in butlerConfig:
                 localOverrides = butlerConfig
-            config = configClass(localOverrides)
+            config = configClass(localOverrides, searchPaths=searchPaths)
             # Re-attach it using the global namespace
             self.update({configClass.component: config})
             # Remove the key from the butlerConfig since we have already

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -158,6 +158,7 @@ class Config(collections.abc.MutableMapping):
 
     def __init__(self, other=None):
         self._data = {}
+        self.configFile = None
 
         if other is None:
             return
@@ -226,6 +227,7 @@ class Config(collections.abc.MutableMapping):
         log.debug("Opening YAML config file: %s", path)
         with open(path, "r") as f:
             self.__initFromYaml(f)
+        self.configFile = path
 
     def __initFromYaml(self, stream):
         """Loads a YAML config from any readable stream that contains one.

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -46,7 +46,7 @@ log = logging.getLogger(__name__)
 CONFIG_PATH = "DAF_BUTLER_CONFIG_PATH"
 
 
-class Loader(yaml.CLoader):
+class Loader(yaml.CSafeLoader):
     """YAML Loader that supports file include directives
 
     Uses ``!include`` directive in a YAML file to point to another

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -186,7 +186,7 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @staticmethod
-    def fromConfig(config, registry):
+    def fromConfig(config, registry, butlerRoot=None):
         """Create datastore from type specified in config file.
 
         Parameters
@@ -195,9 +195,9 @@ class Datastore(metaclass=ABCMeta):
             Configuration instance.
         """
         cls = doImport(config["datastore", "cls"])
-        return cls(config=config, registry=registry)
+        return cls(config=config, registry=registry, butlerRoot=butlerRoot)
 
-    def __init__(self, config, registry):
+    def __init__(self, config, registry, butlerRoot=None):
         self.config = DatastoreConfig(config)
         self.registry = registry
         self.name = "ABCDataStore"

--- a/python/lsst/daf/butler/core/dimensions/dataId.py
+++ b/python/lsst/daf/butler/core/dimensions/dataId.py
@@ -96,7 +96,7 @@ class DimensionKeyDict(Mapping):
             self._keys = DimensionSet(universe, byName.keys())
 
         if where is None:
-            where = lambda x: True  # noqa E731; better than shadowing via def
+            where = lambda x: True  # noqa: E731; better than shadowing via def
 
         # Make a new dictionary keyed by DimensionElement in the right order,
         # using factory() when no value is available.

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -121,7 +121,7 @@ class Registry(metaclass=ABCMeta):
                                   toCopy=(("skypix", "cls"), ("skypix", "level")))
 
     @staticmethod
-    def fromConfig(registryConfig, schemaConfig=None, dimensionConfig=None, create=False):
+    def fromConfig(registryConfig, schemaConfig=None, dimensionConfig=None, create=False, butlerRoot=None):
         """Create `Registry` subclass instance from `config`.
 
         Uses ``registry.cls`` from `config` to determine which subclass to
@@ -174,9 +174,10 @@ class Registry(metaclass=ABCMeta):
                 raise ValueError("Incompatible Registry configuration: {}".format(registryConfig))
 
         cls = doImport(registryConfig["cls"])
-        return cls(registryConfig, schemaConfig, dimensionConfig, create=create)
+        return cls(registryConfig, schemaConfig, dimensionConfig, create=create, butlerRoot=butlerRoot)
 
-    def __init__(self, registryConfig, schemaConfig=None, dimensionConfig=None, create=False):
+    def __init__(self, registryConfig, schemaConfig=None, dimensionConfig=None, create=False,
+                 butlerRoot=None):
         assert isinstance(registryConfig, RegistryConfig)
         self.config = registryConfig
         self._pixelization = None

--- a/python/lsst/daf/butler/core/repoRelocation.py
+++ b/python/lsst/daf/butler/core/repoRelocation.py
@@ -1,0 +1,56 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Routines to support relocation of a file-based Butler repository."""
+
+__all__ = ("ROOT_TAG", "replaceRoot")
+
+import os.path
+
+# The special string to be used in configuration files to indicate that
+# the butler root location should be used.
+ROOT_TAG = "<root>"
+
+
+def replaceRoot(configRoot, butlerRoot):
+    """Update a configuration root with the butler root location (if
+    necessary).
+
+    Parameters
+    ----------
+    configRoot : `str`
+        Directory root location as specified in a configuration file.
+    butlerRoot : `str`
+        Butler root directory.  Absolute path is inserted into the
+        ``configRoot`` where the ``<root>`` string is found.  If `None`
+        the current working directory is used for the root.
+
+    Returns
+    -------
+    newRoot : `str`
+        New configuration string, with the root tag replaced with the butler
+        root if that tag was present in the supplied configuration root.
+    """
+
+    if butlerRoot is None:
+        butlerRoot = os.path.curdir
+
+    return configRoot.replace(ROOT_TAG, os.path.abspath(butlerRoot))

--- a/python/lsst/daf/butler/core/repoRelocation.py
+++ b/python/lsst/daf/butler/core/repoRelocation.py
@@ -21,18 +21,21 @@
 
 """Routines to support relocation of a file-based Butler repository."""
 
-__all__ = ("ROOT_TAG", "replaceRoot")
+__all__ = ("BUTLER_ROOT_TAG", "replaceRoot")
 
 import os.path
 
-# The special string to be used in configuration files to indicate that
-# the butler root location should be used.
-ROOT_TAG = "<root>"
+BUTLER_ROOT_TAG = "<butlerRoot>"
+"""The special string to be used in configuration files to indicate that
+the butler root location should be used."""
 
 
 def replaceRoot(configRoot, butlerRoot):
-    """Update a configuration root with the butler root location (if
-    necessary).
+    """Update a configuration root with the butler root location.
+
+    No changes are made if the special root string is not found in the
+    configuration entry.  The name of the tag is defined in
+    the module variable `~lsst.daf.butler.core.repoRelocation.BUTLER_ROOT_TAG`.
 
     Parameters
     ----------
@@ -40,8 +43,9 @@ def replaceRoot(configRoot, butlerRoot):
         Directory root location as specified in a configuration file.
     butlerRoot : `str`
         Butler root directory.  Absolute path is inserted into the
-        ``configRoot`` where the ``<root>`` string is found.  If `None`
-        the current working directory is used for the root.
+        ``configRoot`` where the
+        `~lsst.daf.butler.core.repoRelocation.BUTLER_ROOT_TAG` string is
+        found.  If `None` the current working directory is used for the root.
 
     Returns
     -------
@@ -53,4 +57,4 @@ def replaceRoot(configRoot, butlerRoot):
     if butlerRoot is None:
         butlerRoot = os.path.curdir
 
-    return configRoot.replace(ROOT_TAG, os.path.abspath(butlerRoot))
+    return configRoot.replace(BUTLER_ROOT_TAG, os.path.abspath(butlerRoot))

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -163,7 +163,7 @@ class Singleton(type):
 
     _instances = {}
 
-    def __call__(cls):  # noqa N805
+    def __call__(cls):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__()
         return cls._instances[cls]

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -123,7 +123,7 @@ class ChainedDatastore(Datastore):
 
         return
 
-    def __init__(self, config, registry=None):
+    def __init__(self, config, registry=None, butlerRoot=None):
         super().__init__(config, registry)
 
         self.storageClassFactory = StorageClassFactory()
@@ -133,7 +133,7 @@ class ChainedDatastore(Datastore):
         for c in self.config["datastores"]:
             c = DatastoreConfig(c)
             datastoreType = doImport(c["cls"])
-            datastore = datastoreType(c, registry)
+            datastore = datastoreType(c, registry, butlerRoot=butlerRoot)
             log.debug("Creating child datastore %s", datastore.name)
             self.datastores.append(datastore)
 

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -91,7 +91,7 @@ class InMemoryDatastore(Datastore):
     """A new datastore is created every time and datasets disappear when
     the process shuts down."""
 
-    def __init__(self, config, registry=None):
+    def __init__(self, config, registry=None, butlerRoot=None):
         super().__init__(config, registry)
 
         self.storageClassFactory = StorageClassFactory()

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -408,7 +408,7 @@ class PosixDatastore(Datastore):
         if formatter is None:
             formatter = self.formatterFactory.getFormatter(ref)
 
-        fullPath = os.path.join(self.root, path)
+        fullPath = os.path.normpath(os.path.join(self.root, path))
         if not os.path.exists(fullPath):
             raise FileNotFoundError("File at '{}' does not exist; note that paths to ingest are "
                                     "assumed to be relative to self.root unless they are absolute."

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -420,6 +420,8 @@ class PosixDatastore(Datastore):
                 if os.path.commonpath([absRoot, path]) != absRoot:
                     raise RuntimeError("'{}' is not inside repository root '{}'".format(path, self.root))
                 path = os.path.relpath(path, absRoot)
+            elif path.startswith(os.path.pardir):
+                raise RuntimeError(f"'{path}' is outside repository root '{self.root}'")
         else:
             template = self.templates.getTemplate(ref)
             location = self.locationFactory.fromPath(template.format(ref))

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -112,6 +112,13 @@ class PosixDatastore(Datastore):
         if "root" not in self.config:
             raise ValueError("No root directory specified in configuration")
 
+        # Name ourselves either using an explicit name or a name
+        # derived from the (unexpanded) root
+        if "name" in self.config:
+            self.name = self.config["name"]
+        else:
+            self.name = "POSIXDatastore@{}".format(self.config["root"])
+
         # Support repository relocation in config
         self.root = replaceRoot(self.config["root"], butlerRoot)
 
@@ -131,9 +138,6 @@ class PosixDatastore(Datastore):
         # Read the file naming templates
         self.templates = FileTemplates(self.config["templates"])
         self.templates.normalizeDimensions(self.registry.dimensions)
-
-        # Name ourselves
-        self.name = "POSIXDatastore@{}".format(self.root)
 
         # Storage of paths and formatters, keyed by dataset_id
         types = {"path": str, "formatter": str, "storage_class": str,

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -48,10 +48,14 @@ class YamlFormatter(FileFormatter):
         data : `object`
             Either data as Python object read from YAML file, or None
             if the file could not be opened.
+
+        Notes
+        -----
+        The `~yaml.UnsafeLoader` is used when parsing the YAML file.
         """
         try:
             with open(path, "r") as fd:
-                data = yaml.load(fd)
+                data = yaml.load(fd, Loader=yaml.UnsafeLoader)
         except FileNotFoundError:
             data = None
 

--- a/python/lsst/daf/butler/gen2convert/walker.py
+++ b/python/lsst/daf/butler/gen2convert/walker.py
@@ -108,7 +108,7 @@ class ConversionWalker:
         calibDict = None
         if os.path.exists(repoCfgPath):
             with open(repoCfgPath, "r") as f:
-                repoCfg = yaml.load(f)
+                repoCfg = yaml.load(f, Loader=yaml.UnsafeLoader)
             parentPaths = [parent.root for parent in repoCfg.parents]
             MapperClass = repoCfg.mapper
         elif os.path.exists(calibPath):

--- a/python/lsst/daf/butler/gen2convert/walker.py
+++ b/python/lsst/daf/butler/gen2convert/walker.py
@@ -28,7 +28,7 @@ import sqlite3
 import datetime
 
 # register YAML loader for repositoryCfg.yaml files.
-import lsst.daf.persistence.repositoryCfg   # noqa F401
+import lsst.daf.persistence.repositoryCfg   # noqa: F401
 
 from astro_metadata_translator import ObservationInfo
 from lsst.afw.image import readMetadata

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -70,7 +70,7 @@ class SqlRegistry(Registry):
     absolute path. Can be None if no defaults specified.
     """
 
-    def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False):
+    def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False, butlerRoot=None):
         registryConfig = SqlRegistryConfig(registryConfig)
         super().__init__(registryConfig, dimensionConfig=dimensionConfig)
         self.storageClasses = StorageClassFactory()

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -1,6 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
-  root: <root>/butler_test_repository
+  root: <butlerRoot>/butler_test_repository
   templates:
     default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
     calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -1,6 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
-  root: ./butler_test_repository
+  root: <root>/butler_test_repository
   templates:
     default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
     calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -1,4 +1,5 @@
 datastore:
+  name: SecondDatastore
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
   root: <root>/butler_test_repository2
   records:

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -1,7 +1,7 @@
 datastore:
   name: SecondDatastore
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
-  root: <root>/butler_test_repository2
+  root: <butlerRoot>/butler_test_repository2
   records:
     table: PosixDatastoreRecords2
   templates:

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -1,6 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
-  root: ./butler_test_repository2
+  root: <root>/butler_test_repository2
   records:
     table: PosixDatastoreRecords2
   templates:

--- a/tests/config/testConfigs/datastores/posixDatastore.yaml
+++ b/tests/config/testConfigs/datastores/posixDatastore.yaml
@@ -1,0 +1,3 @@
+datastore:
+  records:
+    table: OverrideRecord

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -34,6 +34,7 @@ from lsst.daf.butler import StorageClassFactory
 from lsst.daf.butler import DatasetType, DatasetRef
 from lsst.daf.butler import FileTemplateValidationError, ValidationError
 from examplePythonTypes import MetricsExample
+from lsst.daf.butler.core.repoRelocation import BUTLER_ROOT_TAG
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -405,7 +406,7 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     validationCanFail = True
 
     datastoreStr = ["/tmp"]
-    datastoreName = ["POSIXDatastore@<root>"]
+    datastoreName = [f"POSIXDatastore@{BUTLER_ROOT_TAG}"]
     registryStr = "/gen3.sqlite3'"
 
     def testPutTemplates(self):
@@ -482,7 +483,7 @@ class ChainedDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     fullConfigKey = ".datastore.datastores.1.formatters"
     validationCanFail = True
     datastoreStr = ["datastore='InMemory", "/PosixDatastore_1,", "/PosixDatastore_2'"]
-    datastoreName = ["InMemoryDatastore@", "POSIXDatastore@<root>/PosixDatastore_1",
+    datastoreName = ["InMemoryDatastore@", f"POSIXDatastore@{BUTLER_ROOT_TAG}/PosixDatastore_1",
                      "SecondDatastore"]
     registryStr = "/gen3.sqlite3'"
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -364,12 +364,17 @@ class ButlerTests:
     def testStringification(self):
         butler = Butler(self.configFile)
         butlerStr = str(butler)
-        if self.datastoreStr is not None:
 
+        if self.datastoreStr is not None:
             for testStr in self.datastoreStr:
                 self.assertIn(testStr, butlerStr)
         if self.registryStr is not None:
             self.assertIn(self.registryStr, butlerStr)
+
+        datastoreName = butler.datastore.name
+        if self.datastoreName is not None:
+            for testStr in self.datastoreName:
+                self.assertIn(testStr, datastoreName)
 
 
 class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
@@ -379,6 +384,7 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     validationCanFail = True
 
     datastoreStr = ["butler_test_repository"]
+    datastoreName = ["POSIXDatastore@<root>/butler_test_repository"]
     registryStr = "registry='sqlite:///:memory:'"
 
     def testPutTemplates(self):
@@ -445,6 +451,7 @@ class InMemoryDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     useTempRoot = False
     validationCanFail = False
     datastoreStr = ["datastore='InMemory'"]
+    datastoreName = ["InMemoryDatastore@"]
     registryStr = "registry='sqlite:///:memory:'"
 
 
@@ -454,6 +461,7 @@ class ChainedDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     fullConfigKey = ".datastore.datastores.1.formatters"
     validationCanFail = True
     datastoreStr = ["datastore='InMemory", "/butler_test_repository,", "/butler_test_repository2'"]
+    datastoreName = ["InMemoryDatastore@", "POSIXDatastore@<root>/butler_test_repository", "SecondDatastore"]
     registryStr = "registry='sqlite:///:memory:'"
 
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -363,10 +363,13 @@ class ButlerTests:
 
     def testStringification(self):
         butler = Butler(self.configFile)
+        butlerStr = str(butler)
         if self.datastoreStr is not None:
-            self.assertIn(self.datastoreStr, str(butler))
+
+            for testStr in self.datastoreStr:
+                self.assertIn(testStr, butlerStr)
         if self.registryStr is not None:
-            self.assertIn(self.registryStr, str(butler))
+            self.assertIn(self.registryStr, butlerStr)
 
 
 class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
@@ -375,7 +378,7 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     fullConfigKey = ".datastore.formatters"
     validationCanFail = True
 
-    datastoreStr = "datastore='./butler_test_repository"
+    datastoreStr = ["butler_test_repository"]
     registryStr = "registry='sqlite:///:memory:'"
 
     def testPutTemplates(self):
@@ -407,7 +410,8 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
 
         # Put with exactly the data ID keys needed
         ref = butler.put(metric, "metric1", dataId1)
-        self.assertTrue(os.path.exists(os.path.join(self.root, "ingest/metric1/DummyCamComp_423.pickle")))
+        self.assertTrue(os.path.exists(os.path.join(butler.datastore.root,
+                                                    "ingest/metric1/DummyCamComp_423.pickle")))
 
         # Check the template based on dimensions
         butler.datastore.templates.validateTemplates([ref])
@@ -417,7 +421,8 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
         # defining them  to behave now; the important thing is that they
         # must be consistent).
         ref = butler.put(metric, "metric2", dataId2)
-        self.assertTrue(os.path.exists(os.path.join(self.root, "ingest/metric2/DummyCamComp_423.pickle")))
+        self.assertTrue(os.path.exists(os.path.join(butler.datastore.root,
+                                                    "ingest/metric2/DummyCamComp_423.pickle")))
 
         # Check the template based on dimensions
         butler.datastore.templates.validateTemplates([ref])
@@ -439,7 +444,7 @@ class InMemoryDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     fullConfigKey = None
     useTempRoot = False
     validationCanFail = False
-    datastoreStr = "datastore='InMemory'"
+    datastoreStr = ["datastore='InMemory'"]
     registryStr = "registry='sqlite:///:memory:'"
 
 
@@ -448,7 +453,7 @@ class ChainedDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
     fullConfigKey = ".datastore.datastores.1.formatters"
     validationCanFail = True
-    datastoreStr = "datastore='InMemory, ./butler_test_repository, ./butler_test_repository2'"
+    datastoreStr = ["datastore='InMemory", "/butler_test_repository,", "/butler_test_repository2'"]
     registryStr = "registry='sqlite:///:memory:'"
 
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -29,7 +29,7 @@ import shutil
 import pickle
 
 from lsst.daf.butler.core.safeFileIo import safeMakeDir
-from lsst.daf.butler import Butler, Config
+from lsst.daf.butler import Butler, Config, ButlerConfig
 from lsst.daf.butler import StorageClassFactory
 from lsst.daf.butler import DatasetType, DatasetRef
 from lsst.daf.butler import FileTemplateValidationError, ValidationError
@@ -51,6 +51,26 @@ class TransactionTestError(Exception):
     that might otherwise occur when a standard exception is used.
     """
     pass
+
+
+class ButlerConfigTests(unittest.TestCase):
+    """Simple tests for ButlerConfig that are not tested in other test cases.
+    """
+
+    def testSearchPath(self):
+        configFile = os.path.join(TESTDIR, "config", "basic", "butler.yaml")
+        with self.assertLogs("lsst.daf.butler", level="DEBUG") as cm:
+            config1 = ButlerConfig(configFile)
+        self.assertNotIn("testConfigs", "\n".join(cm.output))
+
+        overrideDirectory = os.path.join(TESTDIR, "config", "testConfigs")
+        with self.assertLogs("lsst.daf.butler", level="DEBUG") as cm:
+            config2 = ButlerConfig(configFile, searchPaths=[overrideDirectory])
+        self.assertIn("testConfigs", "\n".join(cm.output))
+
+        key = ("datastore", "records", "table")
+        self.assertNotEqual(config1[key], config2[key])
+        self.assertEqual(config2[key], "OverrideRecord")
 
 
 class ButlerTests:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -384,8 +384,8 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     fullConfigKey = ".datastore.formatters"
     validationCanFail = True
 
-    datastoreStr = ["/datastore"]
-    datastoreName = ["POSIXDatastore@<root>/datastore"]
+    datastoreStr = ["/tmp"]
+    datastoreName = ["POSIXDatastore@<root>"]
     registryStr = "/gen3.sqlite3'"
 
     def testPutTemplates(self):
@@ -461,8 +461,8 @@ class ChainedDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
     fullConfigKey = ".datastore.datastores.1.formatters"
     validationCanFail = True
-    datastoreStr = ["datastore='InMemory", "/datastore/PosixDatastore_1,", "/datastore/PosixDatastore_2'"]
-    datastoreName = ["InMemoryDatastore@", "POSIXDatastore@<root>/datastore/PosixDatastore_1",
+    datastoreStr = ["datastore='InMemory", "/PosixDatastore_1,", "/PosixDatastore_2'"]
+    datastoreName = ["InMemoryDatastore@", "POSIXDatastore@<root>/PosixDatastore_1",
                      "SecondDatastore"]
     registryStr = "/gen3.sqlite3'"
 
@@ -470,6 +470,7 @@ class ChainedDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
 class ButlerExplicitRootTestCase(PosixDatastoreButlerTestCase):
     """Test that a yaml file in one location can refer to a root in another."""
 
+    datastoreStr = ["dir1"]
     # Disable the makeRepo test since we are deliberately not using
     # butler.yaml as the config name.
     fullConfigKey = None

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -99,7 +99,7 @@ class ButlerFitsTests(FitsCatalogDatasetsHelper, DatasetTestHelper):
                                                     "physical_filter": "d-r"})
         butler.put(exposure, datasetTypeName, dataId)
         # Get the full thing
-        full = butler.get(datasetTypeName, dataId)  # noqa F841
+        butler.get(datasetTypeName, dataId)
         # TODO enable check for equality (fix for Exposure type)
         # self.assertEqual(full, exposure)
         # Get a component


### PR DESCRIPTION
* Allow a datastore/registry root to be specified relative to the location of the `butler.yaml` file.
* Allow the name of a posix datastore to be specified in the config file.