### PR TITLE
DM-19373: Add lsst.meas.algorithms.Defects to StorageClass and formatter

### DIFF
--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -29,6 +29,7 @@ datastore:
     SimpleCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     SourceCatalog: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     ObjectMaskCatalog: lsst.pipe.tasks.objectMasks.RegionFileFormatter
+    DefectsList: lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter
     ImageF: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     ImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter
     DecoratedImageU: lsst.daf.butler.formatters.fitsExposureFormatter.FitsExposureFormatter

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -79,6 +79,8 @@ storageClasses:
     pytype: lsst.daf.base.PropertyList
   PropertySet:
     pytype: lsst.daf.base.PropertySet
+  DefectsList:
+    pytype: lsst.meas.algorithms.Defects
   Exposure:
     pytype: lsst.afw.image.Exposure
     assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler


### PR DESCRIPTION
Uses the normal FITS catalog formatter since writeFits and
readFits work properly.