### PR TITLE
DM-19614: Skip transmission curves in gen2convert.

### DIFF
--- a/config/gen2convert.yaml
+++ b/config/gen2convert.yaml
@@ -48,10 +48,6 @@ collections:
     raw: raw
     ref_cat: ref/{name}
     ref_cat_config: ref/{name}
-    transmission_filter: calib
-    transmission_sensor: calib
-    transmission_optics: calib
-    transmission_atmosphere: calib
 runs:
   # Names of Collections (after processing via the above section)
   # that should be assigned to a particular Run (dict values are integer
@@ -75,3 +71,13 @@ storageClasses:
   BackgroundList: Background
   Config: Config
   raw: ExposureU
+skip:
+  # DatasetTypes that should never be converted, generally because they're
+  # better added to Gen3 repos via some other means.
+  # All of the below are handled by writeCuratedCalibrations (at least
+  # on HSC).
+  - bfKernel
+  - transmission_filter
+  - transmission_sensor
+  - transmission_optics
+  - transmission_atmosphere

--- a/python/lsst/daf/butler/gen2convert/writer.py
+++ b/python/lsst/daf/butler/gen2convert/writer.py
@@ -331,7 +331,7 @@ class ConversionWriter:
             refs = []
             for datasetTypeName, datasets in repo.gen2.datasets.items():
                 datasetType = self.datasetTypes.get(datasetTypeName, None)
-                if datasetType is None:
+                if datasetType is None or datasetTypeName in self.config.get("skip", []):
                     log.debug("Skipping insertion of '%s' from %s", datasetTypeName, repo.gen2.root)
                     continue
                 log.info("Inserting '%s' from %s", datasetTypeName, repo.gen2.root)


### PR DESCRIPTION
These are now to be treated as curated calibrations, added explicitly by Instrument objects.