### PR TITLE
DM-19615: Change raw StorageClass in gen2convert to Exposure.

### DIFF
--- a/config/gen2convert.yaml
+++ b/config/gen2convert.yaml
@@ -70,7 +70,7 @@ storageClasses:
   TransmissionCurve: TablePersistableTransmissionCurve
   BackgroundList: Background
   Config: Config
-  raw: ExposureU
+  raw: Exposure
 skip:
   # DatasetTypes that should never be converted, generally because they're
   # better added to Gen3 repos via some other means.


### PR DESCRIPTION
LSST raws in particular will not be unsigned short.