### PR TITLE
DM-19671: Allow setConfigRoot to retain input values

### DIFF
--- a/bin.src/makeButlerRepo.py
+++ b/bin.src/makeButlerRepo.py
@@ -22,6 +22,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import logging
 
 from lsst.daf.butler import Butler, Config
 
@@ -36,6 +37,16 @@ if __name__ == "__main__":
     parser.add_argument("--standalone", action="store_true", default=False,
                         help=("Include all defaults in the config file in the repo, insulating "
                               "the repo from changes in package defaults."))
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Turn on debug reporting.")
+    parser.add_argument("--override", "-o", action="store_true",
+                        help="Allow values in the supplied config to override any root settings.")
     args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    forceConfigRoot = not args.override
+
     config = Config(args.config) if args.config is not None else None
-    Butler.makeRepo(args.root, config=config, standalone=args.standalone)
+    Butler.makeRepo(args.root, config=config, standalone=args.standalone, forceConfigRoot=forceConfigRoot)

--- a/bin.src/makeButlerRepo.py
+++ b/bin.src/makeButlerRepo.py
@@ -37,6 +37,9 @@ if __name__ == "__main__":
     parser.add_argument("--standalone", action="store_true", default=False,
                         help=("Include all defaults in the config file in the repo, insulating "
                               "the repo from changes in package defaults."))
+    parser.add_argument("--outfile", "-f", default=None, type=str,
+                        help="Name of output file to receive repository configuration."
+                             " Default is to write butler.yaml into the specified root.")
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Turn on debug reporting.")
     parser.add_argument("--override", "-o", action="store_true",
@@ -49,4 +52,5 @@ if __name__ == "__main__":
     forceConfigRoot = not args.override
 
     config = Config(args.config) if args.config is not None else None
-    Butler.makeRepo(args.root, config=config, standalone=args.standalone, forceConfigRoot=forceConfigRoot)
+    Butler.makeRepo(args.root, config=config, standalone=args.standalone, forceConfigRoot=forceConfigRoot,
+                    outfile=args.outfile)

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -105,7 +105,7 @@ class Butler:
 
     @staticmethod
     def makeRepo(root, config=None, standalone=False, createRegistry=True, searchPaths=None,
-                 forceConfigRoot=True):
+                 forceConfigRoot=True, outfile=None):
         """Create an empty data repository by adding a butler.yaml config
         to a repository root directory.
 
@@ -141,6 +141,9 @@ class Butler:
             of the root directory for a datastore or registry to be given.
             If this parameter is `True` the values for ``root`` will be
             forced into the resulting config if appropriate.
+        outfile : `str`, optional
+            If not-`None`, the output configuration will be written to this
+            location rather than into the repository itself.
 
         Returns
         -------
@@ -183,7 +186,15 @@ class Butler:
         registryClass.setConfigRoot(BUTLER_ROOT_TAG, config, full, overwrite=forceConfigRoot)
         if standalone:
             config.merge(full)
-        config.dumpToFile(os.path.join(root, "butler.yaml"))
+
+        # Write out the config
+        if outfile is not None:
+            # Force root so that we can find everything else
+            config["root"] = root
+        else:
+            outfile = os.path.join(root, "butler.yaml")
+        config.dumpToFile(outfile)
+
         # Create Registry and populate tables
         registryClass.fromConfig(config, create=createRegistry, butlerRoot=root)
         return config

--- a/python/lsst/daf/butler/butler.py
+++ b/python/lsst/daf/butler/butler.py
@@ -117,7 +117,9 @@ class Butler:
             Configuration to write to the repository, after setting any
             root-dependent Registry or Datastore config options.  Can not
             be a `ButlerConfig` or a `ConfigSubset`.  If `None`, default
-            configuration will be used.
+            configuration will be used.  Root-dependent config options
+            specified in this config are not overwritten.  This allows
+            specialist defaults to be specified.
         standalone : `bool`
             If True, write all expanded defaults, not just customized or
             repository-specific settings.
@@ -168,9 +170,9 @@ class Butler:
 
         full = ButlerConfig(config, searchPaths=searchPaths)  # this applies defaults
         datastoreClass = doImport(full["datastore", "cls"])
-        datastoreClass.setConfigRoot(BUTLER_ROOT_TAG, config, full)
+        datastoreClass.setConfigRoot(BUTLER_ROOT_TAG, config, full, overwrite=False)
         registryClass = doImport(full["registry", "cls"])
-        registryClass.setConfigRoot(BUTLER_ROOT_TAG, config, full)
+        registryClass.setConfigRoot(BUTLER_ROOT_TAG, config, full, overwrite=False)
         if standalone:
             config.merge(full)
         config.dumpToFile(os.path.join(root, "butler.yaml"))

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -731,13 +731,13 @@ class Config(collections.abc.MutableMapping):
             self.dump(f)
 
     @staticmethod
-    def overrideParameters(configType, config, full, toUpdate=None, toCopy=None, overwrite=True):
-        """Generic helper function for overriding specific config parameters
+    def updateParameters(configType, config, full, toUpdate=None, toCopy=None, overwrite=True):
+        """Generic helper function for updating specific config parameters.
 
         Allows for named parameters to be set to new values in bulk, and
         for other values to be set by copying from a reference config.
 
-        Assumes that the supplied config is compatible with ```configType``
+        Assumes that the supplied config is compatible with ``configType``
         and will attach the updated values to the supplied config by
         looking for the related component key.  It is assumed that
         ``config`` and ``full`` are from the same part of the

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -731,7 +731,7 @@ class Config(collections.abc.MutableMapping):
             self.dump(f)
 
     @staticmethod
-    def overrideParameters(configType, config, full, toUpdate=None, toCopy=None):
+    def overrideParameters(configType, config, full, toUpdate=None, toCopy=None, overwrite=True):
         """Generic helper function for overriding specific config parameters
 
         Allows for named parameters to be set to new values in bulk, and
@@ -769,6 +769,9 @@ class Config(collections.abc.MutableMapping):
         toCopy : `tuple`, optional
             `tuple` of keys whose values should be copied from ``full``
             into ``config``.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite.
 
         Raises
         ------
@@ -791,12 +794,20 @@ class Config(collections.abc.MutableMapping):
 
         if toUpdate:
             for key, value in toUpdate.items():
-                localConfig[key] = value
+                if key in localConfig and not overwrite:
+                    log.debug("Not overriding key '%s' with value '%s' in config %s",
+                              key, value, localConfig.__class__.__name__)
+                else:
+                    localConfig[key] = value
 
         if toCopy:
             localFullConfig = configType(full, mergeDefaults=False)
             for key in toCopy:
-                localConfig[key] = localFullConfig[key]
+                if key in localConfig and not overwrite:
+                    log.debug("Not overriding key '%s' from defaults in config %s",
+                              key, value, localConfig.__class__.__name__)
+                else:
+                    localConfig[key] = localFullConfig[key]
 
         # Reattach to parent if this is a child config
         if configType.component in config:

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -761,7 +761,7 @@ class Config(collections.abc.MutableMapping):
 
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         toUpdate : `dict`, optional
             A `dict` defining the keys to update and the new value to use.
             The keys and values can be any supported by `Config`
@@ -770,7 +770,7 @@ class Config(collections.abc.MutableMapping):
             `tuple` of keys whose values should be copied from ``full``
             into ``config``.
         overwrite : `bool`, optional
-            If `False`, do not modify a value in ``config`` if the value
+            If `False`, do not modify a value in ``config`` if the key
             already exists.  Default is always to overwrite.
 
         Raises

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -181,7 +181,7 @@ class Datastore(metaclass=ABCMeta):
             modified by this method.
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -163,7 +163,7 @@ class Datastore(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for this Datastore to
         be appropriate for a new empty repository with the given root.
 
@@ -182,6 +182,16 @@ class Datastore(metaclass=ABCMeta):
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -96,7 +96,7 @@ class Registry(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for this Registry to
         be appropriate for a new empty repository with the given root.
 
@@ -115,9 +115,19 @@ class Registry(metaclass=ABCMeta):
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
         Config.overrideParameters(RegistryConfig, config, full,
-                                  toCopy=(("skypix", "cls"), ("skypix", "level")))
+                                  toCopy=(("skypix", "cls"), ("skypix", "level")), overwrite=overwrite)
 
     @staticmethod
     def fromConfig(registryConfig, schemaConfig=None, dimensionConfig=None, create=False, butlerRoot=None):

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -126,8 +126,8 @@ class Registry(metaclass=ABCMeta):
         will not be overridden by this method if ``overwrite`` is `False`.
         This allows explicit values set in external configs to be retained.
         """
-        Config.overrideParameters(RegistryConfig, config, full,
-                                  toCopy=(("skypix", "cls"), ("skypix", "level")), overwrite=overwrite)
+        Config.updateParameters(RegistryConfig, config, full,
+                                toCopy=(("skypix", "cls"), ("skypix", "level")), overwrite=overwrite)
 
     @staticmethod
     def fromConfig(registryConfig, schemaConfig=None, dimensionConfig=None, create=False, butlerRoot=None):

--- a/python/lsst/daf/butler/core/registry.py
+++ b/python/lsst/daf/butler/core/registry.py
@@ -114,7 +114,7 @@ class Registry(metaclass=ABCMeta):
             modified by this method.
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -87,7 +87,7 @@ class ChainedDatastore(Datastore):
             modified by this method.
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -69,7 +69,7 @@ class ChainedDatastore(Datastore):
     """Key to specify where child datastores are configured."""
 
     @classmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for child Datastores to
         be appropriate for a new empty repository with the given root.
 
@@ -88,6 +88,16 @@ class ChainedDatastore(Datastore):
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
 
         # Extract the part of the config we care about updating
@@ -108,7 +118,7 @@ class ChainedDatastore(Datastore):
             fullChildConfig = DatastoreConfig(fullChild, mergeDefaults=False)
             datastoreClass = doImport(fullChildConfig["cls"])
             newroot = "{}/{}_{}".format(root, datastoreClass.__qualname__, idx)
-            datastoreClass.setConfigRoot(newroot, childConfig, fullChildConfig)
+            datastoreClass.setConfigRoot(newroot, childConfig, fullChildConfig, overwrite=overwrite)
 
             # Reattach to parent
             datastoreConfig[containerKey, idx] = childConfig

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -136,7 +136,7 @@ class InMemoryDatastore(Datastore):
             modified by this method.
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -116,7 +116,7 @@ class InMemoryDatastore(Datastore):
         return "InMemory"
 
     @classmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for this Datastore to
         be appropriate for a new empty repository with the given root.
 
@@ -137,6 +137,16 @@ class InMemoryDatastore(Datastore):
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
         return
 

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -84,7 +84,7 @@ class PosixDatastore(Datastore):
                                                       "checksum", "file_size"])
 
     @classmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for this Datastore to
         be appropriate for a new empty repository with the given root.
 
@@ -103,10 +103,20 @@ class PosixDatastore(Datastore):
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
         Config.overrideParameters(DatastoreConfig, config, full,
                                   toUpdate={"root": root},
-                                  toCopy=("cls", ("records", "table")))
+                                  toCopy=("cls", ("records", "table")), overwrite=overwrite)
 
     def __init__(self, config, registry, butlerRoot=None):
         super().__init__(config, registry)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -114,9 +114,9 @@ class PosixDatastore(Datastore):
         will not be overridden by this method if ``overwrite`` is `False`.
         This allows explicit values set in external configs to be retained.
         """
-        Config.overrideParameters(DatastoreConfig, config, full,
-                                  toUpdate={"root": root},
-                                  toCopy=("cls", ("records", "table")), overwrite=overwrite)
+        Config.updateParameters(DatastoreConfig, config, full,
+                                toUpdate={"root": root},
+                                toCopy=("cls", ("records", "table")), overwrite=overwrite)
 
     def __init__(self, config, registry, butlerRoot=None):
         super().__init__(config, registry)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -102,7 +102,7 @@ class PosixDatastore(Datastore):
             modified by this method.
             Repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided

--- a/python/lsst/daf/butler/registries/oracleRegistry.py
+++ b/python/lsst/daf/butler/registries/oracleRegistry.py
@@ -68,8 +68,8 @@ class OracleRegistry(SqlRegistry):
         This allows explicit values set in external configs to be retained.
         """
         super().setConfigRoot(root, config, full, overwrite=overwrite)
-        Config.overrideParameters(RegistryConfig, config, full,
-                                  toCopy=("cls", "deferDatasetIdQueries"), overwrite=overwrite)
+        Config.updateParameters(RegistryConfig, config, full,
+                                toCopy=("cls", "deferDatasetIdQueries"), overwrite=overwrite)
 
     def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False,
                  butlerRoot=None):

--- a/python/lsst/daf/butler/registries/oracleRegistry.py
+++ b/python/lsst/daf/butler/registries/oracleRegistry.py
@@ -55,7 +55,7 @@ class OracleRegistry(SqlRegistry):
             A complete Butler config with all defaults expanded;
             repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided

--- a/python/lsst/daf/butler/registries/oracleRegistry.py
+++ b/python/lsst/daf/butler/registries/oracleRegistry.py
@@ -40,7 +40,7 @@ class OracleRegistry(SqlRegistry):
     """
 
     @classmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for this Registry to
         be appropriate for a new empty repository with the given root.
 
@@ -56,10 +56,20 @@ class OracleRegistry(SqlRegistry):
             repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
-        super().setConfigRoot(root, config, full)
+        super().setConfigRoot(root, config, full, overwrite=overwrite)
         Config.overrideParameters(RegistryConfig, config, full,
-                                  toCopy=("cls", "deferDatasetIdQueries"))
+                                  toCopy=("cls", "deferDatasetIdQueries"), overwrite=overwrite)
 
     def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False,
                  butlerRoot=None):

--- a/python/lsst/daf/butler/registries/sqliteRegistry.py
+++ b/python/lsst/daf/butler/registries/sqliteRegistry.py
@@ -66,7 +66,7 @@ class SqliteRegistry(SqlRegistry):
     """
 
     @classmethod
-    def setConfigRoot(cls, root, config, full):
+    def setConfigRoot(cls, root, config, full, overwrite=True):
         """Set any filesystem-dependent config options for this Registry to
         be appropriate for a new empty repository with the given root.
 
@@ -82,11 +82,21 @@ class SqliteRegistry(SqlRegistry):
             repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
             should be copied from `full` to `Config`.
+        overwrite : `bool`, optional
+            If `False`, do not modify a value in ``config`` if the value
+            already exists.  Default is always to overwrite with the provided
+            ``root``.
+
+        Notes
+        -----
+        If a keyword is explicitly defined in the supplied ``config`` it
+        will not be overridden by this method if ``overwrite`` is `False`.
+        This allows explicit values set in external configs to be retained.
         """
-        super().setConfigRoot(root, config, full)
+        super().setConfigRoot(root, config, full, overwrite=overwrite)
         Config.overrideParameters(RegistryConfig, config, full,
                                   toUpdate={"db": f"sqlite:///{root}/gen3.sqlite3"},
-                                  toCopy=("cls", "deferDatasetIdQueries"))
+                                  toCopy=("cls", "deferDatasetIdQueries"), overwrite=overwrite)
 
     def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False, butlerRoot=None):
         registryConfig = SqlRegistryConfig(registryConfig)

--- a/python/lsst/daf/butler/registries/sqliteRegistry.py
+++ b/python/lsst/daf/butler/registries/sqliteRegistry.py
@@ -94,9 +94,9 @@ class SqliteRegistry(SqlRegistry):
         This allows explicit values set in external configs to be retained.
         """
         super().setConfigRoot(root, config, full, overwrite=overwrite)
-        Config.overrideParameters(RegistryConfig, config, full,
-                                  toUpdate={"db": f"sqlite:///{root}/gen3.sqlite3"},
-                                  toCopy=("cls", "deferDatasetIdQueries"), overwrite=overwrite)
+        Config.updateParameters(RegistryConfig, config, full,
+                                toUpdate={"db": f"sqlite:///{root}/gen3.sqlite3"},
+                                toCopy=("cls", "deferDatasetIdQueries"), overwrite=overwrite)
 
     def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False, butlerRoot=None):
         registryConfig = SqlRegistryConfig(registryConfig)

--- a/python/lsst/daf/butler/registries/sqliteRegistry.py
+++ b/python/lsst/daf/butler/registries/sqliteRegistry.py
@@ -81,7 +81,7 @@ class SqliteRegistry(SqlRegistry):
             A complete Butler config with all defaults expanded;
             repository-specific options that should not be obtained
             from defaults when Butler instances are constructed
-            should be copied from `full` to `Config`.
+            should be copied from ``full`` to ``config``.
         overwrite : `bool`, optional
             If `False`, do not modify a value in ``config`` if the value
             already exists.  Default is always to overwrite with the provided


### PR DESCRIPTION
Adjust setConfigRoot such that it will optionally not override values in the supplied config.  This is the common use case from makeRepo where an external config would like to set a value for root, but that value was always being overridden.

Update makeRepo to disable overwrite.