### PR TITLE
Test fix of Location and LocationFactory.

### DIFF
--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -266,7 +266,6 @@ class PosixDatastore(Datastore):
         ValueError
             Formatter failed to process the dataset.
         """
-
         log.debug("Retrieve %s from %s with parameters %s", ref, self.name, parameters)
 
         # Get file metadata and internal metadata
@@ -536,7 +535,6 @@ class PosixDatastore(Datastore):
             guessing is not allowed.
 
         """
-
         # if this has never been written then we have to guess
         if not self.exists(ref):
             if not predict:


### PR DESCRIPTION
If I run the following code

```
import lsst.daf.butler as dafButler

LocationFactory = dafButler.LocationFactory('datastoreRoot')

absloc = locationFactory.fromPath('/absolute/relative/file.ext')
relloc = locationFactory.fromPath('relative/file.ext')

print('path         ', absloc.path)
print('pathInStore  ', absloc.pathInStore)
print('uri          ', absloc.uri)
print('str          ', absloc)

print()
print('path         ', relloc.path)
print('pathInStore  ', relloc.pathInStore)
print('uri          ', relloc.uri)
print('str          ', relloc)

absloc = locationFactory.fromUri('file:///absolute/relative/file.ext')
relloc = locationFactory.fromUri('file://relative/file.ext')

print('\n\n')
print('path         ', absloc.path)
print('pathInStore  ', absloc.pathInStore)
print('uri          ', absloc.uri)
print('str          ', absloc)

print()
print('path         ', relloc.path)
print('pathInStore  ', relloc.pathInStore)
print('uri          ', relloc.uri)
print('str          ', relloc)
```

I get the following outputs
```
path          datastoreRoot/absolute/relative/file.ext
pathInStore   absolute/relative/file.ext
uri           file:///absolute/relative/file.ext
str           file:///absolute/relative/file.ext

path          datastoreRoot/relative/file.ext
pathInStore   relative/file.ext
uri           file:///relative/file.ext
str           file:///relative/file.ext
```
and
```
path          datastoreRoot/absolute/relative/file.ext
pathInStore   absolute/relative/file.ext
uri           file:///absolute/relative/file.ext
str           file:///absolute/relative/file.ext

path          datastoreRoot/file.ext
pathInStore   file.ext
uri           file://relative/file.ext
str           file://relative/file.ext
```

The problem is assuming that `file://relative/file.ext` is a valid URI. It seems to me from the behaviour of `urllib` that this is not correct. The following are correct `file://` URI's:
```
file://localhost/absolute/relative/file.ext
file:///absolute/relative/file.ext
```
The following URIs seem to be "incorrect"
```
file://relative/file.ext
file://file.ext`
```
This is the reason why `pathInStore` is returned differently depending on whether the `Location` was created by using `fromUri` or `fromPath`. The `relative` is interpreted as `localhost` instead.

This PR is a proposition of a solution to this that enables the `Location` to treat `file://relative` and `file:///absolute/relative...` paths differently by assuming that the `datastoreRoot` provided to the `LocationFactory` is either an absolute path or a path relative to current directory and that the `Location` path is then relative to that. I do not know if this is desired behaviour or not but it seems to follow the logic seen elsewhere in `daf_butler`. Naturally, checks for consistent root locations when dealing with absolute paths are now mandatory. 

Comments welcome.