### PR TITLE
DM-19851: Use window function for multi-collection query

### DIFF
--- a/python/lsst/daf/butler/sql/singleDatasetQueryBuilder.py
+++ b/python/lsst/daf/butler/sql/singleDatasetQueryBuilder.py
@@ -250,6 +250,8 @@ class SingleDatasetQueryBuilder(QueryBuilder):
             _columns(datasetCollectionTable, ["collection"]) + [firstColl]
 
         subq = select(columns).select_from(subJoin).where(subWhere)
+        # subquery needs a unique alias name
+        subq = subq.alias("mcsubq_" + datasetType.name)
         whereClause = subq.columns.collection == subq.columns.first_collection
 
         return cls(registry, fromClause=subq, whereClause=whereClause, datasetType=datasetType,


### PR DESCRIPTION
This replaces a query which used JOIN to find best collection for a
dataset with a query that uses window function for the same purpose. It
should reduce the number of passes over table data and improve
performance.