### PR TITLE
DM-20842: Change Formatter API

### DIFF
--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -221,6 +221,56 @@ class FormatterFactory:
         """
         return self._mappingFactory.getLookupKeys()
 
+    def getFormatterClassWithMatch(self, entity):
+        """Get a the matching formatter class along with the matching registry
+        key.
+
+        Parameters
+        ----------
+        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+            Entity to use to determine the formatter to return.
+            `StorageClass` will be used as a last resort if `DatasetRef`
+            or `DatasetType` instance is provided.  Supports instrument
+            override if a `DatasetRef` is provided configured with an
+            ``instrument`` value for the data ID.
+
+        Returns
+        -------
+        matchKey : `LookupKey`
+            The key that resulted in the successful match.
+        formatter : `type`
+            The class of the registered formatter.
+        """
+        if isinstance(entity, str):
+            names = (entity,)
+        else:
+            names = entity._lookupNames()
+        matchKey, formatter = self._mappingFactory.getClassFromRegistryWithMatch(names)
+        log.debug("Retrieved formatter %s from key '%s' for entity '%s'", getFullTypeName(formatter),
+                  matchKey, entity)
+
+        return matchKey, formatter
+
+    def getFormatterClass(self, entity):
+        """Get the matching formatter class.
+
+        Parameters
+        ----------
+        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+            Entity to use to determine the formatter to return.
+            `StorageClass` will be used as a last resort if `DatasetRef`
+            or `DatasetType` instance is provided.  Supports instrument
+            override if a `DatasetRef` is provided configured with an
+            ``instrument`` value for the data ID.
+
+        Returns
+        -------
+        formatter : `type`
+            The class of the registered formatter.
+        """
+        _, formatter = self.getFormatterClassWithMatch(entity)
+        return formatter
+
     def getFormatterWithMatch(self, entity, *args, **kwargs):
         """Get a new formatter instance along with the matching registry
         key.
@@ -250,7 +300,8 @@ class FormatterFactory:
         else:
             names = entity._lookupNames()
         matchKey, formatter = self._mappingFactory.getFromRegistryWithMatch(names, *args, **kwargs)
-        log.debug("Retrieved formatter from key '%s' for entity '%s'", matchKey, entity)
+        log.debug("Retrieved formatter %s from key '%s' for entity '%s'", getFullTypeName(formatter),
+                  matchKey, entity)
 
         return matchKey, formatter
 

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -99,16 +99,16 @@ class Formatter(metaclass=ABCMeta):
         """
         raise NotImplementedError("Type does not support writing")
 
+    @classmethod
     @abstractmethod
-    def predictPath(self, location=None):
+    def predictPathFromLocation(cls, location):
         """Return the path that would be returned by write, without actually
         writing.
 
         Parameters
         ----------
-        location : `Location`, optional
-            Location of file for which path prediction is required.  If
-            `None` the location associated with the formatter will be used.
+        location : `Location`
+            Location of file for which path prediction is required.
 
         Returns
         -------
@@ -116,6 +116,19 @@ class Formatter(metaclass=ABCMeta):
             Path that would be returned by a call to `Formatter.write()`.
         """
         raise NotImplementedError("Type does not support writing")
+
+    def predictPath(self):
+        """Return the path that would be returned by write, without actually
+        writing.
+
+        Uses the `FileDescriptor` associated with the instance.
+
+        Returns
+        -------
+        path : `str`
+            Path that would be returned by a call to `Formatter.write()`.
+        """
+        return self.predictPathFromLocation(self.fileDescriptor.location)
 
     def segregateParameters(self, parameters=None):
         """Segregate the supplied parameters into those understood by the

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -47,7 +47,7 @@ class Formatter(metaclass=ABCMeta):
     unsupportedParameters = frozenset()
     """Set of parameters not understood by this `Formatter`. An empty set means
     all parameters are supported.  `None` indicates that no parameters
-    are supported.
+    are supported (`frozenset`).
     """
 
     def __init__(self, fileDescriptor=None):
@@ -57,11 +57,18 @@ class Formatter(metaclass=ABCMeta):
 
     @property
     def fileDescriptor(self):
+        """FileDescriptor associated with this formatter
+        (`Formatter`, read-only)"""
         return self._fileDescriptor
 
     @classmethod
     def name(cls):
         """Returns the fully qualified name of the formatter.
+
+        Returns
+        -------
+        name : `str`
+            Fully-qualified name of formatter class.
         """
         return getFullTypeName(cls)
 
@@ -78,7 +85,7 @@ class Formatter(metaclass=ABCMeta):
 
         Returns
         -------
-        inMemoryDataset : `InMemoryDataset`
+        inMemoryDataset : `object`
             The requested Dataset.
         """
         raise NotImplementedError("Type does not support reading")
@@ -89,13 +96,13 @@ class Formatter(metaclass=ABCMeta):
 
         Parameters
         ----------
-        inMemoryDataset : `InMemoryDataset`
+        inMemoryDataset : `object`
             The Dataset to store.
 
         Returns
         -------
         path : `str`
-            The path to where the Dataset was stored.
+            The path to where the Dataset was stored within the datastore.
         """
         raise NotImplementedError("Type does not support writing")
 
@@ -113,7 +120,7 @@ class Formatter(metaclass=ABCMeta):
         Returns
         -------
         path : `str`
-            Path that would be returned by a call to `Formatter.write()`.
+            Path within datastore that would be associated with this location.
         """
         raise NotImplementedError("Type does not support writing")
 
@@ -126,7 +133,8 @@ class Formatter(metaclass=ABCMeta):
         Returns
         -------
         path : `str`
-            Path that would be returned by a call to `Formatter.write()`.
+            Path within datastore that would be associated with the location
+            stored in this `Formatter`.
         """
         return self.predictPathFromLocation(self.fileDescriptor.location)
 
@@ -235,12 +243,12 @@ class FormatterFactory:
         return self._mappingFactory.getLookupKeys()
 
     def getFormatterClassWithMatch(self, entity):
-        """Get a the matching formatter class along with the matching registry
+        """Get the matching formatter class along with the matching registry
         key.
 
         Parameters
         ----------
-        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+        entity : `DatasetRef`, `DatasetType`, `StorageClass`, or `str`
             Entity to use to determine the formatter to return.
             `StorageClass` will be used as a last resort if `DatasetRef`
             or `DatasetType` instance is provided.  Supports instrument
@@ -269,7 +277,7 @@ class FormatterFactory:
 
         Parameters
         ----------
-        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+        entity : `DatasetRef`, `DatasetType`, `StorageClass`, or `str`
             Entity to use to determine the formatter to return.
             `StorageClass` will be used as a last resort if `DatasetRef`
             or `DatasetType` instance is provided.  Supports instrument
@@ -290,7 +298,7 @@ class FormatterFactory:
 
         Parameters
         ----------
-        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+        entity : `DatasetRef`, `DatasetType`, `StorageClass`, or `str`
             Entity to use to determine the formatter to return.
             `StorageClass` will be used as a last resort if `DatasetRef`
             or `DatasetType` instance is provided.  Supports instrument
@@ -323,7 +331,7 @@ class FormatterFactory:
 
         Parameters
         ----------
-        entity : `DatasetRef`, `DatasetType` or `StorageClass`, or `str`
+        entity : `DatasetRef`, `DatasetType`, `StorageClass`, or `str`
             Entity to use to determine the formatter to return.
             `StorageClass` will be used as a last resort if `DatasetRef`
             or `DatasetType` instance is provided.  Supports instrument
@@ -347,7 +355,7 @@ class FormatterFactory:
 
         Parameters
         ----------
-        type_ : `LookupKey`, `str` or `StorageClass` or `DatasetType`
+        type_ : `LookupKey`, `str`, `StorageClass` or `DatasetType`
             Type for which this formatter is to be used.  If a `LookupKey`
             is not provided, one will be constructed from the supplied string
             or by using the ``name`` property of the supplied entity.

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -38,9 +38,10 @@ class Formatter(metaclass=ABCMeta):
 
     Parameters
     ----------
-    fileDescriptor : `FileDescriptor`
+    fileDescriptor : `FileDescriptor`, optional
         Identifies the file to read or write, and the associated storage
-        classes and parameter information.
+        classes and parameter information.  Its value can be `None` if the
+        caller will never call `Formatter.read` or `Formatter.write`.
     """
 
     unsupportedParameters = frozenset()
@@ -49,7 +50,7 @@ class Formatter(metaclass=ABCMeta):
     are supported.
     """
 
-    def __init__(self, fileDescriptor):
+    def __init__(self, fileDescriptor=None):
         if fileDescriptor is not None and not isinstance(fileDescriptor, FileDescriptor):
             raise TypeError("File descriptor must be a FileDescriptor")
         self._fileDescriptor = fileDescriptor

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -74,15 +74,19 @@ class MappingFactory:
         """
         return set(self._registry)
 
-    def getFromRegistryWithMatch(self, *targetClasses):
+    def getFromRegistryWithMatch(self, targetClasses, *args, **kwargs):
         """Get a new instance of the object stored in the registry along with
         the matching key.
 
         Parameters
         ----------
-        *targetClasses : `LookupKey`, `str` or objects with ``name`` attribute
+        targetClasses : `LookupKey`, `str` or objects with ``name`` attribute
             Each item is tested in turn until a match is found in the registry.
             Items with `None` value are skipped.
+        args : `tuple`
+            Positional arguments to use pass to the object constructor.
+        kwargs : `dict`
+            Keyword arguments to pass to object constructor.
 
         Returns
         -------
@@ -110,21 +114,25 @@ class MappingFactory:
                 except KeyError:
                     pass
                 else:
-                    return key, getInstanceOf(typeName)
+                    return key, getInstanceOf(typeName, *args, **kwargs)
 
         # Convert list to a string for error reporting
         msg = ", ".join(str(k) for k in attempts)
         plural = "" if len(attempts) == 1 else "s"
         raise KeyError(f"Unable to find item in registry with key{plural}: {msg}")
 
-    def getFromRegistry(self, *targetClasses):
+    def getFromRegistry(self, targetClasses, *args, **kwargs):
         """Get a new instance of the object stored in the registry.
 
         Parameters
         ----------
-        *targetClasses : `LookupKey`, `str` or objects with ``name`` attribute
+        targetClasses : `LookupKey`, `str` or objects with ``name`` attribute
             Each item is tested in turn until a match is found in the registry.
             Items with `None` value are skipped.
+        args : `tuple`
+            Positional arguments to use pass to the object constructor.
+        kwargs : `dict`
+            Keyword arguments to pass to object constructor.
 
         Returns
         -------
@@ -138,7 +146,7 @@ class MappingFactory:
             Raised if none of the supplied target classes match an item in the
             registry.
         """
-        _, instance = self.getFromRegistryWithMatch(*targetClasses)
+        _, instance = self.getFromRegistryWithMatch(targetClasses, *args, **kwargs)
         return instance
 
     def placeInRegistry(self, registryKey, typeName):

--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -21,6 +21,8 @@
 
 __all__ = ("StoredFileInfo", )
 
+import inspect
+
 from .formatter import Formatter
 from .utils import slotValuesAreEqual
 from .storageClass import StorageClass
@@ -31,9 +33,9 @@ class StoredFileInfo:
 
     Parameters
     ----------
-    formatter : `str` or `Formatter`
+    formatter : `str` or `Formatter` or `Formatter` class.
         Full name of formatter to use to read this Dataset or a `Formatter`
-        instance.
+        instance or class.
     path : `str`
         Path to Dataset, relative to `Datastore` root.
     storageClass : `StorageClass`
@@ -50,9 +52,13 @@ class StoredFileInfo:
     __slots__ = ("_formatter", "_path", "_storageClass", "_checksum", "_size")
 
     def __init__(self, formatter, path, storageClass, checksum=None, size=None):
-        assert isinstance(formatter, str) or isinstance(formatter, Formatter)
-        if isinstance(formatter, Formatter):
+        if isinstance(formatter, str):
+            pass
+        elif isinstance(formatter, Formatter) or (inspect.isclass(formatter) and
+                                                  issubclass(formatter, Formatter)):
             formatter = formatter.name()
+        else:
+            raise ValueError(f"Supplied formatter '{formatter}' is not supported")
         self._formatter = formatter
         assert isinstance(path, str)
         self._path = path

--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -53,12 +53,13 @@ class StoredFileInfo:
 
     def __init__(self, formatter, path, storageClass, checksum=None, size=None):
         if isinstance(formatter, str):
+            # We trust that this string refers to a Formatter
             pass
         elif isinstance(formatter, Formatter) or (inspect.isclass(formatter) and
                                                   issubclass(formatter, Formatter)):
             formatter = formatter.name()
         else:
-            raise ValueError(f"Supplied formatter '{formatter}' is not supported")
+            raise ValueError(f"Supplied formatter '{formatter}' is not a Formatter")
         self._formatter = formatter
         assert isinstance(path, str)
         self._path = path

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -135,7 +135,7 @@ def getFullTypeName(cls):
     return cls.__module__ + "." + cls.__qualname__
 
 
-def getInstanceOf(typeOrName):
+def getInstanceOf(typeOrName, *args, **kwargs):
     """Given the type name or a type, instantiate an object of that type.
 
     If a type name is given, an attempt will be made to import the type.
@@ -144,12 +144,16 @@ def getInstanceOf(typeOrName):
     ----------
     typeOrName : `str` or Python class
         A string describing the Python class to load or a Python type.
+    args : `tuple`
+        Positional arguments to use pass to the object constructor.
+    kwargs : `dict`
+        Keyword arguments to pass to object constructor.
     """
     if isinstance(typeOrName, str):
         cls = doImport(typeOrName)
     else:
         cls = typeOrName
-    return cls()
+    return cls(*args, **kwargs)
 
 
 class Singleton(type):

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -22,7 +22,7 @@
 __all__ = ("iterable", "allSlots", "slotValuesAreEqual", "slotValuesToHash",
            "getFullTypeName", "getInstanceOf", "Singleton", "transactional",
            "getObjectSize", "stripIfNotNone", "PrivateConstructorMeta",
-           "NamedKeyDict")
+           "NamedKeyDict", "getClassOf")
 
 import sys
 import functools
@@ -135,6 +135,33 @@ def getFullTypeName(cls):
     return cls.__module__ + "." + cls.__qualname__
 
 
+def getClassOf(typeOrName):
+    """Given the type name or a type, return the python type.
+
+    If a type name is given, an attempt will be made to import the type.
+
+    Parameters
+    ----------
+    typeOrName : `str` or Python class
+        A string describing the Python class to load or a Python type.
+
+    Returns
+    -------
+    type_ : `type`
+        Directly returns the Python type if a type was provided, else
+        tries to import the given string and returns the resulting type.
+
+    Notes
+    -----
+    This is a thin wrapper around `~lsst.utils.doImport`.
+    """
+    if isinstance(typeOrName, str):
+        cls = doImport(typeOrName)
+    else:
+        cls = typeOrName
+    return cls
+
+
 def getInstanceOf(typeOrName, *args, **kwargs):
     """Given the type name or a type, instantiate an object of that type.
 
@@ -148,11 +175,14 @@ def getInstanceOf(typeOrName, *args, **kwargs):
         Positional arguments to use pass to the object constructor.
     kwargs : `dict`
         Keyword arguments to pass to object constructor.
+
+    Returns
+    -------
+    instance : `object`
+        Instance of the requested type, instantiated with the provided
+        parameters.
     """
-    if isinstance(typeOrName, str):
-        cls = doImport(typeOrName)
-    else:
-        cls = typeOrName
+    cls = getClassOf(typeOrName)
     return cls(*args, **kwargs)
 
 

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -413,10 +413,11 @@ class PosixDatastore(Datastore):
             absolute.
         ref : `DatasetRef`
             Reference to the associated Dataset.
-        formatter : `Formatter` (optional)
+        formatter : `Formatter`, optional
             Formatter that should be used to retreive the Dataset.  If not
             provided, the formatter will be constructed according to
-            Datastore configuration.
+            Datastore configuration.  Can be a the Formatter class or an
+            instance.
         transfer : str (optional)
             If not None, must be one of 'move', 'copy', 'hardlink', or
             'symlink' indicating how to transfer the file.  The new
@@ -445,7 +446,7 @@ class PosixDatastore(Datastore):
                                                " configuration.")
 
         if formatter is None:
-            formatter = self.formatterFactory.getFormatter(ref, None)
+            formatter = self.formatterFactory.getFormatterClass(ref)
 
         fullPath = os.path.normpath(os.path.join(self.root, path))
         if not os.path.exists(fullPath):
@@ -464,7 +465,7 @@ class PosixDatastore(Datastore):
         else:
             template = self.templates.getTemplate(ref)
             location = self.locationFactory.fromPath(template.format(ref))
-            newPath = formatter.predictPath(location)
+            newPath = formatter.predictPathFromLocation(location)
             newFullPath = os.path.join(self.root, newPath)
             if os.path.exists(newFullPath):
                 raise FileExistsError("File '{}' already exists".format(newFullPath))

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -642,7 +642,7 @@ class PosixDatastore(Datastore):
         formatterFailed = []
         for entity in entities:
             try:
-                self.formatterFactory.getFormatter(entity, None)
+                self.formatterFactory.getFormatterClass(entity)
             except KeyError as e:
                 formatterFailed.append(str(e))
                 if logFailures:

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -306,7 +306,7 @@ class PosixDatastore(Datastore):
         try:
             result = formatter.read(component=component)
         except Exception as e:
-            raise ValueError(f"Failure from formatter '{formatter.name()}' for Dataset {ref.id}: {e}")
+            raise ValueError(f"Failure from formatter '{formatter.name()}' for Dataset {ref.id}") from e
 
         # Process any left over parameters
         if assemblerParams:

--- a/python/lsst/daf/butler/formatters/fileFormatter.py
+++ b/python/lsst/daf/butler/formatters/fileFormatter.py
@@ -172,13 +172,14 @@ class FileFormatter(Formatter):
 
         return fileDescriptor.location.pathInStore
 
-    def predictPath(self, location=None):
+    @classmethod
+    def predictPathFromLocation(cls, location):
         """Return the path that would be returned by write, without actually
         writing.
 
         Parameters
         ----------
-        location : `Location`, optional
+        location : `Location`
             Location of file for which path prediction is required.  If
             `None` the location associated with the formatter will be used.
 
@@ -187,8 +188,6 @@ class FileFormatter(Formatter):
         path : `str`
             Path that would be returned by a call to `Formatter.write()`.
         """
-        if location is None:
-            location = self.fileDescriptor.location
         location = copy.deepcopy(location)
-        location.updateExtension(self.extension)
+        location.updateExtension(cls.extension)
         return location.pathInStore

--- a/python/lsst/daf/butler/formatters/fileFormatter.py
+++ b/python/lsst/daf/butler/formatters/fileFormatter.py
@@ -35,7 +35,7 @@ class FileFormatter(Formatter):
 
     extension = None
     """Default file extension to use for writing files. None means that no
-    modifications will be made to the supplied file extension."""
+    modifications will be made to the supplied file extension. (`str`)"""
 
     @abstractmethod
     def _readFile(self, path, pytype=None):
@@ -162,7 +162,7 @@ class FileFormatter(Formatter):
         Returns
         -------
         path : `str`
-            The `URI` where the primary file is stored.
+            The path where the primary file is stored within the datastore.
         """
         fileDescriptor = self.fileDescriptor
         # Update the location with the formatter-preferred file extension
@@ -180,13 +180,12 @@ class FileFormatter(Formatter):
         Parameters
         ----------
         location : `Location`
-            Location of file for which path prediction is required.  If
-            `None` the location associated with the formatter will be used.
+            Location of file for which path prediction is required.
 
         Returns
         -------
         path : `str`
-            Path that would be returned by a call to `Formatter.write()`.
+            Path within datastore that would be associated with this location.
         """
         location = copy.deepcopy(location)
         location.updateExtension(cls.extension)

--- a/python/lsst/daf/butler/formatters/fileFormatter.py
+++ b/python/lsst/daf/butler/formatters/fileFormatter.py
@@ -62,15 +62,13 @@ class FileFormatter(Formatter):
         pass
 
     @abstractmethod
-    def _writeFile(self, inMemoryDataset, fileDescriptor):
+    def _writeFile(self, inMemoryDataset):
         """Write the in memory dataset to file on disk.
 
         Parameters
         ----------
         inMemoryDataset : `object`
             Object to serialize.
-        fileDescriptor : `FileDescriptor`
-            Details of the file to be written.
 
         Raises
         ------
@@ -100,14 +98,11 @@ class FileFormatter(Formatter):
         """
         return inMemoryDataset
 
-    def read(self, fileDescriptor, component=None):
+    def read(self, component=None):
         """Read data from a file.
 
         Parameters
         ----------
-        fileDescriptor : `FileDescriptor`
-            Identifies the file to read, type to read it into and parameters
-            to be used for reading.
         component : `str`, optional
             Component to read from the file. Only used if the `StorageClass`
             for reading differed from the `StorageClass` used to write the
@@ -125,6 +120,7 @@ class FileFormatter(Formatter):
             Component requested but this file does not seem to be a concrete
             composite.
         """
+        fileDescriptor = self.fileDescriptor
 
         # Read the file naively
         path = fileDescriptor.location.path
@@ -155,36 +151,44 @@ class FileFormatter(Formatter):
 
         return data
 
-    def write(self, inMemoryDataset, fileDescriptor):
+    def write(self, inMemoryDataset):
         """Write a Python object to a file.
 
         Parameters
         ----------
         inMemoryDataset : `object`
             The Python object to store.
-        fileDescriptor : `FileDescriptor`
-            Identifies the file to read, type to read it into and parameters
-            to be used for reading.
 
         Returns
         -------
         path : `str`
             The `URI` where the primary file is stored.
         """
+        fileDescriptor = self.fileDescriptor
         # Update the location with the formatter-preferred file extension
         fileDescriptor.location.updateExtension(self.extension)
 
-        self._writeFile(inMemoryDataset, fileDescriptor)
+        self._writeFile(inMemoryDataset)
 
         return fileDescriptor.location.pathInStore
 
-    def predictPath(self, location):
+    def predictPath(self, location=None):
         """Return the path that would be returned by write, without actually
         writing.
 
-        location : `Location`
-            The location to simulate writing to.
+        Parameters
+        ----------
+        location : `Location`, optional
+            Location of file for which path prediction is required.  If
+            `None` the location associated with the formatter will be used.
+
+        Returns
+        -------
+        path : `str`
+            Path that would be returned by a call to `Formatter.write()`.
         """
+        if location is None:
+            location = self.fileDescriptor.location
         location = copy.deepcopy(location)
         location.updateExtension(self.extension)
         return location.pathInStore

--- a/python/lsst/daf/butler/formatters/fitsCatalogFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsCatalogFormatter.py
@@ -52,19 +52,17 @@ class FitsCatalogFormatter(FileFormatter):
 
         return pytype.readFits(path)
 
-    def _writeFile(self, inMemoryDataset, fileDescriptor):
+    def _writeFile(self, inMemoryDataset):
         """Write the in memory dataset to file on disk.
 
         Parameters
         ----------
         inMemoryDataset : `object`
             Object to serialize.
-        fileDescriptor : `FileDescriptor`
-            Details of the file to be written.
 
         Raises
         ------
         Exception
             The file could not be written.
         """
-        inMemoryDataset.writeFits(fileDescriptor.location.path)
+        inMemoryDataset.writeFits(self.fileDescriptor.location.path)

--- a/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
@@ -196,23 +196,21 @@ class FitsExposureFormatter(Formatter):
         inMemoryDataset.writeFits(self.fileDescriptor.location.path)
         return self.fileDescriptor.location.pathInStore
 
-    def predictPath(self, location=None):
+    @classmethod
+    def predictPathFromLocation(cls, location):
         """Return the path that would be returned by write, without actually
         writing.
 
         Parameters
         ----------
-        location : `Location`, optional
-            Location of file for which path prediction is required.  If
-            `None` the location associated with the formatter will be used.
+        location : `Location`,
+            Location of file for which path prediction is required.
 
         Returns
         -------
         path : `str`
             Path that would be returned by a call to `Formatter.write()`.
         """
-        if location is None:
-            location = self.fileDescriptor.location
         location = copy.deepcopy(location)
-        location.updateExtension(self.extension)
+        location.updateExtension(cls.extension)
         return location.pathInStore

--- a/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
@@ -36,7 +36,8 @@ class FitsExposureFormatter(Formatter):
     @property
     def metadata(self):
         """The metadata read from this file. It will be stripped as
-        components are extracted from it.
+        components are extracted from it
+        (`lsst.daf.base.PropertyList`).
         """
         if self._metadata is None:
             self._metadata = self.readMetadata()
@@ -209,7 +210,7 @@ class FitsExposureFormatter(Formatter):
         Returns
         -------
         path : `str`
-            Path that would be returned by a call to `Formatter.write()`.
+            Path within datastore that would be associated with this location.
         """
         location = copy.deepcopy(location)
         location.updateExtension(cls.extension)

--- a/python/lsst/daf/butler/formatters/jsonFormatter.py
+++ b/python/lsst/daf/butler/formatters/jsonFormatter.py
@@ -57,7 +57,7 @@ class JsonFormatter(FileFormatter):
 
         return data
 
-    def _writeFile(self, inMemoryDataset, fileDescriptor):
+    def _writeFile(self, inMemoryDataset):
         """Write the in memory dataset to file on disk.
 
         Will look for `_asdict()` method to aid JSON serialization, following
@@ -67,15 +67,13 @@ class JsonFormatter(FileFormatter):
         ----------
         inMemoryDataset : `object`
             Object to serialize.
-        fileDescriptor : `FileDescriptor`
-            Details of the file to be written.
 
         Raises
         ------
         Exception
             The file could not be written.
         """
-        with open(fileDescriptor.location.path, "w") as fd:
+        with open(self.fileDescriptor.location.path, "w") as fd:
             if hasattr(inMemoryDataset, "_asdict"):
                 inMemoryDataset = inMemoryDataset._asdict()
             json.dump(inMemoryDataset, fd)

--- a/python/lsst/daf/butler/formatters/jsonFormatter.py
+++ b/python/lsst/daf/butler/formatters/jsonFormatter.py
@@ -33,7 +33,7 @@ class JsonFormatter(FileFormatter):
     extension = ".json"
 
     unsupportedParameters = None
-    """This formatter does not support any parameters"""
+    """This formatter does not support any parameters (`frozenset`)"""
 
     def _readFile(self, path, pytype=None):
         """Read a file from the path in JSON format.

--- a/python/lsst/daf/butler/formatters/pexConfigFormatter.py
+++ b/python/lsst/daf/butler/formatters/pexConfigFormatter.py
@@ -71,19 +71,17 @@ class PexConfigFormatter(FileFormatter):
         instance.load(path)
         return instance
 
-    def _writeFile(self, inMemoryDataset, fileDescriptor):
+    def _writeFile(self, inMemoryDataset):
         """Write the in memory dataset to file on disk.
 
         Parameters
         ----------
         inMemoryDataset : `object`
             Object to serialize.
-        fileDescriptor : `FileDescriptor`
-            Details of the file to be written.
 
         Raises
         ------
         Exception
             The file could not be written.
         """
-        inMemoryDataset.save(fileDescriptor.location.path)
+        inMemoryDataset.save(self.fileDescriptor.location.path)

--- a/python/lsst/daf/butler/formatters/pickleFormatter.py
+++ b/python/lsst/daf/butler/formatters/pickleFormatter.py
@@ -61,20 +61,18 @@ class PickleFormatter(FileFormatter):
 
         return data
 
-    def _writeFile(self, inMemoryDataset, fileDescriptor):
+    def _writeFile(self, inMemoryDataset):
         """Write the in memory dataset to file on disk.
 
         Parameters
         ----------
         inMemoryDataset : `object`
             Object to serialize.
-        fileDescriptor : `FileDescriptor`
-            Details of the file to be written.
 
         Raises
         ------
         Exception
             The file could not be written.
         """
-        with open(fileDescriptor.location.path, "wb") as fd:
+        with open(self.fileDescriptor.location.path, "wb") as fd:
             pickle.dump(inMemoryDataset, fd, protocol=-1)

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -61,7 +61,7 @@ class YamlFormatter(FileFormatter):
 
         return data
 
-    def _writeFile(self, inMemoryDataset, fileDescriptor):
+    def _writeFile(self, inMemoryDataset):
         """Write the in memory dataset to file on disk.
 
         Will look for `_asdict()` method to aid YAML serialization, following
@@ -71,15 +71,13 @@ class YamlFormatter(FileFormatter):
         ----------
         inMemoryDataset : `object`
             Object to serialize.
-        fileDescriptor : `FileDescriptor`
-            Details of the file to be written.
 
         Raises
         ------
         Exception
             The file could not be written.
         """
-        with open(fileDescriptor.location.path, "w") as fd:
+        with open(self.fileDescriptor.location.path, "w") as fd:
             if hasattr(inMemoryDataset, "_asdict"):
                 inMemoryDataset = inMemoryDataset._asdict()
             yaml.dump(inMemoryDataset, stream=fd)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -45,7 +45,7 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         formatterTypeName = "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
         storageClassName = "Image"
         self.factory.registerFormatter(storageClassName, formatterTypeName)
-        f = self.factory.getFormatter(storageClassName)
+        f = self.factory.getFormatter(storageClassName, None)
         self.assertIsInstance(f, Formatter)
         # Defer the import so that we ensure that the infrastructure loaded
         # it on demand previously
@@ -53,7 +53,7 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         self.assertEqual(type(f), FitsCatalogFormatter)
 
         with self.assertRaises(KeyError):
-            f = self.factory.getFormatter("Missing")
+            f = self.factory.getFormatter("Missing", None)
 
     def testRegistryWithStorageClass(self):
         """Test that the registry can be given a StorageClass object.
@@ -69,11 +69,11 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         self.factory.registerFormatter(sc, formatterTypeName)
 
         # Retrieve using the class
-        f = self.factory.getFormatter(sc)
+        f = self.factory.getFormatter(sc, None)
         self.assertIsInstance(f, Formatter)
 
         # Retrieve using the DatasetType
-        f2 = self.factory.getFormatter(datasetType)
+        f2 = self.factory.getFormatter(datasetType, None)
         self.assertIsInstance(f, Formatter)
         self.assertEqual(f.name(), f2.name())
 
@@ -98,20 +98,20 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         sc = StorageClass("DummySC", dict, None)
         refPviHsc = self.makeDatasetRef("pvi", dimensions, sc, {"instrument": "DummyHSC",
                                                                 "physical_filter": "v"})
-        refPviHscFmt = self.factory.getFormatter(refPviHsc)
+        refPviHscFmt = self.factory.getFormatter(refPviHsc, None)
         self.assertIsInstance(refPviHscFmt, Formatter)
         self.assertIn("JsonFormatter", refPviHscFmt.name())
 
         refPviNotHsc = self.makeDatasetRef("pvi", dimensions, sc, {"instrument": "DummyNotHSC",
                                                                    "physical_filter": "v"})
-        refPviNotHscFmt = self.factory.getFormatter(refPviNotHsc)
+        refPviNotHscFmt = self.factory.getFormatter(refPviNotHsc, None)
         self.assertIsInstance(refPviNotHscFmt, Formatter)
         self.assertIn("PickleFormatter", refPviNotHscFmt.name())
 
         # Create a DatasetRef that should fall back to using Dimensions
         refPvixHsc = self.makeDatasetRef("pvix", dimensions, sc, {"instrument": "DummyHSC",
                                                                   "physical_filter": "v"})
-        refPvixNotHscFmt = self.factory.getFormatter(refPvixHsc)
+        refPvixNotHscFmt = self.factory.getFormatter(refPvixHsc, None)
         self.assertIsInstance(refPvixNotHscFmt, Formatter)
         self.assertIn("PickleFormatter", refPvixNotHscFmt.name())
 
@@ -119,7 +119,7 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         dimensionsNoV = universe.extract(("physical_filter", "instrument"))
         refPvixNotHscDims = self.makeDatasetRef("pvix", dimensionsNoV, sc, {"instrument": "DummyHSC",
                                                                             "physical_filter": "v"})
-        refPvixNotHscDims_fmt = self.factory.getFormatter(refPvixNotHscDims)
+        refPvixNotHscDims_fmt = self.factory.getFormatter(refPvixNotHscDims, None)
         self.assertIsInstance(refPvixNotHscDims_fmt, Formatter)
         self.assertIn("YamlFormatter", refPvixNotHscDims_fmt.name())
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -45,7 +45,7 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         formatterTypeName = "lsst.daf.butler.formatters.fitsCatalogFormatter.FitsCatalogFormatter"
         storageClassName = "Image"
         self.factory.registerFormatter(storageClassName, formatterTypeName)
-        f = self.factory.getFormatter(storageClassName, None)
+        f = self.factory.getFormatter(storageClassName)
         self.assertIsInstance(f, Formatter)
         # Defer the import so that we ensure that the infrastructure loaded
         # it on demand previously
@@ -53,7 +53,7 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         self.assertEqual(type(f), FitsCatalogFormatter)
 
         with self.assertRaises(KeyError):
-            f = self.factory.getFormatter("Missing", None)
+            f = self.factory.getFormatter("Missing")
 
     def testRegistryWithStorageClass(self):
         """Test that the registry can be given a StorageClass object.
@@ -69,11 +69,11 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         self.factory.registerFormatter(sc, formatterTypeName)
 
         # Retrieve using the class
-        f = self.factory.getFormatter(sc, None)
+        f = self.factory.getFormatter(sc)
         self.assertIsInstance(f, Formatter)
 
         # Retrieve using the DatasetType
-        f2 = self.factory.getFormatter(datasetType, None)
+        f2 = self.factory.getFormatter(datasetType)
         self.assertIsInstance(f, Formatter)
         self.assertEqual(f.name(), f2.name())
 
@@ -98,20 +98,20 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         sc = StorageClass("DummySC", dict, None)
         refPviHsc = self.makeDatasetRef("pvi", dimensions, sc, {"instrument": "DummyHSC",
                                                                 "physical_filter": "v"})
-        refPviHscFmt = self.factory.getFormatter(refPviHsc, None)
+        refPviHscFmt = self.factory.getFormatter(refPviHsc)
         self.assertIsInstance(refPviHscFmt, Formatter)
         self.assertIn("JsonFormatter", refPviHscFmt.name())
 
         refPviNotHsc = self.makeDatasetRef("pvi", dimensions, sc, {"instrument": "DummyNotHSC",
                                                                    "physical_filter": "v"})
-        refPviNotHscFmt = self.factory.getFormatter(refPviNotHsc, None)
+        refPviNotHscFmt = self.factory.getFormatter(refPviNotHsc)
         self.assertIsInstance(refPviNotHscFmt, Formatter)
         self.assertIn("PickleFormatter", refPviNotHscFmt.name())
 
         # Create a DatasetRef that should fall back to using Dimensions
         refPvixHsc = self.makeDatasetRef("pvix", dimensions, sc, {"instrument": "DummyHSC",
                                                                   "physical_filter": "v"})
-        refPvixNotHscFmt = self.factory.getFormatter(refPvixHsc, None)
+        refPvixNotHscFmt = self.factory.getFormatter(refPvixHsc)
         self.assertIsInstance(refPvixNotHscFmt, Formatter)
         self.assertIn("PickleFormatter", refPvixNotHscFmt.name())
 
@@ -119,7 +119,7 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         dimensionsNoV = universe.extract(("physical_filter", "instrument"))
         refPvixNotHscDims = self.makeDatasetRef("pvix", dimensionsNoV, sc, {"instrument": "DummyHSC",
                                                                             "physical_filter": "v"})
-        refPvixNotHscDims_fmt = self.factory.getFormatter(refPvixNotHscDims, None)
+        refPvixNotHscDims_fmt = self.factory.getFormatter(refPvixNotHscDims)
         self.assertIsInstance(refPvixNotHscDims_fmt, Formatter)
         self.assertIn("YamlFormatter", refPvixNotHscDims_fmt.name())
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -47,6 +47,9 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         self.factory.registerFormatter(storageClassName, formatterTypeName)
         f = self.factory.getFormatter(storageClassName)
         self.assertIsInstance(f, Formatter)
+
+        fcls = self.factory.getFormatterClass(storageClassName)
+        self.assertEqual(fcls, type(f))
         # Defer the import so that we ensure that the infrastructure loaded
         # it on demand previously
         from lsst.daf.butler.formatters.fitsCatalogFormatter import FitsCatalogFormatter
@@ -76,6 +79,10 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         f2 = self.factory.getFormatter(datasetType)
         self.assertIsInstance(f, Formatter)
         self.assertEqual(f.name(), f2.name())
+
+        # Class directly
+        f2cls = self.factory.getFormatterClass(datasetType)
+        self.assertEqual(f2cls.name(), f.name())
 
         # This might defer the import, pytest may have already loaded it
         from lsst.daf.butler.formatters.yamlFormatter import YamlFormatter


### PR DESCRIPTION
The motivation for this is to simplify formatters so that they know they can store state in their instance without fear that a Datastore is going to reuse the Formatter for some other location.
    
* This changes the read() and write() methods since they no longer need FileDescriptor parameter.
* All the formatters need to be tweaked.
* Datastore needs changing to ensure that FileDescriptor is created a bit earlier.
* getFormatter gets an extra argument which can be None for formatters that will not be using read/write at all.

@TallJimbo , @parejkoj does this look okay to you?