### PR TITLE
DM-20953: Add support for range selection to gen3 expression parser

### DIFF
--- a/python/lsst/daf/butler/exprParser/exprTree.py
+++ b/python/lsst/daf/butler/exprParser/exprTree.py
@@ -214,10 +214,13 @@ class RangeLiteral(Node):
         Start value of a range.
     stop : `int`
         End value of a range, inclusive, same or higher than ``start``.
-    stride : `int` or `None`
-        Stride value, must be positive, can be `None`.
+    stride : `int` or `None`, optional
+        Stride value, must be positive, can be `None` which means that stride
+        was not specified. Consumers are supposed to treat `None` the same way
+        as stride=1 but for some consumers it may be useful to know that
+        stride was missing from literal.
     """
-    def __init__(self, start, stop, stride=1):
+    def __init__(self, start, stop, stride=None):
         self.start = start
         self.stop = stop
         self.stride = stride
@@ -227,9 +230,7 @@ class RangeLiteral(Node):
         return visitor.visitRangeLiteral(self.start, self.stop, self.stride, self)
 
     def __str__(self):
-        res = f"{self.start}..{self.stop}"
-        if self.stride is not None:
-            res += f":{self.stride}"
+        res = f"{self.start}..{self.stop}" + (f":{self.stride}" if self.stride else "")
         return res
 
 

--- a/python/lsst/daf/butler/exprParser/exprTree.py
+++ b/python/lsst/daf/butler/exprParser/exprTree.py
@@ -201,6 +201,38 @@ class Identifier(Node):
         return "{name}".format(**vars(self))
 
 
+class RangeLiteral(Node):
+    """Node representing range literal appearing in `IN` list.
+
+    Range literal defines a range of integer numbers with start and
+    end of the range (with inclusive end) and optional stride value
+    (default is 1).
+
+    Attributes
+    ----------
+    start : `int`
+        Start value of a range.
+    stop : `int`
+        End value of a range, inclusive, same or higher than ``start``.
+    stride : `int` or `None`
+        Stride value, must be positive, can be `None`.
+    """
+    def __init__(self, start, stop, stride=1):
+        self.start = start
+        self.stop = stop
+        self.stride = stride
+
+    def visit(self, visitor):
+        # Docstring inherited from Node.visit
+        return visitor.visitRangeLiteral(self.start, self.stop, self.stride, self)
+
+    def __str__(self):
+        res = f"{self.start}..{self.stop}"
+        if self.stride is not None:
+            res += f":{self.stride}"
+        return res
+
+
 class IsIn(Node):
     """Node representing IN or NOT IN expression.
 

--- a/python/lsst/daf/butler/exprParser/parserLex.py
+++ b/python/lsst/daf/butler/exprParser/parserLex.py
@@ -38,7 +38,7 @@ from .ply import lex
 #  Local non-exported definitions --
 # ----------------------------------
 
-_RE_RANGE = re.compile(r"(-?\d+)\s*\.\.\s*(-?\d+)(\s*:\s*(\d+))?")
+_RE_RANGE = r"(?P<start>-?\d+)\s*\.\.\s*(?P<stop>-?\d+)(\s*:\s*(?P<stride>[1-9]\d*))?"
 """Regular expression to match range literal in the form NUM..NUM[:NUM],
 this must match t_RANGE_LITERAL docstring.
 """
@@ -58,7 +58,7 @@ class ParserLexError(Exception):
     remain : str
         Remaining non-parsed part of the expression
     pos : int
-        Current parsing posistion, offset from beginning of expression in
+        Current parsing position, offset from beginning of expression in
         characters
     lineno : int
         Current line number in the expression
@@ -154,15 +154,13 @@ class ParserLex:
         t.value = t.value[1:-1]
         return t
 
-    # range literal in format N..M[:S], spaces allowed
-    # docstring must match _RE_RANGE regexp
+    # range literal in format N..M[:S], spaces allowed, see _RE_RANGE
+    @lex.TOKEN(_RE_RANGE)
     def t_RANGE_LITERAL(self, t):
-        r"""(-?\d+)\s*\.\.\s*(-?\d+)(\s*:\s*(\d+))?
-        """
-        match = _RE_RANGE.match(t.value)
-        start = int(match.group(1))
-        stop = int(match.group(2))
-        stride = match.group(4)
+        match = re.match(_RE_RANGE, t.value)
+        start = int(match.group("start"))
+        stop = int(match.group("stop"))
+        stride = match.group("stride")
         if stride is not None:
             stride = int(stride)
         t.value = (start, stop, stride)

--- a/python/lsst/daf/butler/exprParser/parserLex.py
+++ b/python/lsst/daf/butler/exprParser/parserLex.py
@@ -38,6 +38,11 @@ from .ply import lex
 #  Local non-exported definitions --
 # ----------------------------------
 
+_RE_RANGE = re.compile(r"(-?\d+)\s*\.\.\s*(-?\d+)(\s*:\s*(\d+))?")
+"""Regular expression to match range literal in the form NUM..NUM[:NUM],
+this must match t_RANGE_LITERAL docstring.
+"""
+
 # ------------------------
 #  Exported definitions --
 # ------------------------
@@ -108,6 +113,7 @@ class ParserLex:
     tokens = (
         'NUMERIC_LITERAL',
         'STRING_LITERAL',
+        'RANGE_LITERAL',
         # 'TIME_LITERAL',
         # 'DURATION_LITERAL',
         'IDENTIFIER',
@@ -146,6 +152,20 @@ class ParserLex:
         r"'.*?'"
         # strip quotes
         t.value = t.value[1:-1]
+        return t
+
+    # range literal in format N..M[:S], spaces allowed
+    # docstring must match _RE_RANGE regexp
+    def t_RANGE_LITERAL(self, t):
+        r"""(-?\d+)\s*\.\.\s*(-?\d+)(\s*:\s*(\d+))?
+        """
+        match = _RE_RANGE.match(t.value)
+        start = int(match.group(1))
+        stop = int(match.group(2))
+        stride = match.group(4)
+        if stride is not None:
+            stride = int(stride)
+        t.value = (start, stop, stride)
         return t
 
     # numbers are used as strings by parser, do not convert

--- a/python/lsst/daf/butler/exprParser/parserYacc.py
+++ b/python/lsst/daf/butler/exprParser/parserYacc.py
@@ -259,7 +259,9 @@ class ParserYacc:
     def p_literal_range(self, p):
         """ literal : RANGE_LITERAL
         """
-        p[0] = RangeLiteral(*p[1])
+        # RANGE_LITERAL value is tuple of three numbers
+        start, stop, stride = p[1]
+        p[0] = RangeLiteral(start, stop, stride)
 
     # ---------- end of all grammar rules ----------
 

--- a/python/lsst/daf/butler/exprParser/parserYacc.py
+++ b/python/lsst/daf/butler/exprParser/parserYacc.py
@@ -32,7 +32,7 @@ __all__ = ["ParserYacc", "ParserYaccError", "ParseError", "ParserEOFError"]
 #  Imports for other modules --
 # -----------------------------
 from .exprTree import (BinaryOp, Identifier, IsIn, NumericLiteral,
-                       Parens, StringLiteral, UnaryOp)
+                       Parens, StringLiteral, RangeLiteral, UnaryOp)
 from .ply import yacc
 from .parserLex import ParserLex
 
@@ -245,10 +245,21 @@ class ParserYacc:
         """
         p[0] = NumericLiteral(p[1])
 
+    def p_literal_num_signed(self, p):
+        """ literal : ADD NUMERIC_LITERAL %prec UPLUS
+                    | SUB NUMERIC_LITERAL %prec UMINUS
+        """
+        p[0] = NumericLiteral(p[1] + p[2])
+
     def p_literal_str(self, p):
         """ literal : STRING_LITERAL
         """
         p[0] = StringLiteral(p[1])
+
+    def p_literal_range(self, p):
+        """ literal : RANGE_LITERAL
+        """
+        p[0] = RangeLiteral(*p[1])
 
     # ---------- end of all grammar rules ----------
 

--- a/python/lsst/daf/butler/exprParser/treeVisitor.py
+++ b/python/lsst/daf/butler/exprParser/treeVisitor.py
@@ -72,7 +72,7 @@ class TreeVisitor(ABC):
             Range starting value.
         stop : `int`
             Range final value.
-        stride : `int`
+        stride : `int` or `None`
             Stride, can be `None` if not specified (should be treated same
             as 1).
         node : `Node`

--- a/python/lsst/daf/butler/exprParser/treeVisitor.py
+++ b/python/lsst/daf/butler/exprParser/treeVisitor.py
@@ -63,6 +63,23 @@ class TreeVisitor(ABC):
         """
 
     @abstractmethod
+    def visitRangeLiteral(self, start, stop, stride, node):
+        """Visit RangeLiteral node.
+
+        Parameters
+        ----------
+        start : `int`
+            Range starting value.
+        stop : `int`
+            Range final value.
+        stride : `int`
+            Stride, can be `None` if not specified (should be treated same
+            as 1).
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
     def visitIdentifier(self, name, node):
         """Visit Identifier node.
 

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -143,6 +143,18 @@ class ParserLexTestCase(unittest.TestCase):
         self._assertToken(lexer.token(), "NUMERIC_LITERAL", ".2E5")
         self.assertIsNone(lexer.token())
 
+    def testRangeLiteral(self):
+        """Test for range literals"""
+        lexer = ParserLex.make_lexer()
+
+        lexer.input("0..10 -10..-1 -10..10:2 0 .. 10 0 .. 10 : 2 ")
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (0, 10, None))
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (-10, -1, None))
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (-10, 10, 2))
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (0, 10, None))
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (0, 10, 2))
+        self.assertIsNone(lexer.token())
+
     def testIdentifier(self):
         """Test for numeric literals"""
         lexer = ParserLex.make_lexer()
@@ -179,7 +191,8 @@ class ParserLexTestCase(unittest.TestCase):
 
         expr = ("((instrument='HSC' AND detector != 9) OR instrument='CFHT') "
                 "AND tract=8766 AND patch.cell_x > 5 AND "
-                "patch.cell_y < 4 AND abstract_filter='i'")
+                "patch.cell_y < 4 AND abstract_filter='i' "
+                "or visit IN (1..50:2)")
         tokens = (("LPAREN", "("),
                   ("LPAREN", "("),
                   ("IDENTIFIER", "instrument"),
@@ -210,7 +223,14 @@ class ParserLexTestCase(unittest.TestCase):
                   ("AND", "AND"),
                   ("IDENTIFIER", "abstract_filter"),
                   ("EQ", "="),
-                  ("STRING_LITERAL", "i"))
+                  ("STRING_LITERAL", "i"),
+                  ("OR", "or"),
+                  ("IDENTIFIER", "visit"),
+                  ("IN", "IN"),
+                  ("LPAREN", "("),
+                  ("RANGE_LITERAL", (1, 50, 2)),
+                  ("RPAREN", ")"),
+                  )
         lexer.input(expr)
         for type, value in tokens:
             self._assertToken(lexer.token(), type, value)

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -272,6 +272,24 @@ class ParserLexTestCase(unittest.TestCase):
             lexer.token()
         _assertExc(catcher.exception, expr, ".e2", 7, 3)
 
+        # zero stride in range literal
+        lexer = ParserLex.make_lexer()
+        expr = "1..2:0"
+        lexer.input(expr)
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (1, 2, None))
+        with self.assertRaises(ParserLexError) as catcher:
+            lexer.token()
+        _assertExc(catcher.exception, expr, ":0", 4, 1)
+
+        # negative stride in range literal
+        lexer = ParserLex.make_lexer()
+        expr = "1..2:-10"
+        lexer.input(expr)
+        self._assertToken(lexer.token(), "RANGE_LITERAL", (1, 2, None))
+        with self.assertRaises(ParserLexError) as catcher:
+            lexer.token()
+        _assertExc(catcher.exception, expr, ":-10", 4, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds range literal support inside IN() expressions and adds
translation of that syntax to sqlalchemy. With narrow range it just adds
all its elements to IN() list, if list becomes long (longer than 1000
items) then additional BETWEEN ... AND MOD() are generated.
