### PR TITLE
DM 21015: Fix AWS mock credentials.

### DIFF
--- a/python/lsst/daf/butler/core/s3utils.py
+++ b/python/lsst/daf/butler/core/s3utils.py
@@ -19,7 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ("s3CheckFileExists", "bucketExists")
+__all__ = ("s3CheckFileExists", "bucketExists", "setAwsEnvCredentials",
+           "unsetAwsEnvCredentials")
+
+import os
 
 try:
     import boto3
@@ -126,3 +129,38 @@ def bucketExists(bucketName, client=None):
         return True
     except s3.exceptions.NoSuchBucket:
         return False
+
+
+def setAwsEnvCredentials(accessKeyId='dummyAccessKeyId', secretAccessKey="dummySecretAccessKey"):
+    """Set AWS credentials environmental variables AWS_ACCESS_KEY_ID and
+    AWS_SECRET_ACCESS_KEY.
+
+    Parameters
+    ----------
+    accessKeyId : `str`
+        Value given to AWS_ACCESS_KEY_ID environmental variable. Defaults to
+        'dummyAccessKeyId'
+    secretAccessKey : `str`
+        Value given to AWS_SECRET_ACCESS_KEY environmental variable. Defaults
+        to 'dummySecretAccessKey'
+
+    Returns
+    -------
+    setEnvCredentials : `bool`
+        True when environmental variables were set, False otherwise.
+    """
+    if "AWS_ACCESS_KEY_ID" not in os.environ or "AWS_SECRET_ACCESS_KEY" not in os.environ:
+        os.environ["AWS_ACCESS_KEY_ID"] = accessKeyId
+        os.environ["AWS_SECRET_ACCESS_KEY"] = secretAccessKey
+        return True
+    return False
+
+
+def unsetAwsEnvCredentials():
+    """Unsets AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environmental
+    variables.
+    """
+    if "AWS_ACCESS_KEY_ID" in os.environ:
+        del os.environ["AWS_ACCESS_KEY_ID"]
+    if "AWS_SECRET_ACCESS_KEY" in os.environ:
+        del os.environ["AWS_SECRET_ACCESS_KEY"]

--- a/python/lsst/daf/butler/core/s3utils.py
+++ b/python/lsst/daf/butler/core/s3utils.py
@@ -148,6 +148,11 @@ def setAwsEnvCredentials(accessKeyId='dummyAccessKeyId', secretAccessKey="dummyS
     -------
     setEnvCredentials : `bool`
         True when environmental variables were set, False otherwise.
+
+    Notes
+    -----
+    If either AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY are not set, both
+    values are overwritten.
     """
     if "AWS_ACCESS_KEY_ID" not in os.environ or "AWS_SECRET_ACCESS_KEY" not in os.environ:
         os.environ["AWS_ACCESS_KEY_ID"] = accessKeyId

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -620,11 +620,11 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
         self.bucketName = uri.netloc
 
         # set up some fake credentials if they do not exist
-        if not os.path.exists("~/.aws/credentials"):
-            if "AWS_ACCESS_KEY_ID" not in os.environ:
-                os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
-            if "AWS_SECRET_ACCESS_KEY" not in os.environ:
-                os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+        self.usedDummyCredentials = False
+        if "AWS_ACCESS_KEY_ID" not in os.environ and "AWS_SECRET_ACCESS_KEY" not in os.environ:
+            os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
+            os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+            self.usedDummyCredentials = True
 
         if self.useTempRoot:
             self.root = self.genRoot()
@@ -657,9 +657,9 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        keys = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
-        for key in keys:
-            if key in os.environ and "dummy" in os.environ[key]:
+        if self.usedDummyCredentials:
+            keys = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
+            for key in keys:
                 del os.environ[key]
 
     def checkFileExists(self, root, relpath):

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -51,7 +51,9 @@ from lsst.daf.butler import FileTemplateValidationError, ValidationError
 from examplePythonTypes import MetricsExample
 from lsst.daf.butler.core.repoRelocation import BUTLER_ROOT_TAG
 from lsst.daf.butler.core.location import ButlerURI
-from lsst.daf.butler.core.s3utils import s3CheckFileExists
+from lsst.daf.butler.core.s3utils import (s3CheckFileExists, setAwsEnvCredentials,
+                                          unsetAwsEnvCredentials)
+
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -620,11 +622,7 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
         self.bucketName = uri.netloc
 
         # set up some fake credentials if they do not exist
-        self.usedDummyCredentials = False
-        if "AWS_ACCESS_KEY_ID" not in os.environ and "AWS_SECRET_ACCESS_KEY" not in os.environ:
-            os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
-            os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
-            self.usedDummyCredentials = True
+        self.usingDummyCredentials = setAwsEnvCredentials()
 
         if self.useTempRoot:
             self.root = self.genRoot()
@@ -657,10 +655,7 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        if self.usedDummyCredentials:
-            keys = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
-            for key in keys:
-                del os.environ[key]
+        unsetAwsEnvCredentials()
 
     def checkFileExists(self, root, relpath):
         """Checks if file exists at a given path (relative to root).

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -655,7 +655,8 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        unsetAwsEnvCredentials()
+        if self.usingDummyCredentials:
+            unsetAwsEnvCredentials()
 
     def checkFileExists(self, root, relpath):
         """Checks if file exists at a given path (relative to root).

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -619,6 +619,13 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
         uri = ButlerURI(config[".datastore.datastore.root"])
         self.bucketName = uri.netloc
 
+        # set up some fake credentials if they do not exist
+        if not os.path.exists("~/.aws/credentials"):
+            if "AWS_ACCESS_KEY_ID" not in os.environ:
+                os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
+            if "AWS_SECRET_ACCESS_KEY" not in os.environ:
+                os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+
         if self.useTempRoot:
             self.root = self.genRoot()
         rooturi = f"s3://{self.bucketName}/{self.root}"
@@ -648,6 +655,12 @@ class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
 
         bucket = s3.Bucket(self.bucketName)
         bucket.delete()
+
+        # unset any potentially set dummy credentials
+        keys = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+        for key in keys:
+            if key in os.environ and "dummy" in os.environ[key]:
+                del os.environ[key]
 
     def checkFileExists(self, root, relpath):
         """Checks if file exists at a given path (relative to root).

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -45,6 +45,7 @@ from lsst.daf.butler import StorageClassFactory
 from lsst.daf.butler import DatasetType
 from lsst.daf.butler.core.location import ButlerURI
 from datasetsHelper import FitsCatalogDatasetsHelper, DatasetTestHelper
+from lsst.daf.butler.core.s3utils import setAwsEnvCredentials, unsetAwsEnvCredentials
 
 try:
     import lsst.afw.image
@@ -198,11 +199,7 @@ class S3DatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):
         config.update({"datastore": {"datastore": {"root": rooturi}}})
 
         # set up some fake credentials if they do not exist
-        self.usedDummyCredentials = False
-        if "AWS_ACCESS_KEY_ID" not in os.environ and "AWS_SECRET_ACCESS_KEY" not in os.environ:
-            os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
-            os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
-            self.usedDummyCredentials = True
+        self.usingDummyCredentials = setAwsEnvCredentials()
 
         # MOTO needs to know that we expect Bucket bucketname to exist
         # (this used to be the class attribute bucketName)
@@ -231,10 +228,8 @@ class S3DatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        if self.usedDummyCredentials:
-            keys = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
-            for key in keys:
-                del os.environ[key]
+        if self.usingDummyCredentials:
+            unsetAwsEnvCredentials()
 
 
 if __name__ == "__main__":

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -198,11 +198,11 @@ class S3DatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):
         config.update({"datastore": {"datastore": {"root": rooturi}}})
 
         # set up some fake credentials if they do not exist
-        if not os.path.exists("~/.aws/credentials"):
-            if "AWS_ACCESS_KEY_ID" not in os.environ:
-                os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
-            if "AWS_SECRET_ACCESS_KEY" not in os.environ:
-                os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+        self.usedDummyCredentials = False
+        if "AWS_ACCESS_KEY_ID" not in os.environ and "AWS_SECRET_ACCESS_KEY" not in os.environ:
+            os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
+            os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+            self.usedDummyCredentials = True
 
         # MOTO needs to know that we expect Bucket bucketname to exist
         # (this used to be the class attribute bucketName)
@@ -231,9 +231,9 @@ class S3DatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        keys = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
-        for key in keys:
-            if key in os.environ and "dummy" in os.environ[key]:
+        if self.usedDummyCredentials:
+            keys = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
+            for key in keys:
                 del os.environ[key]
 
 

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -197,6 +197,13 @@ class S3DatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):
         rooturi = f"s3://{self.bucketName}/{self.root}"
         config.update({"datastore": {"datastore": {"root": rooturi}}})
 
+        # set up some fake credentials if they do not exist
+        if not os.path.exists("~/.aws/credentials"):
+            if "AWS_ACCESS_KEY_ID" not in os.environ:
+                os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
+            if "AWS_SECRET_ACCESS_KEY" not in os.environ:
+                os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+
         # MOTO needs to know that we expect Bucket bucketname to exist
         # (this used to be the class attribute bucketName)
         s3 = boto3.resource("s3")
@@ -222,6 +229,12 @@ class S3DatastoreButlerTestCase(ButlerFitsTests, lsst.utils.tests.TestCase):
 
         bucket = s3.Bucket(self.bucketName)
         bucket.delete()
+
+        # unset any potentially set dummy credentials
+        keys = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+        for key in keys:
+            if key in os.environ and "dummy" in os.environ[key]:
+                del os.environ[key]
 
 
 if __name__ == "__main__":

--- a/tests/test_s3utils.py
+++ b/tests/test_s3utils.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import unittest
 
 try:
@@ -34,7 +33,8 @@ except ImportError:
         """
         return cls
 
-from lsst.daf.butler.core.s3utils import bucketExists, s3CheckFileExists
+from lsst.daf.butler.core.s3utils import (bucketExists, s3CheckFileExists,
+                                          setAwsEnvCredentials, unsetAwsEnvCredentials)
 from lsst.daf.butler.core.location import Location, ButlerURI
 
 
@@ -48,12 +48,7 @@ class S3UtilsTestCase(unittest.TestCase):
 
     def setUp(self):
         # set up some fake credentials if they do not exist
-        # set up some fake credentials if they do not exist
-        self.usedDummyCredentials = False
-        if "AWS_ACCESS_KEY_ID" not in os.environ and "AWS_SECRET_ACCESS_KEY" not in os.environ:
-            os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
-            os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
-            self.usedDummyCredentials = True
+        self.usingDummyCredentials = setAwsEnvCredentials()
 
         s3 = boto3.client("s3")
         try:
@@ -80,10 +75,8 @@ class S3UtilsTestCase(unittest.TestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        if self.usedDummyCredentials:
-            keys = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
-            for key in keys:
-                del os.environ[key]
+        if self.usingDummyCredentials:
+            unsetAwsEnvCredentials()
 
     def testBucketExists(self):
         self.assertTrue(bucketExists(f"{self.bucketName}"))

--- a/tests/test_s3utils.py
+++ b/tests/test_s3utils.py
@@ -48,11 +48,12 @@ class S3UtilsTestCase(unittest.TestCase):
 
     def setUp(self):
         # set up some fake credentials if they do not exist
-        if not os.path.exists("~/.aws/credentials"):
-            if "AWS_ACCESS_KEY_ID" not in os.environ:
-                os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
-            if "AWS_SECRET_ACCESS_KEY" not in os.environ:
-                os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+        # set up some fake credentials if they do not exist
+        self.usedDummyCredentials = False
+        if "AWS_ACCESS_KEY_ID" not in os.environ and "AWS_SECRET_ACCESS_KEY" not in os.environ:
+            os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
+            os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+            self.usedDummyCredentials = True
 
         s3 = boto3.client("s3")
         try:
@@ -79,9 +80,9 @@ class S3UtilsTestCase(unittest.TestCase):
         bucket.delete()
 
         # unset any potentially set dummy credentials
-        keys = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
-        for key in keys:
-            if key in os.environ and "dummy" in os.environ[key]:
+        if self.usedDummyCredentials:
+            keys = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY")
+            for key in keys:
                 del os.environ[key]
 
     def testBucketExists(self):

--- a/tests/test_s3utils.py
+++ b/tests/test_s3utils.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 
 try:
@@ -46,6 +47,13 @@ class S3UtilsTestCase(unittest.TestCase):
     fileName = "testFileName"
 
     def setUp(self):
+        # set up some fake credentials if they do not exist
+        if not os.path.exists("~/.aws/credentials"):
+            if "AWS_ACCESS_KEY_ID" not in os.environ:
+                os.environ["AWS_ACCESS_KEY_ID"] = "dummyAccessKeyId"
+            if "AWS_SECRET_ACCESS_KEY" not in os.environ:
+                os.environ["AWS_SECRET_ACCESS_KEY"] = "dummySecreyAccessKey"
+
         s3 = boto3.client("s3")
         try:
             s3.create_bucket(Bucket=self.bucketName)
@@ -69,6 +77,12 @@ class S3UtilsTestCase(unittest.TestCase):
 
         bucket = s3.Bucket(self.bucketName)
         bucket.delete()
+
+        # unset any potentially set dummy credentials
+        keys = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+        for key in keys:
+            if key in os.environ and "dummy" in os.environ[key]:
+                del os.environ[key]
 
     def testBucketExists(self):
         self.assertTrue(bucketExists(f"{self.bucketName}"))


### PR DESCRIPTION
When trying to run the S3 datastore tests, with `boto3` and `moto` installed, they fail unless some values are present in a `~/.aws/credentials` file. 

Tests now check whether the file or if the environmental variables are set and if not sets them. The values are unset at the end of the tests.