### PR TITLE
DM-21024: Edit DbAuth docstring syntax

### DIFF
--- a/python/lsst/daf/butler/core/dbAuth.py
+++ b/python/lsst/daf/butler/core/dbAuth.py
@@ -125,29 +125,29 @@ class DbAuth:
         the database connection URL, the dictionary must also contain a
         ``username`` item.
 
-        Glob-style patterns (using "*" and "?" as wildcards) can be used to
-        match the host and database name portions of the connection URL.  For
-        the username, port, and database name portions, omitting them from the
-        pattern matches against any value in the connection URL.
+        Glob-style patterns (using "``*``" and "``?``" as wildcards) can be
+        used to match the host and database name portions of the connection
+        URL.  For the username, port, and database name portions, omitting them
+        from the pattern matches against any value in the connection URL.
 
         Examples
         --------
 
         The connection URL
-        "postgresql://user@host.example.com:5432/my_database" matches against
+        ``postgresql://user@host.example.com:5432/my_database`` matches against
         the identical string as a pattern.  Other patterns that would match
         include:
 
-        * "postgresql://*"
-        * "postgresql://*.example.com"
-        * "postgresql://*.example.com/my_*"
-        * "postgresql://host.example.com/my_database"
-        * "postgresql://host.example.com:5432/my_database"
-        * "postgresql://user@host.example.com/my_database"
+        * ``postgresql://*``
+        * ``postgresql://*.example.com``
+        * ``postgresql://*.example.com/my_*``
+        * ``postgresql://host.example.com/my_database``
+        * ``postgresql://host.example.com:5432/my_database``
+        * ``postgresql://user@host.example.com/my_database``
 
         Note that the connection URL
-        "postgresql://host.example.com/my_database" would not match against
-        the pattern "postgresql://host.example.com:5432", even if the default
+        ``postgresql://host.example.com/my_database`` would not match against
+        the pattern ``postgresql://host.example.com:5432``, even if the default
         port for the connection is 5432.
         """
         if drivername is None or drivername == "":
@@ -238,7 +238,7 @@ class DbAuth:
 
         See also
         --------
-        `getAuth`
+        getAuth
         """
         components = urllib.parse.urlparse(url)
         username, password = self.getAuth(


### PR DESCRIPTION
This follows on from changes in #180. I've checked that the docs successfully build locally.

- The change in "See also" is necessary since otherwise it generates a breaking error in the Sphinx build.
- The change from quotes to code literals helps avoid issues with accidentally starting an inline emphasis using the glob "*". Escaping the asterisk could also have worked.