### PR TITLE
DM-21210: On transaction abort, PostgreSQL ignores commands in the entire transaction block.

### DIFF
--- a/python/lsst/daf/butler/registries/postgresqlRegistry.py
+++ b/python/lsst/daf/butler/registries/postgresqlRegistry.py
@@ -68,7 +68,7 @@ class PostgreSqlRegistry(SqlRegistry):
         """
         super().setConfigRoot(root, config, full, overwrite=overwrite)
         Config.updateParameters(RegistryConfig, config, full,
-                                overwrite=overwrite)
+                                toCopy=("db",), overwrite=overwrite)
 
     def __init__(self, registryConfig, schemaConfig, dimensionConfig, create=False,
                  butlerRoot=None):

--- a/python/lsst/daf/butler/registries/sqlRegistry.py
+++ b/python/lsst/daf/butler/registries/sqlRegistry.py
@@ -562,8 +562,9 @@ class SqlRegistry(Registry):
                 raise AmbiguousDatasetError(f"Cannot associate dataset {ref} without ID.")
 
             try:
-                self._connection.execute(insertQuery, {"dataset_id": ref.id, "dataset_ref_hash": ref.hash,
-                                                       "collection": collection})
+                with self.transaction():
+                    self._connection.execute(insertQuery, {"dataset_id": ref.id, "dataset_ref_hash": ref.hash,
+                                                           "collection": collection})
             except IntegrityError as exc:
                 # Did we clash with a completely duplicate entry (because this
                 # dataset is already in this collection)?  Or is there already


### PR DESCRIPTION
When an SQL query fails in a transaction, PostgreSQL invalidates the entire transaction. Any subsequent SQL statement will then fail with 

```
sqlalchemy.exc.InternalError: (psycopg2.InternalError) current transaction is aborted, commands ignored until end of transaction block
```

statement. In `SqlRegistry.associate` method an insert statement is expected to fail sometimes, but a rollback is never issued to fix the transaction, leading to this error being raised on any following query, even when correct.

Minor fix to `PostgreSqlRegistry.setConfigRoot` by adding a `toCopy` parameter that I somehow forgot in https://github.com/lsst/daf_butler/pull/189.

I put the transaction in the `SqlRegistry` but I can move it explicitly to `PostgreSqlRegistry`. I don't know if that's desired due to code duplication or not.