### PR TITLE
DM-21222: Stop forcing existence of credentials in connection strings.

### DIFF
--- a/python/lsst/daf/butler/core/connectionString.py
+++ b/python/lsst/daf/butler/core/connectionString.py
@@ -22,7 +22,7 @@
 __all__ = ("DB_AUTH_ENVVAR", "DB_AUTH_PATH", "ConnectionStringFactory")
 
 from sqlalchemy.engine import url
-from lsst.daf.butler.core.dbAuth import DbAuth, DbAuthError
+from lsst.daf.butler.core.dbAuth import DbAuth, DbAuthError, DbAuthPermissionsError
 
 DB_AUTH_ENVVAR = "LSST_DB_AUTH"
 """Default name of the environmental variable that will be used to locate DB
@@ -68,8 +68,7 @@ class ConnectionStringFactory:
         Raises
         ------
         DBAuthError
-            If the credentials file has incorrect permissions, doesn't exist at
-            the given location or is formatted incorrectly.
+            If the credentials file has incorrect permissions.
         """
         # this import can not live on the top because of circular import issue
         from lsst.daf.butler.core.registryConfig import RegistryConfig
@@ -80,20 +79,26 @@ class ConnectionStringFactory:
             if getattr(conStr, key) is None:
                 setattr(conStr, key, regConf.get(key))
 
+        # when host is None we cross our fingers and return
+        if conStr.host is None:
+            return conStr
+
         # allow other mechanisms to insert username and password by not forcing
-        # the credentials to exist, always re-raise only the case where
-        # credentials# file exists but is incorrect permissions, for safety
+        # the credentials to exist. If other mechanisms are used it's possible
+        # that credentials were never set-up, or that there would be no match
+        # in the credentials file. Both need to be ignored.
         try:
             dbAuth = DbAuth(DB_AUTH_PATH, DB_AUTH_ENVVAR)
-        except DbAuthError as e:
-            if 'permissions' in e.args[0]:
-                raise
+            auth = dbAuth.getAuth(conStr.drivername, conStr.username, conStr.host,
+                                  conStr.port, conStr.database)
+        except DbAuthPermissionsError:
+            # re-raise permission error for safety
+            raise
+        except DbAuthError:
+            # credentials file doesn't exist or no match was found
+            pass
         else:
-            if dbAuth.exists(conStr.drivername, conStr.username, conStr.host,
-                             conStr.port, conStr.database):
-                auth = dbAuth.getAuth(conStr.drivername, conStr.username, conStr.host,
-                                      conStr.port, conStr.database)
-                conStr.username = auth[0]
-                conStr.password = auth[1]
+            conStr.username = auth[0]
+            conStr.password = auth[1]
 
         return conStr

--- a/python/lsst/daf/butler/core/dbAuth.py
+++ b/python/lsst/daf/butler/core/dbAuth.py
@@ -82,6 +82,34 @@ class DbAuth:
                 "Unable to load DbAuth configuration file: " +
                 secretPath) from exc
 
+    def exists(self, drivername, username, host, port, database):
+        """Checks whether an glob-like URL entry that matches given parameters
+        exists in the credentials file.
+
+        Parameters
+        ----------
+        drivername : `str`
+            Name of database backend driver from connection URL.
+        username : `str` or None
+            Username from connection URL if present.
+        host : `str`
+            Host name from connection URL if present.
+        port : `str` or `int` or None
+            Port from connection URL if present.
+        database : `str`
+            Database name from connection URL.
+
+        Returns
+        -------
+        exists : `bool`
+            True when an entry is found, False otherwise.
+        """
+        try:
+            self.getAuth(drivername, username, host, port, database)
+        except DbAuthError:
+            return False
+        return True
+
     def getAuth(self, drivername, username, host, port, database):
         """Retrieve a username and password for a database connection.
 

--- a/tests/test_dbAuth.py
+++ b/tests/test_dbAuth.py
@@ -246,13 +246,6 @@ class DbAuthTestCase(unittest.TestCase):
                 r"\(postgresql, None, example\.com, None, foo\)$"):
             auth.getAuth("postgresql", None, "example.com", None, "foo")
 
-        auth = DbAuth(authList=[dict(url="postgresql://*.example.com")])
-        with self.assertRaisesRegex(
-                DbAuthError,
-                r"^Missing password in DbAuth configuration for URL: "
-                r"postgresql://\*\.example\.com$"):
-            auth.getAuth("postgresql", None, "example.com", None, "foo")
-
         auth = DbAuth(authList=[dict(password="testing")])
         with self.assertRaisesRegex(
                 DbAuthError,
@@ -270,14 +263,6 @@ class DbAuthTestCase(unittest.TestCase):
         with self.assertRaisesRegex(
                 DbAuthError,
                 r"^Missing host in URL: postgresql:///foo$"):
-            auth.getAuth("postgresql", None, "example.com", None, "foo")
-
-        auth = DbAuth(authList=[
-            dict(url="postgresql://example.com/foo", password="testing")])
-        with self.assertRaisesRegex(
-                DbAuthError,
-                r"^Missing username in DbAuth configuration for URL: "
-                r"postgresql://example.com/foo$"):
             auth.getAuth("postgresql", None, "example.com", None, "foo")
 
     def test_getUrl(self):
@@ -422,14 +407,6 @@ class DbAuthTestCase(unittest.TestCase):
                 DbAuthError,
                 r"^No matching DbAuth configuration for: "
                 r"\(postgresql, None, example\.com, None, foo\)$"):
-            auth.getUrl("postgresql://example.com/foo")
-
-        auth = DbAuth(authList=[
-            dict(url="postgresql://example.com/foo", password="testing")])
-        with self.assertRaisesRegex(
-                DbAuthError,
-                r"^Missing username in DbAuth configuration for URL: "
-                r"postgresql://example.com/foo$"):
             auth.getUrl("postgresql://example.com/foo")
 
     def test_urlEncoding(self):


### PR DESCRIPTION
Not forcing username and password in connection strings allows other mechanisms, such as Oracle Wallet, to insert the credentials. 

It was difficult to untangle `getAuth` into sub-functionality so `exists` is implemented in terms of `getAuth`. Is that ok?

Would this work?