### PR TITLE
DM-21429: Make Posix- and S3-backed butler tests inherit from a common base.

### DIFF
--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -497,16 +497,6 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         with self.assertRaises(FileExistsError):
             butler.put(metric, "metric3", dataId3)
 
-
-class PosixDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
-    """PosixDatastore specialization of a butler"""
-    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
-    fullConfigKey = ".datastore.formatters"
-    validationCanFail = True
-    datastoreStr = ["/tmp"]
-    datastoreName = [f"PosixDatastore@{BUTLER_ROOT_TAG}"]
-    registryStr = "/gen3.sqlite3"
-
     def testImportExport(self):
         # Run put/get tests just to create and populate a repo.
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
@@ -534,6 +524,16 @@ class PosixDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCa
                         # Test for existence by passing in the DatasetType and
                         # data ID separately, to avoid lookup by dataset_id.
                         self.assertTrue(importButler.datasetExists(ref.datasetType, ref.dataId))
+
+
+class PosixDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
+    """PosixDatastore specialization of a butler"""
+    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
+    fullConfigKey = ".datastore.formatters"
+    validationCanFail = True
+    datastoreStr = ["/tmp"]
+    datastoreName = [f"PosixDatastore@{BUTLER_ROOT_TAG}"]
+    registryStr = "/gen3.sqlite3"
 
 
 class InMemoryDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
@@ -708,6 +708,10 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
         uri = ButlerURI(root)
         client = boto3.client("s3")
         return s3CheckFileExists(uri, client=client)[0]
+
+    @unittest.expectedFailure
+    def testImportExport(self):
+        super().testImportExport()
 
 
 if __name__ == "__main__":

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -426,15 +426,10 @@ class ButlerTests:
                 self.assertIn(testStr, datastoreName)
 
 
-class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
-    """PosixDatastore specialization of a butler"""
-    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
-    fullConfigKey = ".datastore.formatters"
-    validationCanFail = True
-
-    datastoreStr = ["/tmp"]
-    datastoreName = [f"PosixDatastore@{BUTLER_ROOT_TAG}"]
-    registryStr = "/gen3.sqlite3"
+class FileLikeDatastoreButlerTests(ButlerTests):
+    """Common tests and specialization of ButlerTests for butlers backed
+    by datastores that inherit from FileLikeDatastore.
+    """
 
     def checkFileExists(self, root, path):
         """Checks if file exists at a given path (relative to root).
@@ -501,6 +496,16 @@ class PosixDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
 
         with self.assertRaises(FileExistsError):
             butler.put(metric, "metric3", dataId3)
+
+
+class PosixDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
+    """PosixDatastore specialization of a butler"""
+    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
+    fullConfigKey = ".datastore.formatters"
+    validationCanFail = True
+    datastoreStr = ["/tmp"]
+    datastoreName = [f"PosixDatastore@{BUTLER_ROOT_TAG}"]
+    registryStr = "/gen3.sqlite3"
 
     def testImportExport(self):
         # Run put/get tests just to create and populate a repo.
@@ -609,7 +614,7 @@ class ButlerConfigNoRunTestCase(unittest.TestCase):
 
 @unittest.skipIf(not boto3, "Warning: boto3 AWS SDK not found!")
 @mock_s3
-class S3DatastoreButlerTestCase(PosixDatastoreButlerTestCase):
+class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
     """S3Datastore specialization of a butler; an S3 storage Datastore +
     a local in-memory SqlRegistry.
     """


### PR DESCRIPTION
This stops the S3-backed tests from inheriting from the Posix-backed tests and thus picking up an import/export test that won't succeed.