### PR TITLE
DM-21843: Add ordering comparisons to DimensionElement.

### DIFF
--- a/python/lsst/daf/butler/core/dimensions/elements.py
+++ b/python/lsst/daf/butler/core/dimensions/elements.py
@@ -170,6 +170,30 @@ class DimensionElement:
     def __hash__(self) -> int:
         return hash(self.name)
 
+    def __lt__(self, other) -> bool:
+        try:
+            return self.universe._elementIndices[self] < self.universe._elementIndices[other]
+        except KeyError:
+            return NotImplemented
+
+    def __le__(self, other) -> bool:
+        try:
+            return self.universe._elementIndices[self] <= self.universe._elementIndices[other]
+        except KeyError:
+            return NotImplemented
+
+    def __gt__(self, other) -> bool:
+        try:
+            return self.universe._elementIndices[self] > self.universe._elementIndices[other]
+        except KeyError:
+            return NotImplemented
+
+    def __ge__(self, other) -> bool:
+        try:
+            return self.universe._elementIndices[self] >= self.universe._elementIndices[other]
+        except KeyError:
+            return NotImplemented
+
     def hasTable(self) -> bool:
         """Return `True` if this element is associated with a table
         (even if that table "belongs" to another element).

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -41,8 +41,19 @@ class DimensionTestCase(unittest.TestCase):
         self.universe = DimensionUniverse()
 
     def checkGraphInvariants(self, graph):
-        for element in graph.elements:
+        elements = list(graph.elements)
+        for n, element in enumerate(elements):
+            # Ordered comparisons on graphs behave like sets.
             self.assertLessEqual(element.graph, graph)
+            # Ordered comparisons on elements correspond to the ordering within
+            # a DimensionUniverse (topological, with deterministic
+            # tiebreakers).
+            for other in elements[:n]:
+                self.assertLess(other, element)
+                self.assertLessEqual(other, element)
+            for other in elements[n + 1:]:
+                self.assertGreater(other, element)
+                self.assertGreaterEqual(other, element)
         self.assertEqual(DimensionGraph(self.universe, graph.required), graph)
         self.assertCountEqual(graph.required,
                               [dimension for dimension in graph.dimensions


### PR DESCRIPTION
Ordering is equivalent to iteration order in the associated DimensionUniverse.

This should address the problem reported in DM-21843, which involves logic in ctrl_mpexec that assumes data ID keys (which used to be vanilla strings, but are `Dimension` instances since DM-17023) are orderable.
