### PR TITLE
DM-22068: Add StorageClass for ip.isr.StrayLightData.

### DIFF
--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -130,5 +130,7 @@ storageClasses:
     pytype: lsst.base.Packages
   NumpyArray:
     pytype: numpy.ndarray
+  StrayLightData:
+    pytype: lsst.ip.isr.StrayLightData
   Thumbnail:
     pytype: numpy.ndarray


### PR DESCRIPTION
There's no default formatter for this StorageClass because it's an ABC whose subclasses could be persisted completely differently.  It's up to obs_ packages that use stray light data to define a formatter and ensure it is used when ingesting/writing those datasets.
