### PR TITLE
DM-21900: Allow additional dimension information to be used in file templates

### DIFF
--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -6,6 +6,7 @@ datastore:
     calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
     metric: "{collection}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
     test_metric_comp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric2: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
     metric3: "{collection}/{datasetType}/{instrument}"
     metric4: "{collection}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
     physical_filter+: "{collection}/{instrument}_{physical_filter}"

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -449,9 +449,9 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         butler.registry.insertDimensionData("physical_filter", {"instrument": "DummyCamComp",
                                                                 "name": "d-r",
                                                                 "abstract_filter": "R"})
-        butler.registry.insertDimensionData("visit", {"instrument": "DummyCamComp", "id": 423, "name": "423",
+        butler.registry.insertDimensionData("visit", {"instrument": "DummyCamComp", "id": 423, "name": "v423",
                                                       "physical_filter": "d-r"})
-        butler.registry.insertDimensionData("visit", {"instrument": "DummyCamComp", "id": 425, "name": "425",
+        butler.registry.insertDimensionData("visit", {"instrument": "DummyCamComp", "id": 425, "name": "v425",
                                                       "physical_filter": "d-r"})
 
         # Create and store a dataset
@@ -482,7 +482,7 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         # must be consistent).
         ref = butler.put(metric, "metric2", dataId2)
         self.assertTrue(self.checkFileExists(butler.datastore.root,
-                                             "ingest/metric2/d-r/DummyCamComp_423.pickle"))
+                                             "ingest/metric2/d-r/DummyCamComp_v423.pickle"))
 
         # Check the template based on dimensions
         butler.datastore.templates.validateTemplates([ref])


### PR DESCRIPTION
detector.name_in_raft and visit.name now work.