### PR TITLE
DM-21875: Add StorageClass and Formatter support necessary to persist lsst.verify.Measurement in Gen3 repos

### DIFF
--- a/config/datastores/formatters.yaml
+++ b/config/datastores/formatters.yaml
@@ -36,3 +36,4 @@ PropertyList: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
 PropertySet: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
 NumpyArray: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
 Plot: lsst.daf.butler.formatters.matplotlibFormatter.MatplotlibFormatter
+MetricValue: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -144,3 +144,5 @@ storageClasses:
     pytype: numpy.ndarray
   Plot:
     pytype: matplotlib.figure.Figure
+  MetricValue:
+    pytype: lsst.verify.Measurement

--- a/python/lsst/daf/butler/formatters/jsonFormatter.py
+++ b/python/lsst/daf/butler/formatters/jsonFormatter.py
@@ -139,5 +139,9 @@ class JsonFormatter(FileFormatter):
             Object of expected type `pytype`.
         """
         if not hasattr(builtins, pytype.__name__):
-            inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
+            if storageClass.isComposite():
+                inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
+            elif not isinstance(inMemoryDataset, pytype):
+                # Hope that we can pass the arguments in directly
+                inMemoryDataset = pytype(inMemoryDataset)
         return inMemoryDataset

--- a/python/lsst/daf/butler/formatters/yamlFormatter.py
+++ b/python/lsst/daf/butler/formatters/yamlFormatter.py
@@ -150,7 +150,7 @@ class YamlFormatter(FileFormatter):
         if not hasattr(builtins, pytype.__name__):
             if storageClass.isComposite():
                 inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
-            else:
+            elif not isinstance(inMemoryDataset, pytype):
                 # Hope that we can pass the arguments in directly
                 inMemoryDataset = pytype(inMemoryDataset)
         return inMemoryDataset


### PR DESCRIPTION
This PR adds storage and formatter definitions for `lsst.verify.Measurement`. It also mitigates an issue in `YamlFormatter` and `JsonFormatter` involving type conversions during unpersistence.