### PR TITLE
DM-22508: add Database class, concrete implementations, and tests

### DIFF
--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from . import ddl

--- a/python/lsst/daf/butler/registry/databases/oracle.py
+++ b/python/lsst/daf/butler/registry/databases/oracle.py
@@ -1,0 +1,198 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["OracleDatabase"]
+
+import copy
+from typing import Optional
+
+import sqlalchemy
+
+from ..interfaces import Database, ReadOnlyDatabaseError
+from .. import ddl
+from ..nameShrinker import NameShrinker
+
+
+class _Merge(sqlalchemy.sql.expression.Executable, sqlalchemy.sql.ClauseElement):
+    """A SQLAlchemy query that compiles to a MERGE invocation that is the
+    equivalent of PostgreSQL and SQLite's INSERT ... ON CONFLICT REPLACE on the
+    primary key constraint for the table.
+    """
+
+    def __init__(self, table):
+        super().__init__()
+        self.table = table
+
+
+@sqlalchemy.ext.compiler.compiles(_Merge, "oracle")
+def _merge(merge, compiler, **kw):
+    """Generate MERGE query for inserting or updating records.
+    """
+    table = merge.table
+    preparer = compiler.preparer
+
+    allColumns = [col.name for col in table.columns]
+    pkColumns = [col.name for col in table.primary_key]
+    nonPkColumns = [col for col in allColumns if col not in pkColumns]
+
+    # To properly support type decorators defined in core/schema.py we need
+    # to pass column type to `bindparam`.
+    selectColumns = [sqlalchemy.sql.bindparam(col.name, type_=col.type).label(col.name)
+                     for col in table.columns]
+    selectClause = sqlalchemy.sql.select(selectColumns)
+
+    tableAlias = table.alias("t")
+    tableAliasText = compiler.process(tableAlias, asfrom=True, **kw)
+    selectAlias = selectClause.alias("d")
+    selectAliasText = compiler.process(selectAlias, asfrom=True, **kw)
+
+    condition = sqlalchemy.sql.and_(
+        *[tableAlias.columns[col] == selectAlias.columns[col] for col in pkColumns]
+    )
+    conditionText = compiler.process(condition, **kw)
+
+    query = f"MERGE INTO {tableAliasText}" \
+            f"\nUSING {selectAliasText}" \
+            f"\nON ({conditionText})"
+    updates = []
+    for col in nonPkColumns:
+        src = compiler.process(selectAlias.columns[col], **kw)
+        dst = compiler.process(tableAlias.columns[col], **kw)
+        updates.append(f"{dst} = {src}")
+    updates = ", ".join(updates)
+    query += f"\nWHEN MATCHED THEN UPDATE SET {updates}"
+
+    insertColumns = ", ".join([preparer.format_column(col) for col in table.columns])
+    insertValues = ", ".join([compiler.process(selectAlias.columns[col], **kw) for col in allColumns])
+
+    query += f"\nWHEN NOT MATCHED THEN INSERT ({insertColumns}) VALUES ({insertValues})"
+    return query
+
+
+class OracleDatabase(Database):
+    """An implementation of the `Database` interface for Oracle.
+
+    Parameters
+    ----------
+    origin : `int`
+        An integer ID that should be used as the default for any datasets,
+        quanta, or other entities that use a (autoincrement, origin) compound
+        primary key.
+    uri : `str`, optional
+        Database connection string.  If not provided, ``engine`` must be.
+    engine : `sqlalchemy.engine.Engine`, optional
+        SQLAlchemy engine instance to use directly.
+    namespace : `str`, optional
+        Namespace (schema) for all tables used by this database.  May be,
+        `None` which will use the schema implied by ``uri`` or ``engine``
+        (which may be `None` for no schema).
+    prefix : `str`, optional
+        Prefix to add to all table names, effectively defining a virtual
+        schema that can coexist with others within the same actual database
+        schema.  This prefix must not be used in the un-prefixed names of
+        tables.
+    writeable : `bool`, optional
+        If `True` (default) allow writes to the database.
+    """
+
+    def __init__(self, *, origin: int,
+                 uri: Optional[str] = None,
+                 engine: Optional[sqlalchemy.engine.Engine] = None,
+                 namespace: Optional[str] = None,
+                 prefix: Optional[str] = None,
+                 writeable: bool = True):
+        if engine is None:
+            engine = sqlalchemy.engine.create_engine(uri, pool_size=1)
+        connection = engine.connect()
+        # Work around SQLAlchemy assuming that the Oracle limit on identifier
+        # names is even shorter than it is after 12.2.
+        oracle_ver = engine.dialect._get_server_version_info(connection)
+        if oracle_ver < (12, 2):
+            raise RuntimeError("Oracle server version >= 12.2 required.")
+        engine.dialect.max_identifier_length = 128
+        # Get the schema that was included/implicit in the URI we used to
+        # connect.
+        dbapi = engine.raw_connection()
+        if namespace is None:
+            namespace = dbapi.current_schema
+        else:
+            if dbapi.current_schema != namespace:
+                # TODO: could we instead add the schema to the URI before
+                # trying to connect?  Or is an Oracle connection without a
+                # schema not something that can exist?
+                raise RuntimeError("'namespace' and 'uri' arguments specify different schemas.")
+        # TODO: is there anything we can do to make the connection read-only if
+        # writeable is False?  If not (and at present) we just rely on the
+        # Python code being well-behaved and not *trying* to make changes.
+        super().__init__(origin=origin, engine=engine, namespace=namespace, connection=connection)
+        self._writeable = writeable
+        self.dsn = dbapi.dsn
+        self.prefix = prefix
+        self._shrinker = NameShrinker(engine.dialect.max_identifier_length)
+
+    def isWriteable(self) -> bool:
+        return self._writeable
+
+    def __str__(self) -> str:
+        if self.namespace is None:
+            name = self.dsn
+        else:
+            name = f"{self.dsn:self.namespace}"
+        return f"Oracle@{name}"
+
+    def shrinkDatabaseEntityName(self, original: str) -> str:
+        return self._shrinker.shrink(original)
+
+    def expandDatabaseEntityName(self, shrunk: str) -> str:
+        return self._shrinker.expand(shrunk)
+
+    def _convertForeignKeySpec(self, table: str, spec: ddl.ForeignKeySpec, metadata: sqlalchemy.MetaData,
+                               **kwds) -> sqlalchemy.schema.ForeignKeyConstraint:
+        if self.prefix is not None:
+            spec = copy.copy(spec)
+            spec.table = self.prefix + spec.table
+        return super()._convertForeignKeySpec(table, spec, metadata, **kwds)
+
+    def _convertTableSpec(self, name: str, spec: ddl.TableSpec, metadata: sqlalchemy.MetaData,
+                          **kwds) -> sqlalchemy.schema.Table:
+        if self.prefix is not None and not name.startswith(self.prefix):
+            name = self.prefix + name
+        return super()._convertTableSpec(name, spec, metadata, **kwds)
+
+    def getExistingTable(self, name: str, spec: ddl.TableSpec) -> Optional[sqlalchemy.schema.Table]:
+        if self.prefix is not None and not name.startswith(self.prefix):
+            name = self.prefix + name
+        return super().getExistingTable(name, spec)
+
+    def replace(self, table: sqlalchemy.schema.Table, *rows: dict):
+        if not self.isWriteable():
+            raise ReadOnlyDatabaseError(f"Attempt to replace into read-only database '{self}'.")
+        self._connection.execute(_Merge(table), *rows)
+
+    prefix: Optional[str]
+    """A prefix included in all table names to simulate a database namespace
+    (`str` or `None`).
+    """
+
+    dsn: str
+    """The TNS entry of the database this instance is connected to (`str`).
+    """

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -1,0 +1,81 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["PostgresqlDatabase"]
+
+from typing import Optional
+
+import sqlalchemy
+
+from ..interfaces import Database
+
+
+class PostgresqlDatabase(Database):
+    """An implementation of the `Database` interface for PostgreSQL.
+
+    Parameters
+    ----------
+    origin : `int`
+        An integer ID that should be used as the default for any datasets,
+        quanta, or other entities that use a (autoincrement, origin) compound
+        primary key.
+    uri : `str`, optional
+        Database connection string.
+    namespace : `str`, optional
+        Namespace (schema) for all tables used by this database.  May be `None`
+        only if a schema is included in ``uri``.
+    writeable : `bool`, optional
+        If `True` (default) allow writes to the database.
+
+    Notes
+    -----
+    This currently requires the psycopg2 driver to be used as the backend for
+    SQLAlchemy.  Running the tests for this class requires the
+    ``testing.postgresql`` be installed, which we assume indicates that a
+    PostgreSQL server is installed and can be run locally in userspace.
+    """
+
+    def __init__(self, *, origin: int, uri: str, namespace: Optional[str] = None, writeable: bool = True):
+        engine = sqlalchemy.engine.create_engine(uri, pool_size=1)
+        dbapi = engine.raw_connection()
+        try:
+            dsn = dbapi.get_dsn_parameters()
+        except (AttributeError, KeyError) as err:
+            raise RuntimeError(f"Only the psycopg2 driver for PostgreSQL is supported.") from err
+        if namespace is None:
+            namespace = dsn.get("schema")
+            if namespace is None:
+                raise RuntimeError("Namespace (schema) must be provided as an argument or included in URI.")
+        else:
+            if dsn.get("schema", namespace) != namespace:
+                raise RuntimeError("'namespace' and 'uri' arguments specify different schemas.")
+        super().__init__(origin=origin, engine=engine, namespace=namespace)
+        if not writeable:
+            dbapi.set_session(readonly=True)
+        self.dbname = dsn["dbname"]
+        self._writeable = writeable
+
+    def isWriteable(self) -> bool:
+        return self._writeable
+
+    def __str__(self) -> str:
+        return f"PostgreSQL@{self.dbname}:{self.namespace}"

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -1,0 +1,97 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["SqliteDatabase"]
+
+from contextlib import closing
+from typing import Optional
+
+import sqlite3
+import sqlalchemy
+
+from ..interfaces import Database
+
+
+def _onSqlite3Connect(dbapiConnection, connectionRecord):
+    assert isinstance(dbapiConnection, sqlite3.Connection)
+    # Prevent pysqlite from emitting BEGIN and COMMIT statements.
+    dbapiConnection.isolation_level = None
+    # Enable foreign keys
+    with closing(dbapiConnection.cursor()) as cursor:
+        cursor.execute("PRAGMA foreign_keys=ON;")
+        cursor.execute("PRAGMA busy_timeout = 300000;")  # in ms, so 5min (way longer than should be needed)
+
+
+def _onSqlite3Begin(connection):
+    assert connection.dialect.name == "sqlite"
+    # Replace pysqlite's buggy transaction handling that never BEGINs with our
+    # own that does, and tell SQLite to try to acquire a lock as soon as we
+    # start a transaction (this should lead to more blocking and fewer
+    # deadlocks).
+    connection.execute("BEGIN IMMEDIATE")
+    return connection
+
+
+class SqliteDatabase(Database):
+    """An implementation of the `Database` interface for SQLite3.
+
+    Parameters
+    ----------
+    origin : `int`
+        An integer ID that should be used as the default for any datasets,
+        quanta, or other entities that use a (autoincrement, origin) compound
+        primary key.
+    filename : `str`, optional
+        Absolute or relative path to the database file to load, or `None` to
+        create a temporary in-memory database.
+    writeable : `bool`, optional
+        If `True` (default) allow writes to the database.
+    """
+
+    def __init__(self, *, origin: int, filename: Optional[str] = None, writeable: bool = True):
+        target = f"file:{filename}" if filename is not None else ":memory:"
+        if not writeable:
+            target += '?mode=ro&uri=true'
+
+        def creator():
+            return sqlite3.connect(target, check_same_thread=False, uri=True)
+
+        uri = f"sqlite:///{filename}"
+        engine = sqlalchemy.engine.create_engine(uri, poolclass=sqlalchemy.pool.NullPool,
+                                                 creator=creator)
+        sqlalchemy.event.listen(engine, "connect", _onSqlite3Connect)
+        sqlalchemy.event.listen(engine, "begin", _onSqlite3Begin)
+        super().__init__(origin=origin, engine=engine)
+        self._writeable = writeable
+        self.filename = filename
+
+    def isWriteable(self) -> bool:
+        return self._writeable
+
+    def __str__(self) -> str:
+        return f"SQLite3@{self.filename}"
+
+    filename: Optional[str]
+    """Name of the file this database is connected to (`str` or `None`).
+
+    Set to `None` for in-memory databases.
+    """

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -136,14 +136,13 @@ class SqliteDatabase(Database):
             dbList = list(cursor.execute("PRAGMA database_list").fetchall())
         if len(dbList) == 0:
             raise RuntimeError("No database in connection.")
+        if namespace is None:
+            namespace = "main"
         for _, dbname, filename in dbList:
-            if namespace is None and dbname == "main" or dbname == namespace:
+            if dbname == namespace:
                 break
         else:
-            if namespace is None:
-                raise RuntimeError("No 'main' database in connection.")
-            else:
-                raise RuntimeError(f"No '{namespace}' database in connection.")
+            raise RuntimeError(f"No '{namespace}' database in connection.")
         if not filename:
             self.filename = None
         else:

--- a/python/lsst/daf/butler/registry/ddl.py
+++ b/python/lsst/daf/butler/registry/ddl.py
@@ -1,0 +1,190 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ("TableSpec", "FieldSpec", "ForeignKeySpec", "Base64Bytes", "Base64Region")
+
+from base64 import b64encode, b64decode
+from math import ceil
+from dataclasses import dataclass
+from typing import Optional, Tuple, Sequence, Set
+
+import sqlalchemy
+
+from lsst.sphgeom import ConvexPolygon
+from ..core.utils import NamedValueSet
+from sqlalchemy.types import TypeEngine
+
+
+class Base64Bytes(sqlalchemy.TypeDecorator):
+    """A SQLAlchemy custom type that maps Python `bytes` to a base64-encoded
+    `sqlalchemy.String`.
+    """
+
+    impl = sqlalchemy.String
+
+    def __init__(self, nbytes, *args, **kwds):
+        length = 4*ceil(nbytes/3)
+        super().__init__(*args, length=length, **kwds)
+        self.nbytes = nbytes
+
+    def process_bind_param(self, value, dialect):
+        # 'value' is native `bytes`.  We want to encode that to base64 `bytes`
+        # and then ASCII `str`, because `str` is what SQLAlchemy expects for
+        # String fields.
+        if value is None:
+            return None
+        if not isinstance(value, bytes):
+            raise TypeError(
+                f"Base64Bytes fields require 'bytes' values; got '{value}' with type {type(value)}."
+            )
+        return b64encode(value).decode("ascii")
+
+    def process_result_value(self, value, dialect):
+        # 'value' is a `str` that must be ASCII because it's base64-encoded.
+        # We want to transform that to base64-encoded `bytes` and then
+        # native `bytes`.
+        return b64decode(value.encode("ascii")) if value is not None else None
+
+
+class Base64Region(Base64Bytes):
+    """A SQLAlchemy custom type that maps Python `sphgeom.ConvexPolygon` to a
+    base64-encoded `sqlalchemy.String`.
+    """
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return super().process_bind_param(value.encode(), dialect)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        return ConvexPolygon.decode(super().process_result_value(value, dialect))
+
+
+@dataclass
+class FieldSpec:
+    """A struct-like class used to define a column in a logical `Registry`
+    table.
+    """
+
+    name: str
+    """Name of the column."""
+
+    dtype: type
+    """Type of the column; usually a `type` subclass provided by SQLAlchemy
+    that defines both a Python type and a corresponding precise SQL type.
+    """
+
+    length: Optional[int] = None
+    """Length of the type in the database, for variable-length types."""
+
+    nbytes: Optional[int] = None
+    """Natural length used for hash and encoded-region columns, to be converted
+    into the post-encoding length.
+    """
+
+    primaryKey: bool = False
+    """Whether this field is (part of) its table's primary key."""
+
+    autoincrement: bool = False
+    """Whether the database should insert automatically incremented values when
+    no value is provided in an INSERT.
+    """
+
+    nullable: bool = True
+    """Whether this field is allowed to be NULL."""
+
+    doc: Optional[str] = None
+    """Documentation for this field."""
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def getSizedColumnType(self) -> TypeEngine:
+        """Return a sized version of the column type, utilizing either (or
+        neither) of ``self.length`` and ``self.nbytes``.
+
+        Returns
+        -------
+        dtype : `sqlalchemy.types.TypeEngine`
+            A SQLAlchemy column type object.
+        """
+        if self.length is not None:
+            return self.dtype(length=self.length)
+        if self.nbytes is not None:
+            return self.dtype(nbytes=self.nbytes)
+        return self.dtype
+
+
+@dataclass
+class ForeignKeySpec:
+    """A struct-like class used to define a foreign key constraint in a logical
+    `Registry` table.
+    """
+
+    table: str
+    """Name of the target table."""
+
+    source: Tuple[str, ...]
+    """Tuple of source table column names."""
+
+    target: Tuple[str, ...]
+    """Tuple of target table column names."""
+
+    onDelete: Optional[str] = None
+    """SQL clause indicating how to handle deletes to the target table.
+
+    If not `None` (which indicates that a constraint violation exception should
+    be raised), should be either "SET NULL" or "CASCADE".
+    """
+
+
+@dataclass
+class TableSpec:
+    """A struct-like class used to define a table or table-like
+    query interface.
+    """
+
+    fields: NamedValueSet[FieldSpec]
+    """Specifications for the columns in this table."""
+
+    unique: Set[Tuple[str, ...]] = frozenset()
+    """Non-primary-key unique constraints for the table."""
+
+    indexes: Set[Tuple[str, ...]] = frozenset()
+    """Indexes for the table."""
+
+    foreignKeys: Sequence[ForeignKeySpec] = tuple()
+    """Foreign key constraints for the table."""
+
+    doc: Optional[str] = None
+    """Documentation for the table."""
+
+    def __post_init__(self):
+        self.fields = NamedValueSet(self.fields)
+        self.unique = set(self.unique)
+        self.indexes = set(self.indexes)
+        self.foreignKeys = list(self.foreignKeys)

--- a/python/lsst/daf/butler/registry/interfaces/__init__.py
+++ b/python/lsst/daf/butler/registry/interfaces/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .database import *

--- a/python/lsst/daf/butler/registry/interfaces/database.py
+++ b/python/lsst/daf/butler/registry/interfaces/database.py
@@ -611,6 +611,40 @@ class Database(ABC):
             sql = table.insert()
             return [self._connection.execute(sql, row).inserted_primary_key[0] for row in rows]
 
+    @abstractmethod
+    def replace(self, table: sqlalchemy.schema.Table, *rows: dict):
+        """Insert one or more rows into a table, replacing any existing rows
+        for which insertion of a new row would violate the primary key
+        constraint.
+
+        Parameters
+        ----------
+        table : `sqlalchemy.schema.Table`
+            Table rows should be inserted into.
+        rows
+            Positional arguments are the rows to be inserted, as dictionaries
+            mapping column name to value.  The keys in all dictionaries must
+            be the same.
+
+        Raises
+        ------
+        ReadOnlyDatabaseError
+            Raised if `isWriteable` returns `False` when this method is called.
+
+        Notes
+        -----
+        May be used inside transaction contexts, so implementations may not
+        perform operations that interrupt transactions.
+
+        Implementations should raise a `sqlalchemy.exc.IntegrityError`
+        exception when a constraint other than the primary key would be
+        violated.
+
+        Implementations are not required to support `replace` on tables
+        with autoincrement keys.
+        """
+        raise NotImplementedError()
+
     def delete(self, table: sqlalchemy.schema.Table, columns: Iterable[str], *rows: dict) -> int:
         """Delete one or more rows from a table.
 

--- a/python/lsst/daf/butler/registry/interfaces/database.py
+++ b/python/lsst/daf/butler/registry/interfaces/database.py
@@ -1,0 +1,573 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = [
+    "Database",
+    "ReadOnlyDatabaseError",
+    "StaticTablesContext",
+    "TransactionInterruption",
+]
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Tuple,
+)
+
+import sqlalchemy
+
+from .. import ddl
+
+
+def _checkExistingTableDefinition(name: str, spec: ddl.TableSpec, inspection: Dict[str, Any]):
+    """Test that the definition of a table in a `ddl.TableSpec` and from
+    database introspection are consistent.
+
+    Parameters
+    ----------
+    name : `str`
+        Name of the table (only used in error messages).
+    spec : `ddl.TableSpec`
+        Specification of the table.
+    inspection : `dict`
+        Dictionary returned by
+        `sqlalchemy.engine.reflection.Inspector.get_columns`.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if the definitions are inconsistent.
+    """
+    columnNames = [c["name"] for c in inspection]
+    if spec.fields.names != set(columnNames):
+        raise RuntimeError(f"Table '{name}' exists but is defined differently in the database; "
+                           f"specification has columns {list(spec.fields.names)}, while the "
+                           f"table in the database has {columnNames}.")
+
+
+class TransactionInterruption(RuntimeError):
+    """Exception raised when a database operation that will interrupt a
+    transaction is performed in the middle of a transaction.
+
+    This is considered a logic error that should result in reordering calls to
+    `Database` methods.  It is raised whenever a transaction is active that
+    *could* be interrupted, regardless of whether it actually would be given a
+    particular database engine or state, to ensure code depending on `Database`
+    does not accidentally depend on an implementation.
+    """
+
+
+class ReadOnlyDatabaseError(RuntimeError):
+    """Exception raised when a write operation is called on a read-only
+    `Database`.
+    """
+
+
+class StaticTablesContext:
+    """Helper class used to declare the static schema for a registry layer
+    in a database.
+
+    An instance of this class is returned by `Database.declareStaticTables`,
+    which should be the only way it should be constructed.
+    """
+
+    def __init__(self, db: Database):
+        self._db = db
+        self._foreignKeys = []
+        self._inspector = sqlalchemy.engine.reflection.Inspector(self._db._engine)
+        self._tableNames = frozenset(self._inspector.get_table_names(schema=self._db.namespace))
+
+    def addTable(self, name: str, spec: ddl.TableSpec) -> sqlalchemy.schema.Table:
+        """Add a new table to the schema, returning its sqlalchemy
+        representation.
+
+        The new table may not actually be created until the end of the
+        context created by `Database.declareStaticTables`, allowing tables
+        to be declared in any order even in the presence of foreign key
+        relationships.
+        """
+        if name in self._tableNames:
+            _checkExistingTableDefinition(name, spec, self._inspector.get_columns(name,
+                                                                                  schema=self._db.namespace))
+        table = self._db._convertTableSpec(name, spec, self._db._metadata)
+        for foreignKeySpec in spec.foreignKeys:
+            self._foreignKeys.append(
+                (table, self._db._convertForeignKeySpec(name, foreignKeySpec, self._db._metadata))
+            )
+        return table
+
+    def addTableTuple(self, specs: Tuple[ddl.TableSpec, ...]) -> Tuple[sqlalchemy.schema.Table, ...]:
+        """Add a named tuple of tables to the schema, returning their
+        SQLAlchemy representations in a named tuple of the same type.
+
+        The new tables may not actually be created until the end of the
+        context created by `Database.declareStaticTables`, allowing tables
+        to be declared in any order even in the presence of foreign key
+        relationships.
+
+        Notes
+        -----
+        ``specs`` *must* be an instance of a type created by
+        `collections.namedtuple`, not just regular tuple, and the returned
+        object is guaranteed to be the same.  Because `~collections.namedtuple`
+        is just a factory for `type` objects, not an actual type itself,
+        we cannot represent this with type annotations.
+        """
+        return specs._make(self.addTable(name, spec) for name, spec in zip(specs._fields, specs))
+
+
+class Database(ABC):
+    """An abstract interface that represents a particular database engine's
+    representation of a single schema/namespace/database.
+
+    Parameters
+    ----------
+    origin : `int`
+        An integer ID that should be used as the default for any datasets,
+        quanta, or other entities that use a (autoincrement, origin) compound
+        primary key.
+    namespace : `str`, optional
+        Name of the schema or namespace this instance is associated with.
+        This is passed as the ``schema`` argument when constructing a
+        `sqlalchemy.schema.MetaData` instance.  We use ``namespace`` instead to
+        avoid confusion between "schema means namespace" and "schema means
+        table definitions".
+    engine: `sqlalchemy.engine.Engine`.
+        SQLAlchemy engine object.  May be shared with other `Database`
+        instances.
+    connection : `sqlalchemy.engine.Connection`, optional
+        SQLAlchemy connection object.  May be shared with other `Database`
+        instances.  Constructed from ``engine`` if not provided.
+
+    Notes
+    -----
+    `Database` requires all write operations to go through its special named
+    methods.  Our write patterns are sufficiently simple that we don't really
+    need the full flexibility of SQL insert/update/delete syntax, and we need
+    non-standard (but common) functionality in these operations sufficiently
+    often that it seems worthwhile to provide our own generic API.
+
+    In contrast, `Database.query` allows arbitrary ``SELECT`` queries (via
+    their SQLAlchemy representation) to be run, as we expect these to require
+    significantly more sophistication while still being limited to standard
+    SQL.
+
+    `Database` itself has several underscore-prefixed attributes:
+
+     - ``_engine``: the `sqlalchemy.engine.Engine` object
+     - ``_connection``: the `sqlachemy.engine.Connection` object
+     - ``_metadata``: the `sqlalchemy.schema.MetaData` object
+     - ``_transactions``: a list of active `sqlalchemy.engine.Transaction`
+       objects
+
+    These are considered protected (derived classes may access them, but other
+    code should not), and read-only, aside from executing SQL via
+    ``_connection``.
+    """
+
+    def __init__(self, *, origin: int, namespace: Optional[str] = None,
+                 engine: sqlalchemy.engine.Engine,
+                 connection: Optional[sqlalchemy.engine.Connection] = None):
+        self.origin = origin
+        self.namespace = namespace
+        self._engine = engine
+        self._connection = connection if connection is not None else engine.connect()
+        self._metadata = None
+        self._transactions = []
+
+    @contextmanager
+    def transaction(self, *, savepoint: bool = False, interrupting: bool = False) -> None:
+        """Return a context manager that represents a transaction.
+
+        Parameters
+        ----------
+        savepoint : `bool`
+            If `True`, issue a ``SAVEPOINT`` command that allows child
+            transaction blocks that also use ``savepoint=True`` to roll back
+            without rolling back this transaction.
+        interrupting : `bool`
+            If `True`, this transaction block needs to be able to interrupt
+            any existing one in order to yield correct behavior, and hence
+            `TransactionInterruption` should be raised if this is not the
+            outermost transaction.
+
+        Raises
+        ------
+        TransactionInterruption
+            Raised if ``interrupting`` is `True` and a transaction is already
+            active.
+        """
+        if interrupting and self._transactions:
+            raise TransactionInterruption("Logic error in transaction nesting: an operation that would "
+                                          "the active transation context has been requested.")
+        if savepoint:
+            trans = self._connection.begin_nested()
+        else:
+            trans = self._connection.begin()
+        self._transactions.append(trans)
+        try:
+            yield
+            trans.commit()
+        except BaseException:
+            trans.rollback()
+            raise
+        finally:
+            self._transactions.pop()
+
+    @contextmanager
+    def declareStaticTables(self, *, create: bool) -> StaticTablesContext:
+        """Return a context manager in which the database's static DDL schema
+        can be declared.
+
+        Parameters
+        ----------
+        create : `bool`
+            If `True`, attempt to create all tables at the end of the context.
+            If `False`, they will be assumed to already exist.
+
+        Returns
+        -------
+        schema : `StaticTablesContext`
+            A helper object that is used to add new tables.
+
+        Raises
+        ------
+        ReadOnlyDatabaseError
+            Raised if ``create`` is `True`, `Database.isWriteable` is `False`,
+            and one or more declared tables do not already exist.
+
+        Example
+        -------
+        Given a `Database` instance ``db``::
+
+            with db.declareStaticTables(create=True) as schema:
+                schema.addTable("table1", TableSpec(...))
+                schema.addTable("table2", TableSpec(...))
+
+        Notes
+        -----
+        A database's static DDL schema must be declared before any dynamic
+        tables are managed via calls to `ensureTableExists` or
+        `getExistingTable`.  The order in which static schema tables are added
+        inside the context block is unimportant; they will automatically be
+        sorted and added in an order consistent with their foreign key
+        relationships.
+        """
+        if create and not self.isWriteable():
+            raise ReadOnlyDatabaseError(f"Cannot create tables in read-only database {self}.")
+        self._metadata = sqlalchemy.MetaData(schema=self.namespace)
+        try:
+            context = StaticTablesContext(self)
+            yield context
+            for table, foreignKey in context._foreignKeys:
+                table.append_constraint(foreignKey)
+            if create:
+                if self.namespace is not None:
+                    if self.namespace not in context._inspector.get_schema_names():
+                        self._engine.execute(sqlalchemy.schema.CreateSchema(self.namespace))
+                self._metadata.create_all(self._engine)
+        except BaseException:
+            self._metadata.drop_all(self._engine)
+            self._metadata = None
+            raise
+
+    @abstractmethod
+    def isWriteable(self) -> bool:
+        """Return `True` if this database can be modified by this client.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __str__(self) -> str:
+        """Return a human-readable identifier for this `Database`, including
+        any namespace or schema that identifies its names within a `Registry`.
+        """
+        raise NotImplementedError()
+
+    def shrinkDatabaseEntityName(self, original: str) -> str:
+        """Return a version of the given name that fits within this database
+        engine's length limits for table, constraint, indexes, and sequence
+        names.
+
+        Implementations should not assume that simple truncation is safe,
+        because multiple long names often begin with the same prefix.
+
+        The default implementation simply returns the given name.
+
+        Parameters
+        ----------
+        original : `str`
+            The original name.
+
+        Returns
+        -------
+        shrunk : `str`
+            The new, possibly shortened name.
+        """
+        return original
+
+    def expandDatabaseEntityName(self, shrunk: str) -> str:
+        """Retrieve the original name for a database entity that was too long
+        to fit within the database engine's limits.
+
+        Parameters
+        ----------
+        original : `str`
+            The original name.
+
+        Returns
+        -------
+        shrunk : `str`
+            The new, possibly shortened name.
+        """
+        return shrunk
+
+    def _convertFieldSpec(self, table: str, spec: ddl.FieldSpec, metadata: sqlalchemy.MetaData,
+                          **kwds) -> sqlalchemy.schema.Column:
+        """Convert a `FieldSpec` to a `sqlalchemy.schema.Column`.
+
+        Parameters
+        ----------
+        table : `str`
+            Name of the table this column is being added to.
+        spec : `FieldSpec`
+            Specification for the field to be added.
+        metadata : `sqlalchemy.MetaData`
+            SQLAlchemy representation of the DDL schema this field's table is
+            being added to.
+        **kwds
+            Additional keyword arguments to forward to the
+            `sqlalchemy.schema.Column` constructor.  This is provided to make
+            it easier for derived classes to delegate to ``super()`` while
+            making only minor changes.
+
+        Returns
+        -------
+        column : `sqlalchemy.schema.Column`
+            SQLAlchemy representation of the field.
+        """
+        args = [spec.name, spec.getSizedColumnType()]
+        if spec.autoincrement:
+            # Generate a sequence to use for auto incrementing for databases
+            # that do not support it natively.  This will be ignored by
+            # sqlalchemy for databases that do support it.
+            args.append(sqlalchemy.Sequence(self.shrinkDatabaseEntityName(f"{table}_seq_{spec.name}"),
+                                            metadata=metadata))
+        return sqlalchemy.schema.Column(*args, nullable=spec.nullable, primary_key=spec.primaryKey,
+                                        comment=spec.doc, **kwds)
+
+    def _convertForeignKeySpec(self, table: str, spec: ddl.ForeignKeySpec, metadata: sqlalchemy.MetaData,
+                               **kwds) -> sqlalchemy.schema.ForeignKeyConstraint:
+        """Convert a `ForeignKeySpec` to a
+        `sqlalchemy.schema.ForeignKeyConstraint`.
+
+        Parameters
+        ----------
+        table : `str`
+            Name of the table this foreign key is being added to.
+        spec : `ForeignKeySpec`
+            Specification for the foreign key to be added.
+        metadata : `sqlalchemy.MetaData`
+            SQLAlchemy representation of the DDL schema this constraint is
+            being added to.
+        **kwds
+            Additional keyword arguments to forward to the
+            `sqlalchemy.schema.ForeignKeyConstraint` constructor.  This is
+            provided to make it easier for derived classes to delegate to
+            ``super()`` while making only minor changes.
+
+        Returns
+        -------
+        constraint : `sqlalchemy.schema.ForeignKeyConstraint`
+            SQLAlchemy representation of the constraint.
+        """
+        name = self.shrinkDatabaseEntityName(
+            "_".join(["fkey", table, spec.table] + list(spec.target) + list(spec.source))
+        )
+        return sqlalchemy.schema.ForeignKeyConstraint(
+            spec.source,
+            [f"{spec.table}.{col}" for col in spec.target],
+            name=name,
+            ondelete=spec.onDelete
+        )
+
+    def _convertTableSpec(self, name: str, spec: ddl.TableSpec, metadata: sqlalchemy.MetaData,
+                          **kwds) -> sqlalchemy.schema.Table:
+        """Convert a `TableSpec` to a `sqlalchemy.schema.Table`.
+
+        Parameters
+        ----------
+        spec : `TableSpec`
+            Specification for the foreign key to be added.
+        metadata : `sqlalchemy.MetaData`
+            SQLAlchemy representation of the DDL schema this table is being
+            added to.
+        **kwds
+            Additional keyword arguments to forward to the
+            `sqlalchemy.schema.Table` constructor.  This is provided to make it
+            easier for derived classes to delegate to ``super()`` while making
+            only minor changes.
+
+        Returns
+        -------
+        table : `sqlalchemy.schema.Table`
+            SQLAlchemy representation of the table.
+
+        Notes
+        -----
+        This method does not handle ``spec.foreignKeys`` at all, in order to
+        avoid circular dependencies.  These are added by higher-level logic in
+        `ensureTableExists`, `getExistingTable`, and `declareStaticTables`.
+        """
+        args = [self._convertFieldSpec(name, fieldSpec, metadata) for fieldSpec in spec.fields]
+        args.extend(
+            sqlalchemy.schema.UniqueConstraint(
+                *columns,
+                name=self.shrinkDatabaseEntityName("_".join([name, "unq"] + list(columns)))
+            )
+            for columns in spec.unique if columns not in spec.indexes
+        )
+        args.extend(
+            sqlalchemy.schema.Index(
+                self.shrinkDatabaseEntityName("_".join([name, "idx"] + list(columns))),
+                *columns,
+                unique=(columns in spec.unique)
+            )
+            for columns in spec.indexes
+        )
+        return sqlalchemy.schema.Table(name, metadata, *args, comment=spec.doc, info=spec, **kwds)
+
+    def ensureTableExists(self, name: str, spec: ddl.TableSpec) -> sqlalchemy.sql.FromClause:
+        """Ensure that a table with the given name and specification exists,
+        creating it if necessary.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the table (not including namespace qualifiers).
+        spec : `TableSpec`
+            Specification for the table.  This will be used when creating the
+            table, and *may* be used when obtaining an existing table to check
+            for consistency, but no such check is guaranteed.
+
+        Returns
+        -------
+        table : `sqlalchemy.schema.Table`
+            SQLAlchemy representation of the table.
+
+        Raises
+        ------
+        TransactionInterruption
+            Raised if a transaction is active when this method is called.
+        ReadOnlyDatabaseError
+            Raised if `isWriteable` returns `False`, and the table does not
+            already exist.
+        RuntimeError
+            Raised if the table exists but ``spec`` is inconsistent with its
+            definition.
+
+        Notes
+        -----
+        This method may not be called within transactions.  It may be called on
+        read-only databases if and only if the table does in fact already
+        exist.
+
+        Subclasses may override this method, but usually should not need to.
+        """
+        if self._transactions:
+            raise TransactionInterruption("Table creation interrupts transactions.")
+        assert self._metadata is not None, "Static tables must be declared before dynamic tables."
+        table = self.getExistingTable(name, spec)
+        if table is not None:
+            return table
+        if not self.isWriteable():
+            raise ReadOnlyDatabaseError(
+                f"Table {name} does not exist, and cannot be created "
+                f"because database {self} is read-only."
+            )
+        table = self._convertTableSpec(name, spec, self._metadata)
+        for foreignKeySpec in spec.foreignKeys:
+            table.append_constraint(self._convertForeignKeySpec(name, foreignKeySpec, self._metadata))
+        table.create(self._engine)
+        return table
+
+    def getExistingTable(self, name: str, spec: ddl.TableSpec) -> Optional[sqlalchemy.schema.Table]:
+        """Obtain an existing table with the given name and specification.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the table (not including namespace qualifiers).
+        spec : `TableSpec`
+            Specification for the table.  This will be used when creating the
+            SQLAlchemy representation of the table, and it is used to
+            check that the actual table in the database is consistent.
+
+        Returns
+        -------
+        table : `sqlalchemy.schema.Table` or `None`
+            SQLAlchemy representation of the table, or `None` if it does not
+            exist.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if the table exists but ``spec`` is inconsistent with its
+            definition.
+
+        Notes
+        -----
+        This method can be called within transactions and never modifies the
+        database.
+
+        Subclasses may override this method, but usually should not need to.
+        """
+        assert self._metadata is not None, "Static tables must be declared before dynamic tables."
+        table = self._metadata.tables.get(name if self.namespace is None else f"{self.namespace}.{name}")
+        if table is not None:
+            if spec.fields.names != set(table.columns.keys()):
+                raise RuntimeError(f"Table '{name}' has already been defined differently; the new "
+                                   f"specification has columns {list(spec.fields.names)}, while the "
+                                   f"previous definition has {list(table.columns.keys())}.")
+        else:
+            inspector = sqlalchemy.engine.reflection.Inspector(self._engine)
+            if name in inspector.get_table_names(schema=self.namespace):
+                _checkExistingTableDefinition(name, spec, inspector.get_columns(name, schema=self.namespace))
+                table = self._convertTableSpec(name, spec, self._metadata)
+                for foreignKeySpec in spec.foreignKeys:
+                    table.append_constraint(self._convertForeignKeySpec(name, foreignKeySpec, self._metadata))
+                return table
+        return table
+
+    origin: int
+    """An integer ID that should be used as the default for any datasets,
+    quanta, or other entities that use a (autoincrement, origin) compound
+    primary key (`int`).
+    """
+
+    namespace: Optional[str]
+    """The schema or namespace this database instance is associated with
+    (`str` or `None`).
+    """

--- a/python/lsst/daf/butler/registry/interfaces/database.py
+++ b/python/lsst/daf/butler/registry/interfaces/database.py
@@ -725,7 +725,7 @@ class Database(ABC):
         returnIds: `bool`
             If `True` (`False` is default), return the values of the table's
             autoincrement primary key field (which much exist).
-        rows
+        *rows
             Positional arguments are the rows to be inserted, as dictionaries
             mapping column name to value.  The keys in all dictionaries must
             be the same.
@@ -771,7 +771,7 @@ class Database(ABC):
         ----------
         table : `sqlalchemy.schema.Table`
             Table rows should be inserted into.
-        rows
+        *rows
             Positional arguments are the rows to be inserted, as dictionaries
             mapping column name to value.  The keys in all dictionaries must
             be the same.
@@ -806,7 +806,7 @@ class Database(ABC):
             The names of columns that will be used to constrain the rows to
             be deleted; these will be combined via ``AND`` to form the
             ``WHERE`` clause of the delete query.
-        rows
+        *rows
             Positional arguments are the keys of rows to be deleted, as
             dictionaries mapping column name to value.  The keys in all
             dictionaries must exactly the names in ``columns``.
@@ -849,7 +849,7 @@ class Database(ABC):
             existing rows to the keys that will hold these values in the
             ``rows`` dictionaries.  Note that these may not be the same due to
             SQLAlchemy limitations.
-        rows
+        *rows
             Positional arguments are the rows to be updated.  The keys in all
             dictionaries must be the same, and may correspond to either a
             value in the ``where`` dictionary or the name of a column to be
@@ -888,10 +888,10 @@ class Database(ABC):
         ----------
         sql : `sqlalchemy.sql.FromClause`
             A SQLAlchemy representation of a ``SELECT`` query.
-        args
+        *args
             Additional positional arguments are forwarded to
             `sqlalchemy.engine.Connection.execute`.
-        kwds
+        **kwds
             Additional keyword arguments are forwarded to
             `sqlalchemy.engine.Connection.execute`.
 

--- a/python/lsst/daf/butler/registry/nameShrinker.py
+++ b/python/lsst/daf/butler/registry/nameShrinker.py
@@ -1,0 +1,70 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["NameShrinker"]
+
+import hashlib
+
+
+class NameShrinker:
+    """A utility class for `Database` implementations that need a nontrivial
+    implementation of `Database.shrinkDatabaseEntityName` and
+    `Database.expandDatabaseEntityName`.
+
+    Parameters
+    ----------
+    maxLength : `int`
+        The maximum number of characters in a database entity name.
+    hashSize : `int`, optional
+        The size of the hash (in bytes) to use for the tail of the shortened
+        name.  The hash is written in hexadecimal and prefixed with a "_", so
+        the number of characters the hash occupies is ``hashSize*2 + 1``, and
+        hence the number of characters preserved from the beginning of the
+        original name is ``maxLength - hashSize*2 - 1``.
+    """
+    def __init__(self, maxLength: int, hashSize: int = 4):
+        self.maxLength = maxLength
+        self.hashSize = hashSize
+        self._names = {}
+
+    def shrink(self, original: str) -> str:
+        """Shrink a name and remember the mapping between the original name and
+        its shrunk form.
+        """
+        if len(original) <= self.maxLength:
+            return original
+        message = hashlib.blake2b(digest_size=self.hashSize)
+        message.update(original.encode("ascii"))
+        trunc = self.maxLength - 2*self.hashSize - 1
+        shrunk = f"{original[:trunc]}_{message.digest().hex()}"
+        assert len(shrunk) == self.maxLength
+        self._names[shrunk] = original
+        return shrunk
+
+    def expand(self, shrunk: str) -> str:
+        """Return the original name that was passed to a previous call to
+        `shrink`.
+
+        If the given name was not passed to `shrink` or was not modified by
+        it, it is returned unmodified.
+        """
+        return self._names.get(shrunk, shrunk)

--- a/python/lsst/daf/butler/registry/tests/__init__.py
+++ b/python/lsst/daf/butler/registry/tests/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .database import *

--- a/python/lsst/daf/butler/registry/tests/database.py
+++ b/python/lsst/daf/butler/registry/tests/database.py
@@ -33,7 +33,6 @@ from ..interfaces import (
     Database,
     ReadOnlyDatabaseError,
     SynchronizationConflict,
-    TransactionInterruption,
 )
 from .. import ddl
 
@@ -182,7 +181,7 @@ class DatabaseTests(ABC):
         # Calling ensureTableExists inside a transaction block is an error,
         # even if it would do nothing.
         with newDatabase.transaction():
-            with self.assertRaises(TransactionInterruption):
+            with self.assertRaises(AssertionError):
                 newDatabase.ensureTableExists("d", DYNAMIC_TABLE_SPEC)
 
     def testSchemaSeparation(self):
@@ -344,10 +343,10 @@ class DatabaseTests(ABC):
             db.sync(tables.b, keys={"name": "b1"}, compared={"value": 20})
         # Try to sync inside a transaction.  That's always an error, regardless
         # of whether there would be an insertion or not.
-        with self.assertRaises(TransactionInterruption):
+        with self.assertRaises(AssertionError):
             with db.transaction():
                 db.sync(tables.b, keys={"name": "b1"}, extra={"value": 10})
-        with self.assertRaises(TransactionInterruption):
+        with self.assertRaises(AssertionError):
             with db.transaction():
                 db.sync(tables.b, keys={"name": "b2"}, extra={"value": 20})
         # Try to sync in a read-only database.  This should work if and only

--- a/python/lsst/daf/butler/registry/tests/database.py
+++ b/python/lsst/daf/butler/registry/tests/database.py
@@ -32,7 +32,7 @@ from lsst.sphgeom import ConvexPolygon, UnitVector3d
 from ..interfaces import (
     Database,
     ReadOnlyDatabaseError,
-    SynchronizationConflict,
+    DatabaseConflictError,
 )
 from .. import ddl
 
@@ -171,7 +171,7 @@ class DatabaseTests(ABC):
             self.checkTable(DYNAMIC_TABLE_SPEC, table)
         # Trying to get the table with a different specification (at least
         # in terms of what columns are present) should raise.
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(DatabaseConflictError):
             newDatabase.ensureTableExists(
                 "d",
                 ddl.TableSpec(
@@ -339,7 +339,7 @@ class DatabaseTests(ABC):
                          [dict(r) for r in db.query(tables.b.select()).fetchall()])
         # Repeat the operation with an incorrect value in 'compared'; this
         # should raise.
-        with self.assertRaises(SynchronizationConflict):
+        with self.assertRaises(DatabaseConflictError):
             db.sync(tables.b, keys={"name": "b1"}, compared={"value": 20})
         # Try to sync inside a transaction.  That's always an error, regardless
         # of whether there would be an insertion or not.

--- a/python/lsst/daf/butler/registry/tests/database.py
+++ b/python/lsst/daf/butler/registry/tests/database.py
@@ -1,0 +1,203 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["DatabaseTests"]
+
+from abc import ABC, abstractmethod
+from collections import namedtuple
+from typing import ContextManager
+
+import sqlalchemy
+
+from ..interfaces import (
+    Database,
+    ReadOnlyDatabaseError,
+    TransactionInterruption,
+)
+from .. import ddl
+
+StaticTablesTuple = namedtuple("StaticTablesTuple", ["a", "b", "c"])
+
+STATIC_TABLE_SPECS = StaticTablesTuple(
+    a=ddl.TableSpec(
+        fields=[
+            ddl.FieldSpec("name", dtype=sqlalchemy.String, length=16, primaryKey=True),
+            ddl.FieldSpec("region", dtype=ddl.Base64Region, nbytes=128),
+        ]
+    ),
+    b=ddl.TableSpec(
+        fields=[
+            ddl.FieldSpec("id", dtype=sqlalchemy.BigInteger, autoincrement=True, primaryKey=True),
+            ddl.FieldSpec("name", dtype=sqlalchemy.String, length=16, nullable=False),
+            ddl.FieldSpec("value", dtype=sqlalchemy.SmallInteger, nullable=True),
+        ],
+        unique=[("name",)],
+    ),
+    c=ddl.TableSpec(
+        fields=[
+            ddl.FieldSpec("id", dtype=sqlalchemy.BigInteger, autoincrement=True, primaryKey=True),
+            ddl.FieldSpec("origin", dtype=sqlalchemy.BigInteger, primaryKey=True),
+            ddl.FieldSpec("b_id", dtype=sqlalchemy.BigInteger, nullable=True),
+        ],
+        foreignKeys=[
+            ddl.ForeignKeySpec("b", source=("b_id",), target=("id",), onDelete="SET NULL"),
+        ]
+    ),
+)
+
+DYNAMIC_TABLE_SPEC = ddl.TableSpec(
+    fields=[
+        ddl.FieldSpec("c_id", dtype=sqlalchemy.BigInteger, primaryKey=True),
+        ddl.FieldSpec("c_origin", dtype=sqlalchemy.BigInteger, primaryKey=True),
+        ddl.FieldSpec("a_name", dtype=sqlalchemy.String, length=16, nullable=False),
+    ],
+    foreignKeys=[
+        ddl.ForeignKeySpec("c", source=("c_id", "c_origin"), target=("id", "origin"), onDelete="CASCADE"),
+        ddl.ForeignKeySpec("a", source=("a_name",), target=("name",), onDelete="CASCADE"),
+    ]
+)
+
+
+class DatabaseTests(ABC):
+    """Generic tests for the `Database` interface that can be subclassed to
+    generate tests for concrete implementations.
+    """
+
+    @abstractmethod
+    def makeEmptyDatabase(self, origin: int = 0) -> Database:
+        """Return an empty `Database` with the given origin, or an
+        automatically-generated one if ``origin`` is `None`.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def asReadOnly(self, database: Database) -> ContextManager[Database]:
+        """Return a context manager for a read-only connection into the given
+        database.
+
+        The original database should be considered unusable within the context
+        but safe to use again afterwards (this allows the context manager to
+        block write access by temporarily changing user permissions to really
+        guarantee that write operations are not performed).
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def getNewConnection(self, database: Database, *, writeable: bool) -> Database:
+        """Return a new `Database` instance that points to the same underlying
+        storage as the given one.
+        """
+        raise NotImplementedError()
+
+    def checkTable(self, spec: ddl.TableSpec, table: sqlalchemy.schema.Table):
+        self.assertCountEqual(spec.fields.names, table.columns.keys())
+        # Checking more than this currently seems fragile, as it might restrict
+        # what Database implementations do; we don't care if the spec is
+        # actually preserved in terms of types and constraints as long as we
+        # can use the returned table as if it was.
+
+    def checkStaticSchema(self, tables: StaticTablesTuple):
+        self.checkTable(STATIC_TABLE_SPECS.a, tables.a)
+        self.checkTable(STATIC_TABLE_SPECS.b, tables.b)
+        self.checkTable(STATIC_TABLE_SPECS.c, tables.c)
+
+    def testDeclareStaticTables(self):
+        """Tests for `Database.declareStaticSchema` and the methods it
+        delegates to.
+        """
+        # Create the static schema in a new, empty database.
+        newDatabase = self.makeEmptyDatabase()
+        with newDatabase.declareStaticTables(create=True) as context:
+            tables = context.addTableTuple(STATIC_TABLE_SPECS)
+        self.checkStaticSchema(tables)
+        # Check that we can load that schema even from a read-only connection.
+        with self.asReadOnly(newDatabase) as existingReadOnlyDatabase:
+            with existingReadOnlyDatabase.declareStaticTables(create=False) as context:
+                tables = context.addTableTuple(STATIC_TABLE_SPECS)
+            self.checkStaticSchema(tables)
+
+    def testDynamicTables(self):
+        """Tests for `Database.ensureTableExists` and
+        `Database.getExistingTable`.
+        """
+        # Need to start with the static schema.
+        newDatabase = self.makeEmptyDatabase()
+        with newDatabase.declareStaticTables(create=True) as context:
+            context.addTableTuple(STATIC_TABLE_SPECS)
+        # Try to ensure the dyamic table exists in a read-only version of that
+        # database, which should fail because we can't create it.
+        with self.asReadOnly(newDatabase) as existingReadOnlyDatabase:
+            with existingReadOnlyDatabase.declareStaticTables(create=False) as context:
+                context.addTableTuple(STATIC_TABLE_SPECS)
+            with self.assertRaises(ReadOnlyDatabaseError):
+                existingReadOnlyDatabase.ensureTableExists("d", DYNAMIC_TABLE_SPEC)
+        # Just getting the dynamic table before it exists should return None.
+        self.assertIsNone(newDatabase.getExistingTable("d", DYNAMIC_TABLE_SPEC))
+        # Ensure the new table exists back in the original database, which
+        # should create it.
+        table = newDatabase.ensureTableExists("d", DYNAMIC_TABLE_SPEC)
+        self.checkTable(DYNAMIC_TABLE_SPEC, table)
+        # Ensuring that it exists should just return the exact same table
+        # instance again.
+        self.assertIs(newDatabase.ensureTableExists("d", DYNAMIC_TABLE_SPEC), table)
+        # Try again from the read-only database.
+        with self.asReadOnly(newDatabase) as existingReadOnlyDatabase:
+            with existingReadOnlyDatabase.declareStaticTables(create=False) as context:
+                context.addTableTuple(STATIC_TABLE_SPECS)
+            # Just getting the dynamic table should now work...
+            self.assertIsNotNone(existingReadOnlyDatabase.getExistingTable("d", DYNAMIC_TABLE_SPEC))
+            # ...as should ensuring that it exists, since it now does.
+            existingReadOnlyDatabase.ensureTableExists("d", DYNAMIC_TABLE_SPEC)
+            self.checkTable(DYNAMIC_TABLE_SPEC, table)
+        # Trying to get the table with a different specification (at least
+        # in terms of what columns are present) should raise.
+        with self.assertRaises(RuntimeError):
+            newDatabase.ensureTableExists(
+                "d",
+                ddl.TableSpec(
+                    fields=[ddl.FieldSpec("name", dtype=sqlalchemy.String, length=4, primaryKey=True)]
+                )
+            )
+        # Calling ensureTableExists inside a transaction block is an error,
+        # even if it would do nothing.
+        with newDatabase.transaction():
+            with self.assertRaises(TransactionInterruption):
+                newDatabase.ensureTableExists("d", DYNAMIC_TABLE_SPEC)
+
+    def testSchemaSeparation(self):
+        """Test that creating two different `Database` instances allows us
+        to create different tables with the same name in each.
+        """
+        db1 = self.makeEmptyDatabase(origin=1)
+        with db1.declareStaticTables(create=True) as context:
+            tables = context.addTableTuple(STATIC_TABLE_SPECS)
+        self.checkStaticSchema(tables)
+
+        db2 = self.makeEmptyDatabase(origin=2)
+        # Make the DDL here intentionally different so we'll definitely
+        # notice if db1 and db2 are pointing at the same schema.
+        spec = ddl.TableSpec(fields=[ddl.FieldSpec("id", dtype=sqlalchemy.Integer, primaryKey=True)])
+        with db2.declareStaticTables(create=True) as context:
+            # Make the DDL here intentionally different so we'll definitely
+            # notice if db1 and db2 are pointing at the same schema.
+            table = context.addTable("a", spec)
+        self.checkTable(spec, table)

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -42,13 +42,13 @@ class OracleDatabaseTestCase(unittest.TestCase, DatabaseTests):
     def setUpClass(cls):
         # Create a single engine for all Database instances we create, to avoid
         # repeatedly spending time connecting.
-        cls._cs = OracleDatabase.connect(TEST_URI)
+        cls._connection = OracleDatabase.connect(TEST_URI)
         cls._prefixes = []
 
     @classmethod
     def tearDownClass(cls):
         commands = []
-        dbapi = cls._cs.engine.raw_connection()
+        dbapi = cls._connection.connection
         cursor = dbapi.cursor()
         for objectType, objectName in cursor.execute("SELECT object_type, object_name FROM user_objects"):
             if not any(objectName.lower().startswith(prefix) for prefix in cls._prefixes):
@@ -64,10 +64,10 @@ class OracleDatabaseTestCase(unittest.TestCase, DatabaseTests):
     def makeEmptyDatabase(self, origin: int = 0) -> OracleDatabase:
         prefix = f"test_{secrets.token_hex(8).lower()}_"
         self._prefixes.append(prefix)
-        return OracleDatabase(origin=origin, cs=self._cs, prefix=prefix)
+        return OracleDatabase(origin=origin, connection=self._connection, prefix=prefix)
 
     def getNewConnection(self, database: OracleDatabase, *, writeable: bool) -> OracleDatabase:
-        return OracleDatabase(origin=database.origin, cs=self._cs,
+        return OracleDatabase(origin=database.origin, connection=self._connection,
                               prefix=database.prefix, writeable=writeable)
 
     @contextmanager

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -42,13 +42,13 @@ class OracleDatabaseTestCase(unittest.TestCase, DatabaseTests):
     def setUpClass(cls):
         # Create a single engine for all Database instances we create, to avoid
         # repeatedly spending time connecting.
-        cls._engine = sqlalchemy.create_engine(TEST_URI, pool_size=1)
+        cls._cs = OracleDatabase.connect(TEST_URI)
         cls._prefixes = []
 
     @classmethod
     def tearDownClass(cls):
         commands = []
-        dbapi = cls._engine.raw_connection()
+        dbapi = cls._cs.engine.raw_connection()
         cursor = dbapi.cursor()
         for objectType, objectName in cursor.execute("SELECT object_type, object_name FROM user_objects"):
             if not any(objectName.lower().startswith(prefix) for prefix in cls._prefixes):
@@ -64,11 +64,11 @@ class OracleDatabaseTestCase(unittest.TestCase, DatabaseTests):
     def makeEmptyDatabase(self, origin: int = 0) -> OracleDatabase:
         prefix = f"test_{secrets.token_hex(8).lower()}_"
         self._prefixes.append(prefix)
-        return OracleDatabase(origin=origin, engine=self._engine, prefix=prefix)
+        return OracleDatabase(origin=origin, cs=self._cs, prefix=prefix)
 
     def getNewConnection(self, database: OracleDatabase, *, writeable: bool) -> OracleDatabase:
-        return OracleDatabase(origin=database.origin, engine=self._engine, prefix=database.prefix,
-                              namespace=database.namespace, writeable=writeable)
+        return OracleDatabase(origin=database.origin, cs=self._cs,
+                              prefix=database.prefix, writeable=writeable)
 
     @contextmanager
     def asReadOnly(self, database: OracleDatabase) -> OracleDatabase:

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,0 +1,136 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
+import os
+import os.path
+import secrets
+import unittest
+
+import sqlalchemy
+
+from lsst.daf.butler.registry.databases.oracle import OracleDatabase
+from lsst.daf.butler.registry import ddl
+from lsst.daf.butler.registry.tests import DatabaseTests
+
+ENVVAR = "DAF_BUTLER_ORACLE_TEST_URI"
+TEST_URI = os.environ.get(ENVVAR)
+
+
+@unittest.skipUnless(TEST_URI is not None, f"{ENVVAR} environment variable not set.")
+class OracleDatabaseTestCase(unittest.TestCase, DatabaseTests):
+
+    @classmethod
+    def setUpClass(cls):
+        # Create a single engine for all Database instances we create, to avoid
+        # repeatedly spending time connecting.
+        cls._engine = sqlalchemy.create_engine(TEST_URI, pool_size=1)
+        cls._prefixes = []
+
+    @classmethod
+    def tearDownClass(cls):
+        commands = []
+        dbapi = cls._engine.raw_connection()
+        cursor = dbapi.cursor()
+        for objectType, objectName in cursor.execute("SELECT object_type, object_name FROM user_objects"):
+            if not any(objectName.lower().startswith(prefix) for prefix in cls._prefixes):
+                continue
+            if objectType == "TABLE":
+                commands.append(f'DROP TABLE "{objectName}" CASCADE CONSTRAINTS')
+            elif objectType in ("VIEW", "PROCEDURE", "SEQUENCE"):
+                commands.append(f'DROP {objectType} "{objectName}"')
+        for command in commands:
+            cursor.execute(command)
+        cursor.close()
+
+    def makeEmptyDatabase(self, origin: int = 0) -> OracleDatabase:
+        prefix = f"test_{secrets.token_hex(8).lower()}_"
+        self._prefixes.append(prefix)
+        return OracleDatabase(origin=origin, engine=self._engine, prefix=prefix)
+
+    def getNewConnection(self, database: OracleDatabase, *, writeable: bool) -> OracleDatabase:
+        return OracleDatabase(origin=database.origin, engine=self._engine, prefix=database.prefix,
+                              namespace=database.namespace, writeable=writeable)
+
+    @contextmanager
+    def asReadOnly(self, database: OracleDatabase) -> OracleDatabase:
+        yield self.getNewConnection(database, writeable=False)
+
+    def testNameShrinking(self):
+        """Test that too-long names for database entities other than tables
+        and columns (which we preserve, and just expect to fit) are shrunk.
+        """
+        db = self.makeEmptyDatabase(origin=1)
+        with db.declareStaticTables(create=True) as context:
+            # Table and field names are each below the 128-char limit even when
+            # accounting for the prefix, but their combination (which will
+            # appear in sequences and constraints) is not.
+            tableName = "a_table_with_a_very_very_very_very_very_very_very_very_long_72_char_name"
+            fieldName1 = "a_column_with_a_very_very_very_very_very_very_very_very_long_73_char_name"
+            fieldName2 = "another_column_with_a_very_very_very_very_very_very_very_very_long_79_char_name"
+            context.addTable(
+                tableName,
+                ddl.TableSpec(
+                    fields=[
+                        ddl.FieldSpec(
+                            fieldName1,
+                            dtype=sqlalchemy.BigInteger,
+                            autoincrement=True,
+                            primaryKey=True
+                        ),
+                        ddl.FieldSpec(
+                            fieldName2,
+                            dtype=sqlalchemy.String,
+                            length=16,
+                            nullable=False,
+                        ),
+                    ],
+                    unique={(fieldName2,)},
+                )
+            )
+        # Add another table, this time dynamically, with a foreign key to the
+        # first table.
+        db.ensureTableExists(
+            tableName + "_b",
+            ddl.TableSpec(
+                fields=[
+                    ddl.FieldSpec(
+                        fieldName1 + "_b",
+                        dtype=sqlalchemy.BigInteger,
+                        autoincrement=True,
+                        primaryKey=True
+                    ),
+                    ddl.FieldSpec(
+                        fieldName2 + "_b",
+                        dtype=sqlalchemy.String,
+                        length=16,
+                        nullable=False,
+                    ),
+                ],
+                foreignKeys=[
+                    ddl.ForeignKeySpec(tableName, source=(fieldName2 + "_b",), target=(fieldName2,)),
+                ]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -52,11 +52,11 @@ class PostgresqlDatabaseTestCase(unittest.TestCase, DatabaseTests):
 
     def makeEmptyDatabase(self, origin: int = 0) -> PostgresqlDatabase:
         namespace = f"namespace_{secrets.token_hex(8).lower()}"
-        return PostgresqlDatabase(origin=origin, uri=self.server.url(), namespace=namespace)
+        return PostgresqlDatabase.fromUri(origin=origin, uri=self.server.url(), namespace=namespace)
 
     def getNewConnection(self, database: PostgresqlDatabase, *, writeable: bool) -> PostgresqlDatabase:
-        return PostgresqlDatabase(origin=database.origin, uri=self.server.url(),
-                                  namespace=database.namespace, writeable=writeable)
+        return PostgresqlDatabase.fromUri(origin=database.origin, uri=self.server.url(),
+                                          namespace=database.namespace, writeable=writeable)
 
     @contextmanager
     def asReadOnly(self, database: PostgresqlDatabase) -> PostgresqlDatabase:

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,0 +1,64 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
+import secrets
+import unittest
+
+try:
+    # It's possible but silly to have testing.postgresql installed without
+    # having the postgresql server installed (because then nothing in
+    # testing.postgresql would work), so we use the presence of that module
+    # to test whether we can expect the server to be available.
+    import testing.postgresql
+except ImportError:
+    testing = None
+
+from lsst.daf.butler.registry.databases.postgresql import PostgresqlDatabase
+from lsst.daf.butler.registry.tests import DatabaseTests
+
+
+@unittest.skipUnless(testing is not None, "testing.postgresql module not found")
+class PostgresqlDatabaseTestCase(unittest.TestCase, DatabaseTests):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = testing.postgresql.Postgresql()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def makeEmptyDatabase(self, origin: int = 0) -> PostgresqlDatabase:
+        namespace = f"namespace_{secrets.token_hex(8).lower()}"
+        return PostgresqlDatabase(origin=origin, uri=self.server.url(), namespace=namespace)
+
+    def getNewConnection(self, database: PostgresqlDatabase, *, writeable: bool) -> PostgresqlDatabase:
+        return PostgresqlDatabase(origin=database.origin, uri=self.server.url(),
+                                  namespace=database.namespace, writeable=writeable)
+
+    @contextmanager
+    def asReadOnly(self, database: PostgresqlDatabase) -> PostgresqlDatabase:
+        yield self.getNewConnection(database, writeable=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -57,12 +57,13 @@ class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
 
     def makeEmptyDatabase(self, origin: int = 0) -> SqliteDatabase:
         _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
-        cs = SqliteDatabase.connect(filename=filename)
-        return SqliteDatabase.fromConnectionStruct(cs=cs, origin=origin)
+        connection = SqliteDatabase.connect(filename=filename)
+        return SqliteDatabase.fromConnection(connection=connection, origin=origin)
 
     def getNewConnection(self, database: SqliteDatabase, *, writeable: bool) -> SqliteDatabase:
-        cs = SqliteDatabase.connect(filename=database.filename, writeable=writeable)
-        return SqliteDatabase.fromConnectionStruct(origin=database.origin, cs=cs, writeable=writeable)
+        connection = SqliteDatabase.connect(filename=database.filename, writeable=writeable)
+        return SqliteDatabase.fromConnection(origin=database.origin, connection=connection,
+                                             writeable=writeable)
 
     @contextmanager
     def asReadOnly(self, database: SqliteDatabase) -> SqliteDatabase:
@@ -91,7 +92,7 @@ class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
         are equivalent.
         """
         # Create an in-memory database by passing filename=None.
-        memFilename = SqliteDatabase.fromConnectionStruct(SqliteDatabase.connect(filename=None), origin=0)
+        memFilename = SqliteDatabase.fromConnection(SqliteDatabase.connect(filename=None), origin=0)
         self.assertIsNone(memFilename.filename)
         self.assertEqual(memFilename.origin, 0)
         self.assertTrue(memFilename.isWriteable())
@@ -112,7 +113,7 @@ class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
         # Make a temporary file for the rest of the next set of tests.
         _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
         # Create a read-write database by passing in the filename.
-        rwFilename = SqliteDatabase.fromConnectionStruct(SqliteDatabase.connect(filename=filename), origin=0)
+        rwFilename = SqliteDatabase.fromConnection(SqliteDatabase.connect(filename=filename), origin=0)
         self.assertEqual(rwFilename.filename, filename)
         self.assertEqual(rwFilename.origin, 0)
         self.assertTrue(rwFilename.isWriteable())
@@ -130,8 +131,8 @@ class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
         # Test read-only connections against a read-only file.
         with removeWritePermission(filename):
             # Create a read-only database by passing in the filename.
-            roFilename = SqliteDatabase.fromConnectionStruct(SqliteDatabase.connect(filename=filename),
-                                                             origin=0, writeable=False)
+            roFilename = SqliteDatabase.fromConnection(SqliteDatabase.connect(filename=filename),
+                                                       origin=0, writeable=False)
             self.assertEqual(roFilename.filename, filename)
             self.assertEqual(roFilename.origin, 0)
             self.assertFalse(roFilename.isWriteable())

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -1,0 +1,63 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from contextlib import contextmanager
+import os
+import os.path
+import shutil
+import stat
+import tempfile
+import unittest
+
+from lsst.daf.butler.registry.databases.sqlite import SqliteDatabase
+from lsst.daf.butler.registry.tests import DatabaseTests
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(dir=TESTDIR)
+
+    def tearDown(self):
+        if self.root is not None and os.path.exists(self.root):
+            shutil.rmtree(self.root, ignore_errors=True)
+
+    def makeEmptyDatabase(self, origin: int = 0) -> SqliteDatabase:
+        _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
+        return SqliteDatabase(origin=origin, filename=filename)
+
+    def getNewConnection(self, database: SqliteDatabase, *, writeable: bool) -> SqliteDatabase:
+        return SqliteDatabase(origin=database.origin, filename=database.filename, writeable=writeable)
+
+    @contextmanager
+    def asReadOnly(self, database: SqliteDatabase) -> SqliteDatabase:
+        mode = os.stat(database.filename).st_mode
+        try:
+            os.chmod(database.filename, stat.S_IREAD)
+            yield self.getNewConnection(database, writeable=False)
+        finally:
+            os.chmod(database.filename, mode)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -27,10 +27,23 @@ import stat
 import tempfile
 import unittest
 
+import sqlalchemy
+
 from lsst.daf.butler.registry.databases.sqlite import SqliteDatabase
 from lsst.daf.butler.registry.tests import DatabaseTests
+from lsst.daf.butler.registry import ddl
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+@contextmanager
+def removeWritePermission(filename):
+    mode = os.stat(filename).st_mode
+    try:
+        os.chmod(filename, stat.S_IREAD)
+        yield
+    finally:
+        os.chmod(filename, mode)
 
 
 class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
@@ -44,19 +57,91 @@ class SqliteDatabaseTestCase(unittest.TestCase, DatabaseTests):
 
     def makeEmptyDatabase(self, origin: int = 0) -> SqliteDatabase:
         _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
-        return SqliteDatabase(origin=origin, filename=filename)
+        cs = SqliteDatabase.connect(filename=filename)
+        return SqliteDatabase.fromConnectionStruct(cs=cs, origin=origin)
 
     def getNewConnection(self, database: SqliteDatabase, *, writeable: bool) -> SqliteDatabase:
-        return SqliteDatabase(origin=database.origin, filename=database.filename, writeable=writeable)
+        cs = SqliteDatabase.connect(filename=database.filename, writeable=writeable)
+        return SqliteDatabase.fromConnectionStruct(origin=database.origin, cs=cs, writeable=writeable)
 
     @contextmanager
     def asReadOnly(self, database: SqliteDatabase) -> SqliteDatabase:
-        mode = os.stat(database.filename).st_mode
-        try:
-            os.chmod(database.filename, stat.S_IREAD)
+        with removeWritePermission(database.filename):
             yield self.getNewConnection(database, writeable=False)
-        finally:
-            os.chmod(database.filename, mode)
+
+    def isEmptyDatabaseActuallyWriteable(self, database: SqliteDatabase) -> bool:
+        """Check whether we really can modify a database.
+
+        This intentionally allows any exception to be raised (not just
+        `ReadOnlyDatabaseError`) to deal with cases where the file is read-only
+        but the Database was initialized (incorrectly) with writeable=True.
+        """
+        try:
+            with database.declareStaticTables(create=True) as context:
+                context.addTable(
+                    "a",
+                    ddl.TableSpec(fields=[ddl.FieldSpec("b", dtype=sqlalchemy.Integer, primaryKey=True)])
+                )
+            return True
+        except Exception:
+            return False
+
+    def testConnection(self):
+        """Test that different ways of connecting to a SQLite database
+        are equivalent.
+        """
+        # Create an in-memory database by passing filename=None.
+        memFilename = SqliteDatabase.fromConnectionStruct(SqliteDatabase.connect(filename=None), origin=0)
+        self.assertIsNone(memFilename.filename)
+        self.assertEqual(memFilename.origin, 0)
+        self.assertTrue(memFilename.isWriteable())
+        self.assertTrue(self.isEmptyDatabaseActuallyWriteable(memFilename))
+        # Create an in-memory database via a URI.
+        memUri = SqliteDatabase.fromUri("sqlite://", origin=0)
+        self.assertIsNone(memUri.filename)
+        self.assertEqual(memUri.origin, 0)
+        self.assertTrue(memUri.isWriteable())
+        self.assertTrue(self.isEmptyDatabaseActuallyWriteable(memUri))
+        # We don't support SQLite URIs inside SQLAlchemy URIs.
+        with self.assertRaises(NotImplementedError):
+            SqliteDatabase.connect(uri="sqlite:///:memory:?uri=true")
+        # We don't support read-only in-memory databases.
+        with self.assertRaises(NotImplementedError):
+            SqliteDatabase.connect(filename=None, writeable=False)
+
+        # Make a temporary file for the rest of the next set of tests.
+        _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
+        # Create a read-write database by passing in the filename.
+        rwFilename = SqliteDatabase.fromConnectionStruct(SqliteDatabase.connect(filename=filename), origin=0)
+        self.assertEqual(rwFilename.filename, filename)
+        self.assertEqual(rwFilename.origin, 0)
+        self.assertTrue(rwFilename.isWriteable())
+        self.assertTrue(self.isEmptyDatabaseActuallyWriteable(rwFilename))
+        # Create a read-write database via a URI.
+        rwUri = SqliteDatabase.fromUri(f"sqlite:///{filename}", origin=0)
+        self.assertEqual(rwUri.filename, filename)
+        self.assertEqual(rwUri.origin, 0)
+        self.assertTrue(rwUri.isWriteable())
+        self.assertTrue(self.isEmptyDatabaseActuallyWriteable(rwUri))
+        # We don't support SQLite URIs inside SQLAlchemy URIs.
+        with self.assertRaises(NotImplementedError):
+            SqliteDatabase.connect(uri=f"sqlite:///file:{filename}?uri=true")
+
+        # Test read-only connections against a read-only file.
+        with removeWritePermission(filename):
+            # Create a read-only database by passing in the filename.
+            roFilename = SqliteDatabase.fromConnectionStruct(SqliteDatabase.connect(filename=filename),
+                                                             origin=0, writeable=False)
+            self.assertEqual(roFilename.filename, filename)
+            self.assertEqual(roFilename.origin, 0)
+            self.assertFalse(roFilename.isWriteable())
+            self.assertFalse(self.isEmptyDatabaseActuallyWriteable(roFilename))
+            # Create a read-write database via a URI.
+            roUri = SqliteDatabase.fromUri(f"sqlite:///{filename}", origin=0, writeable=False)
+            self.assertEqual(roUri.filename, filename)
+            self.assertEqual(roUri.origin, 0)
+            self.assertFalse(roUri.isWriteable())
+            self.assertFalse(self.isEmptyDatabaseActuallyWriteable(roUri))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The code here is not used at all in Butler yet; it's the beginning of a new backend for Registry, and hence there's some temporary code duplication with existing Registry code.

The testing strategies for PostgreSQL and Oracle merit some special attention:

- For PostgreSQL, we use the `testing.postgresql` module (available via `pip`)  to spin up a local userspace database server to test against.  We do that in `setUpClass` to avoid doing it repeatedly, and then create one or more schemas within that database _per test function_.  We delegate cleaning that all up in `tearDownClass` to `testing.postgresql`.  Tests are skipped if `testing.postgresql` cannot be imported, and we assume that the presence of `testing.postgresql` indicates that the actual PostgreSQL server binaries are in the PATH, because `testing.postgresql` can't ever do anything unless that's true, even though it's not taken care of by `pip` (the `postgresql` conda package does take care of it, however).

- For Oracle, we look for a `DAF_BUTLER_ORACLE_TEST_URI` environment variable that provides the connection string to pass to SQLAlchemy.  If that's set, we make a single connection to the database server (in `setUpClass`) and use (as @MichelleGower has advocated) a randomly-generated prefix for all tables we create in that schema to simulate a virtual schema.  There's custom code in `tearDownClass` that then drops all tables that were created, using a Python DBAPI rewrite of the `clobber.sql` script at https://confluence.lsstcorp.org/display/DM/Oracle+with+Gen3.

While this basically works, it's worth pointing out the disadvantages of the Oracle approach; while the PostgreSQL is obviously much harder to pull off with any proprietary database engine, it'd be really nice to set up something more like that for Oracle, even if it's only something we can interact with via some CI server.  In particular:
 - SQLAlchemy basically takes care of real schemas for us, and we sort of have to fight against it to use table prefixes to make those work like a virtual schema.  The need to use prefixes actually adds more complexity to the `OracleDatabase` specialization than anything else unique to Oracle.
 - By not using real schemas in the Oracle tests, we don't actually get test coverage for trying to use real schemas in Oracle, which we of course really want to do in the future.
 - While I'm pretty sure test cleanup usually happens correctly when tests fail, I'd guess there are myriad ways to interrupt the tests such that the cleanup is at best incomplete.  And that of course means one has to go in and clean things up manually.
 - Running tests against a local server is lot faster - or at least I assume that's the reason for the pretty huge gap between the ~1.6s PostgreSQL tests and Oracle tests, which I've seen take anything between 20s and 3 minutes (it might also be something silly I've done, or overhead in Oracle in creating tables - which tests naturally do a lot more of than production use would).