### PR TITLE
DM-22648: Add DcrModel to Gen3 butler

### DIFF
--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -8,5 +8,5 @@ datastore:
     # valid_first and valid_last here are YYYYMMDD; we assume we'll switch to
     # MJD (DM-15890) before we need more than day resolution, since that's all
     # Gen2 has.
-    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
+    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
   formatters: !include formatters.yaml

--- a/config/datastores/s3Datastore.yaml
+++ b/config/datastores/s3Datastore.yaml
@@ -8,5 +8,5 @@ datastore:
     # valid_first and valid_last here are YYYYMMDD; we assume we'll switch to
     # MJD (DM-15890) before we need more than day resolution, since that's all
     # Gen2 has.
-    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
+    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
   formatters: !include formatters.yaml

--- a/config/dimensions.yaml
+++ b/config/dimensions.yaml
@@ -70,6 +70,20 @@ dimensions:
       - abstract_filter
       cached: true
 
+    subfilter:
+      doc: >
+        A mathematical division of an abstract_filter. Subfilters are used to
+        model wavelength-dependent effects such as differential chromatic
+        refraction.
+      keys:
+      -
+        name: name
+        type: string
+        length: 8
+      implies:
+      - abstract_filter
+      cached: true
+
     detector:
       doc: >
         A detector associated with a particular instrument (not an observation

--- a/config/dimensions.yaml
+++ b/config/dimensions.yaml
@@ -79,7 +79,7 @@ dimensions:
       -
         name: name
         type: string
-        length: 8
+        length: 18
       implies:
       - abstract_filter
       cached: true

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -67,7 +67,8 @@ class DimensionTestCase(unittest.TestCase):
     def testConfigRead(self):
         self.assertEqual(self.universe.dimensions.names,
                          {"instrument", "visit", "exposure", "detector", "physical_filter",
-                          "abstract_filter", "calibration_label", "skymap", "tract", "patch", "htm7", "htm9"})
+                          "abstract_filter", "subfilter", "calibration_label",
+                          "skymap", "tract", "patch", "htm7", "htm9"})
 
     def testGraphs(self):
         self.checkGraphInvariants(self.universe.empty)


### PR DESCRIPTION
Should be merged at the same time as DM-23008, and before DM-21917.
The `subfilter` dimension is used for modeling chromatic effects such as Differential Chromatic Refraction in coadds.