### PR TITLE
DM-23079: refactor opaque table handling in registry according to prototype

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -5,3 +5,5 @@ registry:
     sqlite: lsst.daf.butler.registry.databases.sqlite.SqliteDatabase
     postgresql: lsst.daf.butler.registry.databases.postgresql.PostgresqlDatabase
     oracle: lsst.daf.butler.registry.databases.oracle.OracleDatabase
+  managers:
+    opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager

--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -25,3 +25,8 @@ from ._dbAuth import *
 
 from . import interfaces
 from . import queries
+
+# Some modules intentionally not imported, either because they are purely
+# internal (e.g. nameShrinker.py) or they contain implementations that are
+# always loaded from configuration strings (e.g. databases subpackage,
+# opaque.py, ...).

--- a/python/lsst/daf/butler/registry/interfaces/__init__.py
+++ b/python/lsst/daf/butler/registry/interfaces/__init__.py
@@ -20,3 +20,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ._database import *
+from ._opaque import *

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -1,0 +1,198 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+"""Interfaces for the objects that manage opaque (logical) tables within a
+`Registry`.
+"""
+
+__all__ = ["OpaqueTableStorageManager", "OpaqueTableStorage"]
+
+from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    Iterator,
+    Optional,
+)
+
+from ...core.ddl import TableSpec
+from ._database import Database, StaticTablesContext
+
+
+class OpaqueTableStorage(ABC):
+    """An interface that manages the records associated with a particular
+    opaque table in a `Registry`.
+
+    Parameters
+    ----------
+    name : `str`
+        Name of the opaque table.
+    """
+    def __init__(self, name: str):
+        self.name = name
+
+    @abstractmethod
+    def insert(self, *data: dict):
+        """Insert records into the table
+
+        Parameters
+        ----------
+        *data
+            Each additional positional argument is a dictionary that represents
+            a single row to be added.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def fetch(self, **where: Any) -> Iterator[dict]:
+        """Retrieve records from an opaque table.
+
+        Parameters
+        ----------
+        **where
+            Additional keyword arguments are interpreted as equality
+            constraints that restrict the returned rows (combined with AND);
+            keyword arguments are column names and values are the values they
+            must have.
+
+        Yields
+        ------
+        row : `dict`
+            A dictionary representing a single result row.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete(self, **where: Any):
+        """Remove records from an opaque table.
+
+        Parameters
+        ----------
+        **where
+            Additional keyword arguments are interpreted as equality
+            constraints that restrict the deleted rows (combined with AND);
+            keyword arguments are column names and values are the values they
+            must have.
+        """
+        raise NotImplementedError()
+
+    name: str
+    """The name of the logical table this instance manages (`str`).
+    """
+
+
+class OpaqueTableStorageManager(ABC):
+    """An interface that manages the opaque tables in a `Registry`.
+
+    `OpaqueTableStorageManager` primarily serves as a container and factory for
+    `OpaqueTableStorage` instances, which each provide access to the records
+    for a different (logical) opaque table.
+
+    Notes
+    -----
+    Opaque tables are primarily used by `Datastore` instances to manage their
+    internal data in the same database that hold the `Registry`, but are not
+    limited to this.
+
+    While an opaque table in a multi-layer `Registry` may in fact be the union
+    of multiple tables in different layers, we expect this to be rare, as
+    `Registry` layers will typically correspond to different leaf `Datastore`
+    instances (each with their own opaque table) in a `ChainedDatastore`.
+    """
+
+    @classmethod
+    @abstractmethod
+    def initialize(cls, db: Database, context: StaticTablesContext) -> OpaqueTableStorageManager:
+        """Construct an instance of the manager.
+
+        Parameters
+        ----------
+        db : `Database`
+            Interface to the underlying database engine and namespace.
+        context : `StaticTablesContext`
+            Context object obtained from `Database.declareStaticTables`; used
+            to declare any tables that should always be present in a layer
+            implemented with this manager.
+
+        Returns
+        -------
+        manager : `OpaqueTableStorageManager`
+            An instance of a concrete `OpaqueTableStorageManager` subclass.
+        """
+        raise NotImplementedError()
+
+    def __getitem__(self, name: str) -> OpaqueTableStorage:
+        """Interface to `get` that raises `LookupError` instead of returning
+        `None` on failure.
+        """
+        r = self.get(name)
+        if r is None:
+            raise LookupError(f"No logical table with name '{name}' found.")
+        return r
+
+    @abstractmethod
+    def get(self, name: str) -> Optional[OpaqueTableStorage]:
+        """Return an object that provides access to the records associated with
+        an opaque logical table.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the logical table.
+
+        Returns
+        -------
+        records : `OpaqueTableStorage` or `None`
+            The object representing the records for the given table in this
+            layer, or `None` if there are no records for that table in this
+            layer.
+
+        Note
+        ----
+        Opaque tables must be registered with the layer (see `register`) by
+        the same client before they can safely be retrieved with `get`.
+        Unlike most other manager classes, the set of opaque tables cannot be
+        obtained from an existing data repository.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def register(self, name: str, spec: TableSpec) -> OpaqueTableStorage:
+        """Ensure that this layer can hold records for the given opaque logical
+        table, creating new tables as necessary.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the logical table.
+        spec : `TableSpec`
+            Schema specification for the table to be created.
+
+        Returns
+        -------
+        records : `OpaqueTableStorage`
+            The object representing the records for the given element in this
+            layer.
+
+        Notes
+        -----
+        This operation may not be invoked within a transaction context block.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -1,0 +1,132 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+"""The default concrete implementations of the classes that manage
+opaque tables for `Registry`.
+"""
+
+__all__ = ["ByNameOpaqueTableStorage", "ByNameOpaqueTableStorageManager"]
+
+from typing import (
+    Any,
+    ClassVar,
+    Iterator,
+    Optional,
+)
+
+import sqlalchemy
+
+from ..core.ddl import TableSpec, FieldSpec
+from .interfaces import Database, OpaqueTableStorageManager, OpaqueTableStorage, StaticTablesContext
+
+
+class ByNameOpaqueTableStorage(OpaqueTableStorage):
+    """An implementation of `OpaqueTableStorage` that simply creates a true
+    table for each different named opaque logical table.
+
+    A `ByNameOpaqueTableStorageManager` instance should always be used to
+    construct and manage instances of this class.
+
+    Parameters
+    ----------
+    db : `Database`
+        Database engine interface for the namespace in which this table lives.
+    name : `str`
+        Name of the logical table (also used as the name of the actual table).
+    table : `sqlalchemy.schema.Table`
+        SQLAlchemy representation of the table, which must have already been
+        created in the namespace managed by ``db`` (this is the responsibility
+        of `ByNameOpaqueTableStorageManager`).
+    """
+    def __init__(self, *, db: Database, name: str, table: sqlalchemy.schema.Table):
+        super().__init__(name=name)
+        self._db = db
+        self._table = table
+
+    def insert(self, *data: dict):
+        # Docstring inherited from OpaqueTableStorage.
+        self._db.insert(self._table, *data)
+
+    def fetch(self, **where: Any) -> Iterator[dict]:
+        # Docstring inherited from OpaqueTableStorage.
+        sql = self._table.select().where(
+            sqlalchemy.sql.and_(*[self._table.columns[k] == v for k, v in where.items()])
+        )
+        for row in self._db.query(sql):
+            yield dict(row)
+
+    def delete(self, **where: Any):
+        # Docstring inherited from OpaqueTableStorage.
+        self._db.delete(self._table, where.keys(), where)
+
+
+class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
+    """An implementation of `OpaqueTableStorageManager` that simply creates a
+    true table for each different named opaque logical table.
+
+    Instances of this class should generally be constructed via the
+    `initialize` class method instead of invoking ``__init__`` directly.
+
+    Parameters
+    ----------
+    db : `Database`
+        Database engine interface for the namespace in which this table lives.
+    metaTable : `sqlalchemy.schema.Table`
+        SQLAlchemy representation of the table that records which opaque
+        logical tables exist.
+    """
+    def __init__(self, db: Database, metaTable: sqlalchemy.schema.Table):
+        self._db = db
+        self._metaTable = metaTable
+        self._storage = {}
+
+    _META_TABLE_NAME: ClassVar[str] = "opaque_meta"
+
+    _META_TABLE_SPEC: ClassVar[TableSpec] = TableSpec(
+        fields=[
+            FieldSpec("table_name", dtype=sqlalchemy.String, length=128, primaryKey=True),
+        ],
+    )
+
+    @classmethod
+    def initialize(cls, db: Database, context: StaticTablesContext) -> OpaqueTableStorageManager:
+        # Docstring inherited from OpaqueTableStorageManager.
+        metaTable = context.addTable(cls._META_TABLE_NAME, cls._META_TABLE_SPEC)
+        return cls(db=db, metaTable=metaTable)
+
+    def get(self, name: str) -> Optional[OpaqueTableStorage]:
+        # Docstring inherited from OpaqueTableStorageManager.
+        return self._storage.get(name)
+
+    def register(self, name: str, spec: TableSpec) -> OpaqueTableStorage:
+        # Docstring inherited from OpaqueTableStorageManager.
+        result = self._storage.get(name)
+        if result is None:
+            # Create the table itself.  If it already exists but wasn't in
+            # the dict because it was added by another client since this one
+            # was initialized, that's fine.
+            table = self._db.ensureTableExists(name, spec)
+            # Add a row to the meta table so we can find this table in the
+            # future.  Also okay if that already exists, so we use sync.
+            self._db.sync(self._metaTable, keys={"table_name": name})
+            result = ByNameOpaqueTableStorage(name=name, table=table, db=self._db)
+            self._storage[name] = result
+        return result


### PR DESCRIPTION
The motivation for these changes isn't obvious in isolation, because it's the first step in much larger refactor; see the message on the last commit and https://confluence.lsstcorp.org/display/DM/Architectural+Prototype+for+the+New+Gen3+Registry for more information.