### PR TITLE
DM-23678: Flush the write before reading in S3

### DIFF
--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -179,6 +179,9 @@ class S3Datastore(FileLikeDatastore):
         except NotImplementedError:
             with tempfile.NamedTemporaryFile(suffix=formatter.extension) as tmpFile:
                 tmpFile.file.write(serializedDataset)
+                # Flush the write. Do not close the file because that
+                # will delete it.
+                tmpFile.file.flush()
                 formatter._fileDescriptor.location = Location(*os.path.split(tmpFile.name))
                 result = formatter.read(component=getInfo.component)
         except Exception as e:


### PR DESCRIPTION
On some operating systems reading from a file (within the same process)
that has been written to but not closed will not work.  Flush the
buffer before reading.

Closing the file would result in it being deleted.