### PR TITLE
DM-21849: overhaul collections system

### DIFF
--- a/config/datastores/posixDatastore.yaml
+++ b/config/datastores/posixDatastore.yaml
@@ -8,5 +8,5 @@ datastore:
     # valid_first and valid_last here are YYYYMMDD; we assume we'll switch to
     # MJD (DM-15890) before we need more than day resolution, since that's all
     # Gen2 has.
-    default: "{collection:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
   formatters: !include formatters.yaml

--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -8,3 +8,4 @@ registry:
   managers:
     opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
     dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
+    collections: lsst.daf.butler.registry.collections.nameKey.AggressiveNameKeyCollectionManager

--- a/doc/lsst.daf.butler/concreteStorageClasses.rst
+++ b/doc/lsst.daf.butler/concreteStorageClasses.rst
@@ -21,19 +21,23 @@ The loaded columns are the product of the values for all levels.
 Levels not included in the dict are included in their entirety.
 
 For example, the ``deepCoadd_obj`` dataset is typically defined as a hierarchical table with levels ``dataset``, ``filter``, and ``column``, which take values such as ``("meas", "HSC-R", "base_SdssShape_xx")``.
-Retrieving this dataset via::
+Retrieving this dataset via:
 
-    butler.get(
-        "deepCoadd_obj", ...,
-        parameters={
-            "columns": {"dataset": "meas",
-                        "filter": ["HSC-R", "HSC-I"],
-                        "column": ["base_SdssShape_xx", "base_SdssShape_yy"]}
-        }
-    )
+.. code-block:: python
 
-is equivalent to (but potentially much more efficient than)::
+   butler.get(
+       "deepCoadd_obj", ...,
+       parameters={
+           "columns": {"dataset": "meas",
+                       "filter": ["HSC-R", "HSC-I"],
+                       "column": ["base_SdssShape_xx", "base_SdssShape_yy"]}
+       }
+   )
 
-  full = butler.get("deepCoadd_obj", ...)
-  full.loc[:, ["meas", ["HSC-R", "HSC-I"],
-               ["base_SdssShape_xx", "base_SdssShape_yy"]]]
+is equivalent to (but potentially much more efficient than):
+
+.. code-block:: python
+
+   full = butler.get("deepCoadd_obj", ...)
+   full.loc[:, ["meas", ["HSC-R", "HSC-I"],
+                ["base_SdssShape_xx", "base_SdssShape_yy"]]]

--- a/doc/lsst.daf.butler/configuring.rst
+++ b/doc/lsst.daf.butler/configuring.rst
@@ -49,7 +49,7 @@ Overriding Root Paths
 ---------------------
 
 In addition to the configuration options described above, there are some values that have a special meaning.
-For `~lsst.daf.butler.RegistryConfig` and `~lsst.daf.butler.DatastoreConfig` the ``root`` key, which can be used to specify paths, can include values using the special tag ``<butlerRoot>``.
+For `~lsst.daf.butler.registry.RegistryConfig` and `~lsst.daf.butler.DatastoreConfig` the ``root`` key, which can be used to specify paths, can include values using the special tag ``<butlerRoot>``.
 At run time, this tag will be replaced by a value derived from the location of the main butler configuration file, or else from the value of the ``root`` key found at the top of the butler configuration.
 
 Currently, if you create a butler configuration file that loads another butler configuration file, via ``includeConfigs``, then any ``<butlerRoot>`` tags will be replaced with the location of the new file, not the original.

--- a/doc/lsst.daf.butler/dimensions.rst
+++ b/doc/lsst.daf.butler/dimensions.rst
@@ -1,5 +1,7 @@
 .. _lsst.daf.butler-dimensions_overview:
 
+.. py:currentmodule:: lsst.daf.butler
+
 Overview
 --------
 Dimensions are astronomical concepts that are used to label and organize datasets.

--- a/doc/lsst.daf.butler/dimensions.rst
+++ b/doc/lsst.daf.butler/dimensions.rst
@@ -9,7 +9,7 @@ In the `Registry` database, most dimensions are associated with a table that con
 Examples of dimensions include instruments, detectors, visits, and tracts.
 
 Instances of the `Dimension` class represent one of these concepts, not values of the type of one of those concepts (e.g. "detector", not a particular detector).
-In fact, a dimension "value" can mean different things in different contexts: it could mean the value of the primary key or other unique identifier for particular entity (the integer ID or string name for a particular detector), or it could represent a complete record in the table for that dimension.
+In fact, a dimension "value" can mean different things in different contexts: it could mean the value of the primary key or other unique identifier for a particular entity (the integer ID or string name for a particular detector), or it could represent a complete record in the table for that dimension.
 
 The dimensions schema also has some tables that do not map directly to `Dimension` instances.
 Some of these provide extra metadata fields for combinations of dimensions, and are represented by the `DimensionElement` class in Python (this is also the base class of the `Dimension` class, and provides much of its functionality).
@@ -36,7 +36,7 @@ It also categorizes those dimensions into `~DimensionGraph.required` and `~Dimen
 `DimensionGraph` also guarantees a deterministic and topological sort order for its elements.
 
 Because `Dimension` instances have a `~Dimension.name` attribute, we typically
-use `NamedValueSet` and `NamedKeyDict` as containers when immutability is needed or the guarantees of `DimensionGraph`.
+use `~lsst.daf.butler.core.utils.NamedValueSet` and `~lsst.daf.butler.core.utils.NamedKeyDict` as containers when immutability is needed or the guarantees of `DimensionGraph`.
 This allows the string names of dimensions to be used as well in most places where `Dimension` instances are expected.
 
 The complete set of all compatible dimensions is held by a special subclass of `DimensionGraph`, `DimensionUniverse`.
@@ -57,7 +57,7 @@ Most `Butler` and `Registry` APIs that accept data IDs as input accept both dict
 
 The data IDs returned by the `Butler` or `Registry` (and most of those used internally) are usually instances of the `DataCoordinate` class or its subclass, `ExpandedDataCoordinate`.
 `DataCoordinate` itself is complete but minimal.
-It contains only the keys that correspond to its `DimensionGraph`'s `~DimensionGraph.required` subset - that is, the minimal set of keys needed to fully identify all other dimensions in the graph.
+It contains only the keys that correspond to its `DimensionGraph`'s `~DimensionGraph.required` subset --- that is, the minimal set of keys needed to fully identify all other dimensions in the graph.
 Informal dictionary data IDs can be transformed into `DataCoordinate` instances by calling `DataCoordinate.standardize` (which is what most `Butler` and `Registry` APIs that accept data IDs do under the hood).
 
 `ExpandedDataCoordinate` is its maximal counterpart.
@@ -70,7 +70,7 @@ Spatial and Temporal Dimensions
 -------------------------------
 
 Dimensions can be *spatial* or *temporal* (or both, or neither), meaning that each record is associated with a region on the sky or a timespan (respectively).
-The overlaps between regions and timespans define many-to-many relationships between dimensions that -- along with the one-to-many ID-based dependencies -- generally provide a way to fully relate any set of dimensions.
+The overlaps between regions and timespans define many-to-many relationships between dimensions that --- along with the one-to-many ID-based dependencies --- generally provide a way to fully relate any set of dimensions.
 This produces a natural, concise query system; dimension relationships can be used to construct the full ``JOIN`` clause of a SQL ``SELECT`` with no input from the user, allowing them to specify just the ``WHERE`` clause (see `Registry.queryDimensions` and `Registry.queryDatasets`).
 It is also possible to associate a region or timespan with a combination of dimensions (such as the region for a visit and a detector), by defining a `DimensionElement` for that combination.
 

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -26,6 +26,7 @@ Using the Butler
   :maxdepth: 1
 
   configuring.rst
+  organizing.rst
   queries.rst
   use-in-tests.rst
 

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -26,7 +26,7 @@ Using the Butler
   :maxdepth: 1
 
   configuring.rst
-  exprParser.rst
+  queries.rst
   use-in-tests.rst
 
 .. _lsst.daf.butler-scripts:
@@ -80,6 +80,9 @@ Python API reference
    :no-main-docstr:
 
 .. automodapi:: lsst.daf.butler.registry.queries
+   :no-main-docstr:
+
+.. automodapi:: lsst.daf.butler.registry.wildcards
    :no-main-docstr:
 
 Example datastores

--- a/doc/lsst.daf.butler/organizing.rst
+++ b/doc/lsst.daf.butler/organizing.rst
@@ -16,9 +16,9 @@ Most of the time, however, users identify a dataset using a combination of three
  - a data ID;
  - a collection.
 
-Most collections are constrained to contain only on dataset with a particular dataset type and data ID, so this combination is usually enough to resolve a dataset (see :ref:`daf_butler_collections` for exceptions).
+Most collections are constrained to contain only one dataset with a particular dataset type and data ID, so this combination is usually enough to resolve a dataset (see :ref:`daf_butler_collections` for exceptions).
 
-A dataset's type and data ID are intrinsic to it - while there may be many datasets with a particular dataset type and/or data ID, the dataset type and data ID associated with a dataset are set and fixed when it is created.
+A dataset's type and data ID are intrinsic to it --- while there may be many datasets with a particular dataset type and/or data ID, the dataset type and data ID associated with a dataset are set and fixed when it is created.
 A `DatasetRef` always has both a dataset type attribute and a data ID, though the latter may be empty.
 Dataset types are discussed below in :ref:`daf_butler_dataset_types`, while data IDs are one aspect of the larger :ref:`Dimensions <lsst.daf.butler-dimensions_overview>` system and are discussed in :ref:`lsst.daf.butler-dimensions_data_ids`.
 
@@ -31,14 +31,14 @@ Collections are discussed further below in :ref:`daf_butler_collections`.
 Dataset types
 -------------
 
-The names "dataset" and "dataset type" (which `lsst.daf.butler` inherits from its `lsst.daf.persistence` predecessor) are intended to evoke the relationship between an instance and its class in object-oriented programming, but this is a metaphor, *not* a relationship that maps to any particular Python objects: we don't have any Python class that fully represents the *dataset* concept (`DatasetRef` is the closest), and the `DatasetType` class is a regular class, not a metaclass.
+The names "dataset" and "dataset type" (which ``daf_butler`` inherits from its ``daf_persistence`` predecessor) are intended to evoke the relationship between an instance and its class in object-oriented programming, but this is a metaphor, *not* a relationship that maps to any particular Python objects: we don't have any Python class that fully represents the *dataset* concept (`DatasetRef` is the closest), and the `DatasetType` class is a regular class, not a metaclass.
 So a *dataset type* is represented in Python as a `DatasetType` *instance*.
 
 A dataset type defines both the dimensions used in a dataset's data ID (so all data IDs for a particular dataset type have the same keys, at least when put in standard form) and the storage class that corresponds to its in-memory Python type and maps to the file format (or generalization thereof) used by a `Datastore` to store it.
 These are associated with an arbitrary string name.
 
-Beyond that definition, what a dataset type *means* isn't really specififed by the butler itself, but we expect higher-level code that *uses* butler to make that clear, and one anticipates case is worth calling out here: a dataset type roughly corresponds to the role its datasets play in a processing pipeline.
-In other words, a particular pipeline will typically accept particular dataset types as inputs and produce particular dataset types as outputs (and may produce and consumed other dataset types as intermediates).
+Beyond that definition, what a dataset type *means* isn't really specified by the butler itself, but we expect higher-level code that *uses* butler to make that clear, and one anticipated case is worth calling out here: a dataset type roughly corresponds to the role its datasets play in a processing pipeline.
+In other words, a particular pipeline will typically accept particular dataset types as inputs and produce particular dataset types as outputs (and may produce and consume other dataset types as intermediates).
 And while the exact dataset types used may be configurable, changing a dataset type will generally involve substituting one dataset type for a very similar one (most of the time with the same dimensions and storage class).
 
 .. _daf_butler_collections:
@@ -73,7 +73,7 @@ Tagged Collections
 `CollectionType.TAGGED` collections are the most flexible type of collection; datasets can be `associated <Registry.associate>` with or `disassociated <Registry.disassociate>` from a ``TAGGED`` collection at any time, as long as the usual contraint on a collection having only one dataset with a particular dataset type and data ID is maintained.
 Membership in a ``TAGGED`` collection is implemented in the `Registry` database as a single row in a many-to-many join table (a "tag") and is completely decoupled from the actual storage of the dataset.
 
-Tags are thus both extremely lightweight relative to copies or re-ingests of files or other `Datastore` content, and *slightly** more expensive to store and possibly query than than the ``RUN`` or ``CHAINED`` collection representations (which have no per-dataset costs).
+Tags are thus both extremely lightweight relative to copies or re-ingests of files or other `Datastore` content, and *slightly* more expensive to store and possibly query than the ``RUN`` or ``CHAINED`` collection representations (which have no per-dataset costs).
 The latter is rarely important, but higher-level code should avoid  automatically creating ``TAGGED`` collections that may not ever be used.
 
 Chained Collection

--- a/doc/lsst.daf.butler/organizing.rst
+++ b/doc/lsst.daf.butler/organizing.rst
@@ -1,0 +1,87 @@
+.. _daf_butler_organizing_datasets:
+
+Organizing and identifying datasets
+===================================
+
+.. py:currentmodule:: lsst.daf.butler
+
+Each dataset in a repository is associated with an opaque unique integer ID, which we currently call its ``dataset_id``, and it's usually seen in Python code as the value of `DatasetRef.id`.
+This is the number used as the primary key in most `Registry` tables that refer to datasets, and it's the only way the contents of a `Datastore` are matched to those in a `Registry`.
+With that number, the dataset is fully identified, and anything else about it can be unambiguously looked up.
+We call a `DatasetRef` whose `~DatasetRef.id` attribute is not `None` a *resolved* `DatasetRef`.
+
+Most of the time, however, users identify a dataset using a combination of three other attributes:
+
+ - a dataset type;
+ - a data ID;
+ - a collection.
+
+Most collections are constrained to contain only on dataset with a particular dataset type and data ID, so this combination is usually enough to resolve a dataset (see :ref:`daf_butler_collections` for exceptions).
+
+A dataset's type and data ID are intrinsic to it - while there may be many datasets with a particular dataset type and/or data ID, the dataset type and data ID associated with a dataset are set and fixed when it is created.
+A `DatasetRef` always has both a dataset type attribute and a data ID, though the latter may be empty.
+Dataset types are discussed below in :ref:`daf_butler_dataset_types`, while data IDs are one aspect of the larger :ref:`Dimensions <lsst.daf.butler-dimensions_overview>` system and are discussed in :ref:`lsst.daf.butler-dimensions_data_ids`.
+
+In contrast, the relationship between dataset and collections is many-to-many: a collection typically contains many different datasets, and a particular dataset may belong to multiple collections.
+As a result, is is common to search for datasets in multiple collections (often in a well-defined order), and interfaces that provide that functionality can accept a collection search path in :ref:`many different forms <daf_butler_collection_expressions>`.
+Collections are discussed further below in :ref:`daf_butler_collections`.
+
+.. _daf_butler_dataset_types:
+
+Dataset types
+-------------
+
+The names "dataset" and "dataset type" (which `lsst.daf.butler` inherits from its `lsst.daf.persistence` predecessor) are intended to evoke the relationship between an instance and its class in object-oriented programming, but this is a metaphor, *not* a relationship that maps to any particular Python objects: we don't have any Python class that fully represents the *dataset* concept (`DatasetRef` is the closest), and the `DatasetType` class is a regular class, not a metaclass.
+So a *dataset type* is represented in Python as a `DatasetType` *instance*.
+
+A dataset type defines both the dimensions used in a dataset's data ID (so all data IDs for a particular dataset type have the same keys, at least when put in standard form) and the storage class that corresponds to its in-memory Python type and maps to the file format (or generalization thereof) used by a `Datastore` to store it.
+These are associated with an arbitrary string name.
+
+Beyond that definition, what a dataset type *means* isn't really specififed by the butler itself, but we expect higher-level code that *uses* butler to make that clear, and one anticipates case is worth calling out here: a dataset type roughly corresponds to the role its datasets play in a processing pipeline.
+In other words, a particular pipeline will typically accept particular dataset types as inputs and produce particular dataset types as outputs (and may produce and consumed other dataset types as intermediates).
+And while the exact dataset types used may be configurable, changing a dataset type will generally involve substituting one dataset type for a very similar one (most of the time with the same dimensions and storage class).
+
+.. _daf_butler_collections:
+
+Collections
+-----------
+
+Collections are lightweight groups of datasets defined in the `Registry`.
+Groups of self-consistent calibration datasets, the outputs of a processing run, and the set of all raw images for a particular instrument are all examples of collections.
+Collections are referred to in code simply as `str` names; various `Registry` methods can be used to manage them and obtain additional information about them when relevant.
+
+There are multiple types of collections, corresponding to the different values of the `CollectionType` enum.
+All collection types are usable in the same way in any context where existing datasets are being queried or retrieved, though the actual searches may be implemented quite differently in terms of database queries.
+Collection types behave completely differently in terms of how and when datasets can be added to or remove from them.
+
+Run Collections
+^^^^^^^^^^^^^^^
+
+A dataset is always added to a `CollectionType.RUN` collection when it is inserted into the `Registry`, and can never be removed from it without fully removing the dataset from the `Registry`.
+There is no other way to add a dataset to a ``RUN`` collection.
+The run collection name *must* be used in any file path templates used by any `Datastore` in order to guarantee uniqueness (other collection types are too flexible to guarantee continued uniqueness over the life of the dataset).
+
+The name "run" reflects the fact that we expect most ``RUN`` collections to be used to store the outputs of processing runs, but they should also be used in any other context in which their lack of flexibility is acceptable, as they are the most efficient type of collection to store and query.
+
+``RUN`` collections that do represent the outputs of processing runs can be associated with a host name string and a timespan, and are expected to be the way in which some provenance is associated with datasets (e.g. a dataset that contains a list of software versions would have the same ``RUN`` as the datasets produced by a processing run that used those versions).
+
+Like most collections, a ``RUN`` can contain at most one dataset with a particular dataset type and data ID.
+
+Tagged Collections
+^^^^^^^^^^^^^^^^^^
+
+`CollectionType.TAGGED` collections are the most flexible type of collection; datasets can be `associated <Registry.associate>` with or `disassociated <Registry.disassociate>` from a ``TAGGED`` collection at any time, as long as the usual contraint on a collection having only one dataset with a particular dataset type and data ID is maintained.
+Membership in a ``TAGGED`` collection is implemented in the `Registry` database as a single row in a many-to-many join table (a "tag") and is completely decoupled from the actual storage of the dataset.
+
+Tags are thus both extremely lightweight relative to copies or re-ingests of files or other `Datastore` content, and *slightly** more expensive to store and possibly query than than the ``RUN`` or ``CHAINED`` collection representations (which have no per-dataset costs).
+The latter is rarely important, but higher-level code should avoid  automatically creating ``TAGGED`` collections that may not ever be used.
+
+Chained Collection
+^^^^^^^^^^^^^^^^^^
+
+A `CollectionType.CHAINED` collection is essentially a multi-collection search path that has been saved in the `Registry` database and associated with a name of its own.
+Querying a ``CHAINED`` collection simply queries its child collections in order, and a ``CHAINED`` collection is always (and only) updated when its child collections are.
+
+``CHAINED`` collections may contain other chained collections, as long as they do not contain cycles, and they can also include restrictions on the dataset types to search for within each child collection (see :ref:`daf_butler_collection_expressions`).
+
+The usual constraint on dataset type and data ID uniqueness within a collection is only lazily enforced for chained collections: operations that query them either deduplicate results themselves or terminate single-dataset searches after the first match in a child collection is found.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -21,7 +21,7 @@ Arguments that specify one or more dataset types can generally take any of the f
  - `str` values (corresponding to `DatasetType.name`);
  - `re.Pattern` values (matched to `DatasetType.name` strings, via `~re.Pattern.fullmatch`);
  - iterables of any of the above;
- - the special value `...`, which matches all dataset types.
+ - the special value "``...``", which matches all dataset types.
 
 Some of these are not allowed in certain contexts (as documented there).
 
@@ -36,11 +36,11 @@ Arguments that specify one or more collections are similar to those for dataset 
  - `re.Pattern` values (matched to the collection name, via `~re.Pattern.fullmatch`);
  - a `tuple` of (`str`, *dataset-type-restriction*) - see below;
  - iterables of any of the above;
- - the special value `...`, which matches all collections;
+ - the special value "``...``", which matches all collections;
  - a mapping from `str` to *dataset-type-restriction*.
 
 A *dataset-type-restriction* is a :ref:`DatasetType expression <daf_butler_dataset_type_expressions>` that limits a search for datasets in the associated collection to just the specified dataset types.
-Unlike most other DatasetType expressions, it may not contain regular expressions (but it may be `...`, which is the implied value when no
+Unlike most other DatasetType expressions, it may not contain regular expressions (but it may be "``...``", which is the implied value when no
 restriction is given, as it means "no restriction").
 In contexts where restrictions are meaningless (e.g. `~Registry.queryCollections` when the ``datasetType`` argument is `None`) they are allowed but ignored.
 
@@ -52,9 +52,9 @@ Ordered collection searches
 
 An *ordered* collection expression is required in contexts where we want to search collections only until a dataset with a particular dataset type and data ID is found.
 These include all direct `Butler` operations, the definitions of `~CollectionType.CHAINED` collections, `Registry.findDataset`, and the ``deduplicate=True`` mode of `Registry.queryDatasets`.
-In these contexts, regular expressions and `...` are not allowed for collection names, because they make it impossible to unambiguously define the order in which to search.
+In these contexts, regular expressions and "``...``" are not allowed for collection names, because they make it impossible to unambiguously define the order in which to search.
 Dataset type restrictions are allowed in these contexts, and those
-may be (and usually are) `...`.
+may be (and usually are) "``...``".
 
 Ordered collection searches are processed by the `~registry.wildcards.CollectionSearch` class.
 
@@ -94,7 +94,7 @@ Language operator precedence rules are the same as for the other languages
 like C++ or Python. When in doubt use grouping operators (parentheses) for
 sub-expressions.
 
-General note - the parser itself does not evaluate any expressions even if
+General note --- the parser itself does not evaluate any expressions even if
 they consist of literals only, all evaluation happens in the SQL engine when
 registry runs the resulting SQL query.
 
@@ -162,7 +162,7 @@ expressions which should evaluate to a numeric value.
 Binary arithmetic operators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Language supports five arithmetic operators - ``+`` (add), ``-`` (subtract),
+Language supports five arithmetic operators: ``+`` (add), ``-`` (subtract),
 ``*`` (multiply), ``/`` (divide), and ``%`` (modulo). Usual precedence rules
 apply to these operators. Operands for them can be anything that evaluates to
 a numeric value.
@@ -170,7 +170,7 @@ a numeric value.
 Comparison operators
 ^^^^^^^^^^^^^^^^^^^^
 
-Language supports set of regular comparison operators - ``=``, ``!=``, ``<``,
+Language supports set of regular comparison operators: ``=``, ``!=``, ``<``,
 ``<=``, ``>``, ``>=``. This can be used on operands that evaluate to a numeric
 values, for (in)equality operators operands can also be boolean expressions.
 
@@ -182,7 +182,9 @@ IN operator
 ^^^^^^^^^^^
 
 The ``IN`` operator (and ``NOT IN``) are an expanded version of a regular SQL
-IN operator. Its general syntax looks like::
+IN operator. Its general syntax looks like:
+
+.. code-block:: sql
 
     <expression> IN ( <literal1>[, <literal2>, ... ])
     <expression> NOT IN ( <literal1>[, <literal2>, ... ])
@@ -194,15 +196,19 @@ literals as defined above. It can also be a mixture of integer literals and
 range literals (language allows mixing of string literals and ranges but it
 may not make sense when translated to SQL).
 
-For an example of range usage, these two expressions are equivalent::
+For an example of range usage, these two expressions are equivalent:
 
-    visit IN (100, 110, 130..145:5)
-    visit in (100, 110, 130, 135, 140, 145)
+.. code-block:: sql
 
-as are these::
+   visit IN (100, 110, 130..145:5)
+   visit in (100, 110, 130, 135, 140, 145)
 
-    visit NOT IN (100, 110, 130..145:5)
-    visit Not In (100, 110, 130, 135, 140, 145)
+as are these:
+
+.. code-block:: sql
+
+   visit NOT IN (100, 110, 130..145:5)
+   visit Not In (100, 110, 130, 135, 140, 145)
 
 Boolean operators
 ^^^^^^^^^^^^^^^^^
@@ -223,7 +229,9 @@ sub-expressions in the full expression.
 Examples
 ^^^^^^^^
 
-Few examples of valid expressions using some of the constructs::
+Few examples of valid expressions using some of the constructs:
+
+.. code-block:: sql
 
     visit > 100 AND visit < 200
 

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -1,28 +1,81 @@
-.. _daf_butler_expr_parser:
+.. py:currentmodule:: lsst.daf.butler
 
-Butler expression language
-==========================
+.. _daf_butler_queries:
 
-Butler registry supports a user-supplied expression for constraining input,
-output, or intermediate datasets that can appear in the generated
-QuantumGraph. This page describes the structure and syntax of the expression
-language.
+Querying datasets
+=================
 
-The language grammar is defined in ``exprParser.parserYacc`` module, which is
-responsible for transforming string with user expression into a syntax tree
-with nodes represented by various classes defined in ``exprParser.exprTree``
-module. Modules in ``exprParser`` package are considered butler/registry
-implementation details and are not exposed at the butler package level.
+Datasets in a butler-managed data repository are identified by the combination of their *dataset type* and *data ID* within a *collection*.
+The `Registry` class's query methods (`~Registry.queryDatasetTypes`, `~Registry.queryCollections`, `~Registry.queryDimensions`, and `~Registry.queryDatasets`) allow these to be specified either fully or partially in various ways.
 
-The gramma is based on standard SQL, it is a subset of SQL expression language
-that can appear in WHERE clause of standard SELECT statement with some
-extensions, e.g. range support for ``IN`` operator.
+.. _daf_butler_dataset_type_expressions:
+
+DatasetType expressions
+-----------------------
+
+Arguments that specify one or more dataset types can generally take any of the following:
+
+ - `DatasetType` instances;
+ - `str` values (corresponding to `DatasetType.name`);
+ - `re.Pattern` values (matched to `DatasetType.name` strings, via `~re.Pattern.fullmatch`);
+ - iterables of any of the above;
+ - the special value `...`, which matches all dataset types.
+
+Some of these are not allowed in certain contexts (as documented there).
+
+.. _daf_butler_collection_expressions:
+
+Collection expressions
+----------------------
+
+Arguments that specify one or more collections are similar to those for dataset types; they can take:
+
+ - `str` values (the full collection name);
+ - `re.Pattern` values (matched to the collection name, via `~re.Pattern.fullmatch`);
+ - a `tuple` of (`str`, *dataset-type-restriction*) - see below;
+ - iterables of any of the above;
+ - the special value `...`, which matches all collections;
+ - a mapping from `str` to *dataset-type-restriction*.
+
+A *dataset-type-restriction* is a :ref:`DatasetType expression <daf_butler_dataset_type_expressions>` that limits a search for datasets in the associated collection to just the specified dataset types.
+Unlike most other DatasetType expressions, it may not contain regular expressions (but it may be `...`, which is the implied value when no
+restriction is given, as it means "no restriction").
+In contexts where restrictions are meaningless (e.g. `~Registry.queryCollections` when the ``datasetType`` argument is `None`) they are allowed but ignored.
+
+Collection expressions are processed by the `~registry.wildcards.CollectionQuery`, and `~registry.wildcards.DatasetTypeRestriction` classes.
+User code will rarely need to interact with these directly, but they can be passed to `Registry` instead of the expression objects themselves, and hence may be useful as a way to transform an expression that may include single-pass iterators into an equivalent form that can be reused.
+
+Ordered collection searches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A *ordered* collection expression is required in contexts where we want to search collections only until a dataset with a particular dataset type and data ID is found, such as `~Registy.queryDatasets` when ``deduplicate`` is `True`.
+In these contexts, regular expressions and `...` are not allowed, because they make it impossible to unambiguously define the order in which to search the matching collections.
+
+Ordered collection searches are processed by the `~registry.wildcards.CollectionSearch` class.
+
+.. _daf_butler_dimension_expressions:
+
+Dimension expressions
+---------------------
+
+Constraints on the data IDs returned by a query can take two forms:
+
+ - an explicit data ID value can be provided (as a `dict` or `DataCoordinate` instance) to directly constrain the dimensions in the data ID and indirectly constrain any related dimensions (see :ref:`Dimensions Overview <lsst.daf.butler-dimensions_overview>`);
+
+ - a string expression resembling a SQL WHERE clause can be provided to constrain dimension values in a much more general way.
+
+In most cases, the two can be provided together, requiring that returned data IDs match both constraints.
+The rest of this section describes the latter in detail.
+
+The language grammar is defined in the ``exprParser.parserYacc`` module, which is responsible for transforming a string with the user expression into a syntax tree with nodes represented by various classes defined in the ``exprParser.exprTree`` module.
+Modules in the ``exprParser`` package are considered butler/registry implementation details and are not exposed at the butler package level.
+
+The grammar is based on standard SQL; it is a subset of SQL expression language that can appear in WHERE clause of standard SELECT statement with some extensions, such as range support for the ``IN`` operator.
 
 Expression structure
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
-The expression is passed as a string to a registry methods that build a
-QuantumGraph typically from a command-line application such as ``pipetask``.
+The expression is passed as a string via the ``where`` arguments of `~Registry.queryDimensions` and `~Registry.queryDatasets`.
 The string contains a single boolean expression which evaluates to true or
 false (if it is a valid expression). Expression can contain a bunch of
 standard logical operators, comparisons, literals, and identifiers which are
@@ -43,7 +96,7 @@ registry runs the resulting SQL query.
 Following sections describe each of the parts in detail.
 
 Literals
---------
+^^^^^^^^
 
 The language supports these types of literals:
 
@@ -75,7 +128,7 @@ Examples of range literals:
 * ``-10..-1:2`` -- equivalent to ``-10,-8,-6,-4,-2``
 
 Identifiers
------------
+^^^^^^^^^^^
 
 Identifiers represent values external to a parser, such as values stored in a
 database. The parser itself cannot define identifiers or their values; it is
@@ -95,14 +148,14 @@ for accessing raft name (obviously dotted names need knowledge of database
 schema and how SQL query is built).
 
 Unary arithmetic operators
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Two unary operators ``+`` (plus) and ``-`` (minus) can be used in the
 expressions in front of (numeric) literals, identifiers, or other
 expressions which should evaluate to a numeric value.
 
 Binary arithmetic operators
----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Language supports five arithmetic operators - ``+`` (add), ``-`` (subtract),
 ``*`` (multiply), ``/`` (divide), and ``%`` (modulo). Usual precedence rules
@@ -110,7 +163,7 @@ apply to these operators. Operands for them can be anything that evaluates to
 a numeric value.
 
 Comparison operators
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 Language supports set of regular comparison operators - ``=``, ``!=``, ``<``,
 ``<=``, ``>``, ``>=``. This can be used on operands that evaluate to a numeric
@@ -121,7 +174,7 @@ values, for (in)equality operators operands can also be boolean expressions.
 
 
 IN operator
------------
+^^^^^^^^^^^
 
 The ``IN`` operator (and ``NOT IN``) are an expanded version of a regular SQL
 IN operator. Its general syntax looks like::
@@ -147,7 +200,7 @@ as are these::
     visit Not In (100, 110, 130, 135, 140, 145)
 
 Boolean operators
------------------
+^^^^^^^^^^^^^^^^^
 
 ``NOT`` is the standard unary boolean negation operator.
 
@@ -157,13 +210,13 @@ All boolean operators can work on expressions which return boolean values.
 
 
 Grouping operator
------------------
+^^^^^^^^^^^^^^^^^
 
 Parentheses should be used to change evaluation order (precedence) of
 sub-expressions in the full expression.
 
 Examples
---------
+^^^^^^^^
 
 Few examples of valid expressions using some of the constructs::
 

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -48,7 +48,7 @@ User code will rarely need to interact with these directly, but they can be pass
 Ordered collection searches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A *ordered* collection expression is required in contexts where we want to search collections only until a dataset with a particular dataset type and data ID is found, such as `~Registy.queryDatasets` when ``deduplicate`` is `True`.
+A *ordered* collection expression is required in contexts where we want to search collections only until a dataset with a particular dataset type and data ID is found, such as `~Registry.findDataset` or `~Registy.queryDatasets` (when ``deduplicate`` is `True`).
 In these contexts, regular expressions and `...` are not allowed, because they make it impossible to unambiguously define the order in which to search the matching collections.
 
 Ordered collection searches are processed by the `~registry.wildcards.CollectionSearch` class.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -2,6 +2,8 @@
 
 .. _daf_butler_queries:
 
+.. py:currentmodule:: lsst.daf.butler
+
 Querying datasets
 =================
 
@@ -48,8 +50,11 @@ User code will rarely need to interact with these directly, but they can be pass
 Ordered collection searches
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A *ordered* collection expression is required in contexts where we want to search collections only until a dataset with a particular dataset type and data ID is found, such as `~Registry.findDataset` or `~Registy.queryDatasets` (when ``deduplicate`` is `True`).
-In these contexts, regular expressions and `...` are not allowed, because they make it impossible to unambiguously define the order in which to search the matching collections.
+An *ordered* collection expression is required in contexts where we want to search collections only until a dataset with a particular dataset type and data ID is found.
+These include all direct `Butler` operations, the definitions of `~CollectionType.CHAINED` collections, `Registry.findDataset`, and the ``deduplicate=True`` mode of `Registry.queryDatasets`.
+In these contexts, regular expressions and `...` are not allowed for collection names, because they make it impossible to unambiguously define the order in which to search.
+Dataset type restrictions are allowed in these contexts, and those
+may be (and usually are) `...`.
 
 Ordered collection searches are processed by the `~registry.wildcards.CollectionSearch` class.
 

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -6,7 +6,7 @@ Data Access Butler
 # dependencies.
 
 from .core import *
-from .registry import Registry  # import the registry subpackage directly for other symbols
+from .registry import Registry, CollectionType  # import the registry subpackage directly for other symbols
 from ._butlerConfig import *
 from ._deferredDatasetHandle import *
 from ._butler import *

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -6,7 +6,8 @@ Data Access Butler
 # dependencies.
 
 from .core import *
-from .registry import Registry, CollectionType  # import the registry subpackage directly for other symbols
+# Import the registry subpackage directly for other symbols.
+from .registry import Registry, CollectionType, CollectionSearch, DatasetTypeRestriction
 from ._butlerConfig import *
 from ._deferredDatasetHandle import *
 from ._butler import *

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -928,7 +928,7 @@ class Butler:
             Datasets to prune.  These must be "resolved" references (not just
             a `DatasetType` and data ID).
         disassociate : bool`, optional
-            Disassociate pruned datasets from ``self.collection`` (or the
+            Disassociate pruned datasets from ``self.collections`` (or the
             collection given as the ``collection`` argument).  Dataset that are
             not in this collection are ignored, unless ``purge`` is `True`.
         unstore : `bool`, optional
@@ -960,7 +960,7 @@ class Butler:
             composite datasets.  This will only prune components that are
             actually attached to the given `DatasetRef` objects, which may
             not reflect what is in the database (especially if they were
-            obtained from `Registry.queryDatasets`, which by does not include
+            obtained from `Registry.queryDatasets`, which does not include
             components in its results).
 
         Raises
@@ -1053,7 +1053,7 @@ class Butler:
                 # If we're disassociating but not purging, we can do that
                 # before we try to delete, and it will roll back if deletion
                 # fails.  That will at least do the right thing if deletion
-                # fails because the files couldn't actually be delete (e.g.
+                # fails because the files couldn't actually be deleted (e.g.
                 # due to lack of permissions).
                 for tag in tags:
                     # recursive=False here because refs is already recursive

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -83,17 +83,6 @@ class ButlerValidationError(ValidationError):
 class Butler:
     """Main entry point for the data access system.
 
-    Attributes
-    ----------
-    config : `str`, `ButlerConfig` or `Config`, optional
-        (filename to) configuration. If this is not a `ButlerConfig`, defaults
-        will be read.  If a `str`, may be the path to a directory containing
-        a "butler.yaml" file.
-    datastore : `Datastore`
-        Datastore to use for storage.
-    registry : `Registry`
-        Registry to use for lookups.
-
     Parameters
     ----------
     config : `ButlerConfig`, `Config` or `str`, optional.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -37,6 +37,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Mapping,
     MutableMapping,
     Optional,
     Tuple,
@@ -70,7 +71,8 @@ from .core.safeFileIo import safeMakeDir
 from .core.utils import transactional, getClassOf
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._butlerConfig import ButlerConfig
-from .registry import Registry, RegistryConfig, CollectionType, MissingCollectionError
+from .registry import Registry, RegistryConfig, CollectionType
+from .registry.wildcards import CollectionSearch
 
 log = logging.getLogger(__name__)
 
@@ -95,37 +97,107 @@ class Butler:
         datastore as the given one, but with the given collection and run.
         Incompatible with the ``config``, ``searchPaths``, and ``writeable``
         arguments.
-    collection : `str`, optional
-        Collection to use for all input lookups and (if a
-        `~CollectionType.TAGGED` collection) that new datasets should be
-        associated with in `put` and `ingest`.  May be `None` to either use the
-        value passed to ``run`` for lookups, or to defer passing a collection
-        until the methods that require one are called.  If the collection does
-        not exist, a `~CollectionType.TAGGED` collection will be created.
+    collections : `Any`, optional
+        An expression specifying the collections to be searched (in order) when
+        reading datasets, and optionally dataset type restrictions on them.
+        This may be:
+        - a `str` collection name;
+        - a tuple of (collection name, *dataset type restriction*);
+        - an iterable of either of the above;
+        - a mapping from `str` to *dataset type restriction*.
+
+        See :ref:`daf_butler_collection_expressions` for more information,
+        including the definition of a *dataset type restriction*.  All
+        collections must either already exist or be specified to be created
+        by other arguments.
     run : `str`, optional
-        Name of the `~CollectionType.RUN` collection datasets should be output
-        to in `put` and `ingest`.  If ``collection`` is `None`, this collection
-        will be used by default for input lookups as well.
+        Name of the run datasets should be output to.  If the run
+        does not exist, it will be created.  If ``collections`` is `None`, it
+        will be set to ``[run]``.  If this is not set (and ``writeable`` is
+        not set either), a read-only butler will be created.
+    tags : `Iterable` [ `str` ], optional
+        A list of `~CollectionType.TAGGED` collections that datasets should be
+        associated with in `put` or `ingest` and disassociated from in `prune`.
+        If any of these collections does not exist, it will be created.
+    chains : `Mapping` [ `str`, `Iterable` [ `str` ] ], optional
+        A mapping from the names of new `~CollectionType.CHAINED` collections
+        to an expression identifying their child collections (which takes the
+        same form as the ``collections`` argument.  Chains may be nested only
+        if children precede their parents in this mapping.
     searchPaths : `list` of `str`, optional
         Directory paths to search when calculating the full Butler
         configuration.  Not used if the supplied config is already a
         `ButlerConfig`.
     writeable : `bool`, optional
         Explicitly sets whether the butler supports write operations.  If not
-        provided, a read-only butler is created unless ``run`` is passed.
+        provided, a read-write butler is created if any of ``run``, ``tags``,
+        or ``chains`` is non-empty.
 
-    Raises
-    ------
-    ValueError
-        Raised if neither "collection" nor "run" are provided by argument or
-        config, or if both are provided and are inconsistent.
+    Examples
+    --------
+    While there are many ways to control exactly how a `Butler` interacts with
+    the collections in its `Registry`, the most common cases are still simple.
+
+    For a read-only `Butler` that searches one collection, do::
+
+        butler = Butler("/path/to/repo", collections=["u/alice/DM-50000"])
+
+    For a read-write `Butler` that writes to and reads from a
+    `~CollectionType.RUN` collection::
+
+        butler = Butler("/path/to/repo", run="u/alice/DM-50000/a")
+
+    The `Butler` passed to a ``PipelineTask`` is often much more complex,
+    because we want to write to one `~CollectionType.RUN` collection but read
+    from several others (as well), while defining a new
+    `~CollectionType.CHAINED` collection that combines them all::
+
+        butler = Butler("/path/to/repo", run="u/alice/DM-50000/a",
+                        collections=["u/alice/DM-50000"],
+                        chains={
+                            "u/alice/DM-50000": ["u/alice/DM-50000/a",
+                                                 "u/bob/DM-49998",
+                                                 "raw/hsc"]
+                        })
+
+    This butler will `put` new datasets to the run ``u/alice/DM-50000/a``, but
+    they'll also be available from the chained collection ``u/alice/DM-50000``.
+    Datasets will be read first from that run (since it appears first in the
+    chain), and then from ``u/bob/DM-49998`` and finally ``raw/hsc``.
+    If ``u/alice/DM-50000`` had already been defined, the ``chain`` argument
+    would be unnecessary.  We could also construct a butler that performs
+    exactly the same `put` and `get` operations without actually creating a
+    chained collection, just by passing multiple items is ``collections``::
+
+        butler = Butler("/path/to/repo", run="u/alice/DM-50000/a",
+                        collections=["u/alice/DM-50000/a",
+                                     "u/bob/DM-49998",
+                                     "raw/hsc"])
+
+    Finally, one can always create a `Butler` with no collections::
+
+        butler = Butler("/path/to/repo", writeable=True)
+
+    This can be extremely useful when you just want to use ``butler.registry``,
+    e.g. for inserting dimension data or managing collections, or when the
+    collections you want to use with the butler are not consistent.
+    Passing ``writeable`` explicitly here is only necessary if you want to be
+    able to make changes to the repo - usually the value for ``writeable`` is
+    can be guessed from the collection arguments provided, but it defaults to
+    `False` when there are not collection arguments.
     """
     def __init__(self, config: Union[Config, str, None] = None, *,
                  butler: Optional[Butler] = None,
-                 collection: Optional[str] = None,
+                 collections: Any = None,
                  run: Optional[str] = None,
+                 tags: Iterable[str] = (),
+                 chains: Optional[Mapping[str, Any]] = None,
                  searchPaths: Optional[List[str]] = None,
                  writeable: Optional[bool] = None):
+        # Transform any single-pass iterator into an actual sequence so we
+        # can see if its empty
+        self.tags = tuple(tags)
+        # Load registry, datastore, etc. from config or existing butler.
         if butler is not None:
             if config is not None or searchPaths is not None or writeable is not None:
                 raise TypeError("Cannot pass 'config', 'searchPaths', or 'writeable' "
@@ -142,32 +214,32 @@ class Butler:
             else:
                 butlerRoot = self._config.configDir
             if writeable is None:
-                writeable = run is not None
+                writeable = run is not None or chains is not None or self.tags
             self.registry = Registry.fromConfig(self._config, butlerRoot=butlerRoot, writeable=writeable)
             self.datastore = Datastore.fromConfig(self._config, self.registry, butlerRoot=butlerRoot)
             self.storageClasses = StorageClassFactory()
             self.storageClasses.addFromConfig(self._config)
             self._composites = CompositesMap(self._config, universe=self.registry.dimensions)
+        # Check the many collection arguments for consistency and create any
+        # needed collections that don't exist.
+        if collections is None:
+            if run is not None:
+                collections = (run,)
+            else:
+                collections = ()
+        self.collections = CollectionSearch.fromExpression(collections)
+        if chains is None:
+            chains = {}
+        self.run = run
         if "run" in self._config or "collection" in self._config:
             raise ValueError("Passing a run or collection via configuration is no longer supported.")
-        if run is not None and writeable is False:
-            raise ValueError(f"Butler initialized with run='{run}', "
-                             f"but is read-only; use collection='{run}' instead.")
-        self.run = run
-        if collection is None and run is not None:
-            collection = run
-        self.collection = collection
         if self.run is not None:
-            self.registry.registerRun(self.run)
-        if self.collection is not None:
-            try:
-                self._collectionType = self.registry.getCollectionType(self.collection)
-            except MissingCollectionError:
-                # Collection does not exist; create a new one.
-                self.registry.registerCollection(self.collection, CollectionType.TAGGED)
-                self._collectionType = CollectionType.TAGGED
-        else:
-            self._collectionType = None
+            self.registry.registerCollection(self.run, type=CollectionType.RUN)
+        for tag in self.tags:
+            self.registry.registerCollection(tag, type=CollectionType.TAGGED)
+        for parent, children in chains.items():
+            self.registry.registerCollection(parent, type=CollectionType.CHAINED)
+            self.registry.setCollectionChain(parent, children)
 
     GENERATION: ClassVar[int] = 3
     """This is a Generation 3 Butler.
@@ -310,7 +382,8 @@ class Butler:
         return config
 
     @classmethod
-    def _unpickle(cls, config: ButlerConfig, collection: str, run: Optional[str], writeable: bool) -> Butler:
+    def _unpickle(cls, config: ButlerConfig, collections: Optional[CollectionSearch], run: Optional[str],
+                  tags: Tuple[str, ...], writeable: bool) -> Butler:
         """Callable used to unpickle a Butler.
 
         We prefer not to use ``Butler.__init__`` directly so we can force some
@@ -323,27 +396,31 @@ class Butler:
             Butler configuration, already coerced into a true `ButlerConfig`
             instance (and hence after any search paths for overrides have been
             utilized).
-        collection : `str`
-            String name of a collection to use for read operations.
+        collections : `CollectionSearch`
+            Names of collections to read from.
         run : `str`, optional
-            String name of a run to use for write operations, or `None` for a
-            read-only butler.
+            Name of `~CollectionType.RUN` collection to write to.
+        tags : `tuple` [`str`]
+            Names of `~CollectionType.TAGGED` collections to associate with.
+        writeable : `bool`
+            Whether the Butler should support write operations.
 
         Returns
         -------
         butler : `Butler`
             A new `Butler` instance.
         """
-        return cls(config=config, collection=collection, run=run, writeable=writeable)
+        return cls(config=config, collections=collections, run=run, tags=tags, writeable=writeable)
 
     def __reduce__(self):
         """Support pickling.
         """
-        return (Butler._unpickle, (self._config, self.collection, self.run, self.registry.isWriteable()))
+        return (Butler._unpickle, (self._config, self.collections, self.run, self.tags,
+                                   self.registry.isWriteable()))
 
     def __str__(self):
-        return "Butler(collection='{}', datastore='{}', registry='{}')".format(
-            self.collection, self.datastore, self.registry)
+        return "Butler(collections={}, run={}, tags={}, datastore='{}', registry='{}')".format(
+            self.collections, self.run, self.tags, self.datastore, self.registry)
 
     def isWriteable(self) -> bool:
         """Return `True` if this `Butler` supports write operations.
@@ -424,7 +501,7 @@ class Butler:
 
     def _findDatasetRef(self, datasetRefOrType: Union[DatasetRef, DatasetType, str],
                         dataId: Optional[DataId] = None, *,
-                        collection: Optional[str] = None,
+                        collections: Any = None,
                         allowUnresolved: bool = False,
                         **kwds: Any) -> DatasetRef:
         """Shared logic for methods that start with a search for a dataset in
@@ -439,8 +516,10 @@ class Butler:
             A `dict` of `Dimension` link name, value pairs that label the
             `DatasetRef` within a Collection. When `None`, a `DatasetRef`
             should be provided as the first argument.
-        collection : `str`, optional
-            Name of the collection to search, overriding ``self.collection``.
+        collections : Any, optional
+            Collections to be searched, overriding ``self.collections``.
+            Can be any of the types supported by the ``collections`` argument
+            to butler construction.
         allowUnresolved : `bool`, optional
             If `True`, return an unresolved `DatasetRef` if finding a resolved
             one in the `Registry` fails.  Defaults to `False`.
@@ -460,9 +539,9 @@ class Butler:
             ``allowUnresolved is False``).
         ValueError
             Raised if a resolved `DatasetRef` was passed as an input, but it
-            differs from the one found in the registry in this collection.
+            differs from the one found in the registry.
         TypeError
-            Raised if ``collection`` and ``self.collection`` are both `None`.
+            Raised if no collections were provided.
         """
         datasetType, dataId = self._standardizeArgs(datasetRefOrType, dataId, **kwds)
         if isinstance(datasetRefOrType, DatasetRef):
@@ -472,22 +551,24 @@ class Butler:
         # Expand the data ID first instead of letting registry.findDataset do
         # it, so we get the result even if it returns None.
         dataId = self.registry.expandDataId(dataId, graph=datasetType.dimensions, **kwds)
-        if collection is None:
-            collection = self.collection
-            if collection is None:
-                raise TypeError("No collection provided.")
+        if collections is None:
+            collections = self.collections
+            if not collections:
+                raise TypeError("No input collections provided.")
+        else:
+            collections = CollectionSearch.fromExpression(collections)
         # Always lookup the DatasetRef, even if one is given, to ensure it is
         # present in the current collection.
-        ref = self.registry.findDataset(datasetType, dataId, collections=[collection])
+        ref = self.registry.findDataset(datasetType, dataId, collections=collections)
         if ref is None:
             if allowUnresolved:
                 return DatasetRef(datasetType, dataId)
             else:
                 raise LookupError(f"Dataset {datasetType.name} with data ID {dataId} "
-                                  f"could not be found in collection '{collection}'.")
+                                  f"could not be found in collections {collections}.")
         if idNumber is not None and idNumber != ref.id:
             raise ValueError(f"DatasetRef.id provided ({idNumber}) does not match "
-                             f"id ({ref.id}) in registry in collection '{collection}'.")
+                             f"id ({ref.id}) in registry in collections {collections}.")
         return ref
 
     @transactional
@@ -495,7 +576,7 @@ class Butler:
             dataId: Optional[DataId] = None, *,
             producer: Optional[Quantum] = None,
             run: Optional[str] = None,
-            collection: Optional[str] = None,
+            tags: Optional[Iterable[str]] = None,
             **kwds: Any) -> DatasetRef:
         """Store and register a dataset.
 
@@ -515,12 +596,10 @@ class Butler:
         run : `str`, optional
             The name of the run the dataset should be added to, overriding
             ``self.run``.
-        collection : `str` or `False`, optional
-            The name of a `~CollectionType.TAGGED` collection to associate the
-            dataset with, overriding ``self.collection``.  This collection
-            must have already been added to the `Registry`.  May also be
-            `False` to skip association with ``self.collection`` even when that
-            is a `~CollectionType.TAGGED` collection.
+        tags : `Iterable` [ `str` ], optional
+            The names of a `~CollectionType.TAGGED` collections to associate
+            the dataset with, overriding ``self.tags``.  These collections
+            must have already been added to the `Registry`.
         kwds
             Additional keyword arguments used to augment or construct a
             `DataCoordinate`.  See `DataCoordinate.standardize`
@@ -548,14 +627,21 @@ class Butler:
             if self.run is None:
                 raise TypeError("No run provided.")
             run = self.run
+            # No need to check type for run; first thing we do is
+            # insertDatasets, and that will check for us.
 
-        if collection is None:
-            collection = self.collection
-            collectionType = self._collectionType
-        elif collection is False:
-            collectionType = None
+        if tags is None:
+            tags = self.tags
         else:
-            collectionType = self.registry.getCollectionType(collection)
+            tags = tuple(tags)
+        for tag in tags:
+            # Check that these are tagged collections up front, because we want
+            # to avoid relying on Datastore transactionality to avoid modifying
+            # the repo if there's an error later.
+            collectionType = self.registry.getCollectionType(tag)
+            if collectionType is not CollectionType.TAGGED:
+                raise TypeError(f"Cannot associate into collection '{tag}' of non-TAGGED type "
+                                f"{collectionType.name}.")
 
         isVirtualComposite = self._composites.shouldBeDisassembled(datasetType)
 
@@ -577,8 +663,8 @@ class Butler:
             # This is an entity without a disassembler.
             self.datastore.put(obj, ref)
 
-        if collectionType is CollectionType.TAGGED:
-            self.registry.associate(collection, [ref])  # this is already recursive by default
+        for tag in tags:
+            self.registry.associate(tag, [ref])  # this is already recursive by default
 
         return ref
 
@@ -635,7 +721,7 @@ class Butler:
     def getDeferred(self, datasetRefOrType: Union[DatasetRef, DatasetType, str],
                     dataId: Optional[DataId] = None, *,
                     parameters: Union[dict, None] = None,
-                    collection: Optional[str] = None,
+                    collections: Any = None,
                     **kwds: Any) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset
 
@@ -648,13 +734,13 @@ class Butler:
             A `dict` of `Dimension` link name, value pairs that label the
             `DatasetRef` within a Collection. When `None`, a `DatasetRef`
             should be provided as the first argument.
-        collection : `str`, optional
-            Name of the collection to search, overriding ``self.collection``.
         parameters : `dict`
             Additional StorageClass-defined options to control reading,
             typically used to efficiently read only a subset of the dataset.
-        collection : `str`, optional
-            Collection to search, overriding ``self.collection``.
+        collections : Any, optional
+            Collections to be searched, overriding ``self.collections``.
+            Can be any of the types supported by the ``collections`` argument
+            to butler construction.
         kwds
             Additional keyword arguments used to augment or construct a
             `DataId`.  See `DataId` parameters.
@@ -671,17 +757,17 @@ class Butler:
             ``allowUnresolved is False``).
         ValueError
             Raised if a resolved `DatasetRef` was passed as an input, but it
-            differs from the one found in the registry in this collection.
+            differs from the one found in the registry.
         TypeError
-            Raised if ``collection`` and ``self.collection`` are both `None`.
+            Raised if no collections were provided.
         """
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collection=collection, **kwds)
+        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwds)
         return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters)
 
     def get(self, datasetRefOrType: Union[DatasetRef, DatasetType, str],
             dataId: Optional[DataId] = None, *,
             parameters: Optional[Dict[str, Any]] = None,
-            collection: Optional[str] = None,
+            collections: Any = None,
             **kwds: Any) -> Any:
         """Retrieve a stored dataset.
 
@@ -697,8 +783,10 @@ class Butler:
         parameters : `dict`
             Additional StorageClass-defined options to control reading,
             typically used to efficiently read only a subset of the dataset.
-        collection : `str`, optional
-            Collection to search, overriding ``self.collection``.
+        collections : Any, optional
+            Collections to be searched, overriding ``self.collections``.
+            Can be any of the types supported by the ``collections`` argument
+            to butler construction.
         kwds
             Additional keyword arguments used to augment or construct a
             `DataCoordinate`.  See `DataCoordinate.standardize`
@@ -713,20 +801,20 @@ class Butler:
         ------
         ValueError
             Raised if a resolved `DatasetRef` was passed as an input, but it
-            differs from the one found in the registry in this collection.
+            differs from the one found in the registry.
         LookupError
             Raised if no matching dataset exists in the `Registry`.
         TypeError
-            Raised if ``collection`` and ``self.collection`` are both `None`.
+            Raised if no collections were provided.
         """
         log.debug("Butler get: %s, dataId=%s, parameters=%s", datasetRefOrType, dataId, parameters)
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collection=collection, **kwds)
+        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwds)
         return self.getDirect(ref, parameters=parameters)
 
     def getUri(self, datasetRefOrType: Union[DatasetRef, DatasetType, str],
                dataId: Optional[DataId] = None, *,
                predict: bool = False,
-               collection: Optional[str] = None,
+               collections: Any = None,
                run: Optional[str] = None,
                **kwds: Any) -> str:
         """Return the URI to the Dataset.
@@ -743,8 +831,10 @@ class Butler:
         predict : `bool`
             If `True`, allow URIs to be returned of datasets that have not
             been written.
-        collection : `str`, optional
-            Collection to search, overriding ``self.collection``.
+        collections : Any, optional
+            Collections to be searched, overriding ``self.collections``.
+            Can be any of the types supported by the ``collections`` argument
+            to butler construction.
         run : `str`, optional
             Run to use for predictions, overriding ``self.run``.
         kwds
@@ -770,12 +860,12 @@ class Butler:
             guessing is not allowed.
         ValueError
             Raised if a resolved `DatasetRef` was passed as an input, but it
-            differs from the one found in the registry in this collection.
+            differs from the one found in the registry.
         TypeError
-            Raised if ``collection`` and ``self.collection`` are both `None`.
+            Raised if no collections were provided.
         """
-        ref = self._findDatasetRef(datasetRefOrType, dataId, allowUnresolved=predict, collection=collection,
-                                   **kwds)
+        ref = self._findDatasetRef(datasetRefOrType, dataId, allowUnresolved=predict,
+                                   collections=collections, **kwds)
         if ref.id is None:  # only possible if predict is True
             if run is None:
                 run = self.run
@@ -788,7 +878,7 @@ class Butler:
 
     def datasetExists(self, datasetRefOrType: Union[DatasetRef, DatasetType, str],
                       dataId: Optional[DataId] = None, *,
-                      collection: Optional[str] = None,
+                      collections: Any = None,
                       **kwds: Any) -> bool:
         """Return True if the Dataset is actually present in the Datastore.
 
@@ -801,8 +891,10 @@ class Butler:
             A `dict` of `Dimension` link name, value pairs that label the
             `DatasetRef` within a Collection. When `None`, a `DatasetRef`
             should be provided as the first argument.
-        collection : `str`, optional
-            Collection to search, overriding ``self.collection``.
+        collections : Any, optional
+            Collections to be searched, overriding ``self.collections``.
+            Can be any of the types supported by the ``collections`` argument
+            to butler construction.
         kwds
             Additional keyword arguments used to augment or construct a
             `DataCoordinate`.  See `DataCoordinate.standardize`
@@ -814,18 +906,19 @@ class Butler:
             Raised if the dataset is not even present in the Registry.
         ValueError
             Raised if a resolved `DatasetRef` was passed as an input, but it
-            differs from the one found in the registry in this collection.
+            differs from the one found in the registry.
         TypeError
-            Raised if ``collection`` and ``self.collection`` are both `None`.
+            Raised if no collections were provided.
         """
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collection=collection, **kwds)
+        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwds)
         return self.datastore.exists(ref)
 
     def prune(self, refs: Iterable[DatasetRef], *,
               disassociate: bool = True,
               unstore: bool = False,
-              collection: Optional[str] = None,
+              tags: Optional[Iterable[str]] = None,
               purge: bool = False,
+              run: Optional[str] = None,
               recursive: bool = True):
         """Remove one or more datasets from a collection and/or storage.
 
@@ -843,25 +936,25 @@ class Butler:
             datastores known to this butler.  Note that this will make it
             impossible to retrieve these datasets even via other collections.
             Datasets that are already not stored are ignored by this option.
-        collection : `str`, optional
-            Collection to remove the datasets from, overriding
-            ``self.collection``.  Ignored if ``disassociate`` is `False`.
-            Must be a `~CollectionType.TAGGED` collection, unless ``purge``
-            is `True`, in which case it must be a `~CollectionType.RUN`.
+        tags : `Iterable` [ `str` ], optional
+            `~CollectionType.TAGGED` collections to disassociate the datasets
+            from, overriding ``self.tags``.  Ignored if ``disassociate`` is
+            `False` or ``purge`` is `True`.
         purge : `bool`, optional
             If `True` (`False` is default), completely remove the dataset from
             the `Registry`.  To prevent accidental deletions, ``purge`` may
             only be `True` if all of the following conditions are met:
 
-             - Either ``collection`` is a `~CollectionType.RUN`, or
-               ``collection`` is `None` and ``self.run`` is not `None`,
-               and all given datasets are in that run;
+             - All given datasets are in the given run.
              - ``disassociate`` is `True`;
              - ``unstore`` is `True`;
              - none of the given datasets are components of some other dataset.
 
             This mode may remove provenance information from datasets other
             than those provided, and should be used with extreme care.
+        run : `str`, optional
+            `~CollectionType.RUN` collection to purge from, overriding
+            ``self.run``.  Ignored unless ``purge`` is `True`.
         recursive : `bool`, optional
             If `True` (default) also prune component datasets of any given
             composite datasets.  This will only prune components that are
@@ -911,25 +1004,26 @@ class Butler:
         if not self.isWriteable():
             raise TypeError("Butler is read-only.")
         if purge:
-            if collection is None:
-                collection = self.run
-                if collection is None:
+            if run is None:
+                run = self.run
+                if run is None:
                     raise TypeError("No run provided but purge=True.")
-            collectionType = self.registry.getCollectionType(collection)
+            collectionType = self.registry.getCollectionType(run)
             if collectionType is not CollectionType.RUN:
-                raise TypeError(f"Cannot purge from collection '{collection}' "
+                raise TypeError(f"Cannot purge from collection '{run}' "
                                 f"of non-RUN type {collectionType.name}.")
         elif disassociate:
-            if collection is None:
-                collection = self.collection
-                if collection is None:
-                    raise TypeError("No collection provided but disassociate=True.")
-                collectionType = self._collectionType
+            if tags is None:
+                tags = self.tags
             else:
-                collectionType = self.registry.getCollectionType(collection)
-            if collectionType is not CollectionType.TAGGED:
-                raise TypeError(f"Cannot disassociated from collection '{collection}' "
-                                f"of non-TAGGED type {collectionType.name}.")
+                tags = tuple(tags)
+            if not tags:
+                raise TypeError("No tags provided but disassociate=True.")
+            for tag in tags:
+                collectionType = self.registry.getCollectionType(tag)
+                if collectionType is not CollectionType.TAGGED:
+                    raise TypeError(f"Cannot disassociate from collection '{tag}' "
+                                    f"of non-TAGGED type {collectionType.name}.")
         if purge:
             if not disassociate:
                 raise TypeError("Cannot pass purge=True without disassociate=True.")
@@ -953,15 +1047,18 @@ class Butler:
                 # entries are gone.  But we want to catch as many problems as
                 # we can before the point of no return.
                 for ref in refs:
-                    if ref.run != collection:
-                        raise ValueError(f"Cannot purge '{ref}' because it is not in '{collection}'.")
+                    if ref.run != run:
+                        raise ValueError(f"Cannot purge '{ref}' because it is not in '{run}'.")
             elif disassociate:
                 # If we're disassociating but not purging, we can do that
                 # before we try to delete, and it will roll back if deletion
                 # fails.  That will at least do the right thing if deletion
                 # fails because the files couldn't actually be delete (e.g.
                 # due to lack of permissions).
-                self.registry.disassociate(collection, refs)
+                for tag in tags:
+                    # recursive=False here because refs is already recursive
+                    # if we want it to be.
+                    self.registry.disassociate(tag, refs, recursive=False)
             if unstore:
                 try:
                     # Point of no return: if Datastore.remove ever succeeds
@@ -990,7 +1087,7 @@ class Butler:
 
     @transactional
     def ingest(self, *datasets: FileDataset, transfer: Optional[str] = None, run: Optional[str] = None,
-               collection: Optional[str] = None,):
+               tags: Optional[Iterable[str]] = None,):
         """Store and register one or more datasets that already exist on disk.
 
         Parameters
@@ -1013,12 +1110,10 @@ class Butler:
         run : `str`, optional
             The name of the run ingested datasets should be added to,
             overriding ``self.run``.
-        collection : `str` or `False`, optional
-            The name of a `~CollectionType.TAGGED` collection to associate the
-            dataset(s) with, overriding ``self.collection``.  This collection
-            must have already been added to the `Registry`.  May also be
-            `False` to skip association with ``self.collection`` even when that
-            is a `~CollectionType.TAGGED` collection.
+        tags : `Iterable` [ `str` ], optional
+            The names of a `~CollectionType.TAGGED` collections to associate
+            the dataset with, overriding ``self.tags``.  These collections
+            must have already been added to the `Registry`.
 
         Raises
         ------
@@ -1052,15 +1147,20 @@ class Butler:
             if self.run is None:
                 raise TypeError("No run provided.")
             run = self.run
-
-        if collection is None:
-            collection = self.collection
-            collectionType = self._collectionType
-        elif collection is False:
-            collectionType = None
+            # No need to check run type, since insertDatasets will do that
+            # (safely) for us.
+        if tags is None:
+            tags = self.tags
         else:
-            collectionType = self.registry.getCollectionType(collection)
-
+            tags = tuple(tags)
+        for tag in tags:
+            # Check that these are tagged collections up front, because we want
+            # to avoid relying on Datastore transactionality to avoid modifying
+            # the repo if there's an error later.
+            collectionType = self.registry.getCollectionType(tag)
+            if collectionType is not CollectionType.TAGGED:
+                raise TypeError(f"Cannot associate into collection '{tag}' of non-TAGGED type "
+                                f"{collectionType.name}.")
         # Reorganize the inputs so they're grouped by DatasetType and then
         # data ID.  We also include a list of DatasetRefs for each FileDataset
         # to hold the resolved DatasetRefs returned by the Registry, before
@@ -1079,6 +1179,7 @@ class Butler:
                 groupedData[ref.datasetType][ref.dataId] = (dataset, resolvedRefs)
 
         # Now we can bulk-insert into Registry for each DatasetType.
+        allResolvedRefs = []
         for datasetType, groupForType in groupedData.items():
             refs = self.registry.insertDatasets(datasetType,
                                                 dataIds=groupForType.keys(),
@@ -1097,9 +1198,9 @@ class Butler:
                 dataset.refs = resolvedRefs
                 allResolvedRefs.extend(resolvedRefs)
 
-        # Bulk-associate everything with a tagged collection, if we have one.
-        if collectionType is CollectionType.TAGGED:
-            self.registry.associate(collection, allResolvedRefs)
+        # Bulk-associate everything with any tagged collections.
+        for tag in tags:
+            self.registry.associate(tag, allResolvedRefs)
 
         # Bulk-insert everything into Datastore.
         self.datastore.ingest(*datasets, transfer=transfer)
@@ -1365,11 +1466,17 @@ class Butler:
     describe them (`StorageClassFactory`).
     """
 
+    collections: Optional[CollectionSearch]
+    """The collections to search and any restrictions on the dataset types to
+    search for within them, in order (`CollectionSearch`).
+    """
+
     run: Optional[str]
     """Name of the run this butler writes outputs to (`str` or `None`).
     """
 
-    collection: Optional[str]
-    """Name of the collection this butler searches for datasets (`str` or
-    `None`).
+    tags: Tuple[str, ...]
+    """Names of `~CollectionType.TAGGED` collections this butler associates
+    with in `put` and `ingest`, and disassociates from in `prune` (`tuple` of
+    `str`).
     """

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -489,7 +489,7 @@ class Butler:
                 raise TypeError("No collection provided.")
         # Always lookup the DatasetRef, even if one is given, to ensure it is
         # present in the current collection.
-        ref = self.registry.findDataset(datasetType, dataId, collection=collection)
+        ref = self.registry.findDataset(datasetType, dataId, collections=[collection])
         if ref is None:
             if allowUnresolved:
                 return DatasetRef(datasetType, dataId)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -480,8 +480,8 @@ class Butler:
             idNumber = datasetRefOrType.id
         else:
             idNumber = None
-        # Expand the data ID first instead of letting registry.find do it, so
-        # we get the result even if it returns None.
+        # Expand the data ID first instead of letting registry.findDataset do
+        # it, so we get the result even if it returns None.
         dataId = self.registry.expandDataId(dataId, graph=datasetType.dimensions, **kwds)
         if collection is None:
             collection = self.collection
@@ -489,7 +489,7 @@ class Butler:
                 raise TypeError("No collection provided.")
         # Always lookup the DatasetRef, even if one is given, to ensure it is
         # present in the current collection.
-        ref = self.registry.find(collection, datasetType, dataId)
+        ref = self.registry.findDataset(datasetType, dataId, collection=collection)
         if ref is None:
             if allowUnresolved:
                 return DatasetRef(datasetType, dataId)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1265,7 +1265,7 @@ class Butler:
         if datasetTypeNames:
             entities = [self.registry.getDatasetType(name) for name in datasetTypeNames]
         else:
-            entities = list(self.registry.getAllDatasetTypes())
+            entities = list(self.registry.queryDatasetTypes())
 
         # filter out anything from the ignore list
         if ignore:

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -132,7 +132,7 @@ class DatasetRef:
             return NotImplemented
 
     def __hash__(self) -> int:
-        return hash(self.datasetType, self.dataId, self.id)
+        return hash((self.datasetType, self.dataId, self.id))
 
     @property
     def hash(self) -> bytes:

--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -25,7 +25,7 @@ from ._dbAuth import *
 from ._collectionType import *
 
 from . import wildcards
-from .wildcards import Like  # other symbols are mostly internal
+from .wildcards import CollectionSearch, DatasetTypeRestriction
 from . import interfaces
 from .interfaces import MissingCollectionError
 from . import queries

--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -22,10 +22,12 @@
 from ._config import *
 from ._registry import *
 from ._dbAuth import *
+from ._collectionType import *
 
 from . import wildcards
 from .wildcards import Like  # other symbols are mostly internal
 from . import interfaces
+from .interfaces import MissingCollectionError
 from . import queries
 
 # Some modules intentionally not imported, either because they are purely

--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -23,6 +23,8 @@ from ._config import *
 from ._registry import *
 from ._dbAuth import *
 
+from . import wildcards
+from .wildcards import Like  # other symbols are mostly internal
 from . import interfaces
 from . import queries
 

--- a/python/lsst/daf/butler/registry/_collectionType.py
+++ b/python/lsst/daf/butler/registry/_collectionType.py
@@ -19,7 +19,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ._database import *
-from ._opaque import *
-from ._dimensions import *
-from ._collections import *
+__all__ = [
+    "CollectionType",
+]
+
+import enum
+
+
+class CollectionType(enum.IntEnum):
+    """Enumeration used to label different types of collections.
+    """
+
+    RUN = 1
+    """A ``RUN`` collection (also just called a 'run') is the initial
+    collection a dataset is inserted into and the only one it can never be
+    removed from.
+
+    Within a particular run, there may only be one dataset with a particular
+    dataset type and data ID.
+    """
+
+    TAGGED = 2
+    """Datasets can be associated with and removed from ``TAGGED`` collections
+    arbitrarily.
+
+    Within a particular tagged collection, there may only be one dataset with
+    a particular dataset type and data ID.
+    """

--- a/python/lsst/daf/butler/registry/_collectionType.py
+++ b/python/lsst/daf/butler/registry/_collectionType.py
@@ -46,3 +46,8 @@ class CollectionType(enum.IntEnum):
     Within a particular tagged collection, there may only be one dataset with
     a particular dataset type and data ID.
     """
+
+    CHAINED = 3
+    """A ``CHAINED`` collection is simply an ordered list of other collections
+    to be searched.  These may include other ``CHAINED`` collections.
+    """

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -346,7 +346,8 @@ class Registry:
         """
         id = self._runIdsByName.get(name)
         if id is None:
-            (id,), _ = self._db.sync(self._tables.run, keys={"name": name}, returning=["id"])
+            row, _ = self._db.sync(self._tables.run, keys={"name": name}, returning=["id"])
+            id = row["id"]
             self._runIdsByName[name] = id
             self._runNamesById[id] = name
         # Assume that if the run is in the cache, it's in the database, because

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -58,8 +58,8 @@ from ..core import (
 from ..core import ddl
 from ..core.utils import doImport, iterable, transactional, NamedKeyDict
 from ._config import RegistryConfig
+from .wildcards import WildcardExpression
 from .queries import (
-    CollectionsExpression,
     DatasetRegistryStorage,
     DatasetTypeExpression,
     QueryBuilder,
@@ -1127,7 +1127,7 @@ class Registry:
 
     def queryDimensions(self, dimensions: Union[Iterable[Union[Dimension, str]], Dimension, str], *,
                         dataId: Optional[DataId] = None,
-                        datasets: Optional[Mapping[DatasetTypeExpression, CollectionsExpression]] = None,
+                        datasets: Optional[Mapping[DatasetTypeExpression, WildcardExpression]] = None,
                         where: Optional[str] = None,
                         expand: bool = True,
                         **kwds) -> Iterator[DataCoordinate]:
@@ -1196,7 +1196,7 @@ class Registry:
                     yield result
 
     def queryDatasets(self, datasetType: DatasetTypeExpression, *,
-                      collections: CollectionsExpression,
+                      collections: WildcardExpression,
                       dimensions: Optional[Iterable[Union[Dimension, str]]] = None,
                       dataId: Optional[DataId] = None,
                       where: Optional[str] = None,

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -594,8 +594,8 @@ class Registry:
         return DatasetRef(datasetType=datasetType, dataId=dataId, id=row["dataset_id"], run=run,
                           hash=datasetRefHash, components=components)
 
-    def find(self, collection: str, datasetType: Union[DatasetType, str], dataId: Optional[DataId] = None,
-             **kwds: Any) -> Optional[DatasetRef]:
+    def findDataset(self, datasetType: Union[DatasetType, str], dataId: Optional[DataId] = None, *,
+                    collection: str, **kwds: Any) -> Optional[DatasetRef]:
         """Lookup a dataset.
 
         This can be used to obtain a `DatasetRef` that permits the dataset to
@@ -603,13 +603,13 @@ class Registry:
 
         Parameters
         ----------
-        collection : `str`
-            Identifies the collection to search.
         datasetType : `DatasetType` or `str`
             A `DatasetType` or the name of one.
         dataId : `dict` or `DataCoordinate`, optional
             A `dict`-like object containing the `Dimension` links that identify
             the dataset within a collection.
+        collection : `str`
+            Identifies the collection to search.
         **kwds
             Additional keyword arguments passed to
             `DataCoordinate.standardize` to convert ``dataId`` to a true

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1174,9 +1174,7 @@ class Registry:
         requestedDimensionNames = set(self.dimensions.extract(dimensions).names)
         if datasets is not None:
             for datasetTypeExpr, collectionsExpr in datasets.items():
-                for trueDatasetType in self._datasetStorage.fetchDatasetTypes(datasetTypeExpr,
-                                                                              collections=collectionsExpr,
-                                                                              dataId=standardizedDataId):
+                for trueDatasetType in self._datasetStorage.fetchDatasetTypes(datasetTypeExpr):
                     requestedDimensionNames.update(trueDatasetType.dimensions.names)
                     standardizedDatasets[trueDatasetType] = collectionsExpr
         summary = QuerySummary(
@@ -1279,9 +1277,7 @@ class Registry:
         # (it could be an expression that yields multiple DatasetTypes) and
         # recurse.
         if not isinstance(datasetType, DatasetType):
-            for trueDatasetType in self._datasetStorage.fetchDatasetTypes(datasetType,
-                                                                          collections=collections,
-                                                                          dataId=standardizedDataId):
+            for trueDatasetType in self._datasetStorage.fetchDatasetTypes(datasetType):
                 yield from self.queryDatasets(trueDatasetType, collections=collections,
                                               dimensions=dimensions, dataId=standardizedDataId,
                                               where=where, deduplicate=deduplicate)

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1106,13 +1106,13 @@ class Registry:
         managing more complex queries than those obtainable via `Registry`
         interfaces.
 
-        This is an advanced `SqlRegistry`-only interface; downstream code
-        should prefer `Registry.queryDimensions` and `Registry.queryDatasets`
-        whenever those are sufficient.
+        This is an advanced interface; downstream code should prefer
+        `Registry.queryDimensions` and `Registry.queryDatasets` whenever those
+        are sufficient.
 
         Parameters
         ----------
-        summary: `QuerySummary`
+        summary : `QuerySummary`
             Object describing and categorizing the full set of dimensions that
             will be included in the query.
 

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -36,7 +36,6 @@ import sqlalchemy
 from ...core import ddl
 from ...core.timespan import Timespan, TIMESPAN_FIELD_SPECS
 from .._collectionType import CollectionType
-from ..wildcards import CategorizedWildcard
 from ..interfaces import (
     CollectionManager,
     CollectionRecord,
@@ -258,21 +257,5 @@ class AggressiveNameKeyCollectionManager(CollectionManager):
         except KeyError as err:
             raise MissingCollectionError(f"Collection with key '{err}' not found.") from err
 
-    def query(self, wildcard: Optional[CategorizedWildcard] = None) -> Iterator[CollectionRecord]:
-        # Docstring inherited from CollectionManager.
-        if wildcard is None:
-            yield from self._records.values()
-        else:
-            if wildcard.patterns:
-                sql = sqlalchemy.sql.select(
-                    [self._tables.collection.columns.name]
-                ).select_from(
-                    self._tables.collection
-                ).where(
-                    wildcard.makeWhereExpression(self._tables.collection.columns.name)
-                )
-                for row in self._db.query(sql).fetchall():
-                    yield self._records[row["name"]]
-            else:
-                for name in wildcard.strings:
-                    yield self._records[name]
+    def __iter__(self) -> Iterator[CollectionRecord]:
+        yield from self._records.values()

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -1,0 +1,278 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["AggressiveNameKeyCollectionManager"]
+
+from collections import namedtuple
+from datetime import datetime
+from typing import (
+    Any,
+    Iterator,
+    Optional,
+    TYPE_CHECKING,
+)
+
+import sqlalchemy
+
+from ...core import ddl
+from ...core.timespan import Timespan, TIMESPAN_FIELD_SPECS
+from .._collectionType import CollectionType
+from ..wildcards import CategorizedWildcard
+from ..interfaces import (
+    CollectionManager,
+    CollectionRecord,
+    MissingCollectionError,
+    RunRecord,
+)
+
+if TYPE_CHECKING:
+    from .database import Database, StaticTablesContext
+
+
+_TablesTuple = namedtuple("CollectionTablesTuple", ["collection", "run"])
+
+_TABLES_SPEC = _TablesTuple(
+    collection=ddl.TableSpec(
+        fields=[
+            ddl.FieldSpec("name", dtype=sqlalchemy.String, length=64, primaryKey=True),
+            ddl.FieldSpec("type", dtype=sqlalchemy.SmallInteger, nullable=False),
+        ],
+    ),
+    run=ddl.TableSpec(
+        fields=[
+            ddl.FieldSpec("name", dtype=sqlalchemy.String, length=64, primaryKey=True),
+            TIMESPAN_FIELD_SPECS.begin,
+            TIMESPAN_FIELD_SPECS.end,
+            ddl.FieldSpec("host", dtype=sqlalchemy.String, length=128),
+        ],
+        foreignKeys=[
+            ddl.ForeignKeySpec("collection", source=("name",), target=("name",), onDelete="CASCADE"),
+        ],
+    ),
+)
+
+
+class NameKeyCollectionRecord(CollectionRecord):
+    """A `CollectionRecord` implementation that just uses the string name as
+    the primary/foreign key for collections.
+    """
+
+    @property
+    def key(self) -> str:
+        # Docstring inherited from CollectionRecord.
+        return self.name
+
+
+class NameKeyRunRecord(RunRecord):
+    """A `RunRecord` implementation that just uses the string name as the
+    primary/foreign key for collections.
+    """
+    def __init__(self, db: Database, name: str, *, table: sqlalchemy.schema.Table,
+                 host: Optional[str] = None, timespan: Optional[Timespan[Optional[datetime]]] = None):
+        super().__init__(name=name, type=CollectionType.RUN)
+        self._db = db
+        self._table = table
+        self._host = host
+        if timespan is None:
+            timespan = Timespan(begin=None, end=None)
+        self._timespan = timespan
+
+    def update(self, host: Optional[str] = None, timespan: Optional[Timespan[Optional[datetime]]] = None):
+        # Docstring inherited from RunRecord.
+        if timespan is None:
+            timespan = Timespan(begin=None, end=None)
+        row = {
+            "name": self.name,
+            TIMESPAN_FIELD_SPECS.begin.name: timespan.begin,
+            TIMESPAN_FIELD_SPECS.end.name: timespan.end,
+            "host": host,
+        }
+        count = self._db.update(self._table, {"name": self.name}, row)
+        if count != 1:
+            raise RuntimeError(f"Run update affected {count} records; expected exactly one.")
+        self._host = host
+        self._timespan = timespan
+
+    @property
+    def key(self) -> str:
+        # Docstring inherited from CollectionRecord.
+        return self.name
+
+    @property
+    def host(self) -> Optional[str]:
+        # Docstring inherited from RunRecord.
+        return self._host
+
+    @property
+    def timespan(self) -> Timespan[Optional[datetime]]:
+        # Docstring inherited from RunRecord.
+        return self._timespan
+
+
+class AggressiveNameKeyCollectionManager(CollectionManager):
+    """A `CollectionManager` implementation that uses collection names for
+    primary/foreign keys and aggressively loads all collection/run records in
+    the database into memory.
+
+    Parameters
+    ----------
+    db : `Database`
+        Interface to the underlying database engine and namespace.
+    tables : `_TablesTuple`
+        Named tuple of SQLAlchemy table objects.
+    """
+    def __init__(self, db: Database, tables: _TablesTuple):
+        self._db = db
+        self._tables = tables
+        self._records = {}
+
+    @classmethod
+    def initialize(cls, db: Database, context: StaticTablesContext) -> CollectionManager:
+        # Docstring inherited from CollectionManager.
+        return cls(db, tables=context.addTableTuple(_TABLES_SPEC))
+
+    @classmethod
+    def addCollectionForeignKey(cls, tableSpec: ddl.TableSpec, *, prefix: str = "collection",
+                                onDelete: Optional[str] = None, **kwds: Any) -> ddl.FieldSpec:
+        # Docstring inherited from CollectionManager.
+        if prefix is None:
+            prefix = "collection"
+        original = _TABLES_SPEC.collection.fields["name"]
+        copy = ddl.FieldSpec(cls.getCollectionForeignKeyName(prefix), dtype=original.dtype, **kwds)
+        tableSpec.fields.add(copy)
+        tableSpec.foreignKeys.append(ddl.ForeignKeySpec("collection", source=(copy.name,),
+                                                        target=(original.name,), onDelete=onDelete))
+        return copy
+
+    @classmethod
+    def addRunForeignKey(cls, tableSpec: ddl.TableSpec, *, prefix: str = "run",
+                         onDelete: Optional[str] = None, **kwds: Any) -> ddl.FieldSpec:
+        # Docstring inherited from CollectionManager.
+        if prefix is None:
+            prefix = "run"
+        original = _TABLES_SPEC.run.fields["name"]
+        copy = ddl.FieldSpec(cls.getRunForeignKeyName(prefix), dtype=original.dtype, **kwds)
+        tableSpec.fields.add(copy)
+        tableSpec.foreignKeys.append(ddl.ForeignKeySpec("run", source=(copy.name,),
+                                                        target=(original.name,), onDelete=onDelete))
+        return copy
+
+    @classmethod
+    def getCollectionForeignKeyName(cls, prefix: str = "collection") -> str:
+        return f"{prefix}_name"
+
+    @classmethod
+    def getRunForeignKeyName(cls, prefix: str = "run") -> str:
+        return f"{prefix}_name"
+
+    def refresh(self):
+        # Docstring inherited from CollectionManager.
+        sql = sqlalchemy.sql.select(
+            self._tables.collection.columns + self._tables.run.columns
+        ).select_from(
+            self._tables.collection.join(self._tables.run, isouter=True)
+        )
+        # Put found records into a temporary instead of updating self._records
+        # in place, for exception safety.
+        records = {}
+        for row in self._db.query(sql).fetchall():
+            name = row[self._tables.collection.columns.name]
+            type = CollectionType(row["type"])
+            if type is CollectionType.RUN:
+                record = NameKeyRunRecord(
+                    name=name,
+                    db=self._db,
+                    table=self._tables.run,
+                    host=row[self._tables.run.columns.host],
+                    timespan=Timespan(
+                        begin=row[self._tables.run.columns[TIMESPAN_FIELD_SPECS.begin.name]],
+                        end=row[self._tables.run.columns[TIMESPAN_FIELD_SPECS.end.name]],
+                    )
+                )
+            else:
+                record = NameKeyCollectionRecord(type=type, name=name)
+            records[record.name] = record
+        self._records = records
+
+    def register(self, name: str, type: CollectionType) -> CollectionRecord:
+        # Docstring inherited from CollectionManager.
+        record = self._records.get(name)
+        if record is None:
+            kwds = {"name": name}
+            self._db.sync(
+                self._tables.collection,
+                keys=kwds,
+                compared={"type": int(type)},
+            )
+            if type is CollectionType.RUN:
+                row, _ = self._db.sync(
+                    self._tables.run,
+                    keys=kwds,
+                    returning={"host", TIMESPAN_FIELD_SPECS.begin.name, TIMESPAN_FIELD_SPECS.end.name},
+                )
+                record = NameKeyRunRecord(
+                    db=self._db,
+                    table=self._tables.run,
+                    host=row["host"],
+                    timespan=Timespan(
+                        row[TIMESPAN_FIELD_SPECS.begin.name],
+                        row[TIMESPAN_FIELD_SPECS.end.name]
+                    ),
+                    **kwds
+                )
+            else:
+                record = NameKeyCollectionRecord(type=type, **kwds)
+            self._records[record.name] = record
+        return record
+
+    def find(self, name: str) -> CollectionRecord:
+        # Docstring inherited from CollectionManager.
+        result = self._records.get(name)
+        if result is None:
+            raise MissingCollectionError(f"No collection with name '{name}' found.")
+        return result
+
+    def __getitem__(self, key: Any) -> Optional[CollectionRecord]:
+        # Docstring inherited from CollectionManager.
+        try:
+            return self._records[key]
+        except KeyError as err:
+            raise MissingCollectionError(f"Collection with key '{err}' not found.") from err
+
+    def query(self, wildcard: Optional[CategorizedWildcard] = None) -> Iterator[CollectionRecord]:
+        # Docstring inherited from CollectionManager.
+        if wildcard is None:
+            yield from self._records.values()
+        else:
+            if wildcard.patterns:
+                sql = sqlalchemy.sql.select(
+                    [self._tables.collection.columns.name]
+                ).select_from(
+                    self._tables.collection
+                ).where(
+                    wildcard.makeWhereExpression(self._tables.collection.columns.name)
+                )
+                for row in self._db.query(sql).fetchall():
+                    yield self._records[row["name"]]
+            else:
+                for name in wildcard.strings:
+                    yield self._records[name]

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -1,0 +1,380 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = [
+    "CollectionManager",
+    "CollectionRecord",
+    "MissingCollectionError",
+    "RunRecord",
+]
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import (
+    Any,
+    Iterator,
+    Optional,
+    TYPE_CHECKING,
+)
+
+from ...core import ddl
+from ...core.timespan import Timespan
+from .._collectionType import CollectionType
+
+if TYPE_CHECKING:
+    from ..wildcards import CategorizedWildcard
+    from .database import Database, StaticTablesContext
+
+
+class MissingCollectionError(Exception):
+    """Exception raised when an operation attempts to use a collection that
+    does not exist.
+    """
+
+
+class CollectionRecord(ABC):
+    """A struct used to represent a collection in internal `Registry` APIs.
+
+    User-facing code should always just use a `str` to represent collections.
+
+    Parameters
+    ----------
+    name : `str`
+        Name of the collection.
+    type : `CollectionType`
+        Enumeration value describing the type of the collection.
+    """
+    def __init__(self, name: str, type: CollectionType):
+        self.name = name
+        self.type = type
+
+    @property
+    @abstractmethod
+    def key(self) -> Any:
+        """The primary/foreign key value for this collection.
+        """
+        raise NotImplementedError()
+
+    name: str
+    """Name of the collection (`str`).
+    """
+
+    type: CollectionType
+    """Enumeration value describing the type of the collection
+    (`CollectionType`).
+    """
+
+
+class RunRecord(CollectionRecord):
+    """A subclass of `CollectionRecord` that adds execution information and
+    an interface for updating it.
+    """
+
+    @abstractmethod
+    def update(self, host: Optional[str] = None, timespan: Optional[Timespan[Optional[datetime]]] = None):
+        """Update the database record for this run with new execution
+        information.
+
+        Values not provided will set to ``NULL`` in the database, not ignored.
+
+        Parameters
+        ----------
+        host : `str`, optional
+            Name of the host or system on which this run was produced.
+            Detailed form to be set by higher-level convention; from the
+            `Registry` perspective, this is an entirely opaque value.
+        timespan : `Timespan`, optional
+            Begin and end timestamps for the period over which the run was
+            produced.  `None`/``NULL`` values are interpreted as infinite
+            bounds.
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def host(self) -> Optional[str]:
+        """Return the name of the host or system on which this run was
+        produced (`str` or `None`).
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def timespan(self) -> Timespan[Optional[datetime]]:
+        """Begin and end timestamps for the period over which the run was
+        produced.  `None`/``NULL`` values are interpreted as infinite
+        bounds.
+        """
+        raise NotImplementedError()
+
+
+class CollectionManager(ABC):
+    """An interface for managing the collections (including runs) in a
+    `Registry`.
+
+    Notes
+    -----
+    Each layer in a multi-layer `Registry` has its own record for any
+    collection for which it has datasets (or quanta).  Different layers may
+    use different IDs for the same collection, so any usage of the IDs
+    obtained through the `CollectionManager` APIs are strictly for internal
+    (to `Registry`) use.
+    """
+
+    @classmethod
+    @abstractmethod
+    def initialize(cls, db: Database, context: StaticTablesContext) -> CollectionManager:
+        """Construct an instance of the manager.
+
+        Parameters
+        ----------
+        db : `Database`
+            Interface to the underlying database engine and namespace.
+        context : `StaticTablesContext`
+            Context object obtained from `Database.declareStaticTables`; used
+            to declare any tables that should always be present in a layer
+            implemented with this manager.
+
+        Returns
+        -------
+        manager : `CollectionManager`
+            An instance of a concrete `CollectionManager` subclass.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def addCollectionForeignKey(cls, tableSpec: ddl.TableSpec, *, prefix: str = "collection",
+                                onDelete: Optional[str] = None, **kwds: Any) -> ddl.FieldSpec:
+        """Add a foreign key (field and constraint) referencing the collection
+        table.
+
+        Parameters
+        ----------
+        tableSpec : `ddl.TableSpec`
+            Specification for the table that should reference the collection
+            table.  Will be modified in place.
+        prefix: `str`, optional
+            A name to use for the prefix of the new field; the full name may
+            have a suffix (and is given in the returned `ddl.FieldSpec`).
+        onDelete: `str`, optional
+            One of "CASCADE" or "SET NULL", indicating what should happen to
+            the referencing row if the collection row is deleted.  `None`
+            indicates that this should be an integrity error.
+        **kwds
+            Additional keyword arguments are forwarded to the `ddl.FieldSpec`
+            constructor (only the ``name`` and ``dtype`` arguments are
+            otherwise provided).
+
+        Returns
+        -------
+        fieldSpec : `ddl.FieldSpec`
+            Specification for the field being added.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def addRunForeignKey(cls, tableSpec: ddl.TableSpec, *, prefix: str = "run",
+                         onDelete: Optional[str] = None, **kwds: Any) -> ddl.FieldSpec:
+        """Add a foreign key (field and constraint) referencing the run
+        table.
+
+        Parameters
+        ----------
+        tableSpec : `ddl.TableSpec`
+            Specification for the table that should reference the run table.
+            Will be modified in place.
+        prefix: `str`, optional
+            A name to use for the prefix of the new field; the full name may
+            have a suffix (and is given in the returned `ddl.FieldSpec`).
+        onDelete: `str`, optional
+            One of "CASCADE" or "SET NULL", indicating what should happen to
+            the referencing row if the collection row is deleted.  `None`
+            indicates that this should be an integrity error.
+        **kwds
+            Additional keyword arguments are forwarded to the `ddl.FieldSpec`
+            constructor (only the ``name`` and ``dtype`` arguments are
+            otherwise provided).
+
+        Returns
+        -------
+        fieldSpec : `ddl.FieldSpec`
+            Specification for the field being added.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def getCollectionForeignKeyName(cls, prefix: str = "collection") -> str:
+        """Return the name of the field added by `addCollectionForeignKey`
+        if called with the same prefix.
+
+        Parameters
+        ----------
+        prefix : `str`
+            A name to use for the prefix of the new field; the full name may
+            have a suffix.
+
+        Returns
+        -------
+        name : `str`
+            The field name.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
+    def getRunForeignKeyName(cls, prefix: str = "run") -> str:
+        """Return the name of the field added by `addRunForeignKey`
+        if called with the same prefix.
+
+        Parameters
+        ----------
+        prefix : `str`
+            A name to use for the prefix of the new field; the full name may
+            have a suffix.
+
+        Returns
+        -------
+        name : `str`
+            The field name.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def refresh(self):
+        """Ensure all other operations on this manager are aware of any
+        collections that may have been registered by other clients since it
+        was initialized or last refreshed.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def register(self, name: str, type: CollectionType) -> CollectionRecord:
+        """Ensure that a collection of the given name and type are present
+        in the layer this manager is associated with.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the collection.
+        type : `CollectionType`
+            Enumeration value indicating the type of collection.
+
+        Returns
+        -------
+        record : `CollectionRecord`
+            Object representing the collection, including its type and ID.
+            If ``type is CollectionType.RUN``, this will be a `RunRecord`
+            instance.
+
+        Raises
+        ------
+        TransactionInterruption
+            Raised if this operation is invoked within a `Database.transaction`
+            context.
+        DatabaseConflictError
+            Raised if a collection with this name but a different type already
+            exists.
+
+        Notes
+        -----
+        Concurrent registrations of the same collection should be safe; nothing
+        should happen if the types are consistent, and integrity errors due to
+        inconsistent types should happen before any database changes are made.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def find(self, name: str) -> CollectionRecord:
+        """Return the collection record associated with the given name.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the collection.
+
+        Returns
+        -------
+        record : `CollectionRecord`
+            Object representing the collection, including its type and ID.
+            If ``record.type is CollectionType.RUN``, this will be a
+            `RunRecord` instance.
+
+        Raises
+        ------
+        MissingCollectionError
+            Raised if the given collection does not exist.
+
+        Notes
+        -----
+        Collections registered by another client of the same layer since the
+        last call to `initialize` or `refresh` may not be found.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __getitem__(self, key: Any) -> CollectionRecord:
+        """Return the collection record associated with the given
+        primary/foreign key value.
+
+        Parameters
+        ----------
+        key
+            Internal primary key value for the collection.
+
+        Returns
+        -------
+        record : `CollectionRecord`
+            Object representing the collection, including its type and name.
+            If ``record.type is CollectionType.RUN``, this will be a
+            `RunRecord` instance.
+
+        Raises
+        ------
+        MissingCollectionError
+            Raised if no collection with this key exists.
+
+        Notes
+        -----
+        Collections registered by another client of the same layer since the
+        last call to `initialize` or `refresh` may not be found.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def query(self, wildcard: Optional[CategorizedWildcard] = None) -> Iterator[CollectionRecord]:
+        """Iterate over the collections whose names match an expression.
+
+        Parameters
+        ----------
+        wildcard : `CategorizedWildcard`, optional
+            Preprocessed version of a wildcard expression.  If `None`, all
+            collections are returned.
+
+        Yields
+        ------
+        record : `CollectionRecord`
+            A collection matching the given expression.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -36,12 +36,10 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from ...core import ddl
-from ...core.timespan import Timespan
+from ...core import ddl, Timespan
 from .._collectionType import CollectionType
 
 if TYPE_CHECKING:
-    from ..wildcards import CategorizedWildcard
     from .database import Database, StaticTablesContext
 
 
@@ -363,18 +361,12 @@ class CollectionManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def query(self, wildcard: Optional[CategorizedWildcard] = None) -> Iterator[CollectionRecord]:
-        """Iterate over the collections whose names match an expression.
-
-        Parameters
-        ----------
-        wildcard : `CategorizedWildcard`, optional
-            Preprocessed version of a wildcard expression.  If `None`, all
-            collections are returned.
+    def __iter__(self) -> Iterator[CollectionRecord]:
+        """Iterate over all collections.
 
         Yields
         ------
         record : `CollectionRecord`
-            A collection matching the given expression.
+            The record for a managed collection.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -819,7 +819,7 @@ class Database(ABC):
             elif bad:
                 raise DatabaseConflictError(f"Conflict in sync on column(s) {bad}.")
             inserted = False
-        return result, inserted
+        return {k: v for k, v in zip(returning, result)} if returning is not None else None, inserted
 
     def insert(self, table: sqlalchemy.schema.Table, *rows: dict, returnIds: bool = False,
                ) -> Optional[List[int]]:

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -692,8 +692,8 @@ class Database(ABC):
 
         Raises
         ------
-        DatabaseConflictErrorError
-            Raised if the values in ``compared`` do match the values in the
+        DatabaseConflictError
+            Raised if the values in ``compared`` do not match the values in the
             database.
         ReadOnlyDatabaseError
             Raised if `isWriteable` returns `False`, and no matching record
@@ -963,16 +963,16 @@ class Database(ABC):
             value in the ``where`` dictionary or the name of a column to be
             updated.
 
-        Raises
-        ------
-        ReadOnlyDatabaseError
-            Raised if `isWriteable` returns `False` when this method is called.
-
         Returns
         -------
         count : `int`
             Number of rows matched (regardless of whether the update actually
             modified them).
+
+        Raises
+        ------
+        ReadOnlyDatabaseError
+            Raised if `isWriteable` returns `False` when this method is called.
 
         Notes
         -----

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -307,8 +307,8 @@ class DimensionRecordStorageManager(ABC):
             layer, or `None` if there are no records for that element in this
             layer.
 
-        Note
-        ----
+        Notes
+        -----
         Dimension elements registered by another client of the same layer since
         the last call to `initialize` or `refresh` may not be found.
         """

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -141,7 +141,6 @@ class QueryBuilder:
         """
         assert datasetType.dimensions.issubset(self.summary.requested)
         table = self._datasetStorage.getDatasetSubquery(datasetType, collections=collections,
-                                                        dataId=self.summary.dataId,
                                                         isResult=isResult, addRank=addRank)
         self.joinTable(table, datasetType.dimensions)
         if isResult:

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -37,8 +37,9 @@ from ...core import (
 )
 from ...core.utils import NamedValueSet
 
+from ..wildcards import WildcardExpression
 from ._structs import QuerySummary, QueryColumns, QueryParameters, GivenTime
-from ._datasets import DatasetRegistryStorage, CollectionsExpression
+from ._datasets import DatasetRegistryStorage
 from .expressions import ClauseVisitor
 from ._query import Query
 
@@ -108,7 +109,7 @@ class QueryBuilder:
         )
         self._elements.add(element)
 
-    def joinDataset(self, datasetType: DatasetType, collections: CollectionsExpression, *,
+    def joinDataset(self, datasetType: DatasetType, collections: WildcardExpression, *,
                     isResult: bool = True, addRank: bool = False):
         """Add a dataset search or constraint to the query.
 

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 __all__ = ("QueryBuilder",)
 
-from typing import List, Iterable, TYPE_CHECKING
+from typing import Any, List, Iterable, TYPE_CHECKING
 
 from sqlalchemy.sql import ColumnElement, and_, literal, bindparam, select, FromClause
 import sqlalchemy.sql
@@ -37,7 +37,6 @@ from ...core import (
 )
 from ...core.utils import NamedValueSet
 
-from ..wildcards import WildcardExpression
 from ._structs import QuerySummary, QueryColumns, QueryParameters, GivenTime
 from ._datasets import DatasetRegistryStorage
 from .expressions import ClauseVisitor
@@ -109,7 +108,7 @@ class QueryBuilder:
         )
         self._elements.add(element)
 
-    def joinDataset(self, datasetType: DatasetType, collections: WildcardExpression, *,
+    def joinDataset(self, datasetType: DatasetType, collections: Any, *,
                     isResult: bool = True, addRank: bool = False):
         """Add a dataset search or constraint to the query.
 
@@ -125,8 +124,12 @@ class QueryBuilder:
             The type of datasets to search for.
         collections : sequence of `str` or `Like`, or ``...``
             An expression describing the collections in which to search for
-            the datasets.  ``...`` indicates that all collections should be
-            searched.
+            the datasets.  This may be a single instance of or an iterable of
+            any of the following:
+
+             - a `str` collection name;
+             - a `Like` pattern to match against collection names;
+             - `...`, indicating all collections.
         isResult : `bool`, optional
             If `True` (default), include the ``dataset_id`` column in the
             result columns of the query, allowing complete `DatasetRef`

--- a/python/lsst/daf/butler/registry/queries/_datasets.py
+++ b/python/lsst/daf/butler/registry/queries/_datasets.py
@@ -30,7 +30,6 @@ from sqlalchemy.engine import Connection
 
 from ...core import (
     DatasetType,
-    ExpandedDataCoordinate,
     DimensionGraph,
     DimensionUniverse,
 )
@@ -139,9 +138,7 @@ class DatasetRegistryStorage:
         self._datasetTable = tables["dataset"]
         self._datasetCollectionTable = tables["dataset_collection"]
 
-    def fetchDatasetTypes(self, datasetType: DatasetTypeExpression = ..., *,
-                          collections: CollectionsExpression = ...,
-                          dataId: Optional[ExpandedDataCoordinate] = None) -> List[DatasetType]:
+    def fetchDatasetTypes(self, datasetType: DatasetTypeExpression = ...) -> List[DatasetType]:
         """Retrieve `DatasetType` instances from the database matching an
         expression.
 
@@ -155,18 +152,6 @@ class DatasetRegistryStorage:
             `Like` expression, dataset types whose name match the expression
             will be returned.  The special value ``...`` fetches all dataset
             types.  If no dataset types match, an empty `list` is returned.
-        collections : sequence of `str` or `Like`, or ``...``
-            An expression indicating collections that *may* be used to limit
-            the dataset types returned to only those that might have datasets
-            in these collections.  This is intended as an optimization for
-            higher-level functionality; it may simply be ignored, and cannot
-            be relied upon to filter the returned dataset types.
-        dataId : `ExpandedDataCoordinate`, optional
-            A data ID that *may* be used to limit the dataset types returned
-            to only those with datasets matching the given data ID.  This is
-            intended as an optimization for higher-level functionality; it may
-            simply be ignored, and cannot be relied upon to filter the returned
-            dataset types.
 
         Returns
         -------
@@ -214,7 +199,6 @@ class DatasetRegistryStorage:
 
     def getDatasetSubquery(self, datasetType: DatasetType, *,
                            collections: CollectionsExpression,
-                           dataId: Optional[ExpandedDataCoordinate] = None,
                            isResult: bool = True,
                            addRank: bool = False) -> FromClause:
         """Return a SQL expression that searches for a dataset of a particular
@@ -231,12 +215,6 @@ class DatasetRegistryStorage:
             searched.  Returned datasets are guaranteed to be from one of the
             given collections (unlike the behavior of the same argument in
             `fetchDatasetTypes`).
-        dataId : `ExpandedDataCoordinate`, optional
-            A data ID that *may* be used to limit the datasets returned
-            to only those matching the given data ID.  This is intended as an
-            optimization for higher-level functionality; it may simply be
-            ignored, and cannot be relied upon to filter the returned dataset
-            types.
         isResult : `bool`, optional
             If `True` (default), include the ``dataset_id`` column in the
             result columns of the query.

--- a/python/lsst/daf/butler/registry/queries/_datasets.py
+++ b/python/lsst/daf/butler/registry/queries/_datasets.py
@@ -179,7 +179,9 @@ class DatasetRegistryStorage:
                 for n, record in enumerate(collections.iter(self._collections, datasetType=datasetType)):
                     subsubqueries.append(
                         finishSubquery(
-                            sqlalchemy.sql.select(columns + [sqlalchemy.sql.literal(n).label("rank")]),
+                            sqlalchemy.sql.select(
+                                columns + [sqlalchemy.sql.literal(n).label("rank")]
+                            ),
                             record
                         )
                     )

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -322,32 +322,32 @@ class DatabaseTests(ABC):
         # Insert a row with sync, because it doesn't exist yet.
         values, inserted = db.sync(tables.b, keys={"name": "b1"}, extra={"value": 10}, returning=["id"])
         self.assertTrue(inserted)
-        self.assertEqual([{"id": values[0], "name": "b1", "value": 10}],
+        self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
                          [dict(r) for r in db.query(tables.b.select()).fetchall()])
         # Repeat that operation, which should do nothing but return the
         # requested values.
         values, inserted = db.sync(tables.b, keys={"name": "b1"}, extra={"value": 10}, returning=["id"])
         self.assertFalse(inserted)
-        self.assertEqual([{"id": values[0], "name": "b1", "value": 10}],
+        self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
                          [dict(r) for r in db.query(tables.b.select()).fetchall()])
         # Repeat the operation without the 'extra' arg, which should also just
         # return the existing row.
         values, inserted = db.sync(tables.b, keys={"name": "b1"}, returning=["id"])
         self.assertFalse(inserted)
-        self.assertEqual([{"id": values[0], "name": "b1", "value": 10}],
+        self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
                          [dict(r) for r in db.query(tables.b.select()).fetchall()])
         # Repeat the operation with a different value in 'extra'.  That still
         # shouldn't be an error, because 'extra' is only used if we really do
         # insert.  Also drop the 'returning' argument.
         _, inserted = db.sync(tables.b, keys={"name": "b1"}, extra={"value": 20})
         self.assertFalse(inserted)
-        self.assertEqual([{"id": values[0], "name": "b1", "value": 10}],
+        self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
                          [dict(r) for r in db.query(tables.b.select()).fetchall()])
         # Repeat the operation with the correct value in 'compared' instead of
         # 'extra'.
         _, inserted = db.sync(tables.b, keys={"name": "b1"}, compared={"value": 10})
         self.assertFalse(inserted)
-        self.assertEqual([{"id": values[0], "name": "b1", "value": 10}],
+        self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
                          [dict(r) for r in db.query(tables.b.select()).fetchall()])
         # Repeat the operation with an incorrect value in 'compared'; this
         # should raise.
@@ -368,7 +368,7 @@ class DatabaseTests(ABC):
                 tables = context.addTableTuple(STATIC_TABLE_SPECS)
             _, inserted = rodb.sync(tables.b, keys={"name": "b1"})
             self.assertFalse(inserted)
-            self.assertEqual([{"id": values[0], "name": "b1", "value": 10}],
+            self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
                              [dict(r) for r in rodb.query(tables.b.select()).fetchall()])
             with self.assertRaises(ReadOnlyDatabaseError):
                 rodb.sync(tables.b, keys={"name": "b2"}, extra={"value": 20})

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -209,7 +209,7 @@ class RegistryTests(ABC):
         with self.assertRaises(ConflictingDefinitionError):
             registry.insertDatasets(datasetType, dataIds=[dataId], run=run)
         registry.removeDataset(ref)
-        self.assertIsNone(registry.find(run, datasetType, dataId))
+        self.assertIsNone(registry.findDataset(datasetType, dataId, collection=run))
 
     def testComponents(self):
         """Tests for `Registry.attachComponent` and other dataset operations
@@ -233,12 +233,12 @@ class RegistryTests(ABC):
         self.assertEqual(outParent.components, children)
         # Remove the parent; this should remove all children.
         registry.removeDataset(parent)
-        self.assertIsNone(registry.find(run, parentDatasetType, dataId))
-        self.assertIsNone(registry.find(run, childDatasetType1, dataId))
-        self.assertIsNone(registry.find(run, childDatasetType2, dataId))
+        self.assertIsNone(registry.findDataset(parentDatasetType, dataId, collection=run))
+        self.assertIsNone(registry.findDataset(childDatasetType1, dataId, collection=run))
+        self.assertIsNone(registry.findDataset(childDatasetType2, dataId, collection=run))
 
-    def testFind(self):
-        """Tests for `Registry.find`.
+    def testFindDataset(self):
+        """Tests for `Registry.findDataset`.
         """
         registry = self.makeRegistry()
         self.loadData(registry, "base.yaml")
@@ -247,24 +247,24 @@ class RegistryTests(ABC):
         dataId = {"instrument": "Cam1", "detector": 4}
         registry.registerRun(run)
         inputRef, = registry.insertDatasets(datasetType, dataIds=[dataId], run=run)
-        outputRef = registry.find(run, datasetType, dataId)
+        outputRef = registry.findDataset(datasetType, dataId, collection=run)
         self.assertEqual(outputRef, inputRef)
         # Check that retrieval with invalid dataId raises
         with self.assertRaises(LookupError):
             dataId = {"instrument": "Cam1"}  # no detector
-            registry.find(run, datasetType, dataId)
+            registry.findDataset(datasetType, dataId, collection=run)
         # Check that different dataIds match to different datasets
         dataId1 = {"instrument": "Cam1", "detector": 1}
         inputRef1, = registry.insertDatasets(datasetType, dataIds=[dataId1], run=run)
         dataId2 = {"instrument": "Cam1", "detector": 2}
         inputRef2, = registry.insertDatasets(datasetType, dataIds=[dataId2], run=run)
-        self.assertEqual(registry.find(run, datasetType, dataId1), inputRef1)
-        self.assertEqual(registry.find(run, datasetType, dataId2), inputRef2)
-        self.assertNotEqual(registry.find(run, datasetType, dataId1), inputRef2)
-        self.assertNotEqual(registry.find(run, datasetType, dataId2), inputRef1)
+        self.assertEqual(registry.findDataset(datasetType, dataId1, collection=run), inputRef1)
+        self.assertEqual(registry.findDataset(datasetType, dataId2, collection=run), inputRef2)
+        self.assertNotEqual(registry.findDataset(datasetType, dataId1, collection=run), inputRef2)
+        self.assertNotEqual(registry.findDataset(datasetType, dataId2, collection=run), inputRef1)
         # Check that requesting a non-existing dataId returns None
         nonExistingDataId = {"instrument": "Cam1", "detector": 3}
-        self.assertIsNone(registry.find(run, datasetType, nonExistingDataId))
+        self.assertIsNone(registry.findDataset(datasetType, nonExistingDataId, collection=run))
 
     def testCollections(self):
         """Tests for registry methods that manage collections.
@@ -277,50 +277,50 @@ class RegistryTests(ABC):
         datasetType = "permabias"
         # Find some datasets via their run's collection.
         dataId1 = {"instrument": "Cam1", "detector": 1}
-        ref1 = registry.find(run1, datasetType, dataId1)
+        ref1 = registry.findDataset(datasetType, dataId1, collection=run1)
         self.assertIsNotNone(ref1)
         dataId2 = {"instrument": "Cam1", "detector": 2}
-        ref2 = registry.find(run1, datasetType, dataId2)
+        ref2 = registry.findDataset(datasetType, dataId2, collection=run1)
         self.assertIsNotNone(ref2)
         # Associate those into a new collection,then look for them there.
         tag1 = "tag1"
         registry.registerCollection(tag1, type=CollectionType.TAGGED)
         registry.associate(tag1, [ref1, ref2])
-        self.assertEqual(registry.find(tag1, datasetType, dataId1), ref1)
-        self.assertEqual(registry.find(tag1, datasetType, dataId2), ref2)
+        self.assertEqual(registry.findDataset(datasetType, dataId1, collection=tag1), ref1)
+        self.assertEqual(registry.findDataset(datasetType, dataId2, collection=tag1), ref2)
         # Disassociate one and verify that we can't it there anymore...
         registry.disassociate(tag1, [ref1])
-        self.assertIsNone(registry.find(tag1, datasetType, dataId1))
+        self.assertIsNone(registry.findDataset(datasetType, dataId1, collection=tag1))
         # ...but we can still find ref2 in tag1, and ref1 in the run.
-        self.assertEqual(registry.find(run1, datasetType, dataId1), ref1)
-        self.assertEqual(registry.find(tag1, datasetType, dataId2), ref2)
+        self.assertEqual(registry.findDataset(datasetType, dataId1, collection=run1), ref1)
+        self.assertEqual(registry.findDataset(datasetType, dataId2, collection=tag1), ref2)
         collections = registry.getAllCollections()
         self.assertEqual(collections, {run1, run2, tag1})
         # Associate both refs into tag1 again; ref2 is already there, but that
         # should be a harmless no-op.
         registry.associate(tag1, [ref1, ref2])
-        self.assertEqual(registry.find(tag1, datasetType, dataId1), ref1)
-        self.assertEqual(registry.find(tag1, datasetType, dataId2), ref2)
+        self.assertEqual(registry.findDataset(datasetType, dataId1, collection=tag1), ref1)
+        self.assertEqual(registry.findDataset(datasetType, dataId2, collection=tag1), ref2)
         # Get a different dataset (from a different run) that has the same
         # dataset type and data ID as ref2.
-        ref2b = registry.find("imported_r", datasetType, dataId2)
+        ref2b = registry.findDataset(datasetType, dataId2, collection=run2)
         self.assertNotEqual(ref2, ref2b)
         # Attempting to associate that into tag1 should be an error.
         with self.assertRaises(ConflictingDefinitionError):
             registry.associate(tag1, [ref2b])
         # That error shouldn't have messed up what we had before.
-        self.assertEqual(registry.find(tag1, datasetType, dataId1), ref1)
-        self.assertEqual(registry.find(tag1, datasetType, dataId2), ref2)
+        self.assertEqual(registry.findDataset(datasetType, dataId1, collection=tag1), ref1)
+        self.assertEqual(registry.findDataset(datasetType, dataId2, collection=tag1), ref2)
         # Attempt to associate the conflicting dataset again, this time with
         # a dataset that isn't in the collection and won't cause a conflict.
         # Should also fail without modifying anything.
         dataId3 = {"instrument": "Cam1", "detector": 3}
-        ref3 = registry.find(run1, datasetType, dataId3)
+        ref3 = registry.findDataset(datasetType, dataId3, collection=run1)
         with self.assertRaises(ConflictingDefinitionError):
             registry.associate(tag1, [ref3, ref2b])
-        self.assertEqual(registry.find(tag1, datasetType, dataId1), ref1)
-        self.assertEqual(registry.find(tag1, datasetType, dataId2), ref2)
-        self.assertIsNone(registry.find(tag1, datasetType, dataId3))
+        self.assertEqual(registry.findDataset(datasetType, dataId1, collection=tag1), ref1)
+        self.assertEqual(registry.findDataset(datasetType, dataId2, collection=tag1), ref2)
+        self.assertIsNone(registry.findDataset(datasetType, dataId3, collection=tag1))
 
     def testDatasetLocations(self):
         """Tests for `Registry.insertDatasetLocations`,
@@ -330,9 +330,10 @@ class RegistryTests(ABC):
         self.loadData(registry, "base.yaml")
         self.loadData(registry, "datasets.yaml")
         run = "imported_g"
-        ref = registry.find(run, "permabias", dataId={"instrument": "Cam1", "detector": 1})
-        ref2 = registry.find(run, "permaflat", dataId={"instrument": "Cam1", "detector": 3,
-                                                       "physical_filter": "Cam1-G"})
+        ref = registry.findDataset("permabias", dataId={"instrument": "Cam1", "detector": 1}, collection=run)
+        ref2 = registry.findDataset("permaflat",
+                                    dataId={"instrument": "Cam1", "detector": 3, "physical_filter": "Cam1-G"},
+                                    collection=run)
         datastoreName = "dummystore"
         datastoreName2 = "dummystore2"
         # Test adding information about a new dataset

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -20,40 +20,34 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = ["Like", "WildcardExpression", "CategorizedWildcard"]
+__all__ = ["CategorizedWildcard", "CollectionQuery", "CollectionSearch", "DatasetTypeRestriction"]
 
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Sequence, Union
+import itertools
+import operator
+import re
+from typing import (
+    Any,
+    Callable,
+    FrozenSet,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TYPE_CHECKING,
+    Union,
+)
 
 import sqlalchemy
 
+from ..core import DatasetType
 from ..core.utils import iterable
+from ._collectionType import CollectionType
 
-
-@dataclass(frozen=True)
-class Like:
-    """Simple wrapper around a string pattern used to indicate that a string is
-    a pattern to be used with the SQL ``LIKE`` operator rather than a complete
-    name.
-    """
-
-    pattern: str
-    """The string pattern, in SQL ``LIKE`` syntax.
-    """
-
-
-WildcardExpression = Union[str, Like, Sequence[Union[str, Like]], type(...)]
-"""Type annotation alias for the types accepted to describe a search for
-entities identified by strings.
-
-The interpretation of the allowed values is:
- - a single `str` indicates an exact match;
- - a `Like` instance provides a pattern to be matched with SQL's ``LIKE``
-   operator;
- - a `list` of `str` or `Like` indicates a match against any of those;
- - `...` indicates that any string will match.
-"""
+if TYPE_CHECKING:
+    from .interfaces import CollectionManager, CollectionRecord
 
 
 @dataclass
@@ -61,47 +55,169 @@ class CategorizedWildcard:
     """The results of preprocessing a wildcard expression to separate match
     patterns from strings.
 
-    Should be constructed by calling `categorize` rather than invoking the
-    constructor directly.
+    The `fromExpression` method should almost always be used to construct
+    instances, as the regular constructor performs no checking of inputs (and
+    that can lead to confusing error messages downstream).
     """
 
     @classmethod
-    def categorize(cls, expression: Any) -> Optional[CategorizedWildcard]:
+    def fromExpression(cls, expression: Any, *,
+                       allowAny: bool = True,
+                       allowPatterns: bool = True,
+                       coerceUnrecognized: Optional[Callable[[Any], Union[Tuple[str, Any], str]]] = None,
+                       coerceItemValue: Optional[Callable[[Any], Any]] = None,
+                       defaultItemValue: Optional[Any] = None,
+                       ) -> Union[CategorizedWildcard, type(...)]:
         """Categorize a wildcard expression.
 
         Parameters
         ----------
         expression
-            The expression to parse.  If this is one of the types included in
-            `WildcardExpression`, the `strings` and `patterns` attributes will
-            be populated.  If it is (or is a sequence that contains) other
-            types, these will be added to `other`.
+            The expression to categorize.  May be any of:
+             - `str`;
+             - `re.Pattern` (only if ``allowPatterns`` is `True`);
+             - objects recognized by ``coerceUnrecognized`` (if provided);
+             - two-element tuples of (`str`, value) where value is recognized
+               by ``coerceItemValue`` (if provided);
+             - a non-`str`, non-mapping iterable containing any of the above;
+             - the special value `...` (only if ``allowAny`` is `True`), which
+               matches anything;
+             - a mapping from `str` to a value are recognized by
+               ``coerceItemValue`` (if provided);
+             - a `CategorizedWildcard` instance (passed through unchanged if
+               it meets the requirements specified by keyword arguments).
+        allowAny: `bool`, optional
+            If `False` (`True` is default) raise `TypeError` if `...` is
+            encountered.
+        allowPatterns: `bool`, optional
+            If `False` (`True` is default) raise `TypeError` if a `re.Pattern`
+            is encountered, or if ``expression`` is a `CategorizedWildcard`
+            with `patterns` not empty.
+        coerceUnrecognized: `Callable`, optional
+            A callback that takes a single argument of arbitrary type and
+            returns either a `str` - appended to `strings` - or a `tuple` of
+            (`str`, `Any`) to be appended to `items`.  This will be called on
+            objects of unrecognized type, with the return value added to
+            `strings`. Exceptions will be reraised as `TypeError` (and
+            chained).
+        coerceItemValue: `Callable`, optional
+            If provided, ``expression`` may be a mapping from `str` to any
+            type that can be passed to this function; the result of that call
+            will be stored instead as the value in ``self.items``.
+        defaultItemValue: `Any`, optional
+            If provided, combine this value with any string values encountered
+            (including any returned by ``coerceUnrecognized``) to form a
+            `tuple` and add it to `items`, guaranteeing that `strings` will be
+            empty.  Patterns are never added to `items`.
 
         Returns
         -------
-        categorized : `CategorizedWildcard` or `None`.
-            The struct describing the wildcard.  If ``expression is ...`,
-            `None` is returned.
+        categorized : `CategorizedWildcard` or ``...``.
+            The struct describing the wildcard.  ``...`` is passed through
+            unchanged.
+
+        Raises
+        ------
+        TypeError
+            Raised if an unsupported type is found in the expression.
         """
+        assert expression is not None
+        # See if we were given ...; just return that if we were.
         if expression is ...:
-            return None
-        self = cls(strings=[], patterns=[], other=[])
-        for item in iterable(expression):
-            if isinstance(item, Like):
-                self.patterns.append(Like.pattern)
-            elif isinstance(item, str):
-                self.strings.append(item)
+            if not allowAny:
+                raise TypeError("This expression may not be unconstrained.")
+            return ...
+        if isinstance(expression, cls):
+            # This is already a CategorizedWildcard.  Make sure it meets the
+            # reqs. implied by the kwargs we got.
+            if not allowPatterns and expression.patterns:
+                raise TypeError(f"Regular expression(s) {expression.patterns} "
+                                f"are not allowed in this context.")
+            if defaultItemValue is not None and expression.strings:
+                if expression.items:
+                    raise TypeError("Incompatible preprocessed expression: an ordered sequence of str is "
+                                    "needed, but the original order was lost in the preprocessing.")
+                return cls(strings=[], patterns=expression.patterns,
+                           items=[(k, defaultItemValue) for k in expression.strings])
+            elif defaultItemValue is None and expression.items:
+                if expression.strings:
+                    raise TypeError("Incompatible preprocessed expression: an ordered sequence of items is "
+                                    "needed, but the original order was lost in the preprocessing.")
+                return cls(strings=[k for k, _ in expression.items], patterns=expression.patterns, items=[])
             else:
-                self.other.append(item)
+                # Original expression was created with keyword arguments that
+                # were at least as restrictive as what we just got; pass it
+                # through.
+                return expression
+
+        # If we get here, we know we'll be creating a new instance.
+        # Initialize an empty one now.
+        self = cls(strings=[], patterns=[], items=[])
+
+        # If mappings are allowed, see if we were given a single mapping by
+        # trying to get items.
+        if coerceItemValue is not None:
+            rawItems = None
+            try:
+                rawItems = expression.items()
+            except AttributeError:
+                pass
+            if rawItems is not None:
+                for k, v in rawItems:
+                    try:
+                        self.items.append((k, coerceItemValue(v)))
+                    except Exception as err:
+                        raise TypeError(f"Could not coerce mapping value '{v}' for key '{k}'.") from err
+                return self
+
+        # Not ..., a CategorizedWildcard instance, or a mapping.  Just
+        # process scalars or an iterable.  We put the body of the loop inside
+        # a local function so we can recurse after coercion.
+
+        def process(element: Any, alreadyCoerced: bool = False):
+            if isinstance(element, str):
+                if defaultItemValue is not None:
+                    self.items.append((element, defaultItemValue))
+                else:
+                    self.strings.append(element)
+                return
+            if allowPatterns and isinstance(element, re.Pattern):
+                self.patterns.append(element)
+                return
+            if coerceItemValue is not None:
+                try:
+                    k, v = element
+                except TypeError:
+                    pass
+                else:
+                    if not alreadyCoerced:
+                        if not isinstance(k, str):
+                            raise TypeError(f"Item key '{k}' is not a string.")
+                        try:
+                            v = coerceItemValue(v)
+                        except Exception as err:
+                            raise TypeError(f"Could not coerce tuple item value '{v}' for key '{k}'."
+                                            ) from err
+                    self.items.append((k, v))
+                    return
+            if alreadyCoerced:
+                raise TypeError(f"Object '{element}' returned by coercion function is still unrecognized.")
+            if coerceUnrecognized is not None:
+                try:
+                    process(coerceUnrecognized(element), alreadyCoerced=True)
+                except Exception as err:
+                    raise TypeError(f"Could not coerce expression element '{element}'.") from err
+            else:
+                raise TypeError(f"Unsupported object in wildcard expression: '{element}'.")
+
+        for element in iterable(expression):
+            process(element)
         return self
 
     def makeWhereExpression(self, column: sqlalchemy.sql.ColumnElement
                             ) -> Optional[sqlalchemy.sql.ColumnElement]:
         """Transform the wildcard into a SQLAlchemy boolean expression suitable
         for use in a WHERE clause.
-
-        This only makes use of the items in `strings` and `patterns`; anything
-        in `others` must be handled separately.
 
         Parameters
         ----------
@@ -117,28 +233,472 @@ class CategorizedWildcard:
             if both `strings` and `patterns` are empty, and hence no match is
             possible.
         """
+        if self.items:
+            raise NotImplementedError("Expressions that are processed into items cannot be transformed "
+                                      "automatically into queries.")
+        if self.patterns:
+            raise NotImplementedError("Regular expression patterns are not yet supported here.")
         terms = []
         if len(self.strings) == 1:
             terms.append(column == self.strings[0])
         elif len(self.strings) > 1:
             terms.append(column.in_(self.strings))
-        terms.extend(column.like(pattern) for pattern in self.patterns)
+        # TODO: append terms for regular expressions
         if not terms:
             return None
         return sqlalchemy.sql.or_(*terms)
 
     strings: List[str]
-    """Explicit string values found in the wildcard, either because it is a
-    scalar string or a sequence that contains one or more strings.
+    """Explicit string values found in the wildcard (`list` [ `str` ]).
     """
 
-    patterns: List[str]
-    """The `Like.pattern` attributes of any `Like` instances found in the
-    wildcard, either because it is a scalar `Like` or a sequence that contains
-    one or more `Like` instances.
+    patterns: List[re.Pattern]
+    """Regular expression patterns found in the wildcard
+    (`list` [ `re.Pattern` ]).
     """
 
-    other: List[Any]
-    """Any objects in the wildcard that are not `str` or `Like` instances
-    or iterables.
+    items: List[Tuple[str, Any]]
+    """Two-item tuples that relate string values to other objects
+    (`list` [ `tuple` [ `str`, `Any` ] ]).
     """
+
+
+class DatasetTypeRestriction:
+    """An immutable set-like object that represents a restriction on the
+    dataset types to search for within a collection.
+
+    The `fromExpression` method should almost always be used to construct
+    instances, as the regular constructor performs no checking of inputs (and
+    that can lead to confusing error messages downstream).
+
+    Parameters
+    ----------
+    names : `frozenset` [`str`] or `...`
+        The names of the dataset types included in the restriction, or `...`
+        to permit a search for any dataset type.
+
+    Notes
+    -----
+    This class does not inherit from `collections.abc.Set` (and does not
+    implement the full set interface) because is not always iterable and
+    sometimes has no length (i.e. when ``names`` is ``...``).
+    """
+    def __init__(self, names: Union[FrozenSet[str], type(...)]):
+        self.names = names
+
+    __slots__ = ("names",)
+
+    @classmethod
+    def fromExpression(cls, expression: Any) -> DatasetTypeRestriction:
+        """Process a general expression to construct a `DatasetTypeRestriction`
+        instance.
+
+        Parameters
+        ----------
+        expression
+            May be:
+             - a `DatasetType` instance;
+             - a `str` dataset type name;
+             - any non-mapping iterable containing either of the above;
+             - the special value `...`;
+             - another `DatasetTypeRestriction` instance (passed through
+               unchanged).
+
+        Returns
+        -------
+        restriction : `DatasetTypeRestriction`
+            A `DatasetTypeRestriction` instance.
+        """
+        if isinstance(expression, cls):
+            return expression
+        wildcard = CategorizedWildcard.fromExpression(expression, allowPatterns=False,
+                                                      coerceUnrecognized=lambda d: d.name)
+        if wildcard is ...:
+            return cls.any
+        else:
+            return cls(frozenset(wildcard.strings))
+
+    def __contains__(self, datasetType: DatasetType) -> bool:
+        return (self.names is ... or datasetType.name in self.names
+                or (datasetType.isComponent()
+                    and DatasetType.splitDatasetTypeName(datasetType.name)[0] in self.names))
+
+    def __eq__(self, other: CollectionSearch) -> bool:
+        return self.names == other.names
+
+    def __str__(self) -> str:
+        if self.names is ...:
+            return "..."
+        else:
+            return "{{{}}}".format(", ".join(self.names))
+
+    def __repr__(self) -> str:
+        if self.names is ...:
+            return f"DatasetTypeRestriction(...)"
+        else:
+            return f"DatasetTypeRestriction({self.names!r})"
+
+    @staticmethod
+    def union(*args: DatasetTypeRestriction) -> DatasetTypeRestriction:
+        """Merge one or more `DatasetTypeRestriction` instances, returning one
+        that allows any of the dataset types included in any of them.
+
+        Parameters
+        ----------
+        args
+            Positional arguments are `DatasetTypeRestriction` instances.
+        """
+        if any(a.names is ... for a in args):
+            return DatasetTypeRestriction.any
+        return DatasetTypeRestriction(frozenset.union(*tuple(a.names for a in args)))
+
+    names: Union[FrozenSet[str], type(...)]
+    """The names of the dataset types included (i.e. permitted) by the
+    restriction, or the special value `...` to permit all dataset types
+    (`frozenset` [ `str` ] or `...`).
+    """
+
+
+DatasetTypeRestriction.any = DatasetTypeRestriction(...)
+"""A special `DatasetTypeRestriction` instance that permits any dataset type.
+
+This instance should be preferred instead of constructing a new one with `...`,
+when possible, but it should not be assumed to be the only such instance (i.e.
+don't use ``is`` instead of ``==`` for comparisons).
+"""
+
+
+def _yieldCollectionRecords(
+    record: CollectionRecord,
+    restriction: DatasetTypeRestriction,
+    datasetType: Optional[DatasetType] = None,
+    collectionType: Optional[CollectionType] = None,
+    withRestrictions: bool = False,
+    done: Optional[Set[str]] = None,
+) -> Iterator[CollectionRecord]:
+    """A helper function containing common logic for `CollectionSearch.iter`
+    and `CollectionQuery.iter`: yield a single `CollectionRecord` only if it
+    matches the criteria given in other arguments.
+
+    Parameters
+    ----------
+    record : `CollectionRecord`
+        Record to conditionally yield.
+    restriction : `DatasetTypeRestriction`
+        A restriction that must match ``datasetType`` (if given) in order to
+        yield ``record``.
+    datasetType : `DatasetType`, optional
+        If given, a `DatasetType` instance that must be included in
+        ``restriction`` in order to yield ``record``.
+    collectionType : `CollectionType`, optional
+        If given, a `CollectionType` enumeration value that must match
+        ``record.type`` in order for ``record`` to be yielded.
+    withRestrictions : `bool`, optional
+        If `True` (`False` is default), yield ``restriction`` along with
+        ``record``.
+    done : `set` [ `str` ], optional
+        A `set` of already-yielded collection names; if provided, ``record``
+        will only be yielded if it is not already in ``done``, and ``done``
+        will be updated to include it on return.
+
+    Yields
+    ------
+    record : `CollectionRecord`
+        The given collection record.
+    restriction : `DatasetTypeRestriction`
+        The given dataset type restriction; yielded only if
+        ``withRestrictions`` is `True`.
+    """
+    if collectionType is None or record.type is collectionType:
+        done.add(record.name)
+        if withRestrictions:
+            yield record, restriction
+        else:
+            yield record
+
+
+class CollectionSearch:
+    """An ordered search path of collections and dataset type restrictions.
+
+    The `fromExpression` method should almost always be used to construct
+    instances, as the regular constructor performs no checking of inputs (and
+    that can lead to confusing error messages downstream).
+
+    Parameters
+    ----------
+    items : `list` [ `tuple` [ `str`, `DatasetTypeRestriction` ] ]
+        Tuples that relate a collection name to the restriction on dataset
+        types to search for within it.  This is not a mapping because the
+        same collection name may appear multiple times with different
+        restrictions.
+
+    Notes
+    -----
+    A `CollectionSearch` is used to find a single dataset according to its
+    dataset type and data ID, giving preference to collections in which the
+    order they are specified.  A `CollectionQuery` can be constructed from
+    a broader range of expressions but does not order the collections to be
+    searched.
+
+    `CollectionSearch` is iterable, yielding two-element tuples of `str`
+    (collection name) and `DatasetTypeRestriction`.
+
+    A `CollectionSearch` instance constructed properly (e.g. via
+    `fromExpression`) is a unique representation of a particular search path;
+    it is exactly the same internally and compares as equal to any
+    `CollectionSearch` constructed from an equivalent expression,
+    regardless of how different the original expressions appear.
+    """
+    def __init__(self, items: List[Tuple[[str, DatasetTypeRestriction]]]):
+        assert all(isinstance(v, DatasetTypeRestriction) for _, v in items)
+        self._items = items
+
+    __slots__ = ("_items")
+
+    @classmethod
+    def fromExpression(cls, expression: Any) -> CollectionSearch:
+        """Process a general expression to construct a `CollectionSearch`
+        instance.
+
+        Parameters
+        ----------
+        expression
+            May be:
+             - a `str` collection name;
+             - a two-element `tuple` containing a `str` and any expression
+               accepted by `DatasetTypeRestriction.fromExpression`;
+             - any non-mapping iterable containing either of the above;
+             - a mapping from `str` to any expression accepted by
+               `DatasetTypeRestriction`.
+             - another `CollectionSearch` instance (passed through
+               unchanged).
+
+            Multiple consecutive entries for the same collection with different
+            restrictions will be merged.  Non-consecutive entries will not,
+            because that actually represents a different search path.
+
+        Returns
+        -------
+        collections : `CollectionSearch`
+            A `CollectionSearch` instance.
+        """
+        # First see if this is already a CollectionSearch; just pass that
+        # through unchanged.  This lets us standardize expressions (and turn
+        # single-pass iterators into multi-pass iterables) in advance and pass
+        # them down to other routines that accept arbitrary expressions.
+        if isinstance(expression, cls):
+            return expression
+        wildcard = CategorizedWildcard.fromExpression(expression,
+                                                      allowAny=False,
+                                                      allowPatterns=False,
+                                                      coerceItemValue=DatasetTypeRestriction.fromExpression,
+                                                      defaultItemValue=DatasetTypeRestriction.any)
+        assert wildcard is not ...
+        assert not wildcard.patterns
+        assert not wildcard.strings
+        return cls(
+            # Consolidate repetitions of the same collection name.
+            [(name, DatasetTypeRestriction.union(*tuple(item[1] for item in items)))
+             for name, items in itertools.groupby(wildcard.items, key=operator.itemgetter(0))]
+        )
+
+    def iter(
+        self, manager: CollectionManager, *,
+        datasetType: Optional[DatasetType] = None,
+        collectionType: Optional[CollectionType] = None,
+        withRestrictions: bool = False,
+        done: Optional[Set[str]] = None,
+    ) -> Iterator[CollectionRecord]:
+        """Iterate over collection records that match this instance and the
+        given criteria, in order.
+
+        This method is primarily intended for internal use by `Registry`;
+        other callers should generally prefer `Registry.findDatasets` or
+        other `Registry` query methods.
+
+        Parameters
+        ----------
+        manager : `CollectionManager`
+            Object responsible for managing the collection tables in a
+            `Registry`.
+        datasetType : `DatasetType`, optional
+            If given, only yield collections whose dataset type restrictions
+            include this dataset type.
+        collectionType : `CollectionType`, optional
+            If given, only yield collections of this type.
+        withRestrictions : `bool`, optional
+            If `True` (`False` is default) yield the associated
+            `DatasetTypeRestriction` along with each `CollectionRecord`.
+        done : `set`, optional
+            A `set` containing the names of all collections already yielded;
+            any collections whose names are already present in this set will
+            not be yielded again, and those yielded will be added to it while
+            iterating.  If not provided, an empty `set` will be created and
+            used internally to avoid duplicates.
+        """
+        if done is None:
+            done = set()
+        for name, restriction in self._items:
+            if name not in done and (datasetType is None or datasetType in restriction):
+                yield from _yieldCollectionRecords(
+                    manager.find(name),
+                    restriction,
+                    datasetType=datasetType,
+                    collectionType=collectionType,
+                    withRestrictions=withRestrictions,
+                    done=done,
+                )
+
+    def __iter__(self) -> Iterator[Tuple[str, DatasetTypeRestriction]]:
+        yield from self._items
+
+    def __len__(self) -> bool:
+        return len(self._items)
+
+    def __eq__(self, other: CollectionSearch) -> bool:
+        return self._items == other._items
+
+    def __str__(self) -> str:
+        return "[{}]".format(", ".join(f"{k}: {v}" for k, v in self._items))
+
+    def __repr__(self) -> str:
+        return f"CollectionSearch({self._items!r})"
+
+
+class CollectionQuery:
+    """An unordered query for collections and dataset type restrictions.
+
+    The `fromExpression` method should almost always be used to construct
+    instances, as the regular constructor performs no checking of inputs (and
+    that can lead to confusing error messages downstream).
+
+    Parameters
+    ----------
+    search : `CollectionSearch` or `...`
+        An object representing an ordered search for explicitly-named
+        collections (to be interpreted here as unordered), or the special
+        value `...` indicating all collections.  `...` must be accompanied
+        by ``patterns=None``.
+    patterns : `tuple` of `re.Pattern`
+        Regular expression patterns to match against collection names.
+
+    Notes
+    -----
+    A `CollectionQuery` is used to find all matching datasets in any number
+    of collections, or to find collections themselves.
+
+    `CollectionQuery` is expected to be rarely used outside of `Registry`
+    (which uses it to back several of its "query" methods that take general
+    expressions for collections), but it may occassionally be useful outside
+    `Registry` as a way to preprocess expressions that contain single-pass
+    iterators into a form that can be used to call those `Registry` methods
+    multiple times.
+    """
+    def __init__(self, search: Union[CollectionSearch, type(...)], patterns: Optional[Tuple[str, ...]]):
+        self._search = search
+        self._patterns = patterns
+
+    __slots__ = ("_search", "_patterns")
+
+    @classmethod
+    def fromExpression(cls, expression: Any) -> Union[CollectionQuery, type(...)]:
+        """Process a general expression to construct a `CollectionQuery`
+        instance.
+
+        Parameters
+        ----------
+        expression
+            May be:
+             - a `str` collection name;
+             - a two-element `tuple` containing a `str` and any expression
+               accepted by `DatasetTypeRestriction.fromExpression`;
+             - an `re.Pattern` instance to match (with `re.Pattern.fullmatch`)
+               against collection names;
+             - any non-mapping iterable containing any of the above;
+             - a mapping from `str` to any expression accepted by
+               `DatasetTypeRestriction`.
+             - a `CollectionSearch` instance;
+             - another `CollectionQuery` instance (passed through unchanged).
+
+            Multiple consecutive entries for the same collection with different
+            restrictions will be merged.  Non-consecutive entries will not,
+            because that actually represents a different search path.
+
+        Returns
+        -------
+        collections : `CollectionQuery`
+            A `CollectionQuery` instance.
+        """
+        if isinstance(expression, cls):
+            return expression
+        if expression is ...:
+            return cls.any
+        if isinstance(expression, CollectionSearch):
+            return cls(search=expression, patterns=())
+        wildcard = CategorizedWildcard.fromExpression(expression,
+                                                      allowAny=True,
+                                                      allowPatterns=True,
+                                                      coerceItemValue=DatasetTypeRestriction.fromExpression,
+                                                      defaultItemValue=DatasetTypeRestriction.any)
+        if wildcard is ...:
+            return cls.any
+        assert not wildcard.strings
+        return cls(search=CollectionSearch.fromExpression(wildcard),
+                   patterns=tuple(wildcard.patterns))
+
+    def iter(
+        self, manager: CollectionManager, *,
+        datasetType: Optional[DatasetType] = None,
+        collectionType: Optional[CollectionType] = None,
+        withRestrictions: bool = False,
+    ) -> Iterator[CollectionRecord]:
+        """Iterate over collection records that match this instance and the
+        given criteria, in an arbitrary order.
+
+        This method is primarily intended for internal use by `Registry`;
+        other callers should generally prefer `Registry.queryDatasets` or
+        other `Registry` query methods.
+
+        Parameters
+        ----------
+        manager : `CollectionManager`
+            Object responsible for managing the collection tables in a
+            `Registry`.
+        datasetType : `DatasetType`, optional
+            If given, only yield collections whose dataset type restrictions
+            include this dataset type.
+        collectionType : `CollectionType`, optional
+            If given, only yield collections of this type.
+        withRestrictions : `bool`, optional
+            If `True` (`False` is default) yield the associated
+            `DatasetTypeRestriction` along with each `CollectionRecord`.
+        """
+        if self._search is ...:
+            yield from manager
+        else:
+            done = set()
+            yield from self._search.iter(
+                manager,
+                datasetType=datasetType,
+                collectionType=collectionType,
+                withRestrictions=withRestrictions,
+                done=done,
+            )
+            for record in manager:
+                if record.name not in done and any(p.fullmatch(record.name) for p in self._patterns):
+                    yield from _yieldCollectionRecords(
+                        record,
+                        DatasetTypeRestriction.any,
+                        datasetType=datasetType,
+                        collectionType=collectionType,
+                        withRestrictions=withRestrictions,
+                        done=done,
+                    )
+
+
+CollectionQuery.any = CollectionQuery(..., None)
+"""A special `CollectionQuery` instance that matches any collection.
+
+This instance should be preferred instead of constructing a new one with `...`,
+when possible, but it should not be assumed to be the only such instance.
+"""

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -1,0 +1,144 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = ["Like", "WildcardExpression", "CategorizedWildcard"]
+
+
+from dataclasses import dataclass
+from typing import Any, List, Optional, Sequence, Union
+
+import sqlalchemy
+
+from ..core.utils import iterable
+
+
+@dataclass(frozen=True)
+class Like:
+    """Simple wrapper around a string pattern used to indicate that a string is
+    a pattern to be used with the SQL ``LIKE`` operator rather than a complete
+    name.
+    """
+
+    pattern: str
+    """The string pattern, in SQL ``LIKE`` syntax.
+    """
+
+
+WildcardExpression = Union[str, Like, Sequence[Union[str, Like]], type(...)]
+"""Type annotation alias for the types accepted to describe a search for
+entities identified by strings.
+
+The interpretation of the allowed values is:
+ - a single `str` indicates an exact match;
+ - a `Like` instance provides a pattern to be matched with SQL's ``LIKE``
+   operator;
+ - a `list` of `str` or `Like` indicates a match against any of those;
+ - `...` indicates that any string will match.
+"""
+
+
+@dataclass
+class CategorizedWildcard:
+    """The results of preprocessing a wildcard expression to separate match
+    patterns from strings.
+
+    Should be constructed by calling `categorize` rather than invoking the
+    constructor directly.
+    """
+
+    @classmethod
+    def categorize(cls, expression: Any) -> Optional[CategorizedWildcard]:
+        """Categorize a wildcard expression.
+
+        Parameters
+        ----------
+        expression
+            The expression to parse.  If this is one of the types included in
+            `WildcardExpression`, the `strings` and `patterns` attributes will
+            be populated.  If it is (or is a sequence that contains) other
+            types, these will be added to `other`.
+
+        Returns
+        -------
+        categorized : `CategorizedWildcard` or `None`.
+            The struct describing the wildcard.  If ``expression is ...`,
+            `None` is returned.
+        """
+        if expression is ...:
+            return None
+        self = cls(strings=[], patterns=[], other=[])
+        for item in iterable(expression):
+            if isinstance(item, Like):
+                self.patterns.append(Like.pattern)
+            elif isinstance(item, str):
+                self.strings.append(item)
+            else:
+                self.other.append(item)
+        return self
+
+    def makeWhereExpression(self, column: sqlalchemy.sql.ColumnElement
+                            ) -> Optional[sqlalchemy.sql.ColumnElement]:
+        """Transform the wildcard into a SQLAlchemy boolean expression suitable
+        for use in a WHERE clause.
+
+        This only makes use of the items in `strings` and `patterns`; anything
+        in `others` must be handled separately.
+
+        Parameters
+        ----------
+        column : `sqlalchemy.sql.ColumnElement`
+            A string column in a table or query that should be compared to the
+            wildcard expression.
+
+        Returns
+        -------
+        where : `sqlalchemy.sql.ColumnElement` or `None`
+            A boolean SQL expression that evaluates to true if and only if
+            the value of ``column`` matches the wildcard.  `None` is returned
+            if both `strings` and `patterns` are empty, and hence no match is
+            possible.
+        """
+        terms = []
+        if len(self.strings) == 1:
+            terms.append(column == self.strings[0])
+        elif len(self.strings) > 1:
+            terms.append(column.in_(self.strings))
+        terms.extend(column.like(pattern) for pattern in self.patterns)
+        if not terms:
+            return None
+        return sqlalchemy.sql.or_(*terms)
+
+    strings: List[str]
+    """Explicit string values found in the wildcard, either because it is a
+    scalar string or a sequence that contains one or more strings.
+    """
+
+    patterns: List[str]
+    """The `Like.pattern` attributes of any `Like` instances found in the
+    wildcard, either because it is a scalar `Like` or a sequence that contains
+    one or more `Like` instances.
+    """
+
+    other: List[Any]
+    """Any objects in the wildcard that are not `str` or `Like` instances
+    or iterables.
+    """

--- a/python/lsst/daf/butler/script/validateButlerConfiguration.py
+++ b/python/lsst/daf/butler/script/validateButlerConfiguration.py
@@ -64,8 +64,6 @@ def build_argparser():
                                      "Gen3 Butler repository.")
     parser.add_argument("root",
                         help="Filesystem path for an existing Butler repository.")
-    parser.add_argument("--collection", "-c", default="validate", type=str,
-                        help="Collection to refer to in this repository.")
     parser.add_argument("--quiet", "-q", action="store_true",
                         help="Do not report individual failures.")
     parser.add_argument("--datasettype", "-d", action="append", type=str,
@@ -76,7 +74,7 @@ def build_argparser():
     return parser
 
 
-def validateButlerConfiguration(root, datasetTypes=None, ignore=None, quiet=False, collection="validate"):
+def validateButlerConfiguration(root, datasetTypes=None, ignore=None, quiet=False):
     """Validate a bulter configuration.
 
     Parameters
@@ -89,9 +87,6 @@ def validateButlerConfiguration(root, datasetTypes=None, ignore=None, quiet=Fals
         Dataset types to ignore.
     quiet : `bool`, optional
         If `True` report pass/fail but not details.
-    collection : `str`, optional
-        Collection to use. Sometimes this is needed to ensure that butler
-        can be instantiated properly.
 
     Returns
     -------
@@ -99,10 +94,7 @@ def validateButlerConfiguration(root, datasetTypes=None, ignore=None, quiet=Fals
         `True` if everything looks okay, `False` if there is a problem.
     """
     logFailures = not quiet
-
-    # The collection does not matter for validation but if a run is specified
-    # in the configuration then it must be consistent with this collection
-    butler = Butler(config=root, collection=collection)
+    butler = Butler(config=root)
     try:
         butler.validateConfiguration(logFailures=logFailures, datasetTypeNames=datasetTypes,
                                      ignore=ignore)
@@ -119,7 +111,7 @@ def main():
     ignore = processCommas(args.ignore)
     datasetTypes = processCommas(args.datasettype)
 
-    valid = validateButlerConfiguration(args.root, datasetTypes, ignore, args.quiet, args.collection)
+    valid = validateButlerConfiguration(args.root, datasetTypes, ignore, args.quiet)
 
     if valid:
         print("No problems encountered with configuration.")

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -2,16 +2,16 @@ datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
   root: <butlerRoot>/butler_test_repository
   templates:
-    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{collection}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
-    test_metric_comp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
-    metric2: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
-    metric3: "{collection}/{datasetType}/{instrument}"
-    metric4: "{collection}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
-    physical_filter+: "{collection}/{instrument}_{physical_filter}"
+    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
+    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric2: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
+    metric3: "{run}/{datasetType}/{instrument}"
+    metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+    physical_filter+: "{run}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
-      metric33: "{collection}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+      metric33: "{run}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/posixDatastoreP.yaml
+++ b/tests/config/basic/posixDatastoreP.yaml
@@ -8,15 +8,15 @@ datastore:
       - instrument<DummyCamComp>:
         - metric33
   templates:
-    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{collection}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
-    test_metric_comp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
-    metric3: "{collection}/{datasetType}/{instrument}"
-    metric4: "{collection}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
-    physical_filter+: "{collection}/{instrument}_{physical_filter}"
+    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric3: "{run}/{datasetType}/{instrument}"
+    metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+    physical_filter+: "{run}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
-      metric33: "{collection}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+      metric33: "{run}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/s3Datastore.yaml
+++ b/tests/config/basic/s3Datastore.yaml
@@ -2,15 +2,15 @@ datastore:
   cls: lsst.daf.butler.datastores.s3Datastore.S3Datastore
   root: s3://anybucketname/butlerRoot
   templates:
-    default: "{collection}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{collection}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
-    test_metric_comp: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
-    metric3: "{collection}/{datasetType}/{instrument}"
-    metric4: "{collection}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
-    physical_filter+: "{collection}/{instrument}_{physical_filter}"
+    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
+    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric3: "{run}/{datasetType}/{instrument}"
+    metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+    physical_filter+: "{run}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
-      metric33: "{collection}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+      metric33: "{run}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/templates/templates-nodefault.yaml
+++ b/tests/config/templates/templates-nodefault.yaml
@@ -6,7 +6,7 @@ StorageClassX: "StorageClass/{run}_{datasetType}_{instrument}_{visit}"
 pvi: "{run}_{datasetType}_{instrument}_{physical_filter}"
 # For testing the dimension names match the dataId keys since there is
 # no universe
-instrument+physical_filter: "{collection}_{datasetType}_{physical_filter}_{instrument}"
+instrument+physical_filter: "{run}_{datasetType}_{physical_filter}_{instrument}"
 instrument<HSC>:
-  pvi: "HyperSuprimCam-{collection}/{datasetType}_{physical_filter}_{instrument}"
+  pvi: "HyperSuprimCam-{run}/{datasetType}_{physical_filter}_{instrument}"
   instrument+physical_filter: "hsc/{run}_{datasetType}_{physical_filter}_{instrument}"

--- a/tests/config/templates/templates-withdefault.yaml
+++ b/tests/config/templates/templates-withdefault.yaml
@@ -1,2 +1,2 @@
 # This file defines a default
-default: "{collection}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+default: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"

--- a/tests/data/registry/base.yaml
+++ b/tests/data/registry/base.yaml
@@ -1,0 +1,75 @@
+# Lowest-level reusable test data for registry tests; this includes
+# a single instrument with a few filters and detectors, and a pair
+# of dataset types.
+# More interesting test data can be layered on top of this in other
+# files.
+description: Butler Data Repository Export
+version: 0
+data:
+  -
+    type: dimension
+    element: instrument
+    records:
+      -
+        name: Cam1
+        visit_max: 1024
+        exposure_max: 512
+        detector_max: 4
+  -
+    type: dimension
+    element: physical_filter
+    records:
+      -
+        instrument: Cam1
+        name: Cam1-G
+        abstract_filter: g
+      -
+        instrument: Cam1
+        name: Cam1-R1
+        abstract_filter: r
+      -
+        instrument: Cam1
+        name: Cam1-R2
+        abstract_filter: r
+  -
+    type: dimension
+    element: detector
+    records:
+      -
+        instrument: Cam1
+        id: 1
+        raft: "A"
+        name_in_raft: "a"
+        full_name: "Aa"
+        purpose: "SCIENCE"
+      -
+        instrument: Cam1
+        id: 2
+        raft: "A"
+        name_in_raft: "b"
+        full_name: "Ab"
+        purpose: "SCIENCE"
+      -
+        instrument: Cam1
+        id: 3
+        raft: "B"
+        name_in_raft: "a"
+        full_name: "Ba"
+        purpose: "SCIENCE"
+      -
+        instrument: Cam1
+        id: 4
+        raft: "B"
+        name_in_raft: "b"
+        full_name: "Bb"
+        purpose: "WAVEFRONT"
+  -
+    type: dataset_type
+    name: permaflat
+    dimensions: [instrument, detector, physical_filter, abstract_filter]
+    storage_class: Exposure
+  -
+    type: dataset_type
+    name: permabias
+    dimensions: [instrument, detector]
+    storage_class: Exposure

--- a/tests/data/registry/datasets.yaml
+++ b/tests/data/registry/datasets.yaml
@@ -1,0 +1,125 @@
+# Dataset entries for registry tests.  This must be loaded after base.yaml.
+#
+# This contains two runs with an attempt to give them an interesting degree of
+# completeness and overlap (in data ID + dataset type; because they are
+# different runs, they cannot actually contain any common datasets).
+# In detail:
+# run=imported_g:
+#   permabias for detectors 1-3
+#   permaflat for detectors 2-4, physical_filter=Cam1-G
+# run=imported_r:
+#   permabias for detectors 2-4
+#   permaflat for detectors 1-2, physical_filter=Cam1-R1
+#   permaflat for detectors 3-4, physical_filter=Cam1-R2
+#
+# At present, the path and formatter entries here are missing.  If we ever
+# want to use this data for a tests that involves a datastore, that would need
+# to change.
+description: Butler Data Repository Export
+version: 0
+data:
+  -
+    type: run
+    name: imported_g
+  -
+    type: dataset
+    dataset_type: permabias
+    run: imported_g
+    records:
+    -
+      dataset_id: 1001
+      data_id:
+        instrument: Cam1
+        detector: 1
+    -
+      dataset_id: 1002
+      data_id:
+        instrument: Cam1
+        detector: 2
+    -
+      dataset_id: 1003
+      data_id:
+        instrument: Cam1
+        detector: 3
+  -
+    type: dataset
+    dataset_type: permaflat
+    run: imported_g
+    records:
+    -
+      dataset_id: 1010
+      data_id:
+        instrument: Cam1
+        detector: 2
+        physical_filter: Cam1-G
+        abstract_filter: g
+    -
+      dataset_id: 1020
+      data_id:
+        instrument: Cam1
+        detector: 3
+        physical_filter: Cam1-G
+        abstract_filter: g
+    -
+      dataset_id: 1030
+      data_id:
+        instrument: Cam1
+        detector: 4
+        physical_filter: Cam1-G
+        abstract_filter: g
+  -
+    type: run
+    name: imported_r
+  -
+    type: dataset
+    dataset_type: permabias
+    run: imported_r
+    records:
+    -
+      dataset_id: 2001
+      data_id:
+        instrument: Cam1
+        detector: 2
+    -
+      dataset_id: 2002
+      data_id:
+        instrument: Cam1
+        detector: 3
+    -
+      dataset_id: 2003
+      data_id:
+        instrument: Cam1
+        detector: 4
+  -
+    type: dataset
+    dataset_type: permaflat
+    run: imported_r
+    records:
+    -
+      dataset_id: 2010
+      data_id:
+        instrument: Cam1
+        detector: 1
+        physical_filter: Cam1-R1
+        abstract_filter: r
+    -
+      dataset_id: 2020
+      data_id:
+        instrument: Cam1
+        detector: 2
+        physical_filter: Cam1-R1
+        abstract_filter: r
+    -
+      dataset_id: 2030
+      data_id:
+        instrument: Cam1
+        detector: 3
+        physical_filter: Cam1-R2
+        abstract_filter: r
+    -
+      dataset_id: 2040
+      data_id:
+        instrument: Cam1
+        detector: 4
+        physical_filter: Cam1-R2
+        abstract_filter: r

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -253,7 +253,7 @@ class ButlerPutGetTests:
             self.assertEqual(summary, metric.summary)
             self.assertTrue(butler.datastore.exists(ref.components["summary"]))
 
-            compRef = butler.registry.find(butler.collection, compNameS, dataId)
+            compRef = butler.registry.findDataset(compNameS, dataId, collection=butler.collection)
             butler.prune([compRef], unstore=True)
             with self.assertRaises(LookupError):
                 butler.datasetExists(compNameS, dataId)
@@ -570,7 +570,7 @@ class ButlerTests(ButlerPutGetTests):
         with self.assertRaises(KeyError):
             butler.get(datasetTypeName, dataId)
         # Also check explicitly if Dataset entry is missing
-        self.assertIsNone(butler.registry.find(butler.collection, datasetType, dataId))
+        self.assertIsNone(butler.registry.findDataset(datasetType, dataId, collection=butler.collection))
         # Direct retrieval should not find the file in the Datastore
         with self.assertRaises(FileNotFoundError):
             butler.getDirect(ref)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -253,7 +253,7 @@ class ButlerPutGetTests:
             self.assertEqual(summary, metric.summary)
             self.assertTrue(butler.datastore.exists(ref.components["summary"]))
 
-            compRef = butler.registry.findDataset(compNameS, dataId, collection=butler.collection)
+            compRef = butler.registry.findDataset(compNameS, dataId, collections=[butler.collection])
             butler.prune([compRef], unstore=True)
             with self.assertRaises(LookupError):
                 butler.datasetExists(compNameS, dataId)
@@ -570,7 +570,7 @@ class ButlerTests(ButlerPutGetTests):
         with self.assertRaises(KeyError):
             butler.get(datasetTypeName, dataId)
         # Also check explicitly if Dataset entry is missing
-        self.assertIsNone(butler.registry.findDataset(datasetType, dataId, collection=butler.collection))
+        self.assertIsNone(butler.registry.findDataset(datasetType, dataId, collections=[butler.collection]))
         # Direct retrieval should not find the file in the Datastore
         with self.assertRaises(FileNotFoundError):
             butler.getDirect(ref)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -130,7 +130,7 @@ class ButlerPutGetTests:
         butler = Butler(self.tmpConfigFile, run="ingest/run", collection="ingest")
 
         # There will not be a collection yet
-        collections = butler.registry.getAllCollections()
+        collections = set(butler.registry.queryCollections())
         self.assertEqual(collections, set(["ingest", "ingest/run"]))
 
         # Create and register a DatasetType
@@ -282,7 +282,7 @@ class ButlerPutGetTests:
             butler.get(ref, parameters={"unsupported": True})
 
         # Check we have a collection
-        collections = butler.registry.getAllCollections()
+        collections = set(butler.registry.queryCollections())
         self.assertEqual(collections, {"ingest", "ingest/run"})
 
         # Clean up to check that we can remove something that may have
@@ -361,7 +361,7 @@ class ButlerTests(ButlerPutGetTests):
         butler = Butler(self.tmpConfigFile, run="ingest")
         self.assertIsInstance(butler, Butler)
 
-        collections = butler.registry.getAllCollections()
+        collections = set(butler.registry.queryCollections())
         self.assertEqual(collections, {"ingest"})
 
         butler2 = Butler(butler=butler, collection="other")
@@ -509,7 +509,7 @@ class ButlerTests(ButlerPutGetTests):
             for componentName in storageClass.components:
                 components.add(DatasetType.nameWithComponent(datasetTypeName, componentName))
 
-        fromRegistry = butler.registry.getAllDatasetTypes()
+        fromRegistry = set(butler.registry.queryDatasetTypes())
         self.assertEqual({d.name for d in fromRegistry}, datasetTypeNames | components)
 
         # Now that we have some dataset types registered, validate them
@@ -606,9 +606,9 @@ class ButlerTests(ButlerPutGetTests):
         self.assertNotIn(self.fullConfigKey, limited)
 
         # Collections don't appear until something is put in them
-        collections1 = butler1.registry.getAllCollections()
+        collections1 = set(butler1.registry.queryCollections())
         self.assertEqual(collections1, set())
-        self.assertEqual(butler2.registry.getAllCollections(), collections1)
+        self.assertEqual(set(butler2.registry.queryCollections()), collections1)
 
         # Check that a config with no associated file name will not
         # work properly with relocatable Butler repo

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -299,6 +299,7 @@ class ButlerPutGetTests:
 
         return butler
 
+    def testDeferredCollectionPassing(self):
         # Construct a butler with no run or collection, but make it writeable.
         butler = Butler(self.tmpConfigFile, writeable=True)
         # Create and register a DatasetType
@@ -339,7 +340,7 @@ class ButlerPutGetTests:
         # Deleting the dataset from the new collection should make it findable
         # in the original collection.
         butler.prune([ref], collection="tagged")
-        self.assertFalse(butler.datasetExists(datasetType, dataId, collection=run))
+        self.assertTrue(butler.datasetExists(datasetType, dataId, collection=run))
 
 
 class ButlerTests(ButlerPutGetTests):

--- a/tests/test_matplotlibFormatter.py
+++ b/tests/test_matplotlibFormatter.py
@@ -76,7 +76,7 @@ class MatplotlibFormatterTestCase(unittest.TestCase):
         self.assertTrue(butler.datasetExists(ref))
         with self.assertRaises(ValueError):
             butler.get(ref)
-        butler.remove(ref)
+        butler.prune([ref], unstore=True, purge=True)
         with self.assertRaises(LookupError):
             butler.datasetExists(ref)
 

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -157,6 +157,10 @@ class OracleRegistryTestCase(unittest.TestCase, RegistryTests):
     def tearDownClass(cls):
         cleanUpPrefixes(cls._connection, cls._prefixes)
 
+    @classmethod
+    def getDataDir(cls) -> str:
+        return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
+
     def makeRegistry(self) -> Registry:
         prefix = f"test_{secrets.token_hex(8).lower()}_"
         self._prefixes.append(prefix)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from contextlib import contextmanager
 import secrets
 import unittest
@@ -134,6 +135,10 @@ class PostgresqlRegistryTestCase(unittest.TestCase, RegistryTests):
     @classmethod
     def tearDownClass(cls):
         cls.server.stop()
+
+    @classmethod
+    def getDataDir(cls) -> str:
+        return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
     def makeRegistry(self) -> Registry:
         namespace = f"namespace_{secrets.token_hex(8).lower()}"

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -184,6 +184,10 @@ class SqliteFileRegistryTestCase(unittest.TestCase, RegistryTests):
         if self.root is not None and os.path.exists(self.root):
             shutil.rmtree(self.root, ignore_errors=True)
 
+    @classmethod
+    def getDataDir(cls) -> str:
+        return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
+
     def makeRegistry(self) -> Registry:
         _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
         config = RegistryConfig()
@@ -194,6 +198,10 @@ class SqliteFileRegistryTestCase(unittest.TestCase, RegistryTests):
 class SqliteMemoryRegistryTestCase(unittest.TestCase, RegistryTests):
     """Tests for `Registry` backed by a SQLite in-memory database.
     """
+
+    @classmethod
+    def getDataDir(cls) -> str:
+        return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
     def makeRegistry(self) -> Registry:
         config = RegistryConfig()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -57,12 +57,12 @@ class TestFileTemplates(unittest.TestCase):
         self.assertTemplate(tmplstr,
                             "run2/calexp/00052/U",
                             self.makeDatasetRef("calexp", conform=False))
-        tmplstr = "{collection}/{datasetType}/{visit:05d}/{physical_filter}-trail"
+        tmplstr = "{run}/{datasetType}/{visit:05d}/{physical_filter}-trail"
         self.assertTemplate(tmplstr,
                             "run2/calexp/00052/U-trail",
                             self.makeDatasetRef("calexp", conform=False))
 
-        tmplstr = "{collection}/{datasetType}/{visit:05d}/{physical_filter}-trail-{run}"
+        tmplstr = "{run}/{datasetType}/{visit:05d}/{physical_filter}-trail-{run}"
         self.assertTemplate(tmplstr,
                             "run2/calexp/00052/U-trail-run2",
                             self.makeDatasetRef("calexp", conform=False))
@@ -70,8 +70,8 @@ class TestFileTemplates(unittest.TestCase):
                             "run_2/calexp/00052/U-trail-run_2",
                             self.makeDatasetRef("calexp", run="run/2", conform=False))
 
-        # Retain any "/" in collection
-        tmplstr = "{collection:/}/{datasetType}/{visit:05d}/{physical_filter}-trail-{run}"
+        # Retain any "/" in run
+        tmplstr = "{run:/}/{datasetType}/{visit:05d}/{physical_filter}-trail-{run}"
         self.assertTemplate(tmplstr,
                             "run/2/calexp/00052/U-trail-run_2",
                             self.makeDatasetRef("calexp", run="run/2", conform=False))
@@ -143,22 +143,22 @@ class TestFileTemplates(unittest.TestCase):
         self.assertTemplate(tmplstr, "output/run2_output_52", refMetricOutput)
 
         # Providing a component but not using it
-        tmplstr = "{collection}/{datasetType}/v{visit:05d}"
+        tmplstr = "{run}/{datasetType}/v{visit:05d}"
         with self.assertRaises(KeyError):
             self.assertTemplate(tmplstr, "", refWcs)
 
     def testFields(self):
         # Template, mandatory fields, optional non-special fields,
         # special fields, optional special fields
-        testData = (("{collection}/{datasetType}/{visit:05d}/{physical_filter}-trail",
+        testData = (("{run}/{datasetType}/{visit:05d}/{physical_filter}-trail",
                      set(["visit", "physical_filter"]),
                      set(),
-                     set(["collection", "datasetType"]),
+                     set(["run", "datasetType"]),
                      set()),
-                    ("{collection}/{component:?}_{visit}",
+                    ("{run}/{component:?}_{visit}",
                      set(["visit"]),
                      set(),
-                     set(["collection"]),
+                     set(["run"]),
                      set(["component"]),),
                     ("{run}/{component:?}_{visit:?}_{physical_filter}_{instrument}_{datasetType}",
                      set(["physical_filter", "instrument"]),

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -104,7 +104,7 @@ class ButlerUtilsTestSuite(unittest.TestCase):
 
     def testAddDatasetType(self):
         # 1 for StructuredDataNoComponents, 4 for StructuredData
-        self.assertEqual(len(self.butler.registry.getAllDatasetTypes()), 5)
+        self.assertEqual(len(list(self.butler.registry.queryDatasetTypes())), 5)
 
         # Testing the DatasetType objects is not practical, because all tests
         # need a DimensionUniverse. So just check that we have the dataset


### PR DESCRIPTION
There are a few mostly-separate projects here (and a lot of miscellaneous prep work), combined in one branch to yield only one set of disruptive changes downstream (rather than four).  I've tried hard to keep the commits for those projects separate, but sadly GitHub's chronological rather than topological ordering makes that particularly hard to see.  Here are the commits ordered topologically and grouped by project:

Various cleanups to existing code and other prep work (recommended reviewer @timj):
- 91929abdad2ddec797b848f235e81c50e76f820f
- 837bf0db514e30e6bfa53c53b4db3ed0ed192604
- b58233d549825e6020b175f010f1caa8fd2ad000
- 8be92eb399bea2e6d22c4963173692dd350d30c5 (note that this refactor is extended significantly in a1abbc16994b6f5999758f8cd043e84814db57b4)
- 35d718f0f34742a1fe7b5c935fa8c4c60d57941e
- 40748ecb2c73a7b83cd4b9e3d960d2bc8263639b
- b1599a7ff39edc97f6d30a120b615791278ff2e9
- 90180bfd7d8f50d35ef737fcf2c73b35f4294e9f
- 8815607513371a31b15b6ff7b555e155a8b7899a
- 2cfca3f381b7d5c8a3bcb1b2bf9d10deb84dd8b3
- 2ede6d09ac435fbf530975acbcdc14a8454d0d3a
- 832e86d7f952fc48b8a806d785f13191add03d6b

Reimplement collections in Registry ala prototype, and make runs a type of collection (recommended reviewer @andy-slac):
- 7e1bfa0349c96cbeb8a5d78bcc487e3837a6a7f8
- 05dcd339afe2c7354606d9cbabe751c4b8896b57
- 38ec71c84e1c6bc74a71d76874375c87015ef8b7


Move multi-collection support into Registry and Butler, add CHAINED collections (no preference for reviewer):
- 9d1416db26e9aabcd8ee954330ca08d7e8975bc5
- a1abbc16994b6f5999758f8cd043e84814db57b4
- b4f007c4d06ccc789c10f0037a7bc24de5fc2ff7
- 7baa4bc59c9f8814be01d6d3161bccb6fd84b07f
- b23fd52f2058f7a8f48f9e17d73b94c921e007a8
- f07595fc6b761407d130c2e6f3ab42d9dcb0f6ae
- 1bd64fd1bcd63c88dbf4f7772a5f18aa47a1b6c5