### PR TITLE
DM-23729: Remove cpBias/cpFlat from butler configurations

### DIFF
--- a/config/datastores/formatters.yaml
+++ b/config/datastores/formatters.yaml
@@ -40,5 +40,3 @@ NumpyArray: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
 Plot: lsst.daf.butler.formatters.matplotlibFormatter.MatplotlibFormatter
 MetricValue: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
 BrighterFatterKernel: lsst.daf.butler.formatters.pickleFormatter.PickleFormatter
-cpBias: lsst.obs.decam.DarkEnergyCameraCPCalibFormatter
-cpFlat: lsst.obs.decam.DarkEnergyCameraCPCalibFormatter

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -148,7 +148,3 @@ storageClasses:
     pytype: matplotlib.figure.Figure
   MetricValue:
     pytype: lsst.verify.Measurement
-  cpBias:
-    pytype: lsst.afw.image.ExposureF
-  cpFlat:
-    pytype: lsst.afw.image.ExposureF

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ("Formatter", "FormatterFactory")
+__all__ = ("Formatter", "FormatterFactory", "FormatterParameter")
 
 from abc import ABCMeta, abstractmethod
 import logging
@@ -465,3 +465,7 @@ class FormatterFactory:
             ``overwrite`` is `False`.
         """
         self._mappingFactory.placeInRegistry(type_, formatter, overwrite=overwrite)
+
+
+# Type to use when allowing a Formatter or its class name
+FormatterParameter = Union[None, str, Type[Formatter]]

--- a/python/lsst/daf/butler/core/repoTransfers.py
+++ b/python/lsst/daf/butler/core/repoTransfers.py
@@ -28,7 +28,7 @@ __all__ = ["FileDataset", "RepoExport",
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, Optional, IO, List, Mapping, Tuple, Callable, Union, Type
+from typing import TYPE_CHECKING, Iterable, Optional, IO, List, Mapping, Tuple, Callable, Union
 from collections import defaultdict
 
 import yaml
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from .dimensions import DimensionElement, DimensionRecord, ExpandedDataCoordinate
     from ..registry import Registry
     from .datastore import Datastore
-    from .formatters import Formatter
+    from .formatter import FormatterParameter
 
 
 class RepoTransferFormatConfig(ConfigSubset):
@@ -73,12 +73,12 @@ class FileDataset:
     to `Datastore.export`.
     """
 
-    formatter: Union[None, str, Type[Formatter]]
+    formatter: FormatterParameter
     """A `Formatter` class or fully-qualified name.
     """
 
     def __init__(self, path: str, refs: Union[DatasetRef, List[DatasetRef]], *,
-                 formatter: Union[None, str, Type[Formatter]] = None):
+                 formatter: FormatterParameter = None):
         self.path = path
         if isinstance(refs, DatasetRef):
             refs = [refs]


### PR DESCRIPTION
They aren't storage classes but are specialist dataset types
for DECam that should be handled by instrument classes.