### PR TITLE
DM-23975: Convert subfilter type to int

### DIFF
--- a/config/dimensions.yaml
+++ b/config/dimensions.yaml
@@ -76,10 +76,9 @@ dimensions:
         refraction.
       keys:
       -
-        name: name
-        type: string
-        length: 18
-      implies:
+        name: id
+        type: int
+      requires:
       - abstract_filter
       cached: true
 

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1124,7 +1124,7 @@ class Registry:
         else:
             records = dict(records) if records is not None else {}
         keys = dict(standardized)
-        for element in standardized.graph._primaryKeyTraversalOrder:
+        for element in standardized.graph.primaryKeyTraversalOrder:
             record = records.get(element.name, ...)  # Use ... to mean not found; None might mean NULL
             if record is ...:
                 storage = self._dimensions[element]


### PR DESCRIPTION
`abstract_filter` is now a required dependency of `subfilter`
`subfilter` is now an `int`