### PR TITLE
DM-24018: fix bug in unrestricted queries over collections

### DIFF
--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -66,6 +66,7 @@ class CollectionRecord(ABC):
     def __init__(self, name: str, type: CollectionType):
         self.name = name
         self.type = type
+        assert isinstance(self.type, CollectionType)
 
     @property
     @abstractmethod

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -331,6 +331,10 @@ class RegistryTests(ABC):
         self.assertIs(registry.getCollectionType(chain1), CollectionType.CHAINED)
         # Chained collection exists, but has no collections in it.
         self.assertFalse(registry.getCollectionChain(chain1))
+        # If we query for all collections, we should get the chained collection
+        # only if we don't ask to flatten it (i.e. yield only its children).
+        self.assertEqual(set(registry.queryCollections(flattenChains=False)), {tag1, run1, run2, chain1})
+        self.assertEqual(set(registry.queryCollections(flattenChains=True)), {tag1, run1, run2})
         # Attempt to set its child collections to something circular; that
         # should fail.
         with self.assertRaises(ValueError):

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -421,6 +421,8 @@ def _yieldCollectionRecords(
         The given dataset type restriction; yielded only if
         ``withRestrictions`` is `True`.
     """
+    if done is None:
+        done = set()
     includeChains = includeChains if includeChains is not None else not flattenChains
     if collectionType is None or record.type is collectionType:
         done.add(record.name)
@@ -722,7 +724,17 @@ class CollectionQuery:
             their children, but not both.
         """
         if self._search is ...:
-            yield from manager
+            for record in manager:
+                yield from _yieldCollectionRecords(
+                    manager,
+                    record,
+                    DatasetTypeRestriction.any,
+                    datasetType=datasetType,
+                    collectionType=collectionType,
+                    withRestrictions=withRestrictions,
+                    flattenChains=flattenChains,
+                    includeChains=includeChains,
+                )
         else:
             done = set()
             yield from self._search.iter(


### PR DESCRIPTION
The code path for iterating over collections with the (default) no-restriction expression `...` didn't take into account arguments that indicated how to handle chained collections, causing downstream code to die when it specified that it wanted their children, rather than the chained collections themselves.
