### PR TITLE
DM-15890: Use nanoseconds to represent time in database

### DIFF
--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -57,10 +57,12 @@ EPOCH = astropy.time.Time("1970-01-01 00:00:00", format="iso", scale="tai")
 stored in the database.
 """
 
-MAX_TIME = astropy.time.Time("2038-01-19 03:14:07", format="iso", scale="tai")
+MAX_TIME = astropy.time.Time("2100-01-01 00:00:00", format="iso", scale="tai")
 """Maximum time value that we can store. Assuming 64-bit integer field we
-can actuially store higher values but we intentionally limit it to 2**31-1
-seconds since epoch.
+can actually store higher values but we intentionally limit it to arbitrary
+but reasonably high value. Note that this value will be stored in registry
+database for eternity, so it should not be changed without proper
+consideration.
 """
 
 

--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -31,19 +31,34 @@ databases, a "schema" is also another term for a namespace.
 """
 from __future__ import annotations
 
-__all__ = ("TableSpec", "FieldSpec", "ForeignKeySpec", "Base64Bytes", "Base64Region")
+__all__ = ("TableSpec", "FieldSpec", "ForeignKeySpec", "Base64Bytes", "Base64Region",
+           "AstropyTimeNsecTai")
 
 from base64 import b64encode, b64decode
 from math import ceil
 from dataclasses import dataclass
 from typing import Optional, Tuple, Sequence, Set
+import warnings
 
 import sqlalchemy
+import astropy.time
 
 from lsst.sphgeom import ConvexPolygon
 from .config import Config
 from .exceptions import ValidationError
 from .utils import iterable, stripIfNotNone, NamedValueSet
+
+# These constants can be used by client code
+EPOCH = astropy.time.Time("1970-01-01 00:00:00", format="iso", scale="tai")
+"""Epoch for calculating time delta, this is the minimum time that can be
+stored in the database.
+"""
+
+MAX_TIME = astropy.time.Time("2038-01-19 03:14:07", format="iso", scale="tai")
+"""Maximum time value that we can store. Assuming 64-bit integer field we
+can actuially store higher values but we intentionally limit it to 2**31-1
+seconds since epoch.
+"""
 
 
 class SchemaValidationError(ValidationError):
@@ -125,6 +140,37 @@ class Base64Region(Base64Bytes):
         return ConvexPolygon.decode(super().process_result_value(value, dialect))
 
 
+class AstropyTimeNsecTai(sqlalchemy.TypeDecorator):
+    """A SQLAlchemy custom type that maps Python `astropy.time.Time` to a
+    number of nanoseconds sunce Unix epoch in TAI scale.
+    """
+
+    impl = sqlalchemy.BigInteger
+
+    def process_bind_param(self, value, dialect):
+        # value is astropy.time.Time or None
+        if value is None:
+            return None
+        # anyhting before epoch or after MAX_TIME is truncated
+        if value < EPOCH:
+            warnings.warn(f"{value} is earlier than epoch time {EPOCH}, "
+                          f"epoch time will be used instead")
+            value = EPOCH
+        elif value > MAX_TIME:
+            warnings.warn(f"{value} is later than max. time {MAX_TIME}, "
+                          f"max. time time will be used instead")
+            value = MAX_TIME
+        value = round((value - EPOCH).to_value("sec") * 1e9)
+        return int(value)
+
+    def process_result_value(self, value, dialect):
+        # value is nanoseconds since epoch, or None
+        if value is None:
+            return None
+        delta = astropy.time.TimeDelta(value * 1e-9, format="sec")
+        return EPOCH + delta
+
+
 VALID_CONFIG_COLUMN_TYPES = {
     "string": sqlalchemy.String,
     "int": sqlalchemy.Integer,
@@ -132,7 +178,7 @@ VALID_CONFIG_COLUMN_TYPES = {
     "region": Base64Region,
     "bool": sqlalchemy.Boolean,
     "blob": sqlalchemy.LargeBinary,
-    "datetime": sqlalchemy.DateTime,
+    "datetime": AstropyTimeNsecTai,
     "hash": Base64Bytes
 }
 

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -21,7 +21,7 @@
 
 __all__ = ("Quantum",)
 
-from datetime import datetime
+import astropy.time
 
 from lsst.utils import doImport
 
@@ -65,9 +65,9 @@ class Quantum:
     outputs : `~collections.abc.Mapping`, optional
         Outputs from executing this quantum of work, organized as a mapping
         from `DatasetType` to a list of `DatasetRef`.
-    startTime : `datetime`
+    startTime : `astropy.time.Time`
         The start time for the quantum.
-    endTime : `datetime`
+    endTime : `astropy.time.Time`
         The end time for the quantum.
     host : `str`
         The system on this quantum was executed.
@@ -225,14 +225,16 @@ class Quantum:
         return self._id
 
     @property
-    def startTime(self) -> datetime:
-        """Begin timestamp for the execution of this quantum (`datetime`).
+    def startTime(self) -> astropy.time.Time:
+        """Begin timestamp for the execution of this quantum
+        (`astropy.time.Time`).
         """
         return self._startTime
 
     @property
-    def endTime(self) -> datetime:
-        """End timestamp for the execution of this quantum (`datetime`).
+    def endTime(self) -> astropy.time.Time:
+        """End timestamp for the execution of this quantum
+        (`astropy.time.Time`).
         """
         return self._endTime
 

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -20,15 +20,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = ("Timespan", "TIMESPAN_FIELD_SPECS")
+__all__ = ("Timespan", "TIMESPAN_FIELD_SPECS", "TIMESPAN_MIN", "TIMESPAN_MAX")
 
 import operator
 from typing import Generic, Optional, TypeVar
 
-from sqlalchemy import DateTime
-
 from . import ddl
 
+
+TIMESPAN_MIN = ddl.EPOCH
+TIMESPAN_MAX = ddl.MAX_TIME
 
 T = TypeVar("T")
 
@@ -65,7 +66,9 @@ class Timespan(Generic[T], tuple):
         return (self.begin, self.end)
 
 
+# For timestamps we use Unix time in nanoseconds in TAI scale which need
+# 64-bit integer,
 TIMESPAN_FIELD_SPECS = Timespan(
-    begin=ddl.FieldSpec(name="datetime_begin", dtype=DateTime),
-    end=ddl.FieldSpec(name="datetime_end", dtype=DateTime),
+    begin=ddl.FieldSpec(name="datetime_begin", dtype=ddl.AstropyTimeNsecTai),
+    end=ddl.FieldSpec(name="datetime_end", dtype=ddl.AstropyTimeNsecTai),
 )

--- a/python/lsst/daf/butler/registry/tables.py
+++ b/python/lsst/daf/butler/registry/tables.py
@@ -177,13 +177,13 @@ def makeRegistryTableSpecs(universe: DimensionUniverse, collections: CollectionM
             ),
             ddl.FieldSpec(
                 name="start_time",
-                dtype=sqlalchemy.DateTime,
+                dtype=ddl.AstropyTimeNsecTai,
                 nullable=True,
                 doc="The start time for the quantum.",
             ),
             ddl.FieldSpec(
                 name="end_time",
-                dtype=sqlalchemy.DateTime,
+                dtype=ddl.AstropyTimeNsecTai,
                 nullable=True,
                 doc="The end time for the quantum.",
             ),

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 __all__ = ["RegistryTests"]
 
 from abc import ABC, abstractmethod
-from datetime import datetime
 import os
 
+import astropy.time
 import sqlalchemy
 
 from ...core import (
@@ -784,6 +784,10 @@ class RegistryTests(ABC):
         """Test that we can look up datasets with calibration_label dimensions
         from a data ID with exposure dimensions.
         """
+
+        def _dt(iso_string):
+            return astropy.time.Time(iso_string, format="iso", scale="utc")
+
         registry = self.makeRegistry()
 
         flat = DatasetType(
@@ -811,18 +815,18 @@ class RegistryTests(ABC):
         registry.insertDimensionData(
             "exposure",
             dict(instrument="DummyCam", id=100, name="100", visit=10, physical_filter="dummy_i",
-                 datetime_begin=datetime(2005, 12, 15, 2), datetime_end=datetime(2005, 12, 15, 3)),
+                 datetime_begin=_dt("2005-12-15 02:00:00"), datetime_end=_dt("2005-12-15 03:00:00")),
             dict(instrument="DummyCam", id=101, name="101", visit=11, physical_filter="dummy_i",
-                 datetime_begin=datetime(2005, 12, 16, 2), datetime_end=datetime(2005, 12, 16, 3)),
+                 datetime_begin=_dt("2005-12-16 02:00:00"), datetime_end=_dt("2005-12-16 03:00:00")),
         )
         registry.insertDimensionData(
             "calibration_label",
             dict(instrument="DummyCam", name="first_night",
-                 datetime_begin=datetime(2005, 12, 15, 1), datetime_end=datetime(2005, 12, 15, 4)),
+                 datetime_begin=_dt("2005-12-15 01:00:00"), datetime_end=_dt("2005-12-15 04:00:00")),
             dict(instrument="DummyCam", name="second_night",
-                 datetime_begin=datetime(2005, 12, 16, 1), datetime_end=datetime(2005, 12, 16, 4)),
+                 datetime_begin=_dt("2005-12-16 01:00:00"), datetime_end=_dt("2005-12-16 04:00:00")),
             dict(instrument="DummyCam", name="both_nights",
-                 datetime_begin=datetime(2005, 12, 15, 1), datetime_end=datetime(2005, 12, 16, 4)),
+                 datetime_begin=_dt("2005-12-15 01:00:00"), datetime_end=_dt("2005-12-16 04:00:00")),
         )
         # Different flats for different nights for detectors 1-3 in first
         # collection.

--- a/tests/test_quantum.py
+++ b/tests/test_quantum.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from datetime import datetime
+import astropy.time
 
 from lsst.daf.butler import Quantum, DimensionUniverse, StorageClass, DatasetType, DatasetRef
 from lsst.daf.butler.core.utils import NamedKeyDict
@@ -40,8 +40,8 @@ class QuantumTestCase(unittest.TestCase):
         run = None  # TODO add Run
         taskName = "some.task.object"  # can't use a real PipelineTask due to inverted package dependency
         # Base class arguments
-        startTime = datetime(2018, 1, 1)
-        endTime = datetime(2018, 1, 2)
+        startTime = astropy.time.Time("2018-01-01", format="iso", scale="utc")
+        endTime = astropy.time.Time("2018-01-02", format="iso", scale="utc")
         host = "localhost"
         quantum = Quantum(taskName=taskName, run=run, startTime=startTime, endTime=endTime, host=host)
         self.assertEqual(quantum.taskName, taskName)

--- a/ups/daf_butler.table
+++ b/ups/daf_butler.table
@@ -1,3 +1,4 @@
+setupRequired(astropy)
 setupRequired(sphgeom)
 setupRequired(sqlalchemy)
 setupRequired(numpy)


### PR DESCRIPTION
Most of the code now uses astropy Time for timestamp, conversion to
nanoseconds happens in sqlalchemy type decorator. For YAML we need to
convert astropy time into Python datetime. Added two constants for
min/max times (in astropy format) supported by registry.