### PR TITLE
DM-22173: Implement parsing of time strings in user expression

### DIFF
--- a/python/lsst/daf/butler/registry/dimensions/caching.py
+++ b/python/lsst/daf/butler/registry/dimensions/caching.py
@@ -71,7 +71,7 @@ class CachingDimensionRecordStorage(DimensionRecordStorage):
         timespans: Optional[NamedKeyDict[DimensionElement, Timespan[sqlalchemy.sql.ColumnElement]]] = None,
     ):
         # Docstring inherited from DimensionRecordStorage.
-        self._nested.join(builder, regions=regions, timespans=timespans)
+        return self._nested.join(builder, regions=regions, timespans=timespans)
 
     def insert(self, *records: DimensionRecord):
         # Docstring inherited from DimensionRecordStorage.insert.

--- a/python/lsst/daf/butler/registry/dimensions/query.py
+++ b/python/lsst/daf/butler/registry/dimensions/query.py
@@ -127,6 +127,7 @@ class QueryDimensionRecordStorage(DimensionRecordStorage):
         joinOn = builder.startJoin(self._query, list(self.element.graph.required),
                                    self.element.RecordClass.__slots__)
         builder.finishJoin(self._query, joinOn)
+        return self._query
 
     def insert(self, *records: DimensionRecord):
         # Docstring inherited from DimensionRecordStorage.insert.

--- a/python/lsst/daf/butler/registry/dimensions/spatial.py
+++ b/python/lsst/daf/butler/registry/dimensions/spatial.py
@@ -118,7 +118,7 @@ class SpatialDimensionRecordStorage(TableDimensionRecordStorage):
             dimensions.add(self.element.universe.universe.commonSkyPix)
             builder.joinTable(self._commonSkyPixOverlapTable, dimensions)
             regions[self.element] = self._table.columns[REGION_FIELD_SPEC.name]
-        super().join(builder, regions=None, timespans=timespans)
+        return super().join(builder, regions=None, timespans=timespans)
 
     def insert(self, *records: DimensionRecord):
         # Docstring inherited from DimensionRecordStorage.insert.

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -94,6 +94,7 @@ class TableDimensionRecordStorage(DimensionRecordStorage):
                 joinOn.append(timespanInQuery.overlaps(timespanInTable, ops=sqlalchemy.sql))
             timespans[self.element] = timespanInTable
         builder.finishJoin(self._table, joinOn)
+        return self._table
 
     def fetch(self, dataId: DataCoordinate) -> Optional[DimensionRecord]:
         # Docstring inherited from DimensionRecordStorage.fetch.

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -172,6 +172,11 @@ class DimensionRecordStorage(ABC):
             If `None`, ``self.element`` is not being included in the query via
             a temporal join.
 
+        Returns
+        -------
+        fromClause : `sqlalchemy.sql.FromClause`
+            Table or clause for the element which is joined.
+
         Notes
         -----
         Elements are only included in queries via spatial and/or temporal joins

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -35,7 +35,7 @@ from ...core import (
     DatasetType,
     Timespan,
 )
-from ...core.utils import NamedValueSet
+from ...core.utils import NamedKeyDict
 
 from ._structs import QuerySummary, QueryColumns, QueryParameters, GivenTime
 from ._datasets import DatasetRegistryStorage
@@ -72,7 +72,7 @@ class QueryBuilder:
         self._dimensionStorage = dimensionStorage
         self._datasetStorage = datasetStorage
         self._sql = None
-        self._elements: NamedValueSet[DimensionElement] = NamedValueSet()
+        self._elements: NamedKeyDict[DimensionElement, FromClause] = NamedKeyDict()
         self._columns = QueryColumns()
 
     def hasDimensionKey(self, dimension: Dimension) -> bool:
@@ -101,12 +101,12 @@ class QueryBuilder:
         """
         assert element not in self._elements, "Element already included in query."
         storage = self._dimensionStorage[element]
-        storage.join(
+        fromClause = storage.join(
             self,
             regions=self._columns.regions if element in self.summary.spatial else None,
             timespans=self._columns.timespans if element in self.summary.temporal else None,
         )
-        self._elements.add(element)
+        self._elements[element] = fromClause
 
     def joinDataset(self, datasetType: DatasetType, collections: Any, *,
                     isResult: bool = True, addRank: bool = False):

--- a/python/lsst/daf/butler/registry/queries/exprParser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/exprParser/exprTree.py
@@ -30,7 +30,8 @@ to database directly.
 """
 
 __all__ = ['Node', 'BinaryOp', 'Identifier', 'IsIn', 'NumericLiteral',
-           'Parens', 'StringLiteral', 'UnaryOp']
+           'Parens', 'RangeLiteral', 'StringLiteral', 'TimeLiteral',
+           'UnaryOp']
 
 # -------------------------------
 #  Imports of standard modules --
@@ -150,6 +151,26 @@ class StringLiteral(Node):
     def visit(self, visitor):
         # Docstring inherited from Node.visit
         return visitor.visitStringLiteral(self.value, self)
+
+    def __str__(self):
+        return "'{value}'".format(**vars(self))
+
+
+class TimeLiteral(Node):
+    """Node representing time literal.
+
+    Attributes
+    ----------
+    value : str
+        Literal string value.
+    """
+    def __init__(self, value):
+        Node.__init__(self)
+        self.value = value
+
+    def visit(self, visitor):
+        # Docstring inherited from Node.visit
+        return visitor.visitTimeLiteral(self.value, self)
 
     def __str__(self):
         return "'{value}'".format(**vars(self))

--- a/python/lsst/daf/butler/registry/queries/exprParser/parserLex.py
+++ b/python/lsst/daf/butler/registry/queries/exprParser/parserLex.py
@@ -112,6 +112,7 @@ class ParserLex:
     # List of token names.
     tokens = (
         'NUMERIC_LITERAL',
+        'TIME_LITERAL',
         'STRING_LITERAL',
         'RANGE_LITERAL',
         # 'TIME_LITERAL',
@@ -146,6 +147,13 @@ class ParserLex:
     def t_newline(self, t):
         r'\n+'
         t.lexer.lineno += len(t.value)
+
+    # quoted string prefixed with 'T'
+    def t_TIME_LITERAL(self, t):
+        r"T'.*?'"
+        # strip quotes
+        t.value = t.value[2:-1]
+        return t
 
     # quoted string
     def t_STRING_LITERAL(self, t):

--- a/python/lsst/daf/butler/registry/queries/exprParser/treeVisitor.py
+++ b/python/lsst/daf/butler/registry/queries/exprParser/treeVisitor.py
@@ -63,6 +63,18 @@ class TreeVisitor(ABC):
         """
 
     @abstractmethod
+    def visitTimeLiteral(self, value, node):
+        """Visit TimeLiteral node.
+
+        Parameters
+        ----------
+        value : `TimeLiteral`
+            The value associated with the visited node.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
     def visitRangeLiteral(self, start, stop, stride, node):
         """Visit RangeLiteral node.
 

--- a/python/lsst/daf/butler/registry/queries/expressions.py
+++ b/python/lsst/daf/butler/registry/queries/expressions.py
@@ -120,6 +120,10 @@ class InspectionVisitor(TreeVisitor):
         # Docstring inherited from TreeVisitor.visitStringLiteral
         pass
 
+    def visitTimeLiteral(self, value, node):
+        # Docstring inherited from TreeVisitor.visitTimeLiteral
+        pass
+
     def visitIdentifier(self, name, node):
         # Docstring inherited from TreeVisitor.visitIdentifier
         element, column = categorizeIdentifier(self.universe, name)
@@ -201,6 +205,10 @@ class ClauseVisitor(TreeVisitor):
 
     def visitStringLiteral(self, value, node):
         # Docstring inherited from TreeVisitor.visitStringLiteral
+        return literal(value)
+
+    def visitTimeLiteral(self, value, node):
+        # Docstring inherited from TreeVisitor.visitTimeLiteral
         return literal(value)
 
     def visitIdentifier(self, name, node):

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -155,6 +155,19 @@ class ParserLexTestCase(unittest.TestCase):
         self._assertToken(lexer.token(), "RANGE_LITERAL", (0, 10, 2))
         self.assertIsNone(lexer.token())
 
+    def testTimeLiteral(self):
+        """Test for time literals"""
+        lexer = ParserLex.make_lexer()
+
+        # string can contain anything, lexer does not check it
+        lexer.input("T'2020-03-30' T'2020-03-30 00:00:00' T'2020-03-30T00:00:00' T'123.456' T'time'")
+        self._assertToken(lexer.token(), "TIME_LITERAL", "2020-03-30")
+        self._assertToken(lexer.token(), "TIME_LITERAL", "2020-03-30 00:00:00")
+        self._assertToken(lexer.token(), "TIME_LITERAL", "2020-03-30T00:00:00")
+        self._assertToken(lexer.token(), "TIME_LITERAL", "123.456")
+        self._assertToken(lexer.token(), "TIME_LITERAL", "time")
+        self.assertIsNone(lexer.token())
+
     def testIdentifier(self):
         """Test for numeric literals"""
         lexer = ParserLex.make_lexer()


### PR DESCRIPTION
Time literal was added to a parser in the form `T'string'`, string can
be one of the supported formats for astropy Time class plus optional
format and scale. Some parsing is done in the parser code to determine
string format and convert it to floating number if needed. For
string-based representations (iso, yday, etc.) it relies on astropy
parsing.

Also fixes an issue in QueryBuilder class which had issues with support of
dotted identifiers. 

Documentation for parser is updated with description of supported time
literal syntax.