### PR TITLE
DM-24290: PostgreSQL database handles case when namespace is not provided incorrectly.

### DIFF
--- a/config/datastores/s3Datastore.yaml
+++ b/config/datastores/s3Datastore.yaml
@@ -2,7 +2,7 @@ datastore:
   cls: lsst.daf.butler.datastores.s3Datastore.S3Datastore
   root: <butlerRoot>/datastore
   records:
-    table: s3datastorerecords
+    table: s3_datastore_records
   create: true
   templates:
     # valid_first and valid_last here are YYYYMMDD; we assume we'll switch to

--- a/config/datastores/s3Datastore.yaml
+++ b/config/datastores/s3Datastore.yaml
@@ -8,6 +8,6 @@ datastore:
     # valid_first and valid_last here are YYYYMMDD; we assume we'll switch to
     # MJD (DM-15890) before we need more than day resolution, since that's all
     # Gen2 has.
-    default: "{collection:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{label:?}/{abstract_filter:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{datasetType}_{component:?}_{tract:?}_{patch:?}_{label:?}_{abstract_filter:?}_{physical_filter:?}_{calibration_label:?}_{visit:?}_{exposure:?}_{detector:?}_{instrument:?}_{skymap:?}_{skypix:?}_{run}"
   formatters: !include formatters.yaml
   composites: !include ../composites.yaml

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -340,7 +340,7 @@ class Butler:
                 raise ValueError(f"Bucket {uri.netloc} does not exist!")
             s3 = boto3.client("s3")
             # don't create S3 key when root is at the top-level of an Bucket
-            if not uri.path != "/":
+            if not uri.path == "/":
                 s3.put_object(Bucket=uri.netloc, Key=uri.relativeToPathRoot)
         else:
             raise ValueError(f"Unrecognized scheme: {uri.scheme}")

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -339,8 +339,8 @@ class Butler:
             if not bucketExists(uri.netloc):
                 raise ValueError(f"Bucket {uri.netloc} does not exist!")
             s3 = boto3.client("s3")
-            # don't create root Key if root is at top-level of an Bucket
-            if uri.relativeToPathRoot != ".":
+            # don't create S3 key when root is at the top-level of an Bucket
+            if not uri.path != "/":
                 s3.put_object(Bucket=uri.netloc, Key=uri.relativeToPathRoot)
         else:
             raise ValueError(f"Unrecognized scheme: {uri.scheme}")

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -26,7 +26,6 @@ Configuration classes specific to the Butler
 __all__ = ("ButlerConfig",)
 
 import os.path
-import posixpath
 
 from .core import (
     ButlerURI,
@@ -86,9 +85,9 @@ class ButlerConfig(Config):
                 if os.path.isdir(uri.ospath):
                     other = os.path.join(uri.ospath, "butler.yaml")
             elif uri.scheme == "s3":
-                head, filename = posixpath.split(uri.path)
-                if "." not in filename:
-                    uri.updateFile("butler.yaml")
+                if not uri.dirLike and "." not in uri.basename():
+                    uri = ButlerURI(other, forceDirectory=True)
+                uri.updateFile("butler.yaml")
                 other = uri.geturl()
             else:
                 raise ValueError(f"Unrecognized URI scheme: {uri.scheme}")

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -102,7 +102,12 @@ class ButlerConfig(Config):
 
         configFile = butlerConfig.configFile
         if configFile is not None:
-            self.configDir = os.path.dirname(os.path.abspath(configFile))
+            uri = ButlerURI(configFile)
+            if uri.scheme == "s3":
+                uri.updateFile("")
+                self.configDir = uri.geturl()
+            else:
+                self.configDir = os.path.dirname(os.path.abspath(configFile))
 
         # A Butler config contains defaults defined by each of the component
         # configuration classes. We ask each of them to apply defaults to

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -32,7 +32,6 @@ import yaml
 import sys
 from yaml.representer import Representer
 import io
-import posixpath
 from typing import Sequence, Optional, ClassVar
 
 try:
@@ -807,9 +806,9 @@ class Config(collections.abc.MutableMapping):
                 uri = ButlerURI(os.path.join(uri.ospath, defaultFileName))
             self.dumpToFile(uri.ospath, overwrite=overwrite)
         elif uri.scheme == "s3":
-            head, filename = posixpath.split(uri.path)
-            if "." not in filename:
-                uri.updateFile(defaultFileName)
+            if not uri.dirLike and "." not in uri.basename():
+                uri = ButlerURI(uri.geturl(), forceDirectory=True)
+            uri.updateFile(defaultFileName)
             self.dumpToS3File(uri, overwrite=overwrite)
         else:
             raise ValueError(f"Unrecognized URI scheme: {uri.scheme}")

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -251,6 +251,7 @@ class Config(collections.abc.MutableMapping):
                 self.__initFromYamlFile(uri.ospath)
         else:
             raise RuntimeError("Unhandled config file type:%s" % uri)
+        self.configFile = str(path)
 
     def __initFromS3YamlFile(self, url):
         """Load a file at a given S3 Bucket uri and attempts to load it from
@@ -290,7 +291,6 @@ class Config(collections.abc.MutableMapping):
         log.debug("Opening YAML config file: %s", path)
         with open(path, "r") as f:
             self.__initFromYaml(f)
-        self.configFile = path
 
     def __initFromYaml(self, stream):
         """Loads a YAML config from any readable stream that contains one.

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -113,9 +113,12 @@ class ButlerURI:
         If `True`, scheme-less relative URI will be converted to an absolute
         path using a ``file`` scheme. If `False` scheme-less URI will remain
         scheme-less and will not be updated to ``file`` or absolute path.
+    forceDirectory: `bool`, optional
+        If `True` forces the URI to end with a separator, otherwise given URI
+        is interpreted as is.
     """
 
-    def __init__(self, uri, root=None, forceAbsolute=True):
+    def __init__(self, uri, root=None, forceAbsolute=True, forceDirectory=False):
         if isinstance(uri, str):
             parsed = urllib.parse.urlparse(uri)
         elif isinstance(uri, urllib.parse.ParseResult):
@@ -123,7 +126,14 @@ class ButlerURI:
         else:
             raise ValueError("Supplied URI must be either string or ParseResult")
 
-        parsed = self._fixupFileUri(parsed, root=root, forceAbsolute=forceAbsolute)
+        parsed, dirLike = self._fixupFileUri(parsed, root=root,
+                                             forceAbsolute=forceAbsolute,
+                                             forceDirectory=forceDirectory)
+
+        # relativeToPathRoot indiscriminately strips trailing separators.
+        # Record whether we have trailing separator (dir-like) or not. Note:
+        # updated on ButlerURI.updateFile call
+        self.dirLike = dirLike
         self._uri = parsed
 
     @property
@@ -159,7 +169,11 @@ class ButlerURI:
             p = PurePath(self.path)
         else:
             p = PurePosixPath(self.path)
-        return str(p.relative_to(p.root))
+        if self.dirLike:
+            relToRoot = str(p.relative_to(p.root)) + '/'
+        else:
+            relToRoot = str(p.relative_to(p.root))
+        return relToRoot
 
     @property
     def fragment(self):
@@ -209,6 +223,7 @@ class ButlerURI:
         Notes
         -----
         Updates the URI in place.
+        Updates the ButlerURI.dirLike attribute.
         """
         if self.scheme:
             # POSIX
@@ -219,13 +234,14 @@ class ButlerURI:
         dir, _ = pathclass.split(self.path)
         newpath = pathclass.join(dir, newfile)
 
+        self.dirLike = False
         self._uri = self._uri._replace(path=newpath)
 
     def __str__(self):
         return self.geturl()
 
     @staticmethod
-    def _fixupFileUri(parsed, root=None, forceAbsolute=False):
+    def _fixupFileUri(parsed, root=None, forceAbsolute=False, forceDirectory=False):
         """Fix up relative paths in file URI instances.
 
         Parameters
@@ -236,17 +252,23 @@ class ButlerURI:
             Path to use as root when converting relative to absolute.
             If `None`, it will be the current working directory. This
             is a local file system path, not a URI.
-        forceAbsolute : `bool`
+        forceAbsolute : `bool`, optional
             If `True`, scheme-less relative URI will be converted to an
             absolute path using a ``file`` scheme. If `False` scheme-less URI
             will remain scheme-less and will not be updated to ``file`` or
             absolute path. URIs with a defined scheme will not be affected
             by this parameter.
+        forceDirectory : `bool`, optional
+            If `True` forces the URI to end with a separator, otherwise given
+            URI is interpreted as is.
 
         Returns
         -------
         modified : `~urllib.parse.ParseResult`
             Update result if a file URI is being handled.
+        dirLike : `bool`
+            `True` if given parsed URI has a trailing separator or
+            forceDirectory is True. Otherwise `False`.
 
         Notes
         -----
@@ -255,8 +277,15 @@ class ButlerURI:
         to be turned into absolute paths before they can be used.  This is
         always done regardless of the ``forceAbsolute`` parameter.
 
+        AWS S3 differentiates between keys with trailing POSIX separators (i.e
+        `/dir` and `/dir/`) whereas POSIX does not neccessarily. This must be
+        tracked manually if network location is to be treated interchangeably
+        with POSIX paths.
+
         Scheme-less paths are normalized.
         """
+        # assume we are not dealing with a directory like URI
+        dirLike = False
         if not parsed.scheme or parsed.scheme == "file":
 
             # Replacement values for the URI
@@ -285,37 +314,59 @@ class ButlerURI:
 
                 # normpath strips trailing "/" which makes it hard to keep
                 # track of directory vs file when calling replaceFile
-                # put it back.
+                # find the appropriate separator
                 if "scheme" in replacements:
                     sep = posixpath.sep
                 else:
                     sep = os.sep
 
-                if expandedPath.endswith(os.sep) and not replacements["path"].endswith(sep):
+                # add the trailing separator only if explicitly required or
+                # if it was stripped by normpath. Acknowledge that trailing
+                # separator exists.
+                if forceDirectory or (expandedPath.endswith(os.sep) and not
+                                      replacements["path"].endswith(sep)):
                     replacements["path"] += sep
+                    dirLike = True
 
             elif parsed.scheme == "file":
                 # file URI implies POSIX path separators so split as POSIX,
                 # then join as os, and convert to abspath. Do not handle
                 # home directories since "file" scheme is explicitly documented
                 # to not do tilde expansion.
+                sep = posixpath.sep
                 if posixpath.isabs(parsed.path):
-                    # No change needed
-                    return copy.copy(parsed)
+                    if forceDirectory:
+                        parsed = parsed._replace(path=parsed.path+sep)
+                        dirLike = True
+                    return copy.copy(parsed), dirLike
 
                 replacements["path"] = posixpath.normpath(posixpath.join(os2posix(root), parsed.path))
 
                 # normpath strips trailing "/" so put it back if necessary
-                if parsed.path.endswith(posixpath.sep) and not replacements["path"].endswith(posixpath.sep):
-                    replacements["path"] += posixpath.sep
-
+                # Acknowledge that trailing separator exists.
+                if forceDirectory or (parsed.path.endswith(sep) and not replacements["path"].endswith(sep)):
+                    replacements["path"] += sep
+                    dirLike = True
             else:
                 raise RuntimeError("Unexpectedly got confused by URI scheme")
 
             # ParseResult is a NamedTuple so _replace is standard API
             parsed = parsed._replace(**replacements)
 
-        return parsed
+        elif parsed.scheme == "s3":
+
+            # URI is dir-like if explicitly stated or if it ends on a separator
+            endsOnSep = parsed.path.endswith(posixpath.sep)
+            if forceDirectory or endsOnSep:
+                dirLike = True
+                # only add the separator if it's not already there
+                if not endsOnSep:
+                    parsed = parsed._replace(path=parsed.path+posixpath.sep)
+
+        if dirLike is None:
+            raise RuntimeError("ButlerURI.dirLike attribute not set succesfully.")
+
+        return parsed, dirLike
 
 
 class Location:
@@ -335,7 +386,7 @@ class Location:
 
     def __init__(self, datastoreRootUri, path):
         if isinstance(datastoreRootUri, str):
-            datastoreRootUri = ButlerURI(datastoreRootUri)
+            datastoreRootUri = ButlerURI(datastoreRootUri, forceDirectory=True)
         elif not isinstance(datastoreRootUri, ButlerURI):
             raise ValueError("Datastore root must be a ButlerURI instance")
 
@@ -454,7 +505,8 @@ class LocationFactory:
     """
 
     def __init__(self, datastoreRoot):
-        self._datastoreRootUri = ButlerURI(datastoreRoot, forceAbsolute=True)
+        self._datastoreRootUri = ButlerURI(datastoreRoot, forceAbsolute=True,
+                                           forceDirectory=True)
 
     def __str__(self):
         return f"{self.__class__.__name__}@{self._datastoreRootUri}"

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -126,7 +126,7 @@ class ButlerURI:
         else:
             raise ValueError("Supplied URI must be either string or ParseResult")
 
-        parsed, dirLike = self._fixupFileUri(parsed, root=root,
+        parsed, dirLike = self._fixupPathUri(parsed, root=root,
                                              forceAbsolute=forceAbsolute,
                                              forceDirectory=forceDirectory)
 
@@ -237,8 +237,8 @@ class ButlerURI:
         return self.geturl()
 
     @staticmethod
-    def _fixupFileUri(parsed, root=None, forceAbsolute=False, forceDirectory=False):
-        """Fix up relative paths in file URI instances.
+    def _fixupPathUri(parsed, root=None, forceAbsolute=False, forceDirectory=False):
+        """Fix up relative paths in URI instances.
 
         Parameters
         ----------
@@ -261,7 +261,7 @@ class ButlerURI:
         Returns
         -------
         modified : `~urllib.parse.ParseResult`
-            Update result if a file URI is being handled.
+            Update result if a URI is being handled.
         dirLike : `bool`
             `True` if given parsed URI has a trailing separator or
             forceDirectory is True. Otherwise `False`.
@@ -349,15 +349,13 @@ class ButlerURI:
             # ParseResult is a NamedTuple so _replace is standard API
             parsed = parsed._replace(**replacements)
 
-        elif parsed.scheme == "s3":
-
-            # URI is dir-like if explicitly stated or if it ends on a separator
-            endsOnSep = parsed.path.endswith(posixpath.sep)
-            if forceDirectory or endsOnSep:
-                dirLike = True
-                # only add the separator if it's not already there
-                if not endsOnSep:
-                    parsed = parsed._replace(path=parsed.path+posixpath.sep)
+        # URI is dir-like if explicitly stated or if it ends on a separator
+        endsOnSep = parsed.path.endswith(posixpath.sep)
+        if forceDirectory or endsOnSep:
+            dirLike = True
+            # only add the separator if it's not already there
+            if not endsOnSep:
+                parsed = parsed._replace(path=parsed.path+posixpath.sep)
 
         if dirLike is None:
             raise RuntimeError("ButlerURI.dirLike attribute not set succesfully.")

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -197,23 +197,24 @@ class ButlerURI:
         return self._uri.geturl()
 
     def split(self):
-        """Splits URI into head and tail. Either head or tail can be empty.
-        Equivalent to os.path.split where head preserves the scheme and netloc.
+        """Splits URI into head and tail. Equivalent to os.path.split where
+        head preserves the URI components.
 
         Returns
         -------
-        head: `str`
-            Everything leading up to tail. Trailing slashes are stripped from
-            the head. If `self.path` contains no slashes will be empty.
+        head: `ButlerURI`
+            Everything leading up to tail, expanded and normalized as per
+            ButlerURI rules.
         tail : `str`
             Last `self.path` component. Tail will be empty if path ends on a
             separator. Tail will never contain separators.
         """
         if self.scheme:
             head, tail = posixpath.split(self.path)
-            return f"{self.scheme}://{self.netloc}{head}", tail
         else:
-            return os.path.split(self.path)
+            head, tail = os.path.split(self.path)
+        headuri = self._uri._replace(path=head)
+        return self.__class__(headuri, forceDirectory=True), tail
 
     def basename(self):
         """Returns the base name, last element of path, of the URI. If URI ends
@@ -221,15 +222,26 @@ class ButlerURI:
         by split().
 
         Equivalent of os.path.basename().
+
+        Returns
+        -------
+        tail : `str`
+            Last part of the path attribute. Trail will be empty if path ends
+            on a separator.
         """
         return self.split()[1]
 
     def dirname(self):
-        """Returns the directory name of URI, everything up to the last element
-        of path.
+        """Returns a ButlerURI containing all the directories of the path
+        attribute.
 
-        Equivalent of os.path.dirname except trailing slashes are preserved for
-        URIs with known schemes.
+        Equivalent of os.path.dirname()
+
+        Returns
+        -------
+        head : `ButlerURI`
+            Everything except the tail of path attribute, expanded and
+            normalized as per ButlerURI rules.
         """
         return self.split()[0]
 

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -130,9 +130,6 @@ class ButlerURI:
                                              forceAbsolute=forceAbsolute,
                                              forceDirectory=forceDirectory)
 
-        # relativeToPathRoot indiscriminately strips trailing separators.
-        # Record whether we have trailing separator (dir-like) or not. Note:
-        # updated on ButlerURI.updateFile call
         self.dirLike = dirLike
         self._uri = parsed
 
@@ -169,10 +166,9 @@ class ButlerURI:
             p = PurePath(self.path)
         else:
             p = PurePosixPath(self.path)
-        if self.dirLike:
-            relToRoot = str(p.relative_to(p.root)) + '/'
-        else:
-            relToRoot = str(p.relative_to(p.root))
+        relToRoot = str(p.relative_to(p.root))
+        if self.dirLike and not relToRoot.endswith("/"):
+            relToRoot += "/"
         return relToRoot
 
     @property

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -274,9 +274,7 @@ class ButlerURI:
         always done regardless of the ``forceAbsolute`` parameter.
 
         AWS S3 differentiates between keys with trailing POSIX separators (i.e
-        `/dir` and `/dir/`) whereas POSIX does not neccessarily. This must be
-        tracked manually if network location is to be treated interchangeably
-        with POSIX paths.
+        `/dir` and `/dir/`) whereas POSIX does not neccessarily.
 
         Scheme-less paths are normalized.
         """
@@ -358,7 +356,7 @@ class ButlerURI:
                 parsed = parsed._replace(path=parsed.path+posixpath.sep)
 
         if dirLike is None:
-            raise RuntimeError("ButlerURI.dirLike attribute not set succesfully.")
+            raise RuntimeError("ButlerURI.dirLike attribute not set successfully.")
 
         return parsed, dirLike
 

--- a/python/lsst/daf/butler/core/s3utils.py
+++ b/python/lsst/daf/butler/core/s3utils.py
@@ -38,7 +38,7 @@ def s3CheckFileExists(path, bucket=None, client=None):
 
     Parameters
     ----------
-    path : `Location`, `ButlerURI`, `str`
+    path : `Location`, `ButlerURI` or `str`
         Location or ButlerURI containing the bucket name and filepath.
     bucket : `str`, optional
         Name of the bucket in which to look. If provided, path will be assumed

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -66,7 +66,7 @@ class PostgresqlDatabase(Database):
         except (AttributeError, KeyError) as err:
             raise RuntimeError(f"Only the psycopg2 driver for PostgreSQL is supported.") from err
         if namespace is None:
-            namespace = dsn["schema"]
+            namespace = connection.execute("SELECT current_schema();").scalar()
         self.namespace = namespace
         self.dbname = dsn.get("dbname")
         self._writeable = writeable

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -2,16 +2,16 @@ datastore:
   cls: lsst.daf.butler.datastores.posixDatastore.PosixDatastore
   root: <butlerRoot>/butler_test_repository
   templates:
-    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
-    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
-    metric2: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
-    metric3: "{run}/{datasetType}/{instrument}"
-    metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
-    physical_filter+: "{run}/{instrument}_{physical_filter}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run:/}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
+    test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric2: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
+    metric3: "{run:/}/{datasetType}/{instrument}"
+    metric4: "{run:/}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+    physical_filter+: "{run:/}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
-      metric33: "{run}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+      metric33: "{run:/}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -5,10 +5,10 @@ datastore:
   records:
     table: posix_datastore_records_2
   templates:
-    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}{component:?}"
-    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run:/}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}{component:?}"
+    test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/posixDatastore2P.yaml
+++ b/tests/config/basic/posixDatastore2P.yaml
@@ -11,10 +11,10 @@ datastore:
       - instrument<DummyCamComp>:
         - metric33
   templates:
-    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
-    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run:/}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+    test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/posixDatastoreP.yaml
+++ b/tests/config/basic/posixDatastoreP.yaml
@@ -8,15 +8,15 @@ datastore:
       - instrument<DummyCamComp>:
         - metric33
   templates:
-    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
-    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
-    metric3: "{run}/{datasetType}/{instrument}"
-    metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
-    physical_filter+: "{run}/{instrument}_{physical_filter}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run:/}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+    test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric3: "{run:/}/{datasetType}/{instrument}"
+    metric4: "{run:/}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+    physical_filter+: "{run:/}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
-      metric33: "{run}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+      metric33: "{run:/}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/s3Datastore.yaml
+++ b/tests/config/basic/s3Datastore.yaml
@@ -2,16 +2,16 @@ datastore:
   cls: lsst.daf.butler.datastores.s3Datastore.S3Datastore
   root: s3://anybucketname/butlerRoot
   templates:
-    default: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
-    calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
-    metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
-    test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
-    metric2: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
-    metric3: "{run}/{datasetType}/{instrument}"
-    metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
-    physical_filter+: "{run}/{instrument}_{physical_filter}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
+    calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+    metric: "{run:/}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
+    test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric2: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
+    metric3: "{run:/}/{datasetType}/{instrument}"
+    metric4: "{run:/}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+    physical_filter+: "{run:/}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
-      metric33: "{run}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
+      metric33: "{run:/}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
   formatters:
     StructuredDataDictYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter
     StructuredDataListYaml: lsst.daf.butler.formatters.yamlFormatter.YamlFormatter

--- a/tests/config/basic/s3Datastore.yaml
+++ b/tests/config/basic/s3Datastore.yaml
@@ -6,6 +6,7 @@ datastore:
     calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
     metric: "{run}/{datasetType}.{component:?}/{instrument:?}_{datasetType}_v{visit:08d}_f{physical_filter}_d{detector:?}_{component:?}"
     test_metric_comp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{instrument}_{component:?}"
+    metric2: "{run}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
     metric3: "{run}/{datasetType}/{instrument}"
     metric4: "{run}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
     physical_filter+: "{run}/{instrument}_{physical_filter}"

--- a/tests/config/templates/templates-nodefault.yaml
+++ b/tests/config/templates/templates-nodefault.yaml
@@ -1,12 +1,12 @@
 # This file disables defaulting
 default: False
-calexp: "{run}/{datasetType}.{component:?}/{datasetType}_i{instrument}_v{visit}_f{physical_filter:?}_{component:?}"
-calexp.wcs: "{run}/{datasetType}.{component}-a-wcs-{instrument}-{visit}-{physical_filter}"
-StorageClassX: "StorageClass/{run}_{datasetType}_{instrument}_{visit}"
-pvi: "{run}_{datasetType}_{instrument}_{physical_filter}"
+calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_i{instrument}_v{visit}_f{physical_filter:?}_{component:?}"
+calexp.wcs: "{run:/}/{datasetType}.{component}-a-wcs-{instrument}-{visit}-{physical_filter}"
+StorageClassX: "StorageClass/{run:/}_{datasetType}_{instrument}_{visit}"
+pvi: "{run:/}_{datasetType}_{instrument}_{physical_filter}"
 # For testing the dimension names match the dataId keys since there is
 # no universe
-instrument+physical_filter: "{run}_{datasetType}_{physical_filter}_{instrument}"
+instrument+physical_filter: "{run:/}_{datasetType}_{physical_filter}_{instrument}"
 instrument<HSC>:
-  pvi: "HyperSuprimCam-{run}/{datasetType}_{physical_filter}_{instrument}"
-  instrument+physical_filter: "hsc/{run}_{datasetType}_{physical_filter}_{instrument}"
+  pvi: "HyperSuprimCam-{run:/}/{datasetType}_{physical_filter}_{instrument}"
+  instrument+physical_filter: "hsc/{run:/}_{datasetType}_{physical_filter}_{instrument}"

--- a/tests/config/templates/templates-nodefault2.yaml
+++ b/tests/config/templates/templates-nodefault2.yaml
@@ -1,2 +1,2 @@
 # This file disables defaulting without specifying any value for default
-calexp: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+calexp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"

--- a/tests/config/templates/templates-withdefault.yaml
+++ b/tests/config/templates/templates-withdefault.yaml
@@ -1,2 +1,2 @@
 # This file defines a default
-default: "{run}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"
+default: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit}_f{physical_filter:?}_{component:?}"

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -960,7 +960,7 @@ class ButlerMakeRepoOutfileTestCase(ButlerPutGetTests, unittest.TestCase):
     def testConfigExistence(self):
         c = Config(self.tmpConfigFile)
         uri_config = ButlerURI(c["root"])
-        uri_expected = ButlerURI(self.root)
+        uri_expected = ButlerURI(self.root, forceDirectory=True)
         self.assertEqual(uri_config.geturl(), uri_expected.geturl())
         self.assertNotIn(":", uri_config.path, "Check for URI concatenated with normal path")
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -815,7 +815,6 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         # dependency); should not change template (at least the way we're
         # defining them  to behave now; the important thing is that they
         # must be consistent).
-
         ref = butler.put(metric, "metric2", dataId2)
         self.assertTrue(self.checkFileExists(butler.datastore.root,
                                              "ingest/metric2/d-r/DummyCamComp_v423.pickle"))

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -815,6 +815,7 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         # dependency); should not change template (at least the way we're
         # defining them  to behave now; the important thing is that they
         # must be consistent).
+
         ref = butler.put(metric, "metric2", dataId2)
         self.assertTrue(self.checkFileExists(butler.datastore.root,
                                              "ingest/metric2/d-r/DummyCamComp_v423.pickle"))
@@ -1096,8 +1097,8 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
         `lsst.daf.butler.core.s3utils.s3checkFileExists` call.
         """
         uri = ButlerURI(root)
-        client = boto3.client("s3")
-        return s3CheckFileExists(uri, client=client)[0]
+        uri.updateFile(relpath)
+        return s3CheckFileExists(uri)[0]
 
     @unittest.expectedFailure
     def testImportExport(self):

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -140,6 +140,7 @@ class LocationTestCase(unittest.TestCase):
 
         pathInStore = "relative/path/file.ext"
         loc1 = factory.fromPath(pathInStore)
+
         self.assertEqual(loc1.path, os.path.join(root, pathInStore))
         self.assertEqual(loc1.pathInStore, pathInStore)
         self.assertTrue(loc1.uri.startswith("file:///"))


### PR DESCRIPTION
Solves issue described in [DM-24290 point 1.a](https://jira.lsstcorp.org/browse/DM-24290) when namespace is not provided it is set to an non-existent DSN "schema" key. Went unnoticed because all the tests provide explicit namespace arguments. 