### PR TITLE
DM-13403: numpy types fail in butler dataIds

### DIFF
--- a/python/lsst/daf/butler/core/dimensions/coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/coordinate.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 __all__ = ("DataCoordinate", "ExpandedDataCoordinate", "DataId")
 
+import numbers
 from typing import Any, Tuple, Mapping, Optional, Dict, Union, TYPE_CHECKING
 
 from lsst.sphgeom import Region
@@ -198,8 +199,8 @@ class DataCoordinate(IndexedTupleDict):
         """
         for k, v in self.items():
             update(k.name.encode("utf8"))
-            if isinstance(v, int):
-                update(v.to_bytes(64, "big", signed=False))
+            if isinstance(v, numbers.Integral):
+                update(int(v).to_bytes(64, "big", signed=False))
             elif isinstance(v, str):
                 update(v.encode("utf8"))
             else:

--- a/python/lsst/daf/butler/core/dimensions/coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/coordinate.py
@@ -154,6 +154,9 @@ class DataCoordinate(IndexedTupleDict):
             graph = DimensionGraph(universe, names=d.keys())
         try:
             values = tuple(d[name] for name in graph.required.names)
+            # some backends cannot handle numpy.int64 type which is
+            # a subclass of numbers.Integral, convert that to int.
+            values = tuple(int(val) if isinstance(val, numbers.Integral) else val for val in values)
         except KeyError as err:
             raise KeyError(f"No value in data ID ({mapping}) for required dimension {err}.") from err
         return DataCoordinate(graph, values)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -30,6 +30,7 @@ import shutil
 import pickle
 import string
 import random
+import numpy as np
 
 try:
     import boto3
@@ -679,7 +680,7 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         butler.registry.registerDatasetType(DatasetType("metric2", dimensions, storageClass))
         butler.registry.registerDatasetType(DatasetType("metric3", dimensions, storageClass))
 
-        dataId1 = {"instrument": "DummyCamComp", "visit": 423}
+        dataId1 = {"instrument": "DummyCamComp", "visit": np.int64(423)}
         dataId2 = {"instrument": "DummyCamComp", "visit": 423, "physical_filter": "d-r"}
         dataId3 = {"instrument": "DummyCamComp", "visit": 425}
 


### PR DESCRIPTION
At least one database backend cannot handle `numpy.int64` type which is
a subclass of `numbers.Integral`. This patch replaces all values of
Integral type in a DataCoordinate with ints.