### PR TITLE
DM-23671: Change datastore remove to a trash + emptyTrash

### DIFF
--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = ["DatasetRef"]
+__all__ = ["DatasetRef", "FakeDatasetRef"]
 
 import hashlib
 from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Tuple
@@ -362,3 +362,44 @@ class DatasetRef:
     `unresolved` to add or remove this information when creating a new
     `DatasetRef`.
     """
+
+
+@immutable
+class FakeDatasetRef:
+    """A fake `DatasetRef` that can be used internally by butler where
+    only the dataset ID is available.
+
+    Should only be used when registry can not be used to create a full
+    `DatasetRef` from the ID.  A particular use case is during dataset
+    deletion when solely the ID is available.
+
+    Parameters
+    ----------
+    id : `int`
+        The dataset ID.
+    """
+    __slots__ = ("id",)
+
+    def __new__(cls, id: int):
+        self = super().__new__(cls)
+        self.id = id
+        return self
+
+    def __str__(self):
+        return f"dataset_id={self.id}"
+
+    def __repr__(self):
+        return f"FakeDatasetRef({self.id})"
+
+    def __eq__(self, other: FakeDatasetRef):
+        try:
+            return self.id == other.id
+        except AttributeError:
+            return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+    @property
+    def components(self):
+        return {}

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -403,3 +403,7 @@ class FakeDatasetRef:
     @property
     def components(self):
         return {}
+
+    @staticmethod
+    def flatten(refs: Iterable[FakeDatasetRef], *, parents: bool = True) -> Iterator[DatasetRef]:
+        return DatasetRef.flatten(refs, parents=parents)

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -586,13 +586,15 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def trash(self, datasetRef):
+    def trash(self, datasetRef, ignore_errors=True):
         """Indicate to the Datastore that a Dataset can be moved to the trash.
 
         Parameters
         ----------
         datasetRef : `DatasetRef`
             Reference to the required Dataset.
+        ignore_errors : `bool`, optional
+            Determine whether errors should be ignored.
 
         Raises
         ------
@@ -607,8 +609,13 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def emptyTrash(self):
+    def emptyTrash(self, ignore_errors=True):
         """Remove all datasets from the trash.
+
+        Parameters
+        ----------
+        ignore_errors : `bool`, optional
+            Determine whether errors should be ignored.
 
         Notes
         -----

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -586,6 +586,38 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
+    def trash(self, datasetRef):
+        """Indicate to the Datastore that a Dataset can be moved to the trash.
+
+        Parameters
+        ----------
+        datasetRef : `DatasetRef`
+            Reference to the required Dataset.
+
+        Raises
+        ------
+        FileNotFoundError
+            When Dataset does not exist.
+
+        Notes
+        -----
+        Some Datastores may implement this method as a silent no-op to
+        disable Dataset deletion through standard interfaces.
+        """
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
+    def emptyTrash(self):
+        """Remove all datasets from the trash.
+
+        Notes
+        -----
+        Some Datastores may implement this method as a silent no-op to
+        disable Dataset deletion through standard interfaces.
+        """
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
     def transfer(self, inputDatastore, datasetRef):
         """Retrieve a Dataset from an input `Datastore`, and store the result
         in this `Datastore`.

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -487,17 +487,26 @@ class ChainedDatastore(Datastore):
             of the child datastores removed the dataset.
         """
         log.debug(f"Removing {ref}")
+        self.trash(ref)
+        self.emptyTrash()
+
+    def trash(self, ref):
+        log.debug("Trashing %s", ref)
 
         counter = 0
         for datastore in self.datastores:
             try:
-                datastore.remove(ref)
+                datastore.trash(ref)
                 counter += 1
             except FileNotFoundError:
                 pass
 
         if counter == 0:
             raise FileNotFoundError(f"Could not remove from any child datastore: {ref}")
+
+    def emptyTrash(self):
+        for datastore in self.datastores:
+            datastore.emptyTrash()
 
     def transfer(self, inputDatastore, ref):
         """Retrieve a Dataset from an input `Datastore`,

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -242,12 +242,12 @@ class ChainedDatastore(Datastore):
             Reference to the required Dataset.
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
-            a slice of the Dataset to be loaded.
+            a slice of the dataset to be loaded.
 
         Returns
         -------
         inMemoryDataset : `object`
-            Requested Dataset or slice thereof as an InMemoryDataset.
+            Requested dataset or slice thereof as an InMemoryDataset.
 
         Raises
         ------
@@ -262,7 +262,7 @@ class ChainedDatastore(Datastore):
         for datastore in self.datastores:
             try:
                 inMemoryObject = datastore.get(ref, parameters)
-                log.debug("Found Dataset %s in datastore %s", ref, datastore.name)
+                log.debug("Found dataset %s in datastore %s", ref, datastore.name)
                 return inMemoryObject
             except FileNotFoundError:
                 pass
@@ -281,7 +281,7 @@ class ChainedDatastore(Datastore):
         Parameters
         ----------
         inMemoryDataset : `object`
-            The Dataset to store.
+            The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
 
@@ -420,8 +420,8 @@ class ChainedDatastore(Datastore):
         Returns
         -------
         uri : `str`
-            URI string pointing to the Dataset within the datastore. If the
-            Dataset does not exist in the datastore, and if ``predict`` is
+            URI string pointing to the dataset within the datastore. If the
+            dataset does not exist in the datastore, and if ``predict`` is
             `True`, the URI will be a prediction and will include a URI
             fragment "#predicted".
 
@@ -470,7 +470,7 @@ class ChainedDatastore(Datastore):
         raise FileNotFoundError("Dataset {} not in any datastore".format(ref))
 
     def remove(self, ref):
-        """Indicate to the Datastore that a Dataset can be removed.
+        """Indicate to the datastore that a dataset can be removed.
 
         The dataset will be removed from each datastore.  The dataset is
         not required to exist in every child datastore.
@@ -478,7 +478,7 @@ class ChainedDatastore(Datastore):
         Parameters
         ----------
         ref : `DatasetRef`
-            Reference to the required Dataset.
+            Reference to the required dataset.
 
         Raises
         ------
@@ -509,7 +509,7 @@ class ChainedDatastore(Datastore):
             datastore.emptyTrash()
 
     def transfer(self, inputDatastore, ref):
-        """Retrieve a Dataset from an input `Datastore`,
+        """Retrieve a dataset from an input `Datastore`,
         and store the result in this `Datastore`.
 
         Parameters
@@ -517,7 +517,7 @@ class ChainedDatastore(Datastore):
         inputDatastore : `Datastore`
             The external `Datastore` from which to retreive the Dataset.
         ref : `DatasetRef`
-            Reference to the required Dataset in the input data store.
+            Reference to the required dataset in the input data store.
 
         Returns
         -------

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -487,26 +487,30 @@ class ChainedDatastore(Datastore):
             of the child datastores removed the dataset.
         """
         log.debug(f"Removing {ref}")
-        self.trash(ref)
-        self.emptyTrash()
+        self.trash(ref, ignore_errors=False)
+        self.emptyTrash(ignore_errors=False)
 
-    def trash(self, ref):
+    def trash(self, ref, ignore_errors=True):
         log.debug("Trashing %s", ref)
 
         counter = 0
         for datastore in self.datastores:
             try:
-                datastore.trash(ref)
+                datastore.trash(ref, ignore_errors=ignore_errors)
                 counter += 1
             except FileNotFoundError:
                 pass
 
         if counter == 0:
-            raise FileNotFoundError(f"Could not remove from any child datastore: {ref}")
+            err_msg = f"Could not mark for removal from any child datastore: {ref}"
+            if ignore_errors:
+                log.warning(err_msg)
+            else:
+                raise FileNotFoundError(err_msg)
 
-    def emptyTrash(self):
+    def emptyTrash(self, ignore_errors=True):
         for datastore in self.datastores:
-            datastore.emptyTrash()
+            datastore.emptyTrash(ignore_errors=ignore_errors)
 
     def transfer(self, inputDatastore, ref):
         """Retrieve a dataset from an input `Datastore`,

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -274,7 +274,7 @@ class FileLikeDatastore(GenericBaseDatastore):
         # Docstring inherited from GenericBaseDatastore
         records = list(self.registry.fetchOpaqueData(self._tableName, dataset_id=ref.id))
         if len(records) == 0:
-            raise KeyError(f"Unable to retrieve location associated with Dataset {ref}.")
+            raise KeyError(f"Unable to retrieve location associated with dataset {ref}.")
         assert len(records) == 1, "Primary key constraint should make more than one result impossible."
         record = records[0]
         # Convert name of StorageClass to instance
@@ -376,7 +376,7 @@ class FileLikeDatastore(GenericBaseDatastore):
             Reference to the required Dataset.
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
-            a slice of the Dataset to be loaded.
+            a slice of the dataset to be loaded.
 
         Returns
         -------
@@ -388,7 +388,7 @@ class FileLikeDatastore(GenericBaseDatastore):
         # Get file metadata and internal metadata
         location, storedFileInfo = self._get_dataset_location_info(ref)
         if location is None:
-            raise FileNotFoundError(f"Could not retrieve Dataset {ref}.")
+            raise FileNotFoundError(f"Could not retrieve dataset {ref}.")
 
         # We have a write storage class and a read storage class and they
         # can be different for concrete composites.
@@ -417,7 +417,7 @@ class FileLikeDatastore(GenericBaseDatastore):
         Parameters
         ----------
         inMemoryDataset : `object`
-            The Dataset to store.
+            The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
 
@@ -589,8 +589,8 @@ class FileLikeDatastore(GenericBaseDatastore):
         Returns
         -------
         uri : `str`
-            URI string pointing to the Dataset within the datastore. If the
-            Dataset does not exist in the datastore, and if ``predict`` is
+            URI string pointing to the dataset within the datastore. If the
+            dataset does not exist in the datastore, and if ``predict`` is
             `True`, the URI will be a prediction and will include a URI
             fragment "#predicted".
             If the datastore does not have entities that relate well
@@ -640,7 +640,7 @@ class FileLikeDatastore(GenericBaseDatastore):
 
     @transactional
     def trash(self, ref):
-        """Indicate to the Datastore that a Dataset can be removed.
+        """Indicate to the datastore that a dataset can be removed.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -24,7 +24,6 @@
 __all__ = ("FileLikeDatastore", )
 
 import logging
-import itertools
 from abc import abstractmethod
 
 from sqlalchemy import Integer, String
@@ -357,7 +356,7 @@ class FileLikeDatastore(GenericBaseDatastore):
             raise RuntimeError(f"Datastore inconsistency error. {storedFileInfo.path} not in registry")
 
         # Get all the refs associated with this dataset if it is a composite
-        theseRefs = {r.id for r in itertools.chain([ref], ref.components.values())}
+        theseRefs = {r.id for r in ref.flatten([ref])}
 
         # Remove these refs from all the refs and if there is nothing left
         # then we can delete

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -202,10 +202,11 @@ class GenericBaseDatastore(Datastore):
         This method is used for immediate removal of a dataset and is
         generally reserved for internal testing of datastore APIs.
         It is implemented by calling `trash()` and then immediately calling
-        `emptyTrash()`.
+        `emptyTrash()`.  This call is meant to be immediate so errors
+        encountered during removal are not ignored.
         """
-        self.trash(ref)
-        self.emptyTrash()
+        self.trash(ref, ignore_errors=False)
+        self.emptyTrash(ignore_errors=False)
 
     def transfer(self, inputDatastore, ref):
         """Retrieve a dataset from an input `Datastore`,

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -59,7 +59,7 @@ class GenericBaseDatastore(Datastore):
         Parameters
         ----------
         ref : `DatasetRef`
-            The Dataset that is to be queried.
+            The dataset that is to be queried.
 
         Returns
         -------
@@ -80,7 +80,7 @@ class GenericBaseDatastore(Datastore):
         Parameters
         ----------
         ref : `DatasetRef`
-            The Dataset that has been removed.
+            The dataset that has been removed.
         """
         raise NotImplementedError()
 
@@ -159,7 +159,7 @@ class GenericBaseDatastore(Datastore):
         Parameters
         ----------
         inMemoryDataset : `object`
-            The Dataset to store.
+            The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
         """
@@ -180,7 +180,7 @@ class GenericBaseDatastore(Datastore):
         return
 
     def remove(self, ref):
-        """Indicate to the Datastore that a Dataset can be removed.
+        """Indicate to the Datastore that a dataset can be removed.
 
         .. warning::
 
@@ -208,7 +208,7 @@ class GenericBaseDatastore(Datastore):
         self.emptyTrash()
 
     def transfer(self, inputDatastore, ref):
-        """Retrieve a Dataset from an input `Datastore`,
+        """Retrieve a dataset from an input `Datastore`,
         and store the result in this `Datastore`.
 
         Parameters
@@ -216,7 +216,7 @@ class GenericBaseDatastore(Datastore):
         inputDatastore : `Datastore`
             The external `Datastore` from which to retreive the Dataset.
         ref : `DatasetRef`
-            Reference to the required Dataset in the input data store.
+            Reference to the required dataset in the input data store.
 
         """
         assert inputDatastore is not self  # unless we want it for renames?

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -98,12 +98,11 @@ class GenericBaseDatastore(Datastore):
         expandedItemInfos = []
 
         for ref, itemInfo in refsAndInfos:
-            # Main dataset.
-            expandedRefs.append(ref)
-            expandedItemInfos.append(itemInfo)
-            # Conmponents (using the same item info).
-            expandedRefs.extend(ref.components.values())
-            expandedItemInfos.extend([itemInfo] * len(ref.components))
+            # Need the main dataset and the components
+            expandedRefs.extend(ref.flatten([ref]))
+
+            # Need one for the main ref and then one for each component
+            expandedItemInfos.extend([itemInfo] * (len(ref.components) + 1))
 
         self.registry.insertDatasetLocations(self.name, expandedRefs)
         self.addStoredItemInfo(expandedRefs, expandedItemInfos)
@@ -125,8 +124,7 @@ class GenericBaseDatastore(Datastore):
         # Note that a ref can point to component dataset refs that
         # have been deleted already from registry but are still in
         # the python object. moveDatasetLocationToTrash will deal with that.
-        allRefs = [ref] + [compRef for compRef in ref.components.values()]
-        self.registry.moveDatasetLocationToTrash(self.name, allRefs)
+        self.registry.moveDatasetLocationToTrash(self.name, list(ref.flatten([ref])))
 
     def _post_process_get(self, inMemoryDataset, readStorageClass, assemblerParams=None):
         """Given the Python object read from the datastore, manipulate

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -227,12 +227,12 @@ class InMemoryDatastore(GenericBaseDatastore):
             Reference to the required Dataset.
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
-            a slice of the Dataset to be loaded.
+            a slice of the dataset to be loaded.
 
         Returns
         -------
         inMemoryDataset : `object`
-            Requested Dataset or slice thereof as an InMemoryDataset.
+            Requested dataset or slice thereof as an InMemoryDataset.
 
         Raises
         ------
@@ -281,7 +281,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         Parameters
         ----------
         inMemoryDataset : `object`
-            The Dataset to store.
+            The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
 
@@ -336,8 +336,8 @@ class InMemoryDatastore(GenericBaseDatastore):
         Returns
         -------
         uri : `str`
-            URI string pointing to the Dataset within the datastore. If the
-            Dataset does not exist in the datastore, and if ``predict`` is
+            URI string pointing to the dataset within the datastore. If the
+            dataset does not exist in the datastore, and if ``predict`` is
             `True`, the URI will be a prediction and will include a URI
             fragment "#predicted".
             If the datastore does not have entities that relate well
@@ -363,7 +363,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         return "mem://{}".format(name)
 
     def trash(self, ref):
-        """Indicate to the Datastore that a Dataset can be removed.
+        """Indicate to the Datastore that a dataset can be removed.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -25,7 +25,6 @@ __all__ = ("StoredMemoryItemInfo", "InMemoryDatastore")
 
 import time
 import logging
-import itertools
 from dataclasses import dataclass
 from typing import Dict, Optional, Any
 
@@ -403,7 +402,7 @@ class InMemoryDatastore(GenericBaseDatastore):
             realID, _ = self._get_dataset_info(ref)
 
             allRefs = self.related[realID]
-            theseRefs = {r.id for r in itertools.chain([ref], ref.components.values())}
+            theseRefs = {r.id for r in ref.flatten([ref])}
             remainingRefs = allRefs - theseRefs
             if not remainingRefs:
                 artifactsToRemove.add(realID)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -121,12 +121,12 @@ class PosixDatastore(FileLikeDatastore):
             Reference to the required Dataset.
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
-            a slice of the Dataset to be loaded.
+            a slice of the dataset to be loaded.
 
         Returns
         -------
         inMemoryDataset : `object`
-            Requested Dataset or slice thereof as an InMemoryDataset.
+            Requested dataset or slice thereof as an InMemoryDataset.
 
         Raises
         ------
@@ -157,7 +157,7 @@ class PosixDatastore(FileLikeDatastore):
         try:
             result = formatter.read(component=getInfo.component)
         except Exception as e:
-            raise ValueError(f"Failure from formatter '{formatter.name()}' for Dataset {ref.id}") from e
+            raise ValueError(f"Failure from formatter '{formatter.name()}' for dataset {ref.id}") from e
 
         return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams)
 
@@ -168,7 +168,7 @@ class PosixDatastore(FileLikeDatastore):
         Parameters
         ----------
         inMemoryDataset : `object`
-            The Dataset to store.
+            The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
 
@@ -383,7 +383,7 @@ class PosixDatastore(FileLikeDatastore):
         for ref in refs:
             location, storedFileInfo = self._get_dataset_location_info(ref)
             if location is None:
-                raise FileNotFoundError(f"Could not retrieve Dataset {ref}.")
+                raise FileNotFoundError(f"Could not retrieve dataset {ref}.")
             if transfer is None:
                 # TODO: do we also need to return the readStorageClass somehow?
                 yield FileDataset(refs=[ref], path=location.pathInStore, formatter=storedFileInfo.formatter)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -86,23 +86,31 @@ class PosixDatastore(FileLikeDatastore):
                 raise ValueError(f"No valid root at: {self.root}")
             safeMakeDir(self.root)
 
-    def exists(self, ref):
-        """Check if the dataset exists in the datastore.
+    def _artifact_exists(self, location):
+        """Check that an artifact exists in this datastore at the specified
+        location.
 
         Parameters
         ----------
-        ref : `DatasetRef`
-            Reference to the required dataset.
+        location : `Location`
+            Expected location of the artifact associated with this datastore.
 
         Returns
         -------
         exists : `bool`
-            `True` if the entity exists in the `Datastore`.
+            True if the location can be found, false otherwise.
         """
-        location, _ = self._get_dataset_location_info(ref)
-        if location is None:
-            return False
         return os.path.exists(location.path)
+
+    def _delete_artifact(self, location):
+        """Delete the artifact from the datastore.
+
+        Parameters
+        ----------
+        location : `Location`
+            Location of the artifact associated with this datastore.
+        """
+        os.remove(location.path)
 
     def get(self, ref, parameters=None):
         """Load an InMemoryDataset from the store.
@@ -338,41 +346,6 @@ class PosixDatastore(FileLikeDatastore):
         size = stat.st_size
         return StoredFileInfo(formatter=formatter, path=path, storageClass=ref.datasetType.storageClass,
                               file_size=size, checksum=checksum)
-
-    def remove(self, ref):
-        """Indicate to the Datastore that a Dataset can be removed.
-
-        .. warning::
-
-            This method does not support transactions; removals are
-            immediate, cannot be undone, and are not guaranteed to
-            be atomic if deleting either the file or the internal
-            database records fails.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Reference to the required Dataset.
-
-        Raises
-        ------
-        FileNotFoundError
-            Attempt to remove a dataset that does not exist.
-        """
-        # Get file metadata and internal metadata
-        location, _ = self._get_dataset_location_info(ref)
-        if location is None:
-            raise FileNotFoundError(f"Requested dataset ({ref}) does not exist")
-
-        if not os.path.exists(location.path):
-            raise FileNotFoundError(f"No such file: {location.uri}")
-
-        if self._can_remove_dataset_artifact(ref):
-            # Only reference to this path so we can remove it
-            os.remove(location.path)
-
-        # Remove rows from registries
-        self._remove_from_registry(ref)
 
     @staticmethod
     def computeChecksum(filename, algorithm="blake2b", block_size=8192):

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -122,12 +122,12 @@ class S3Datastore(FileLikeDatastore):
             Reference to the required Dataset.
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
-            a slice of the Dataset to be loaded.
+            a slice of the dataset to be loaded.
 
         Returns
         -------
         inMemoryDataset : `object`
-            Requested Dataset or slice thereof as an InMemoryDataset.
+            Requested dataset or slice thereof as an InMemoryDataset.
 
         Raises
         ------
@@ -193,7 +193,7 @@ class S3Datastore(FileLikeDatastore):
                 formatter._fileDescriptor.location = Location(*os.path.split(tmpFile.name))
                 result = formatter.read(component=getInfo.component)
         except Exception as e:
-            raise ValueError(f"Failure from formatter for Dataset {ref.id}: {e}") from e
+            raise ValueError(f"Failure from formatter for dataset {ref.id}: {e}") from e
 
         return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams)
 
@@ -204,7 +204,7 @@ class S3Datastore(FileLikeDatastore):
         Parameters
         ----------
         inMemoryDataset : `object`
-            The Dataset to store.
+            The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
 

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -87,23 +87,31 @@ class S3Datastore(FileLikeDatastore):
             # missing. Further discussion can make this happen though.
             raise IOError(f"Bucket {self.locationFactory.netloc} does not exist!")
 
-    def exists(self, ref):
-        """Check if the dataset exists in the datastore.
+    def _artifact_exists(self, location):
+        """Check that an artifact exists in this datastore at the specified
+        location.
 
         Parameters
         ----------
-        ref : `DatasetRef`
-            Reference to the required dataset.
+        location : `Location`
+            Expected location of the artifact associated with this datastore.
 
         Returns
         -------
         exists : `bool`
-            `True` if the entity exists in the `Datastore`.
+            True if the location can be found, false otherwise.
         """
-        location, _ = self._get_dataset_location_info(ref)
-        if location is None:
-            return False
-        return s3CheckFileExists(location, client=self.client)[0]
+        return s3CheckFileExists(location, client=self.client)
+
+    def _delete_artifact(self, location):
+        """Delete the artifact from the datastore.
+
+        Parameters
+        ----------
+        location : `Location`
+            Location of the artifact associated with this datastore.
+        """
+        self.client.delete_object(Bucket=location.netloc, Key=location.relativeToPathRoot)
 
     def get(self, ref, parameters=None):
         """Load an InMemoryDataset from the store.
@@ -329,38 +337,3 @@ class S3Datastore(FileLikeDatastore):
         return StoredFileInfo(formatter=formatter, path=tgtLocation.pathInStore,
                               storageClass=ref.datasetType.storageClass,
                               file_size=size, checksum=None)
-
-    def remove(self, ref):
-        """Indicate to the Datastore that a Dataset can be removed.
-
-        .. warning::
-
-            This method does not support transactions; removals are
-            immediate, cannot be undone, and are not guaranteed to
-            be atomic if deleting either the file or the internal
-            database records fails.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Reference to the required Dataset.
-
-        Raises
-        ------
-        FileNotFoundError
-            Attempt to remove a dataset that does not exist.
-        """
-        location, _ = self._get_dataset_location_info(ref)
-        if location is None:
-            raise FileNotFoundError(f"Requested dataset ({ref}) does not exist")
-
-        if not s3CheckFileExists(location, client=self.client):
-            raise FileNotFoundError(f"No such file: {location.uri}")
-
-        if self._can_remove_dataset_artifact(ref):
-            # https://github.com/boto/boto3/issues/507 - there is no way of
-            # knowing if the file was actually deleted
-            self.client.delete_object(Bucket=location.netloc, Key=location.relativeToPathRoot)
-
-        # Remove rows from registries
-        self._remove_from_registry(ref)

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1028,7 +1028,7 @@ class Registry:
             Raised if ``any(ref.id is None for ref in refs)``.
         """
         self._db.insert(
-            self._tables.dataset_storage,
+            self._tables.dataset_location,
             *[{"datastore_name": datastoreName, "dataset_id": _checkAndGetId(ref)} for ref in refs]
         )
 
@@ -1054,7 +1054,7 @@ class Registry:
         AmbiguousDatasetError
             Raised if ``ref.id`` is `None`.
         """
-        table = self._tables.dataset_storage
+        table = self._tables.dataset_location
         result = self._db.query(
             sqlalchemy.sql.select(
                 [table.columns.datastore_name]
@@ -1083,7 +1083,7 @@ class Registry:
             Raised if ``ref.id`` is `None`.
         """
         self._db.delete(
-            self._tables.dataset_storage,
+            self._tables.dataset_location,
             ["dataset_id", "datastore_name"],
             {"dataset_id": _checkAndGetId(ref), "datastore_name": datastoreName}
         )

--- a/python/lsst/daf/butler/registry/tables.py
+++ b/python/lsst/daf/butler/registry/tables.py
@@ -44,7 +44,7 @@ RegistryTablesTuple = namedtuple(
         "dataset_collection",
         "quantum",
         "dataset_consumers",
-        "dataset_storage",
+        "dataset_location",
     ]
 )
 
@@ -336,7 +336,7 @@ def makeRegistryTableSpecs(universe: DimensionUniverse, collections: CollectionM
                 ),
             ],
         ),
-        dataset_storage=ddl.TableSpec(
+        dataset_location=ddl.TableSpec(
             doc=(
                 "A table that provides information on whether a Dataset is stored in "
                 "one or more Datastores.  The presence or absence of a record in this "

--- a/python/lsst/daf/butler/registry/tables.py
+++ b/python/lsst/daf/butler/registry/tables.py
@@ -45,6 +45,7 @@ RegistryTablesTuple = namedtuple(
         "quantum",
         "dataset_consumers",
         "dataset_location",
+        "dataset_location_trash",
     ]
 )
 
@@ -198,6 +199,43 @@ def makeRegistryTableSpecs(universe: DimensionUniverse, collections: CollectionM
     )
     collections.addRunForeignKey(quantum, onDelete="CASCADE", nullable=False)
 
+    # We want the dataset_location and dataset_location_trash tables
+    # to have the same definition
+    dataset_location_spec = dict(
+        doc=(
+            "A table that provides information on whether a Dataset is stored in "
+            "one or more Datastores.  The presence or absence of a record in this "
+            "table itself indicates whether the Dataset is present in that "
+            "Datastore. "
+        ),
+        fields=[
+            ddl.FieldSpec(
+                name="dataset_id",
+                dtype=sqlalchemy.BigInteger,
+                primaryKey=True,
+                nullable=False,
+                doc="Link to the dataset table.",
+            ),
+            ddl.FieldSpec(
+                name="datastore_name",
+                dtype=sqlalchemy.String,
+                length=256,
+                primaryKey=True,
+                nullable=False,
+                doc="Name of the Datastore this entry corresponds to.",
+            ),
+        ],
+    )
+
+    dataset_location = ddl.TableSpec(**dataset_location_spec,
+                                     foreignKeys=[
+                                         ddl.ForeignKeySpec(
+                                             table="dataset", source=("dataset_id",), target=("dataset_id",)
+                                         )
+                                     ])
+
+    dataset_location_trash = ddl.TableSpec(**dataset_location_spec)
+
     # All other table specs are fully static and do not depend on
     # configuration.
     return RegistryTablesTuple(
@@ -336,34 +374,6 @@ def makeRegistryTableSpecs(universe: DimensionUniverse, collections: CollectionM
                 ),
             ],
         ),
-        dataset_location=ddl.TableSpec(
-            doc=(
-                "A table that provides information on whether a Dataset is stored in "
-                "one or more Datastores.  The presence or absence of a record in this "
-                "table itself indicates whether the Dataset is present in that "
-                "Datastore. "
-            ),
-            fields=[
-                ddl.FieldSpec(
-                    name="dataset_id",
-                    dtype=sqlalchemy.BigInteger,
-                    primaryKey=True,
-                    nullable=False,
-                    doc="Link to the dataset table.",
-                ),
-                ddl.FieldSpec(
-                    name="datastore_name",
-                    dtype=sqlalchemy.String,
-                    length=256,
-                    primaryKey=True,
-                    nullable=False,
-                    doc="Name of the Datastore this entry corresponds to.",
-                ),
-            ],
-            foreignKeys=[
-                ddl.ForeignKeySpec(
-                    table="dataset", source=("dataset_id",), target=("dataset_id",)
-                )
-            ],
-        ),
+        dataset_location=dataset_location,
+        dataset_location_trash=dataset_location_trash,
     )

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -386,7 +386,7 @@ class RegistryTests(ABC):
 
     def testDatasetLocations(self):
         """Tests for `Registry.insertDatasetLocations`,
-        `Registry.getDatasetLocations`, and `Registry.removeDatasetLocations`.
+        `Registry.getDatasetLocations`, and `Registry.removeDatasetLocation`.
         """
         registry = self.makeRegistry()
         self.loadData(registry, "base.yaml")
@@ -408,14 +408,14 @@ class RegistryTests(ABC):
         self.assertEqual(len(addresses), 2)
         self.assertIn(datastoreName, addresses)
         self.assertIn(datastoreName2, addresses)
-        registry.removeDatasetLocation(datastoreName, ref)
+        registry.removeDatasetLocation(datastoreName, [ref])
         addresses = registry.getDatasetLocations(ref)
         self.assertEqual(len(addresses), 1)
         self.assertNotIn(datastoreName, addresses)
         self.assertIn(datastoreName2, addresses)
         with self.assertRaises(OrphanedRecordError):
             registry.removeDataset(ref)
-        registry.removeDatasetLocation(datastoreName2, ref)
+        registry.removeDatasetLocation(datastoreName2, [ref])
         addresses = registry.getDatasetLocations(ref)
         self.assertEqual(len(addresses), 0)
         self.assertNotIn(datastoreName2, addresses)


### PR DESCRIPTION
Splits the remove step into two phases. The first moves a row from the dataset_location to the dataset_location_trash table. The second step deletes all the datasets that have been trashed. This will hopefully reduce further the chances of datasets being deleted and leaving the datastore in an inconsistent state.

I need to clean up some of the commits but tests all pass so it's ready for a look.