### PR TITLE
DM-24347: Allow a component dataset to be None

### DIFF
--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -258,10 +258,10 @@ class InMemoryDatastore(GenericBaseDatastore):
 
         inMemoryDataset = self.datasets[realID]
 
+        component = ref.datasetType.component()
+
         # Different storage classes implies a component request
         if readStorageClass != writeStorageClass:
-
-            component = ref.datasetType.component()
 
             if component is None:
                 raise ValueError("Storage class inconsistency ({} vs {}) but no"
@@ -273,7 +273,8 @@ class InMemoryDatastore(GenericBaseDatastore):
 
         # Since there is no formatter to process parameters, they all must be
         # passed to the assembler.
-        return self._post_process_get(inMemoryDataset, readStorageClass, parameters)
+        return self._post_process_get(inMemoryDataset, readStorageClass, parameters,
+                                      isComponent=component is not None)
 
     def put(self, inMemoryDataset, ref):
         """Write a InMemoryDataset with a given `DatasetRef` to the store.

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -157,7 +157,8 @@ class PosixDatastore(FileLikeDatastore):
         try:
             result = formatter.read(component=getInfo.component)
         except Exception as e:
-            raise ValueError(f"Failure from formatter '{formatter.name()}' for dataset {ref.id}") from e
+            raise ValueError(f"Failure from formatter '{formatter.name()}' for dataset {ref.id}"
+                             f" ({ref.datasetType.name} from {location.path}): {e}") from e
 
         return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams,
                                       isComponent=getInfo.component is not None)

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -159,7 +159,8 @@ class PosixDatastore(FileLikeDatastore):
         except Exception as e:
             raise ValueError(f"Failure from formatter '{formatter.name()}' for dataset {ref.id}") from e
 
-        return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams)
+        return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams,
+                                      isComponent=getInfo.component is not None)
 
     @transactional
     def put(self, inMemoryDataset, ref):

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -193,7 +193,8 @@ class S3Datastore(FileLikeDatastore):
                 formatter._fileDescriptor.location = Location(*os.path.split(tmpFile.name))
                 result = formatter.read(component=getInfo.component)
         except Exception as e:
-            raise ValueError(f"Failure from formatter for dataset {ref.id}: {e}") from e
+            raise ValueError(f"Failure from formatter '{formatter.name()}' for dataset {ref.id}"
+                             f" ({ref.datasetType.name} from {location.uri}): {e}") from e
 
         return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams,
                                       isComponent=getInfo.component is not None)

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -195,7 +195,8 @@ class S3Datastore(FileLikeDatastore):
         except Exception as e:
             raise ValueError(f"Failure from formatter for dataset {ref.id}: {e}") from e
 
-        return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams)
+        return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams,
+                                      isComponent=getInfo.component is not None)
 
     @transactional
     def put(self, inMemoryDataset, ref):

--- a/python/lsst/daf/butler/formatters/fileFormatter.py
+++ b/python/lsst/daf/butler/formatters/fileFormatter.py
@@ -177,7 +177,9 @@ class FileFormatter(Formatter):
         # component coercing it to its appropriate pytype
         data = self._assembleDataset(data, component)
 
-        if data is None:
+        # Special case components by allowing a formatter to return None
+        # to indicate that the component was understood but is missing
+        if data is None and component is None:
             raise ValueError(f"Unable to read data with URI {self.fileDescriptor.location.uri}")
 
         return data

--- a/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
+++ b/python/lsst/daf/butler/formatters/fitsExposureFormatter.py
@@ -109,7 +109,7 @@ class FitsExposureFormatter(Formatter):
                         'metadata': ('readMetadata', False),
                         'filter': ('readFilter', False),
                         'polygon': ('readValidPolygon', False),
-                        'appCorrMap': ('readApCorrMap', False),
+                        'apCorrMap': ('readApCorrMap', False),
                         'visitInfo': ('readVisitInfo', False),
                         'transmissionCurve': ('readTransmissionCurve', False),
                         'detector': ('readDetector', False),

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -184,12 +184,20 @@ class MetricsExample:
     def __eq__(self, other):
         return self.summary == other.summary and self.output == other.output and self.data == other.data
 
+    def __str__(self):
+        return str(self.exportAsDict())
+
+    def __repr__(self):
+        return f"MetricsExample({self.exportAsDict()})"
+
     def exportAsDict(self):
         """Convert object contents to a single python dict."""
         exportDict = {"summary": self.summary,
                       "output": self.output}
         if self.data is not None:
             exportDict["data"] = list(self.data)
+        else:
+            exportDict["data"] = None
         return exportDict
 
     def _asdict(self):

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -476,6 +476,9 @@ class ButlerTests(ButlerPutGetTests):
         self.assertEqual(uri1, uri2)
 
         # Test that removing one does not break the second
+        # This line will issue a warning log message for a ChainedDatastore
+        # that uses an InMemoryDatastore since in-memory can not ingest
+        # files.
         butler.prune([datasets[0].refs[0]], unstore=True, disassociate=False)
         self.assertFalse(butler.datasetExists(datasetTypeName, dataId1))
         self.assertTrue(butler.datasetExists(datasetTypeName, dataId2))

--- a/tests/test_datastoreFits.py
+++ b/tests/test_datastoreFits.py
@@ -185,7 +185,8 @@ class DatastoreFitsTests(FitsCatalogDatasetsHelper, DatasetTestHelper, Datastore
             compRef = self.makeDatasetRef(ref.datasetType.componentTypeName(compName), dimensions,
                                           storageClass.components[compName], dataId, id=ref.id)
             component = datastore.get(compRef)
-            self.assertIsInstance(component, compRef.datasetType.storageClass.pytype)
+            # This check is done also inside datastore
+            self.assertIsInstance(component, (compRef.datasetType.storageClass.pytype, type(None)))
 
         # Get the WCS component to check it
         wcsRef = self.makeDatasetRef(ref.datasetType.componentTypeName("wcs"), dimensions,


### PR DESCRIPTION
 Sometimes when we store a dataset, not all the components are defined. Registry won't register them in that case but there are some code paths that will still cause a datastore to try to return a None component.