### PR TITLE
DM-24543: handle conflicting CLI subcommand names

### DIFF
--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -20,12 +20,18 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import click
+from collections import defaultdict
 import logging
 import os
+import yaml
 
 from . import cmd as butlerCommands
 from .utils import to_upper
 from lsst.utils import doImport
+
+# localCmdPkg identifies commands that are in this package, in the dict of
+# commands used in this file.
+localCmdPkg = "localPackage"
 
 log = logging.getLogger(__name__)
 
@@ -49,12 +55,23 @@ def cmdNameToFuncName(commandName):
 
 class LoaderCLI(click.MultiCommand):
 
+    def __init__(self, *args, **kwargs):
+        self.commands = None
+        super().__init__(*args, **kwargs)
+
     @staticmethod
     def _getPluginList():
+        """Get the list of importable yaml files that contain butler cli data.
+
+        Returns
+        -------
+        `list` [`str`]
+            The list of files that contain yaml data about a cli plugin.
+        """
         pluginModules = os.environ.get("DAF_BUTLER_PLUGINS")
-        if not pluginModules:
-            return []
-        return pluginModules.split(":")
+        if pluginModules:
+            return pluginModules.split(":")
+        return []
 
     @staticmethod
     def _importPlugin(pluginName):
@@ -79,25 +96,26 @@ class LoaderCLI(click.MultiCommand):
             return None
 
     @staticmethod
-    def _getLocalCommand(commandName):
-        """Search the commands provided by this package and return the command
-        if found.
+    def _mergeCommandLists(a, b):
+        """Combine two dicts whose keys are strings (command name) and values
+        are list of string (the package(s) that provide the named command).
 
         Parameters
         ----------
-        commandName : string
-            The name of the command to search for.
+        a : `defaultdict` [`str`: `list` [`str`]]
+            The key is the command name. The value is a list of package(s) that
+            contains the command.
+        b : (same as a)
 
         Returns
         -------
-        Command object
-            A Click command that can be executed.
+        commands : `defaultdict` [`str`: [`str`]]
+            For convenience, returns a extended with b. ('a' is modified in
+            place.)
         """
-        try:
-            return getattr(butlerCommands, commandName)
-        except AttributeError:
-            pass
-        return None
+        for key, val in b.items():
+            a[key].extend(val)
+        return a
 
     @staticmethod
     def _getLocalCommands():
@@ -105,10 +123,74 @@ class LoaderCLI(click.MultiCommand):
 
         Returns
         -------
-        list of string
-            The names of the commands.
+        commands : `defaultdict` [`str`, `list` [`str`]]
+            The key is the command name. The value is a list of package(s) that
+            contains the command.
         """
-        return [funcNameToCmdName(f) for f in butlerCommands.__all__]
+        return defaultdict(list, {funcNameToCmdName(f): [localCmdPkg] for f in butlerCommands.__all__})
+
+    @classmethod
+    def _getPluginCommands(cls):
+        """Get the commands offered by plugin packages.
+
+        Returns
+        -------
+        commands : `defaultdict` [`str`, `list` [`str`]]
+            The key is the command name. The value is a list of package(s) that
+            contains the command.
+        """
+        commands = defaultdict(list)
+        for pluginName in cls._getPluginList():
+            try:
+                with open(pluginName, "r") as resourceFile:
+                    resources = defaultdict(list, yaml.safe_load(resourceFile))
+            except Exception as err:
+                log.warning(f"Error loading commands from {pluginName}, skipping. {err}")
+                continue
+            if "cmd" not in resources:
+                log.warning(f"No commands found in {pluginName}, skipping.")
+                continue
+            pluginCommands = {cmd: [resources["cmd"]["import"]] for cmd in resources["cmd"]["commands"]}
+            cls._mergeCommandLists(commands, defaultdict(list, pluginCommands))
+        return commands
+
+    @classmethod
+    def _getCommands(cls):
+        """Get the commands offered by daf_butler and plugin packages.
+
+        Returns
+        -------
+        commands : `defaultdict` [`str`, `list` [`str`]]
+            The key is the command name. The value is a list of package(s) that
+            contains the command.
+        """
+        commands = cls._mergeCommandLists(cls._getLocalCommands(), cls._getPluginCommands())
+        return commands
+
+    @staticmethod
+    def _raiseIfDuplicateCommands(commands):
+        """If any provided command is offered by more than one package raise an
+        exception.
+
+        Parameters
+        ----------
+        commands : `defaultdict` [`str`, `list` [`str`]]
+            The key is the command name. The value is a list of package(s) that
+            contains the command.
+
+        Raises
+        ------
+        click.ClickException
+            Raised if a command is offered by more than one package, with an
+            error message to be displayed to the user.
+        """
+
+        msg = ""
+        for command, packages in commands.items():
+            if len(packages) > 1:
+                msg += f"Command '{command}' exists in packages {', '.join(packages)}. "
+        if msg:
+            raise click.ClickException(msg + "Duplicate commands are not supported, aborting.")
 
     def list_commands(self, ctx):
         """Used by Click to get all the commands that can be called by the
@@ -121,17 +203,14 @@ class LoaderCLI(click.MultiCommand):
 
         Returns
         -------
-        List of string
+        commands : `list` [`str`]
             The names of the commands that can be called by the butler command.
         """
-        commands = self._getLocalCommands()
-        for pluginName in self._getPluginList():
-            plugin = self._importPlugin(pluginName)
-            if plugin is None:
-                continue
-            commands.extend([funcNameToCmdName(command) for command in plugin.__all__])
-        commands.sort()
-        return commands
+        if self.commands is None:
+            self.commands = self._getCommands()
+        self._raiseIfDuplicateCommands(self.commands)
+        log.debug(self.commands.keys())
+        return self.commands.keys()
 
     def get_command(self, context, name):
         """Used by Click to get a single command for execution.
@@ -145,27 +224,17 @@ class LoaderCLI(click.MultiCommand):
 
         Returns
         -------
-        click.Command
+        command : click.Command
             A Command that wraps a callable command function.
         """
-        name = cmdNameToFuncName(name)
-        localCmd = self._getLocalCommand(name)
-        if localCmd is not None:
-            return localCmd
-        for pluginName in self._getPluginList():
-            plugin = self._importPlugin(pluginName)
-            if plugin is None:
-                continue
-            for command in plugin.__all__:
-                if command == name:
-                    fullCommand = pluginName + "." + command
-                    try:
-                        cmd = doImport(fullCommand)
-                    except Exception as err:
-                        log.debug("Command import exception: %s", err)
-                        context.fail("Could not import command {fullCommand}")
-                    return cmd
-        return None
+        if self.commands is None:
+            self.commands = self._getCommands()
+        if name not in self.commands:
+            return None
+        self._raiseIfDuplicateCommands(self.commands)
+        if self.commands[name][0] == localCmdPkg:
+            return getattr(butlerCommands, cmdNameToFuncName(name))
+        return doImport(self.commands[name][0] + "." + cmdNameToFuncName(name))
 
 
 @click.command(cls=LoaderCLI)

--- a/tests/test_cliCmdConfigDump.py
+++ b/tests/test_cliCmdConfigDump.py
@@ -34,8 +34,6 @@ from lsst.daf.butler.cli import butler
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
-os.environ["DAF_BUTLER_PLUGINS"] = "lsst.daf.butler.cli.cmd"
-
 
 class Suite(unittest.TestCase):
 
@@ -44,11 +42,11 @@ class Suite(unittest.TestCase):
         runner = click.testing.CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(butler.cli, ["create", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
 
             # test dumping to stdout:
             result = runner.invoke(butler.cli, ["config-dump", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             # check for some expected keywords:
             cfg = yaml.safe_load(result.stdout)
             self.assertIn("composites", cfg)
@@ -60,9 +58,9 @@ class Suite(unittest.TestCase):
         runner = click.testing.CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(butler.cli, ["create", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             result = runner.invoke(butler.cli, ["config-dump", "--repo", "here", "--file=there"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             # check for some expected keywords:
             with open("there", "r") as f:
                 cfg = yaml.safe_load(f)
@@ -75,9 +73,9 @@ class Suite(unittest.TestCase):
         runner = click.testing.CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(butler.cli, ["create", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             result = runner.invoke(butler.cli, ["config-dump", "--repo", "here", "--subset", "datastore"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             cfg = yaml.safe_load(result.stdout)
             # the datastore cfg is expected to have exactly six keys:
             self.assertIs(len(cfg.keys()), 6)
@@ -93,7 +91,7 @@ class Suite(unittest.TestCase):
         runner = click.testing.CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(butler.cli, ["create", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             # test dumping to stdout:
             result = runner.invoke(butler.cli, ["config-dump", "--repo", "here", "--subset", "foo"])
             self.assertEqual(result.exit_code, 1)

--- a/tests/test_cliCmdConfigValidate.py
+++ b/tests/test_cliCmdConfigValidate.py
@@ -41,10 +41,10 @@ class Suite(unittest.TestCase):
         runner = click.testing.CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(butler.cli, ["create", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             # verify the just-created repo validates without error
             result = runner.invoke(butler.cli, ["config-validate", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             self.assertEqual(result.stdout, "No problems encountered with configuration.\n")
 
     def testConfigValidate_ignore(self):
@@ -52,11 +52,11 @@ class Suite(unittest.TestCase):
         runner = click.testing.CliRunner()
         with runner.isolated_filesystem():
             result = runner.invoke(butler.cli, ["create", "--repo", "here"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             # verify the just-created repo validates without error
             result = runner.invoke(butler.cli, ["config-validate", "--repo", "here",
                                    "--ignore", "storageClasses,repoTransferFormats", "-i", "dimensions"])
-            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.exit_code, 0, result.stdout)
             self.assertEqual(result.stdout, "No problems encountered with configuration.\n")
 
 

--- a/tests/test_commandLine.py
+++ b/tests/test_commandLine.py
@@ -33,8 +33,6 @@ from lsst.daf.butler.cli import butler
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
-os.environ["DAF_BUTLER_PLUGINS"] = "lsst.daf.butler.cli.cmd"
-
 
 class Suite(unittest.TestCase):
 


### PR DESCRIPTION
Refactor the plugin loader so that commands with the same name in
different plugins are found and an error rased.