### PR TITLE
Attempt to run mypy on a subset of the package (PR is for travis testing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/*
 .mypy_cache/
 .idea/
 .vscode/
+mypy.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ matrix:
     - python: '3.7'
       install:
       - pip install flake8
-      script: flake8
+      - pip install mypy
+      script:
+      - flake8
+      - cd python && mypy -p lsst.daf.butler

--- a/python/SConscript
+++ b/python/SConscript
@@ -1,0 +1,6 @@
+# -*- python -*-
+from lsst.sconsUtils import state
+mypy = state.env.Command("../mypy.log", "lsst/daf/butler",
+                         "cd python && mypy -p lsst.daf.butler 2>&1 | tee -a ../mypy.log")
+
+state.env.Alias("mypy", mypy)

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -43,7 +43,7 @@ from ..wildcards import CollectionSearch
 from .._collectionType import CollectionType
 
 if TYPE_CHECKING:
-    from .database import Database, StaticTablesContext
+    from ._database import Database, StaticTablesContext
 
 
 class MissingCollectionError(Exception):

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -175,8 +175,7 @@ class Database(ABC):
 
     `Database` itself has several underscore-prefixed attributes:
 
-     - ``_cs``: SQLAlchemy objects representing the connection and transaction
-        state.
+     - ``_connection``: SQLAlchemy object representing the connection.
      - ``_metadata``: the `sqlalchemy.schema.MetaData` object representing
         the tables and other schema entities.
 

--- a/python/lsst/daf/butler/registry/nameShrinker.py
+++ b/python/lsst/daf/butler/registry/nameShrinker.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 __all__ = ["NameShrinker"]
 
 import hashlib
+from typing import Dict
 
 
 class NameShrinker:
@@ -44,7 +45,7 @@ class NameShrinker:
     def __init__(self, maxLength: int, hashSize: int = 4):
         self.maxLength = maxLength
         self.hashSize = hashSize
-        self._names = {}
+        self._names: Dict[str, str] = {}
 
     def shrink(self, original: str) -> str:
         """Shrink a name and remember the mapping between the original name and

--- a/python/lsst/daf/butler/registry/simpleQuery.py
+++ b/python/lsst/daf/butler/registry/simpleQuery.py
@@ -25,6 +25,7 @@ __all__ = ("Select", "SimpleQuery")
 
 from typing import (
     Any,
+    ClassVar,
     List,
     Optional,
     Union,
@@ -42,7 +43,8 @@ class Select:
     """Tag class used to indicate that a field should be returned in
     a SELECT query.
     """
-    pass
+
+    Or: ClassVar
 
 
 Select.Or = Union[T, Type[Select]]

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,0 +1,20 @@
+[mypy]
+warn_unused_configs = True
+namespace_packages = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-astropy.*]
+ignore_missing_imports = True
+
+[mypy-boto3]
+ignore_missing_imports = True
+
+[mypy-lsst.*]
+ignore_missing_imports = True
+ignore_errors = True
+
+[mypy-lsst.daf.butler.registry.interfaces.*]
+ignore_missing_imports = False
+ignore_errors = False


### PR DESCRIPTION
The setup here is probably a little unusual, because it turned out to be quite tricky to get mypy to determine that the root of our package tree is `lsst` (which has no `__init__.py`), not `python` (which also has no `__init__.py`) or `daf` (the first directory that _does_ have such a file).  The only solution I could find was to run mypy from the `python` directory, with a config that enables namespace package support.

This was difficult to diagnose because if you run mypy on files or directories, it mostly doesn't care what the package root is, and seems to be working - but it will not obey configuration that's targeted at a particular directory, and AFAICT the config option that's supposed to warn about that (`warn_unused_configs = True`) didn't actually warn (maybe it doesn't work on globs?).  Anyhow, if you run it with `-p lsst.daf.butler` instead of on files/directories, it will complain if it doesn't recognize the package, so that seems much safer.

Anyhow, the config disables checking for all of `lsst.*`, then re-enables it for just `lsst.daf.butler.registry.interfaces.*`; we can enable other sub-packages as we clean them up.