### PR TITLE
Improve connection string matching by ignoring driver value.

### DIFF
--- a/python/lsst/daf/butler/registry/_dbAuth.py
+++ b/python/lsst/daf/butler/registry/_dbAuth.py
@@ -97,7 +97,8 @@ class DbAuth:
         Parameters
         ----------
         dialectname : `str`
-            Database dialect, f.e. sqlite, mysql, postgresql, oracle, or mssql.
+            Database dialect, for example sqlite, mysql, postgresql, oracle,
+            or mssql.
         username : `str` or None
             Username from connection URL if present.
         host : `str`
@@ -131,9 +132,8 @@ class DbAuth:
         the database connection URL, the dictionary must also contain a
         ``username`` item.
 
-        The ``url`` item of the authorization dictionaries can contain both the
-        dialect and the driver of the database URL but the driver is ignored
-        during matching.
+        The ``url`` item must begin with a dialect and is not allowed to
+        specify dialect+driver.
 
         Glob-style patterns (using "``*``" and "``?``" as wildcards) can be
         used to match the host and database name portions of the connection
@@ -181,13 +181,16 @@ class DbAuth:
                 raise DbAuthError(
                     "Missing database dialect in URL: " + authDict["url"])
 
+            if "+" in components.scheme:
+                raise DbAuthError("Authorization dictionary URLs should only specify "
+                                  f"dialects, got: {components.scheme}. instead.")
+
             # dialect and driver are allowed in db string, since functionality
             # could change. Connecting to a DB using different driver does not
             # change dbname/user/pass and other auth info so we ignore it.
             # https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls
             dialect = dialectname.split("+")[0]
-            componentsDialect = components.scheme.split("+")[0]
-            if dialect != componentsDialect:
+            if dialect != components.scheme:
                 continue
 
             # Check for same database name

--- a/python/lsst/daf/butler/registry/connectionString.py
+++ b/python/lsst/daf/butler/registry/connectionString.py
@@ -47,12 +47,16 @@ class ConnectionStringFactory:
 
     @classmethod
     def fromConfig(cls, registryConfig):
-        """Parses the 'db' and, if they exist, username, password, host, port
-        and database keys from given config.
+        """Parses the `db`, and, if they exist, username, password, host, port
+        and database keys from the given config.
 
         If no  username and password are found in the connection string, or in
         the config, they are retrieved from a file at `DB_AUTH_PATH` or
         `DB_AUTH_ENVVAR`. Sqlite dialect does not require a password.
+
+        The `db` key value of the given config specifies the default connection
+        string, such that if no additional connection string parameters are
+        provided or retrieved, the `db` key is returned unmodified.
 
         Parameters
         ----------
@@ -73,13 +77,13 @@ class ConnectionStringFactory:
 
         Notes
         -----
-        Matching requires drivername, host and database keys. If drivername is
-        not specified in the db string and host and database keys are not found
-        in the db string, or as explicit keys in the config, the matcher
-        returns an unchanged connection string.
-        Insufficiently specified connection strings are interpreted as
-        indication that a 3rd party authentication mechanism, f.e. Oracle
-        Wallet, are used and are not modified.
+        Matching requires dialect, host and database keys. If dialect is not
+        specified in the db string and host and database keys are not found in
+        the db string, or as explicit keys in the config, the matcher returns
+        an unchanged connection string.
+        Insufficiently specified connection strings are interpreted as an
+        indication that a 3rd party authentication mechanism, such as Oracle
+        Wallet, is being used and therefore are left unmodified.
         """
         # this import can not live on the top because of circular import issue
         from lsst.daf.butler.registry import RegistryConfig
@@ -90,7 +94,7 @@ class ConnectionStringFactory:
             if getattr(conStr, key) is None:
                 setattr(conStr, key, regConf.get(key))
 
-        # allow 3rd party authentication mechanisms by assuming connection
+        # Allow 3rd party authentication mechanisms by assuming connection
         # string is correct when we can not recognize (dialect, host, database)
         # matching keys.
         if any((conStr.drivername is None,

--- a/python/lsst/daf/butler/registry/connectionString.py
+++ b/python/lsst/daf/butler/registry/connectionString.py
@@ -47,9 +47,8 @@ class ConnectionStringFactory:
 
     @classmethod
     def fromConfig(cls, registryConfig):
-        """Parses the 'db' key in the config, and if they exist username,
-        password, host, port and database keys, and returns an connection
-        string object.
+        """Parses the 'db' and, if they exist, username, password, host, port
+        and database keys from given config.
 
         If no  username and password are found in the connection string, or in
         the config, they are retrieved from a file at `DB_AUTH_PATH` or
@@ -71,6 +70,16 @@ class ConnectionStringFactory:
             If the credentials file has incorrect permissions.
         DbAuthError
             A problem occured when retrieving DB authentication.
+
+        Notes
+        -----
+        Matching requires drivername, host and database keys. If drivername is
+        not specified in the db string and host and database keys are not found
+        in the db string, or as explicit keys in the config, the matcher
+        returns an unchanged connection string.
+        Insufficiently specified connection strings are interpreted as
+        indication that a 3rd party authentication mechanism, f.e. Oracle
+        Wallet, are used and are not modified.
         """
         # this import can not live on the top because of circular import issue
         from lsst.daf.butler.registry import RegistryConfig
@@ -81,14 +90,15 @@ class ConnectionStringFactory:
             if getattr(conStr, key) is None:
                 setattr(conStr, key, regConf.get(key))
 
-        # when host is None we cross our fingers and return
-        if conStr.host is None:
+        # allow 3rd party authentication mechanisms by assuming connection
+        # string is correct when we can not recognize (dialect, host, database)
+        # matching keys.
+        if any((conStr.drivername is None,
+               conStr.host is None,
+               conStr.database is None)):
             return conStr
 
-        # allow other mechanisms to insert username and password by not forcing
-        # the credentials to exist. If other mechanisms are used it's possible
-        # that credentials were never set-up, or that there would be no match
-        # in the credentials file. Both need to be ignored.
+        # Ignore when credentials are not set up, or when no matches are found
         try:
             dbAuth = DbAuth(DB_AUTH_PATH, DB_AUTH_ENVVAR)
             auth = dbAuth.getAuth(conStr.drivername, conStr.username, conStr.host,
@@ -97,8 +107,7 @@ class ConnectionStringFactory:
             # credentials file doesn't exist or no matches were found
             pass
         else:
-            # only assign auth when *no* errors were raised, otherwise assume
-            # connection string was correct
+            # only assign auth when *no* errors were raised
             conStr.username = auth[0]
             conStr.password = auth[1]
 

--- a/tests/config/dbAuth/db-auth.yaml
+++ b/tests/config/dbAuth/db-auth.yaml
@@ -20,3 +20,6 @@
 - url: "postgresql://*"
   username: user
   password: test8
+- url: "oracle://*.example.com"
+  username: user
+  password: test9

--- a/tests/config/dbAuth/registryConf5.yaml
+++ b/tests/config/dbAuth/registryConf5.yaml
@@ -1,0 +1,4 @@
+# tests that connection string factory leaves non-standard strings unmodified (f.e. Oracle Wallet)
+registry:
+  db: "oracle+cx_oracle://@oracleRegistry"
+  expected: "oracle+cx_oracle://@oracleRegistry"

--- a/tests/config/dbAuth/registryConf6.yaml
+++ b/tests/config/dbAuth/registryConf6.yaml
@@ -1,0 +1,6 @@
+# tests that dbAuth can match Oracle strings.
+registry:
+  db: "oracle+cx_oracle://oracle.example.com"
+  database: "my_database"
+  port: 5432
+  expected: "oracle+cx_oracle://user:test9@oracle.example.com:5432/my_database"

--- a/tests/test_dbAuth.py
+++ b/tests/test_dbAuth.py
@@ -218,11 +218,11 @@ class DbAuthTestCase(unittest.TestCase):
         auth = DbAuth(authList=[])
         with self.assertRaisesRegex(
                 DbAuthError,
-                r"^Missing drivername parameter$"):
+                r"^Missing dialectname parameter$"):
             auth.getAuth(None, None, None, None, None)
         with self.assertRaisesRegex(
                 DbAuthError,
-                r"^Missing drivername parameter$"):
+                r"^Missing dialectname parameter$"):
             auth.getAuth("", None, None, None, None)
         with self.assertRaisesRegex(
                 DbAuthError,
@@ -255,7 +255,7 @@ class DbAuthTestCase(unittest.TestCase):
         auth = DbAuth(authList=[dict(url="testing", password="testing")])
         with self.assertRaisesRegex(
                 DbAuthError,
-                r"^Missing database driver in URL: testing$"):
+                r"^Missing database dialect in URL: testing$"):
             auth.getAuth("postgresql", None, "example.com", None, "foo")
 
         auth = DbAuth(authList=[
@@ -389,7 +389,7 @@ class DbAuthTestCase(unittest.TestCase):
         auth = DbAuth(authList=[])
         with self.assertRaisesRegex(
                 DbAuthError,
-                r"^Missing drivername parameter$"):
+                r"^Missing dialectname parameter$"):
             auth.getUrl("/")
         with self.assertRaisesRegex(
                 DbAuthError,


### PR DESCRIPTION
Ignore driver during DB authentication matching and ensure Oracle-Wallet-like URL is correctly passed through connection string unchanged.