### PR TITLE
DM-24780: add initial mypy support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bin/*
 .mypy_cache/
 .idea/
 .vscode/
+mypy.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ matrix:
     - python: '3.7'
       install:
       - pip install flake8
-      script: flake8
+      - pip install mypy
+      script:
+      - flake8
+      - cd python && mypy -p lsst.daf.butler

--- a/python/SConscript
+++ b/python/SConscript
@@ -1,0 +1,6 @@
+# -*- python -*-
+from lsst.sconsUtils import state
+mypy = state.env.Command("../mypy.log", "lsst/daf/butler",
+                         "cd python && mypy -p lsst.daf.butler 2>&1 | tee -a ../mypy.log")
+
+state.env.Alias("mypy", mypy)

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -43,7 +43,7 @@ from ..wildcards import CollectionSearch
 from .._collectionType import CollectionType
 
 if TYPE_CHECKING:
-    from .database import Database, StaticTablesContext
+    from ._database import Database, StaticTablesContext
 
 
 class MissingCollectionError(Exception):

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -94,7 +94,8 @@ class RunRecord(CollectionRecord):
     """
 
     @abstractmethod
-    def update(self, host: Optional[str] = None, timespan: Optional[Timespan[astropy.time.Time]] = None):
+    def update(self, host: Optional[str] = None,
+               timespan: Optional[Timespan[astropy.time.Time]] = None) -> None:
         """Update the database record for this run with new execution
         information.
 
@@ -156,7 +157,7 @@ class ChainedCollectionRecord(CollectionRecord):
         """
         return self._children
 
-    def update(self, manager: CollectionManager, children: CollectionSearch):
+    def update(self, manager: CollectionManager, children: CollectionSearch) -> None:
         """Redefine this chain to search the given child collections.
 
         This method should be used by all external code to set children.  It
@@ -184,7 +185,7 @@ class ChainedCollectionRecord(CollectionRecord):
         self._update(manager, children)
         self._children = children
 
-    def refresh(self, manager: CollectionManager):
+    def refresh(self, manager: CollectionManager) -> None:
         """Load children from the database, using the given manager to resolve
         collection primary key values into records.
 
@@ -203,7 +204,7 @@ class ChainedCollectionRecord(CollectionRecord):
         self._children = self._load(manager)
 
     @abstractmethod
-    def _update(self, manager: CollectionManager, children: CollectionSearch):
+    def _update(self, manager: CollectionManager, children: CollectionSearch) -> None:
         """Protected implementation hook for setting the `children` property.
 
         This method should be implemented by subclasses to update the database
@@ -375,7 +376,7 @@ class CollectionManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def refresh(self):
+    def refresh(self) -> None:
         """Ensure all other operations on this manager are aware of any
         collections that may have been registered by other clients since it
         was initialized or last refreshed.
@@ -420,7 +421,7 @@ class CollectionManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def remove(self, name: str):
+    def remove(self, name: str) -> None:
         """Completely remove a collection.
 
         Any existing `CollectionRecord` objects that correspond to the removed

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -175,8 +175,7 @@ class Database(ABC):
 
     `Database` itself has several underscore-prefixed attributes:
 
-     - ``_cs``: SQLAlchemy objects representing the connection and transaction
-        state.
+     - ``_connection``: SQLAlchemy object representing the connection.
      - ``_metadata``: the `sqlalchemy.schema.MetaData` object representing
         the tables and other schema entities.
 

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -37,6 +37,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
 )
 import warnings
@@ -48,7 +49,7 @@ from ...core import ddl, time_utils
 from .._exceptions import ConflictingDefinitionError
 
 
-def _checkExistingTableDefinition(name: str, spec: ddl.TableSpec, inspection: List[Dict[str, Any]]):
+def _checkExistingTableDefinition(name: str, spec: ddl.TableSpec, inspection: List[Dict[str, Any]]) -> None:
     """Test that the definition of a table in a `ddl.TableSpec` and from
     database introspection are consistent.
 
@@ -467,7 +468,7 @@ class Database(ABC):
         return name
 
     def _convertFieldSpec(self, table: str, spec: ddl.FieldSpec, metadata: sqlalchemy.MetaData,
-                          **kwds) -> sqlalchemy.schema.Column:
+                          **kwds: Any) -> sqlalchemy.schema.Column:
         """Convert a `FieldSpec` to a `sqlalchemy.schema.Column`.
 
         Parameters
@@ -502,7 +503,7 @@ class Database(ABC):
                                         comment=spec.doc, **kwds)
 
     def _convertForeignKeySpec(self, table: str, spec: ddl.ForeignKeySpec, metadata: sqlalchemy.MetaData,
-                               **kwds) -> sqlalchemy.schema.ForeignKeyConstraint:
+                               **kwds: Any) -> sqlalchemy.schema.ForeignKeyConstraint:
         """Convert a `ForeignKeySpec` to a
         `sqlalchemy.schema.ForeignKeyConstraint`.
 
@@ -538,7 +539,7 @@ class Database(ABC):
         )
 
     def _convertTableSpec(self, name: str, spec: ddl.TableSpec, metadata: sqlalchemy.MetaData,
-                          **kwds) -> sqlalchemy.schema.Table:
+                          **kwds: Any) -> sqlalchemy.schema.Table:
         """Convert a `TableSpec` to a `sqlalchemy.schema.Table`.
 
         Parameters
@@ -750,7 +751,7 @@ class Database(ABC):
         already exist.
         """
 
-        def check():
+        def check() -> Tuple[int, Optional[List[str]], Optional[List]]:
             """Query for a row that matches the ``key`` argument, and compare
             to what was given by the caller.
 
@@ -769,7 +770,7 @@ class Database(ABC):
                 Results in the database that correspond to the columns given
                 in ``returning``, or `None` if ``returning is None``.
             """
-            toSelect = set()
+            toSelect: Set[str] = set()
             if compared is not None:
                 toSelect.update(compared.keys())
             if returning is not None:
@@ -789,7 +790,7 @@ class Database(ABC):
             existing = fetched[0]
             if compared is not None:
 
-                def safeNotEqual(a, b):
+                def safeNotEqual(a: Any, b: Any) -> bool:
                     if isinstance(a, astropy.time.Time):
                         return not time_utils.times_equal(a, b)
                     return a != b
@@ -800,7 +801,7 @@ class Database(ABC):
             else:
                 inconsistencies = []
             if returning is not None:
-                toReturn = [existing[k] for k in returning]
+                toReturn: Optional[list] = [existing[k] for k in returning]
             else:
                 toReturn = None
             return 1, inconsistencies, toReturn
@@ -874,7 +875,11 @@ class Database(ABC):
             elif bad:
                 raise DatabaseConflictError(f"Conflict in sync on column(s) {bad}.")
             inserted = False
-        return {k: v for k, v in zip(returning, result)} if returning is not None else None, inserted
+        if returning is None:
+            return None, inserted
+        else:
+            assert result is not None
+            return {k: v for k, v in zip(returning, result)}, inserted
 
     def insert(self, table: sqlalchemy.schema.Table, *rows: dict, returnIds: bool = False,
                ) -> Optional[List[int]]:
@@ -926,7 +931,7 @@ class Database(ABC):
             return [self._connection.execute(sql, row).inserted_primary_key[0] for row in rows]
 
     @abstractmethod
-    def replace(self, table: sqlalchemy.schema.Table, *rows: dict):
+    def replace(self, table: sqlalchemy.schema.Table, *rows: dict) -> None:
         """Insert one or more rows into a table, replacing any existing rows
         for which insertion of a new row would violate the primary key
         constraint.
@@ -1045,7 +1050,8 @@ class Database(ABC):
         )
         return self._connection.execute(sql, *rows).rowcount
 
-    def query(self, sql: sqlalchemy.sql.FromClause, *args, **kwds) -> sqlalchemy.engine.ResultProxy:
+    def query(self, sql: sqlalchemy.sql.FromClause,
+              *args: Any, **kwds: Any) -> sqlalchemy.engine.ResultProxy:
         """Run a SELECT query against the database.
 
         Parameters

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -33,6 +33,7 @@ from typing import (
     Any,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Sequence,
@@ -47,7 +48,7 @@ from ...core import ddl, time_utils
 from .._exceptions import ConflictingDefinitionError
 
 
-def _checkExistingTableDefinition(name: str, spec: ddl.TableSpec, inspection: Dict[str, Any]):
+def _checkExistingTableDefinition(name: str, spec: ddl.TableSpec, inspection: List[Dict[str, Any]]):
     """Test that the definition of a table in a `ddl.TableSpec` and from
     database introspection are consistent.
 
@@ -95,7 +96,7 @@ class StaticTablesContext:
 
     def __init__(self, db: Database):
         self._db = db
-        self._foreignKeys = []
+        self._foreignKeys: List[Tuple[sqlalchemy.schema.Table, sqlalchemy.schema.ForeignKeyConstraint]] = []
         self._inspector = sqlalchemy.engine.reflection.Inspector(self._db._connection)
         self._tableNames = frozenset(self._inspector.get_table_names(schema=self._db.namespace))
 
@@ -136,7 +137,8 @@ class StaticTablesContext:
         is just a factory for `type` objects, not an actual type itself,
         we cannot represent this with type annotations.
         """
-        return specs._make(self.addTable(name, spec) for name, spec in zip(specs._fields, specs))
+        return specs._make(self.addTable(name, spec)                     # type: ignore
+                           for name, spec in zip(specs._fields, specs))  # type: ignore
 
 
 class Database(ABC):
@@ -188,7 +190,7 @@ class Database(ABC):
         self.origin = origin
         self.namespace = namespace
         self._connection = connection
-        self._metadata = None
+        self._metadata: Optional[sqlalchemy.schema.MetaData] = None
 
     @classmethod
     def makeDefaultUri(cls, root: str) -> Optional[str]:
@@ -299,7 +301,7 @@ class Database(ABC):
         raise NotImplementedError()
 
     @contextmanager
-    def transaction(self, *, interrupting: bool = False) -> None:
+    def transaction(self, *, interrupting: bool = False) -> Iterator:
         """Return a context manager that represents a transaction.
 
         Parameters
@@ -326,7 +328,7 @@ class Database(ABC):
             raise
 
     @contextmanager
-    def declareStaticTables(self, *, create: bool) -> StaticTablesContext:
+    def declareStaticTables(self, *, create: bool) -> Iterator[StaticTablesContext]:
         """Return a context manager in which the database's static DDL schema
         can be declared.
 
@@ -702,7 +704,7 @@ class Database(ABC):
              compared: Optional[Dict[str, Any]] = None,
              extra: Optional[Dict[str, Any]] = None,
              returning: Optional[Sequence[str]] = None,
-             ) -> Tuple[Optional[Dict[str, Any], bool]]:
+             ) -> Tuple[Optional[Dict[str, Any]], bool]:
         """Insert into a table as necessary to ensure database contains
         values equivalent to the given ones.
 
@@ -919,6 +921,7 @@ class Database(ABC):
             raise ReadOnlyDatabaseError(f"Attempt to insert into read-only database '{self}'.")
         if not returnIds:
             self._connection.execute(table.insert(), *rows)
+            return None
         else:
             sql = table.insert()
             return [self._connection.execute(sql, row).inserted_primary_key[0] for row in rows]

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -25,6 +25,7 @@ __all__ = ("DatasetRecordStorageManager", "DatasetRecordStorage")
 
 from abc import ABC, abstractmethod
 from typing import (
+    Any,
     Dict,
     Iterable,
     Iterator,
@@ -115,7 +116,7 @@ class DatasetRecordStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def associate(self, collection: CollectionRecord, datasets: Iterable[DatasetRef]):
+    def associate(self, collection: CollectionRecord, datasets: Iterable[DatasetRef]) -> None:
         """Associate one or more datasets with a collection.
 
         Parameters
@@ -144,7 +145,7 @@ class DatasetRecordStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def disassociate(self, collection: CollectionRecord, datasets: Iterable[DatasetRef]):
+    def disassociate(self, collection: CollectionRecord, datasets: Iterable[DatasetRef]) -> None:
         """Remove one or more datasets from a collection.
 
         Parameters
@@ -245,9 +246,9 @@ class DatasetRecordStorageManager(ABC):
 
     @classmethod
     @abstractmethod
-    def addDatasetForeignKey(cls, tableSpec: ddl.TableSpec, *, name: str = "dataset",
-                             constraint: bool = True, onDelete: Optional[str] = None,
-                             **kwargs) -> ddl.FieldSpec:
+    def addDatasetForeignKey(cls, tableSpec: ddl.TableSpec, *,
+                             name: str = "dataset", constraint: bool = True, onDelete: Optional[str] = None,
+                             **kwargs: Any) -> ddl.FieldSpec:
         """Add a foreign key (field and constraint) referencing the dataset
         table.
 
@@ -279,7 +280,7 @@ class DatasetRecordStorageManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def refresh(self, *, universe: DimensionUniverse):
+    def refresh(self, *, universe: DimensionUniverse) -> None:
         """Ensure all other operations on this manager are aware of any
         dataset types that may have been registered by other clients since
         it was initialized or last refreshed.

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -133,7 +133,7 @@ class DimensionRecordStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def clearCaches(self):
+    def clearCaches(self) -> None:
         """Clear any in-memory caches held by the storage instance.
 
         This is called by `Registry` when transactions are rolled back, to
@@ -148,7 +148,7 @@ class DimensionRecordStorage(ABC):
         builder: QueryBuilder, *,
         regions: Optional[NamedKeyDict[DimensionElement, sqlalchemy.sql.ColumnElement]] = None,
         timespans: Optional[NamedKeyDict[DimensionElement, Timespan[sqlalchemy.sql.ColumnElement]]] = None,
-    ):
+    ) -> sqlalchemy.sql.FromClause:
         """Add the dimension element's logical table to a query under
         construction.
 
@@ -187,7 +187,7 @@ class DimensionRecordStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def insert(self, *records: DimensionRecord):
+    def insert(self, *records: DimensionRecord) -> None:
         """Insert one or more records into storage.
 
         Parameters
@@ -313,7 +313,7 @@ class DimensionRecordStorageManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def refresh(self):
+    def refresh(self) -> None:
         """Ensure all other operations on this manager are aware of any
         dataset types that may have been registered by other clients since
         it was initialized or last refreshed.
@@ -379,7 +379,7 @@ class DimensionRecordStorageManager(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def clearCaches(self):
+    def clearCaches(self) -> None:
         """Clear any in-memory caches held by nested `DimensionRecordStorage`
         instances.
 

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -49,7 +49,7 @@ class OpaqueTableStorage(ABC):
         self.name = name
 
     @abstractmethod
-    def insert(self, *data: dict):
+    def insert(self, *data: dict) -> None:
         """Insert records into the table
 
         Parameters
@@ -80,7 +80,7 @@ class OpaqueTableStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def delete(self, **where: Any):
+    def delete(self, **where: Any) -> None:
         """Remove records from an opaque table.
 
         Parameters

--- a/python/lsst/daf/butler/registry/nameShrinker.py
+++ b/python/lsst/daf/butler/registry/nameShrinker.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 __all__ = ["NameShrinker"]
 
 import hashlib
+from typing import Dict
 
 
 class NameShrinker:
@@ -44,7 +45,7 @@ class NameShrinker:
     def __init__(self, maxLength: int, hashSize: int = 4):
         self.maxLength = maxLength
         self.hashSize = hashSize
-        self._names = {}
+        self._names: Dict[str, str] = {}
 
     def shrink(self, original: str) -> str:
         """Shrink a name and remember the mapping between the original name and

--- a/python/lsst/daf/butler/registry/simpleQuery.py
+++ b/python/lsst/daf/butler/registry/simpleQuery.py
@@ -25,6 +25,7 @@ __all__ = ("Select", "SimpleQuery")
 
 from typing import (
     Any,
+    ClassVar,
     List,
     Optional,
     Union,
@@ -42,7 +43,8 @@ class Select:
     """Tag class used to indicate that a field should be returned in
     a SELECT query.
     """
-    pass
+
+    Or: ClassVar
 
 
 Select.Or = Union[T, Type[Select]]

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,0 +1,20 @@
+[mypy]
+warn_unused_configs = True
+namespace_packages = True
+
+[mypy-sqlalchemy.*]
+ignore_missing_imports = True
+
+[mypy-astropy.*]
+ignore_missing_imports = True
+
+[mypy-boto3]
+ignore_missing_imports = True
+
+[mypy-lsst.*]
+ignore_missing_imports = True
+ignore_errors = True
+
+[mypy-lsst.daf.butler.registry.interfaces.*]
+ignore_missing_imports = False
+ignore_errors = False

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 warn_unused_configs = True
+warn_redundant_casts = True
 namespace_packages = True
 
 [mypy-sqlalchemy.*]
@@ -18,3 +19,8 @@ ignore_errors = True
 [mypy-lsst.daf.butler.registry.interfaces.*]
 ignore_missing_imports = False
 ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+strict_equality = True
+warn_unreachable = True
+warn_unused_ignores = True


### PR DESCRIPTION
Copying from #273, where this work started:
> The setup here is probably a little unusual, because it turned out to be quite tricky to get mypy to determine that the root of our package tree is `lsst` (which has no `__init__.py`), not `python` (which also has no `__init__.py`) or `daf` (the first directory that _does_ have such a file).  The only solution I could find was to run mypy from the `python` directory, with a config that enables namespace package support.
>
> This was difficult to diagnose because if you run mypy on files or directories, it mostly doesn't care what the package root is, and seems to be working - but it will not obey configuration that's targeted at a particular directory, and AFAICT the config option that's supposed to warn about that (`warn_unused_configs = True`) didn't actually warn (maybe it doesn't work on globs?).  Anyhow, if you run it with `-p lsst.daf.butler` instead of on files/directories, it will complain if it doesn't recognize the package, so that seems much safer.
>
> Anyhow, the config disables checking for all of `lsst.*`, then re-enables it for just `lsst.daf.butler.registry.interfaces.*`; we can enable other sub-packages as we clean them up.