### PR TITLE
DM-24829: Use a magic string for no component in datastore record

### DIFF
--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -510,7 +510,7 @@ StorageClasses
 
         # If we have parameters they should be a frozen set so that the
         # parameters in the class can not be modified.
-        pk = f"_cls_parameters"
+        pk = "_cls_parameters"
         if pk in clsargs:
             clsargs[pk] = frozenset(clsargs[pk])
 

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -62,6 +62,9 @@ from .genericDatastore import GenericBaseDatastore
 
 log = logging.getLogger(__name__)
 
+# String to use when a Python None is encountered
+NULLSTR = "__NULL_STRING__"
+
 
 class _IngestPrepData(Datastore.IngestPrepData):
     """Helper class for FileLikeDatastore ingest implementation.
@@ -282,7 +285,7 @@ class FileLikeDatastore(GenericBaseDatastore):
             if component is None:
                 # Use empty string since we want this to be part of the
                 # primary key.
-                component = ""
+                component = NULLSTR
             records.append(
                 dict(dataset_id=ref.id, formatter=info.formatter, path=info.path,
                      storage_class=info.storageClass.name, component=component,
@@ -309,7 +312,7 @@ class FileLikeDatastore(GenericBaseDatastore):
             component = None
         else:
             if component is None:
-                where["component"] = ""
+                where["component"] = NULLSTR
 
         # Look for the dataset_id -- there might be multiple matches
         # if we have disassembled the dataset.
@@ -327,7 +330,7 @@ class FileLikeDatastore(GenericBaseDatastore):
         else:
             records_by_component = {}
             for r in records:
-                this_component = r["component"] if r["component"] else None
+                this_component = r["component"] if r["component"] and r["component"] != NULLSTR else None
                 records_by_component[this_component] = r
 
             # Look for component by name else fall back to the parent
@@ -360,7 +363,8 @@ class FileLikeDatastore(GenericBaseDatastore):
         for record in records:
             # Convert name of StorageClass to instance
             storageClass = self.storageClassFactory.getStorageClass(record["storage_class"])
-            component = record["component"] if record["component"] else None
+            component = record["component"] if (record["component"]
+                                                and record["component"] != NULLSTR) else None
 
             info = StoredFileInfo(formatter=record["formatter"],
                                   path=record["path"],

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -1018,7 +1018,7 @@ class FileLikeDatastore(GenericBaseDatastore):
                 self.removeStoredItemInfo(ref)
             except Exception as e:
                 if ignore_errors:
-                    log.warning(f"Error removing dataset %s (%s) from internal registry of %s: %s",
+                    log.warning("Error removing dataset %s (%s) from internal registry of %s: %s",
                                 ref.id, location.uri, self.name, e)
                     continue
                 else:

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1119,8 +1119,8 @@ class Registry:
                 if element.alwaysJoin:
                     raise InconsistentDataIdError(
                         f"Could not fetch record for element {element.name} via keys {keys}, ",
-                        f"but it is marked alwaysJoin=True; this means one or more dimensions are not "
-                        f"related."
+                        "but it is marked alwaysJoin=True; this means one or more dimensions are not "
+                        "related."
                     )
                 records.update((d, None) for d in element.implied)
         return ExpandedDataCoordinate(standardized.graph, standardized.values(), records=records)

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -246,7 +246,7 @@ class DefaultChainedCollectionRecord(ChainedCollectionRecord):
         for child, restriction in children.iter(manager, withRestrictions=True, flattenChains=False):
             if restriction.names is ...:
                 rows.append({"parent": self.key, "child": child.key,
-                             "position": next(position), "dataset_type_name": ""})
+                             "position": next(position), "dataset_type_name": None})
             else:
                 for name in restriction.names:
                     rows.append({"parent": self.key, "child": child.key,

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -64,7 +64,7 @@ class PostgresqlDatabase(Database):
         try:
             dsn = dbapi.get_dsn_parameters()
         except (AttributeError, KeyError) as err:
-            raise RuntimeError(f"Only the psycopg2 driver for PostgreSQL is supported.") from err
+            raise RuntimeError("Only the psycopg2 driver for PostgreSQL is supported.") from err
         if namespace is None:
             namespace = connection.execute("SELECT current_schema();").scalar()
         self.namespace = namespace

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -283,7 +283,11 @@ class SqliteDatabase(Database):
         constraints = []
         if spec.dtype == sqlalchemy.String:
             name = self.shrinkDatabaseEntityName("_".join([table, "len", spec.name]))
-            constraints.append(sqlalchemy.CheckConstraint(f"length({spec.name})<={spec.length}",
+            constraints.append(sqlalchemy.CheckConstraint(f"length({spec.name})<={spec.length}"
+                                                          # Oracle converts
+                                                          # empty strings to
+                                                          # NULL so check
+                                                          f" AND length({spec.name})>=1",
                                                           name=name))
 
         constraints.extend(super()._makeColumnConstraints(table, spec))

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -334,7 +334,7 @@ class DatasetTypeRestriction:
 
     def __repr__(self) -> str:
         if self.names is ...:
-            return f"DatasetTypeRestriction(...)"
+            return "DatasetTypeRestriction(...)"
         else:
             return f"DatasetTypeRestriction({self.names!r})"
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1036,7 +1036,7 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
     datastoreName = ["S3Datastore@s3://{bucketName}/{root}"]
     """The expected format of the S3Datastore string."""
 
-    registryStr = f":memory:"
+    registryStr = ":memory:"
     """Expected format of the Registry string."""
 
     def genRoot(self):

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -226,7 +226,7 @@ class SqliteMemoryRegistryTests(RegistryTests):
 
     def makeRegistry(self) -> Registry:
         config = self.makeRegistryConfig()
-        config["db"] = f"sqlite://"
+        config["db"] = "sqlite://"
         return Registry.fromConfig(config, create=True)
 
     def testRegions(self):


### PR DESCRIPTION
We were using an empty string but Oracle forces those
to be NULL and that breaks things.