### PR TITLE
DM-25034 make an install-external-data butler subcommand

### DIFF
--- a/python/lsst/daf/butler/cli/cmd/__init__.py
+++ b/python/lsst/daf/butler/cli/cmd/__init__.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ["butler_import", "create", "config_dump", "config_validate"]
+__all__ = ["butler_import", "create", "config_dump", "config_validate", "install_external_data"]
 
 
-from .commands import butler_import, create, config_dump, config_validate
+from .commands import butler_import, create, config_dump, config_validate, install_external_data

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -23,7 +23,7 @@ import click
 
 from ..opt import dataset_type_option, directory_argument, repo_argument, run_option, transfer_option
 from ..utils import split_commas, cli_handle_exception, typeStrAcceptsMultiple
-from ...script import butlerImport, createRepo, configDump, configValidate
+from ...script import butlerImport, createRepo, configDump, configValidate, installExternalData
 
 
 # The conversion from the import command name to the butler_import function
@@ -87,3 +87,23 @@ def config_dump(*args, **kwargs):
 def config_validate(*args, **kwargs):
     """Validate the configuration files for a Gen3 Butler repository."""
     cli_handle_exception(configValidate, *args, **kwargs)
+
+
+@click.command()
+@repo_argument(required=True)
+@click.option("--source",
+              help="Source of external data")
+@click.option("--tract",
+              type=int,
+              default=0,
+              help="Tract identifier")
+@click.option("--visit-ccd",
+              nargs=2,
+              type=int,
+              default=[],
+              multiple=True,
+              metavar="INT INT ...",
+              help="Visit and CCD of jointcal data to ingest.")
+def install_external_data(*args, **kwargs):
+    "Install extenral data"
+    cli_handle_exception(installExternalData, *args, **kwargs)

--- a/python/lsst/daf/butler/script/__init__.py
+++ b/python/lsst/daf/butler/script/__init__.py
@@ -23,3 +23,4 @@ from .butlerImport import butlerImport
 from .createRepo import createRepo
 from .configDump import configDump
 from .configValidate import configValidate
+from .installExternalData import installExternalData

--- a/python/lsst/daf/butler/script/installExternalData.py
+++ b/python/lsst/daf/butler/script/installExternalData.py
@@ -1,0 +1,78 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+from lsst.daf.persistence import Butler
+
+
+def linkFile(source, butler, datasetType, dataId):
+    """Link a file in the butler to some source outside
+
+    We use links to avoid copying files unnecessarily, and because the
+    ci_hsc_gen3 ``exportExternalData`` script expects everything to live
+    in testdata_ci_hsc still.
+
+    Parameters
+    ----------
+    source : `str`
+        Filename for source data.
+    butler : `lsst.daf.peristence.Butler`
+        Data butler.
+    datasetType : `str`
+        Dataset type in butler.
+    dataId : `dict`
+        Data identifiers.
+    """
+    target = butler.get(f"{datasetType}_filename", dataId)[0]
+    dirName = os.path.dirname(target)
+    if not os.path.isdir(dirName):
+        os.makedirs(dirName)
+    os.symlink(os.path.relpath(source, dirName), target)
+
+
+def installJointcal(source, butler, tract, visitCcdList):
+    """Install jointcal data
+
+    The jointcal data is read from the nominated ``source``, and written using
+    the butler.
+
+    Parameters
+    ----------
+    source : `str`
+        Path to the source jointcal data.
+    butler : `lsst.daf.persistence.Butler`
+        Data butler.
+    tract : `int`
+        Tract identifier.
+    visitCcdList : iterable of pair of `int`
+        [[`visit`, `ccd`], ...]
+    """
+    for visit, ccd in visitCcdList:
+        suffix = f"{visit:07d}-{ccd:03d}.fits"
+        dataId = dict(tract=tract, visit=visit, ccd=ccd)
+        linkFile(os.path.join(source, f"jointcal_photoCalib-{suffix}"), butler, "jointcal_photoCalib", dataId)
+        linkFile(os.path.join(source, f"jointcal_wcs-{suffix}"), butler, "jointcal_wcs", dataId)
+
+
+def installExternalData(repo, source, tract, visit_ccd):
+    butler = Butler(repo)
+    installJointcal(source, butler, tract, visit_ccd)

--- a/tests/test_cliCmdInstallExternalData.py
+++ b/tests/test_cliCmdInstallExternalData.py
@@ -1,0 +1,65 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for daf_butler CLI install-external-data command.
+"""
+
+import unittest
+
+from lsst.daf.butler.tests.mockeredTest import MockeredTestBase
+
+
+class InstallExternalDataTestCase(MockeredTestBase):
+
+    defaultExpected = dict(repo=None,
+                           source=None,
+                           tract=0,
+                           visit_ccd=())
+
+    def test_minimal(self):
+        """Test only the required parameters, and omit the optional parameters.
+        """
+        self.run_test(["install-external-data", "here"],
+                      self.makeExpected(repo="here"))
+
+    def test_all(self):
+        """Test all the parameters, except export_file which gets its own test
+        case below.
+        """
+        self.run_test(["install-external-data", "here",
+                       "--source", "thesource",
+                       "--tract", "42",
+                       "--visit-ccd", "1", "23",
+                       "--visit-ccd", "2", "34"],
+                      self.makeExpected(repo="here",
+                                        source="thesource",
+                                        tract=42,
+                                        visit_ccd=((1, 23), (2, 34))))
+
+    def test_missingArgument(self):
+        """Verify the command fails if either of the positional arguments,
+        REPO or DIRECTORY, is missing."""
+        self.run_missing(["install-external-data"],
+                         'Error: Missing argument "REPO".')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
help looks like this:

```
$ butler install-external-data --help
Usage: butler install-external-data [OPTIONS] REPO

  Install extenral data

  REPO is the URI or path to an existing data repository root or
  configuration file.

Options:
  --source TEXT            Source of external data
  --tract INTEGER          Tract identifier
  --visit-ccd INT INT ...  Visit and CCD of jointcal data to ingest.
  -h, --help               Show this message and exit.
```