### PR TITLE
DM-25347: Use BigInteger consistently for most ID fields (and a few others).

### DIFF
--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -164,7 +164,7 @@ class AstropyTimeNsecTai(sqlalchemy.TypeDecorator):
 
 VALID_CONFIG_COLUMN_TYPES = {
     "string": sqlalchemy.String,
-    "int": sqlalchemy.Integer,
+    "int": sqlalchemy.BigInteger,
     "float": sqlalchemy.Float,
     "region": Base64Region,
     "bool": sqlalchemy.Boolean,

--- a/python/lsst/daf/butler/core/dimensions/elements.py
+++ b/python/lsst/daf/butler/core/dimensions/elements.py
@@ -34,7 +34,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from sqlalchemy import Integer
+from sqlalchemy import BigInteger
 
 from lsst.sphgeom import Pixelization
 from ..utils import immutable
@@ -506,7 +506,7 @@ class SkyPixDimension(Dimension):
 
     def __init__(self, name: str, pixelization: Pixelization):
         related = RelatedDimensions(required=set(), implied=set(), spatial=name)
-        uniqueKeys = [ddl.FieldSpec(name="id", dtype=Integer, primaryKey=True, nullable=False)]
+        uniqueKeys = [ddl.FieldSpec(name="id", dtype=BigInteger, primaryKey=True, nullable=False)]
         super().__init__(name, related=related, uniqueKeys=uniqueKeys)
         self.pixelization = pixelization
 

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -27,7 +27,7 @@ __all__ = ("FileLikeDatastore", )
 import logging
 from abc import abstractmethod
 
-from sqlalchemy import Integer, String
+from sqlalchemy import BigInteger, String
 
 from dataclasses import dataclass
 from typing import (
@@ -206,7 +206,7 @@ class FileLikeDatastore(GenericBaseDatastore):
     def makeTableSpec(cls) -> ddl.TableSpec:
         return ddl.TableSpec(
             fields=[
-                ddl.FieldSpec(name="dataset_id", dtype=Integer, primaryKey=True),
+                ddl.FieldSpec(name="dataset_id", dtype=BigInteger, primaryKey=True),
                 ddl.FieldSpec(name="path", dtype=String, length=256, nullable=False),
                 ddl.FieldSpec(name="formatter", dtype=String, length=128, nullable=False),
                 ddl.FieldSpec(name="storage_class", dtype=String, length=64, nullable=False),
@@ -214,7 +214,7 @@ class FileLikeDatastore(GenericBaseDatastore):
                 ddl.FieldSpec(name="component", dtype=String, length=32, primaryKey=True),
                 # TODO: should checksum be Base64Bytes instead?
                 ddl.FieldSpec(name="checksum", dtype=String, length=128, nullable=True),
-                ddl.FieldSpec(name="file_size", dtype=Integer, nullable=True),
+                ddl.FieldSpec(name="file_size", dtype=BigInteger, nullable=True),
             ],
             unique=frozenset(),
         )

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -48,14 +48,14 @@ if TYPE_CHECKING:
 _TABLES_SPEC = CollectionTablesTuple(
     collection=ddl.TableSpec(
         fields=[
-            ddl.FieldSpec("collection_id", dtype=sqlalchemy.Integer, primaryKey=True, autoincrement=True),
+            ddl.FieldSpec("collection_id", dtype=sqlalchemy.BigInteger, primaryKey=True, autoincrement=True),
             ddl.FieldSpec("name", dtype=sqlalchemy.String, length=64, nullable=False),
             ddl.FieldSpec("type", dtype=sqlalchemy.SmallInteger, nullable=False),
         ],
         unique=[("name",)],
     ),
-    run=makeRunTableSpec("collection_id", sqlalchemy.Integer),
-    collection_chain=makeCollectionChainTableSpec("collection_id", sqlalchemy.Integer),
+    run=makeRunTableSpec("collection_id", sqlalchemy.BigInteger),
+    collection_chain=makeCollectionChainTableSpec("collection_id", sqlalchemy.BigInteger),
 )
 
 


### PR DESCRIPTION
SQLite doesn't really pay attention to types, so we hadn't really been paying for the fact that we've been telling other DBs to use 32-bit integers so much.