### PR TITLE
DM-25327: Add file extension validation on ingest

### DIFF
--- a/config/datastores/formatters.yaml
+++ b/config/datastores/formatters.yaml
@@ -36,7 +36,10 @@ ExposureI: lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter
 SkyMap: lsst.daf.butler.formatters.pickle.PickleFormatter
 Background: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Config: lsst.daf.butler.formatters.pexConfig.PexConfigFormatter
-Packages: lsst.daf.butler.formatters.pickle.PickleFormatter
+Packages:
+  formatter: lsst.obs.base.formatters.packages.PackagesFormatter
+  parameters:
+    format: yaml
 PropertyList: lsst.daf.butler.formatters.yaml.YamlFormatter
 PropertySet: lsst.daf.butler.formatters.yaml.YamlFormatter
 NumpyArray: lsst.daf.butler.formatters.pickle.PickleFormatter

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -78,12 +78,13 @@ class Formatter(metaclass=ABCMeta):
     supported."""
 
     supportedExtensions: ClassVar[AbstractSet[str]] = frozenset()
-    """Set of all extensions supported by this formatter.  Only expected
-    to be populated by Formatters that write files. Any extension assigned
-    to the ``extension`` property will be automatically included in the
-    list of supported extensions."""
+    """Set of all extensions supported by this formatter.
 
-    def __init__(self, fileDescriptor: FileDescriptor, dataId: DataCoordinate = None,
+    Only expected to be populated by Formatters that write files. Any extension
+    assigned to the ``extension`` property will be automatically included in
+    the list of supported extensions."""
+
+    def __init__(self, fileDescriptor: FileDescriptor, dataId: Optional[DataCoordinate] = None,
                  writeParameters: Optional[Dict[str, Any]] = None,
                  writeRecipes: Optional[Dict[str, Any]] = None):
         if not isinstance(fileDescriptor, FileDescriptor):

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -325,7 +325,7 @@ class Formatter(metaclass=ABCMeta):
 
         if ext in supported:
             return
-        raise ValueError(f"Extension '{ext}' is not supported by Formatter '{cls.__name__}'")
+        raise ValueError(f"Extension '{ext}' on '{location}' is not supported by Formatter '{cls.__name__}'")
 
     def predictPath(self) -> str:
         """Return the path that would be returned by write, without actually

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -291,6 +291,21 @@ class ButlerURI:
         self.dirLike = False
         self._uri = self._uri._replace(path=newpath)
 
+    def getExtension(self) -> str:
+        """Return the file extension associated with this URI path.
+
+        Returns
+        -------
+        ext : `str`
+            The file extension (including the ``.``). Can be empty string
+            if there is no file extension.
+        """
+        if not self.scheme:
+            _, ext = os.path.splitext(self.path)
+        else:
+            _, ext = posixpath.splitext(self.path)
+        return ext
+
     def __str__(self) -> str:
         return self.geturl()
 

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -292,19 +292,21 @@ class ButlerURI:
         self._uri = self._uri._replace(path=newpath)
 
     def getExtension(self) -> str:
-        """Return the file extension associated with this URI path.
+        """Return the file extension(s) associated with this URI path.
 
         Returns
         -------
         ext : `str`
             The file extension (including the ``.``). Can be empty string
-            if there is no file extension.
+            if there is no file extension. Will return all file extensions
+            as a single extension such that ``file.fits.gz`` will return
+            a value of ``.fits.gz``.
         """
         if not self.scheme:
-            _, ext = os.path.splitext(self.path)
+            extensions = PurePath(self.path).suffixes
         else:
-            _, ext = posixpath.splitext(self.path)
-        return ext
+            extensions = PurePosixPath(self.path).suffixes
+        return "".join(extensions)
 
     def __str__(self) -> str:
         return self.geturl()
@@ -547,6 +549,8 @@ class Location:
     def updateExtension(self, ext: Optional[str]) -> None:
         """Update the file extension associated with this `Location`.
 
+        All file extensions are replaced.
+
         Parameters
         ----------
         ext : `str`
@@ -556,10 +560,12 @@ class Location:
         if ext is None:
             return
 
-        if not self._datastoreRootUri.scheme:
-            path, _ = os.path.splitext(self.pathInStore)
-        else:
-            path, _ = posixpath.splitext(self.pathInStore)
+        # Get the extension and remove it from the path if one is found
+        # .fits.gz counts as one extension do not use os.path.splitext
+        current = self.getExtension()
+        path = self.pathInStore
+        if current:
+            path = path[:-len(current)]
 
         # Ensure that we have a leading "." on file extension (and we do not
         # try to modify the empty string)
@@ -569,19 +575,21 @@ class Location:
         self._path = path + ext
 
     def getExtension(self) -> str:
-        """Return the file extension associated with this location.
+        """Return the file extension(s) associated with this location.
 
         Returns
         -------
         ext : `str`
             The file extension (including the ``.``). Can be empty string
-            if there is no file extension.
+            if there is no file extension. Will return all file extensions
+            as a single extension such that ``file.fits.gz`` will return
+            a value of ``.fits.gz``.
         """
         if not self._datastoreRootUri.scheme:
-            _, ext = os.path.splitext(self.pathInStore)
+            extensions = PurePath(self.path).suffixes
         else:
-            _, ext = posixpath.splitext(self.pathInStore)
-        return ext
+            extensions = PurePath(self.path).suffixes
+        return "".join(extensions)
 
 
 class LocationFactory:

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -263,10 +263,12 @@ class PosixDatastore(FileLikeDatastore):
 
         fullPath = os.path.normpath(os.path.join(self.root, path))
         if transfer is not None:
-            template = self.templates.getTemplate(ref)
-            location = self.locationFactory.fromPath(template.format(ref))
-            newPath = formatter.predictPathFromLocation(location)
-            newFullPath = os.path.join(self.root, newPath)
+            # Work out the name we want this ingested file to have
+            # inside the datastore
+            location = self._calculate_ingested_datastore_name(ButlerURI(fullPath), ref, formatter)
+
+            newPath = location.pathInStore
+            newFullPath = location.path
             if os.path.exists(newFullPath):
                 raise FileExistsError(f"File '{newFullPath}' already exists.")
             storageDir = os.path.dirname(newFullPath)

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -21,15 +21,20 @@
 
 from __future__ import annotations
 
-__all__ = ("FormatterTest", "DoNothingFormatter")
+__all__ = ("FormatterTest", "DoNothingFormatter", "LenientYamlFormatter")
 
 from typing import (
+    TYPE_CHECKING,
     Any,
     Mapping,
     Optional,
 )
 
 from ..core import Formatter
+from ..formatters.yaml import YamlFormatter
+
+if TYPE_CHECKING:
+    from ..core import Location
 
 
 class DoNothingFormatter(Formatter):
@@ -62,3 +67,13 @@ class FormatterTest(Formatter):
             if "mode" not in recipes[recipeName]:
                 raise RuntimeError("'mode' is a required write recipe parameter")
         return recipes
+
+
+class LenientYamlFormatter(YamlFormatter):
+    """A test formatter that allows any file extension but always reads and
+    writes YAML."""
+    extension = ".yaml"
+
+    @classmethod
+    def validateExtension(cls, location: Location) -> None:
+        return

--- a/tests/config/basic/posixDatastoreP.yaml
+++ b/tests/config/basic/posixDatastoreP.yaml
@@ -31,7 +31,7 @@ datastore:
     ThingOne: lsst.daf.butler.formatters.yaml.YamlFormatter
     datasetType.component: lsst.daf.butler.formatters.yaml.YamlFormatter
     pvi: lsst.daf.butler.formatters.pickle.PickleFormatter
-    visit+physical_filter+instrument: lsst.daf.butler.formatters.yaml.YamlFormatter
+    visit+physical_filter+instrument: lsst.daf.butler.tests.testFormatters.LenientYamlFormatter
     instrument<DummyHSC>:
       pvi: lsst.daf.butler.formatters.json.JsonFormatter
       StructuredData: lsst.daf.butler.formatters.pickle.PickleFormatter

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -667,11 +667,15 @@ class DatastoreConstraintsTests(DatastoreTestsBase):
         dimensions = self.universe.extract(("visit", "physical_filter", "instrument"))
         dataId = {"visit": 52, "physical_filter": "V", "instrument": "DummyCamComp"}
 
-        # Write empty file suitable for ingest check
-        testfile = tempfile.NamedTemporaryFile()
+        # Write empty file suitable for ingest check (JSON and YAML variants)
+        testfile_y = tempfile.NamedTemporaryFile(suffix=".yaml")
+        testfile_j = tempfile.NamedTemporaryFile(suffix=".json")
         for datasetTypeName, sc, accepted in (("metric", sc1, True), ("metric2", sc1, False),
                                               ("metric33", sc1, True), ("metric2", sc2, True)):
-            with self.subTest(datasetTypeName=datasetTypeName):
+            # Choose different temp file depending on StorageClass
+            testfile = testfile_j if sc.name.endswith("Json") else testfile_y
+
+            with self.subTest(datasetTypeName=datasetTypeName, storageClass=sc.name, file=testfile.name):
                 ref = self.makeDatasetRef(datasetTypeName, dimensions, sc, dataId, conform=False)
                 if accepted:
                     datastore.put(metrics, ref)
@@ -751,14 +755,19 @@ class ChainedDatastorePerStoreConstraintsTests(DatastoreTestsBase, unittest.Test
         dataId1 = {"visit": 52, "physical_filter": "V", "instrument": "DummyCamComp"}
         dataId2 = {"visit": 52, "physical_filter": "V", "instrument": "HSC"}
 
-        # Write empty file suitable for ingest check
-        testfile = tempfile.NamedTemporaryFile()
+        # Write empty file suitable for ingest check (JSON and YAML variants)
+        testfile_y = tempfile.NamedTemporaryFile(suffix=".yaml")
+        testfile_j = tempfile.NamedTemporaryFile(suffix=".json")
 
         for typeName, dataId, sc, accept, ingest in (("metric", dataId1, sc1, (False, True, False), True),
                                                      ("metric2", dataId1, sc1, (False, False, False), False),
                                                      ("metric2", dataId2, sc1, (True, False, False), False),
                                                      ("metric33", dataId2, sc2, (True, True, False), True),
                                                      ("metric2", dataId1, sc2, (False, True, False), True)):
+
+            # Choose different temp file depending on StorageClass
+            testfile = testfile_j if sc.name.endswith("Json") else testfile_y
+
             with self.subTest(datasetTypeName=typeName, dataId=dataId, sc=sc.name):
                 ref = self.makeDatasetRef(typeName, dimensions, sc, dataId,
                                           conform=False)

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -127,11 +127,15 @@ class LocationTestCase(unittest.TestCase):
         self.assertTrue(loc1.uri.startswith("file:///"))
         self.assertTrue(loc1.uri.endswith("file.ext"))
         loc1.updateExtension("fits")
-        self.assertTrue(loc1.uri.endswith("file.fits"))
+        self.assertTrue(loc1.uri.endswith("file.fits"), f"Checking 'fits' extension in {loc1.uri}")
+        loc1.updateExtension("fits.gz")
+        self.assertTrue(loc1.uri.endswith("file.fits.gz"), f"Checking 'fits.gz' extension in {loc1.uri}")
+        loc1.updateExtension(".jpeg")
+        self.assertTrue(loc1.uri.endswith("file.jpeg"), f"Checking 'jpeg' extension in {loc1.uri}")
         loc1.updateExtension(None)
-        self.assertTrue(loc1.uri.endswith("file.fits"))
+        self.assertTrue(loc1.uri.endswith("file.jpeg"), f"Checking unchanged extension in {loc1.uri}")
         loc1.updateExtension("")
-        self.assertTrue(loc1.uri.endswith("file"))
+        self.assertTrue(loc1.uri.endswith("file"), f"Checking no extension in {loc1.uri}")
 
     def testRelativeRoot(self):
         root = os.path.abspath(os.path.curdir)


### PR DESCRIPTION
Ostensibly this PR exists to support the new `PackagesFormatter` which I wanted to demonstrate could work by using the file format as a write parameter rather than embedding the file format in the formatter itself. This required that I change how Formatter.makeUpdatedLocation works and led to me realizing that the predict path location was not the right thing to do on ingest. We were simply assuming that the thing being ingested (with whatever extension it had) could always be handled by the gen3 formatter and we weren't checking. This means that in theory a .pickle file could be ingested and renamed to .yaml file.  Now we do the rename but copy across the file extension from the ingested file and complain if the ingested file has an unsupported extension.