### PR TITLE
Add initial implementation of attribute manager (DM-25354)

### DIFF
--- a/config/registry.yaml
+++ b/config/registry.yaml
@@ -6,6 +6,7 @@ registry:
     postgresql: lsst.daf.butler.registry.databases.postgresql.PostgresqlDatabase
     oracle: lsst.daf.butler.registry.databases.oracle.OracleDatabase
   managers:
+    attributes: lsst.daf.butler.registry.attributes.DefaultButlerAttributeManager
     opaque: lsst.daf.butler.registry.opaque.ByNameOpaqueTableStorageManager
     dimensions: lsst.daf.butler.registry.dimensions.static.StaticDimensionRecordStorageManager
     collections: lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager

--- a/python/lsst/daf/butler/registry/attributes.py
+++ b/python/lsst/daf/butler/registry/attributes.py
@@ -1,0 +1,114 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+"""The default concrete implementation of the class that manages
+attributes for `Registry`.
+"""
+
+__all__ = ["DefaultButlerAttributeManager"]
+
+from typing import (
+    ClassVar,
+    Iterable,
+    Optional,
+    Tuple,
+)
+
+import sqlalchemy
+
+from ..core.ddl import TableSpec, FieldSpec
+from .interfaces import (
+    Database,
+    ButlerAttributeExistsError,
+    ButlerAttributeManager,
+    StaticTablesContext
+)
+
+
+class DefaultButlerAttributeManager(ButlerAttributeManager):
+    """An implementation of `ButlerAttributeManager` that stores attributes
+    in a database table.
+
+    Parameters
+    ----------
+    db : `Database`
+        Database engine interface for the namespace in which this table lives.
+    table : `sqlalchemy.schema.Table`
+        SQLAlchemy representation of the table that stores attributes.
+    """
+    def __init__(self, db: Database, table: sqlalchemy.schema.Table):
+        self._db = db
+        self._table = table
+
+    _TABLE_NAME: ClassVar[str] = "butler_attributes"
+
+    _TABLE_SPEC: ClassVar[TableSpec] = TableSpec(
+        fields=[
+            FieldSpec("name", dtype=sqlalchemy.String, length=1024, primaryKey=True),
+            FieldSpec("value", dtype=sqlalchemy.String, length=65535, nullable=False),
+        ],
+    )
+
+    @classmethod
+    def initialize(cls, db: Database, context: StaticTablesContext) -> ButlerAttributeManager:
+        # Docstring inherited from ButlerAttributeManager.
+        table = context.addTable(cls._TABLE_NAME, cls._TABLE_SPEC)
+        return cls(db=db, table=table)
+
+    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        # Docstring inherited from ButlerAttributeManager.
+        sql = sqlalchemy.sql.select([self._table.columns.value]).where(
+            self._table.columns.name == name
+        )
+        row = self._db.query(sql).fetchone()
+        if row is not None:
+            return row[0]
+        return default
+
+    def set(self, name: str, value: str, *, force: bool = False) -> None:
+        # Docstring inherited from ButlerAttributeManager.
+        if force:
+            self._db.replace(self._table, {
+                "name": name,
+                "value": value,
+            })
+        else:
+            try:
+                self._db.insert(self._table, {
+                    "name": name,
+                    "value": value,
+                })
+            except sqlalchemy.exc.IntegrityError as exc:
+                raise ButlerAttributeExistsError(f"attribute {name} already exists") from exc
+
+    def delete(self, name: str) -> bool:
+        # Docstring inherited from ButlerAttributeManager.
+        numRows = self._db.delete(self._table, ["name"], {"name": name})
+        return numRows > 0
+
+    def items(self) -> Iterable[Tuple[str, str]]:
+        # Docstring inherited from ButlerAttributeManager.
+        sql = sqlalchemy.sql.select([
+            self._table.columns.name,
+            self._table.columns.value,
+        ])
+        for row in self._db.query(sql):
+            yield row[0], row[1]

--- a/python/lsst/daf/butler/registry/interfaces/__init__.py
+++ b/python/lsst/daf/butler/registry/interfaces/__init__.py
@@ -25,3 +25,4 @@ from ._dimensions import *
 from ._collections import *
 from ._datasets import *
 from ._bridge import *
+from ._attributes import *

--- a/python/lsst/daf/butler/registry/interfaces/_attributes.py
+++ b/python/lsst/daf/butler/registry/interfaces/_attributes.py
@@ -1,0 +1,158 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+__all__ = [
+    "ButlerAttributeManager",
+    "ButlerAttributeExistsError",
+]
+
+from abc import ABC, abstractmethod
+from typing import (
+    Iterable,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from ._database import Database, StaticTablesContext
+
+
+class ButlerAttributeExistsError(RuntimeError):
+    """Exception raised when trying to update existing attribute without
+    specifying ``force`` option.
+    """
+
+
+class ButlerAttributeManager(ABC):
+    """An interface for managing butler attributes in a `Registry`.
+
+    Attributes are represented in registry as a set of name-value pairs, both
+    have string type. Any non-string data types (e.g. integers) need to be
+    converted to/from strings on client side. Attribute names can be arbitrary
+    strings, no particular structure is enforced by this interface. Attribute
+    names are globally unique, to avoid potential collision clients should
+    follow some common convention for attribute names, e.g. dot-separated
+    components (``config.managers.opaque``).
+
+    One of the critical pieces of information that will be stored as
+    attribute is the version of database schema which needs to be known
+    before registry can do any operations on database. For that reasons it is
+    likely there will be only one implementation of this interface which uses
+    database table with a stable schema.
+    """
+
+    @classmethod
+    @abstractmethod
+    def initialize(cls, db: Database, context: StaticTablesContext) -> ButlerAttributeManager:
+        """Construct an instance of the manager.
+
+        Parameters
+        ----------
+        db : `Database`
+            Interface to the underlying database engine and namespace.
+        context : `StaticTablesContext`
+            Context object obtained from `Database.declareStaticTables`; used
+            to declare any tables that should always be present in a layer
+            implemented with this manager.
+
+        Returns
+        -------
+        manager : `ButlerAttributeManager`
+            An instance of `ButlerAttributeManager`.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        """Retrieve value of a given attribute.
+
+        Parameters
+        ----------
+        name : `str`
+            Attribute name, arbitrary non-empty string.
+        default : `str`, optional
+            Default value returned when attribute does not exist, can be
+            string or `None`.
+
+        Returns
+        -------
+        value : `str`
+            Attribute value, if attribute does not exist then ``default`` is
+            returned.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def set(self, name: str, value: str, *, force: bool = False) -> None:
+        """Set value for a given attribute.
+
+        Parameters
+        ----------
+        name : `str`
+            Attribute name, arbitrary non-empty string.
+        value : `str`
+            New value for an attribute, an arbitrary string. Due to
+            deficiencies of some database engines we are not allowing empty
+            strings to be stored in the database, and ``value`` cannot be an
+            empty string.
+        force : `bool`, optional
+            Controls handling of existing attributes. With default `False`
+            value an exception is raised if attribute ``name`` already exists,
+            if `True` is passed then value of the existing attribute will be
+            updated.
+
+        Raises
+        ------
+        ButlerAttributeExistsError
+            Raised if attribute already exists but ``force`` option is false.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete(self, name: str) -> bool:
+        """Delete an attribute.
+
+        Parameters
+        ----------
+        name : `str`
+            Attribute name, arbitrary non-empty string.
+
+        Returns
+        -------
+        existed : `bool`
+            `True` is returned if attribute existed before it was deleted.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def items(self) -> Iterable[Tuple[str, str]]:
+        """Iterate over attributes and yield their names and values.
+
+        Yields
+        ------
+        name : `str`
+            Attribute name.
+        value : `str`
+            Corresponding attribute value.
+        """
+        raise NotImplementedError()

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -177,12 +177,14 @@ class OracleRegistryTests(RegistryTests):
         # we can try to pass a prefix through via "+" in a namespace.
         database = OracleDatabase.fromConnection(connection=self._connection, origin=0,
                                                  namespace=f"+{prefix}")
+        attributes = doImport(config["managers", "attributes"])
         opaque = doImport(config["managers", "opaque"])
         dimensions = doImport(config["managers", "dimensions"])
         collections = doImport(config["managers", "collections"])
         datasets = doImport(config["managers", "datasets"])
         datastoreBridges = doImport(config["managers", "datastores"])
         return Registry(database=database,
+                        attributes=attributes,
                         opaque=opaque,
                         dimensions=dimensions,
                         collections=collections,


### PR DESCRIPTION
The interface for the manager defines few trivial operations, additional
methods will be added if needed as we discover new use cases. An
important part of this ticket is to define schema for metadata table
that should stay stable for long time. For this reason I decided to use a
simplest possible key-value storage with both key and value being
strings, reasonably long key (1kB) and value (64kB). I think this should
be sufficient for our current use cases.