### PR TITLE
DM-25411: Fix for expected exception in `put()` method

### DIFF
--- a/python/lsst/daf/butler/registry/attributes.py
+++ b/python/lsst/daf/butler/registry/attributes.py
@@ -85,6 +85,8 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
 
     def set(self, name: str, value: str, *, force: bool = False) -> None:
         # Docstring inherited from ButlerAttributeManager.
+        if not name or not value:
+            raise ValueError("name and value cannot be empty")
         if force:
             self._db.replace(self._table, {
                 "name": name,

--- a/python/lsst/daf/butler/registry/interfaces/_attributes.py
+++ b/python/lsst/daf/butler/registry/interfaces/_attributes.py
@@ -125,6 +125,8 @@ class ButlerAttributeManager(ABC):
         ------
         ButlerAttributeExistsError
             Raised if attribute already exists but ``force`` option is false.
+        ValueError
+            Raised if name or value parameters are empty.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -1030,9 +1030,9 @@ class RegistryTests(ABC):
         self.assertEqual(len(list(attributes.items())), 0)
 
         # cannot store empty key or value
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             attributes.set("", "value")
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             attributes.set("attr", "")
 
         # set value of non-existing key


### PR DESCRIPTION
Added explicit check for empty attribute name and value in put() method,
this should work identically across all backends. Tested with postgres
on my CentOS7 virtual machine and it works OK now. Oracle is still not
tested but should work as well.