### PR TITLE
DM-25447: Add support for read-only components

### DIFF
--- a/config/datastores/formatters.yaml
+++ b/config/datastores/formatters.yaml
@@ -16,6 +16,7 @@ PhotoCalib: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 TransmissionCurve: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Camera: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Detector: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
+Polygon: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Catalog: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 PeakCatalog: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 SimpleCatalog: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -23,6 +23,12 @@ storageClasses:
     pytype: lsst.afw.cameraGeom.Camera
   Detector:
     pytype: lsst.afw.cameraGeom.Detector
+  Box2I:
+    pytype: lsst.geom.Box2I
+  Extent2I:
+    pytype: lsst.geom.Extent2I
+  Point2I:
+    pytype: lsst.geom.Point2I
   Image: &Image
     pytype: lsst.afw.image.Image
     assembler: lsst.daf.butler.assemblers.exposureAssembler.ExposureAssembler
@@ -118,6 +124,10 @@ storageClasses:
       filter: Filter
       detector: Detector
       validPolygon: Polygon
+    readComponents:
+      bbox: Box2I
+      dimensions: Extent2I
+      xy0: Point2I
   ExposureF:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF

--- a/config/storageClasses.yaml
+++ b/config/storageClasses.yaml
@@ -67,6 +67,8 @@ storageClasses:
     pytype: lsst.afw.table.BaseCatalog
   PeakCatalog:
     pytype: lsst.afw.detection.PeakCatalog
+  Polygon:
+    pytype: lsst.afw.geom.Polygon
   SimpleCatalog:
     pytype: lsst.afw.table.SimpleCatalog
   SourceCatalog:
@@ -114,6 +116,8 @@ storageClasses:
       transmissionCurve: TransmissionCurve
       metadata: PropertyList
       filter: Filter
+      detector: Detector
+      validPolygon: Polygon
   ExposureF:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF

--- a/python/lsst/daf/butler/core/assembler.py
+++ b/python/lsst/daf/butler/core/assembler.py
@@ -34,6 +34,7 @@ from typing import (
     Iterable,
     Mapping,
     Optional,
+    Set,
     Tuple,
     Type,
     TYPE_CHECKING,
@@ -361,3 +362,33 @@ class CompositeAssembler:
             raise ValueError(f"Parameters ({parameters}) provided to default implementation.")
 
         return inMemoryDataset
+
+    @classmethod
+    def selectResponsibleComponent(cls, readComponent: str, fromComponents: Set[Optional[str]]) -> str:
+        """Given a possible set of components to choose from, return the
+        component that should be used to calculate the requested read
+        component.
+
+        Parameters
+        ----------
+        readComponent : `str`
+            The component that is being requested.
+        fromComponents : `set` of `str`
+            The available set of component options from which that read
+            component can be derived. `None` can be included but should
+            be ignored.
+
+        Returns
+        -------
+        required : `str`
+            The component that should be used.
+
+        Raises
+        ------
+        NotImplementedError
+            Raised if this assembler refuses to answer the question.
+        ValueError
+            Raised if this assembler can not determine a relevant component
+            from the supplied options.
+        """
+        raise NotImplementedError("This assembler does not support read-only components")

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 __all__ = ("CompositesConfig", "CompositesMap")
 
+import yaml
 import logging
 
 from typing import (
@@ -129,3 +130,11 @@ class CompositesMap:
 
         log.debug("%s will%s be disassembled", matchName, "" if disassemble else " not")
         return disassemble
+
+    def __str__(self) -> str:
+        result = {}
+        result["default"] = self.config["default"]
+        result["disassembled"] = {}
+        for key in self._lut:
+            result["disassembled"][str(key)] = self._lut[key]
+        return yaml.dump(result)

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -32,6 +32,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Iterable,
+    List,
     Mapping,
     Optional,
     Tuple,
@@ -272,6 +273,19 @@ class DatasetType:
         # The component could be a read/write or read component
         return DatasetType(self.componentTypeName(component), dimensions=self.dimensions,
                            storageClass=self.storageClass.allComponents()[component])
+
+    def makeAllComponentDatasetTypes(self) -> List[DatasetType]:
+        """Return all the component dataset types assocaited with this
+        dataset type.
+
+        Returns
+        -------
+        all : `list` of `DatasetType`
+            All the component dataset types. If this is not a composite
+            then returns an empty list.
+        """
+        return [self.makeComponentDatasetType(componentName)
+                for componentName in self.storageClass.allComponents()]
 
     def isComponent(self) -> bool:
         """Boolean indicating whether this `DatasetType` refers to a

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -251,7 +251,7 @@ class DatasetType:
         KeyError
             Requested component is not supported by this `DatasetType`.
         """
-        if component in self.storageClass.components:
+        if component in self.storageClass.allComponents():
             return self.nameWithComponent(self.name, component)
         raise KeyError("Requested component ({}) not understood by this DatasetType".format(component))
 
@@ -269,8 +269,9 @@ class DatasetType:
         datasetType : `DatasetType`
             A new DatasetType instance.
         """
+        # The component could be a read/write or read component
         return DatasetType(self.componentTypeName(component), dimensions=self.dimensions,
-                           storageClass=self.storageClass.components[component])
+                           storageClass=self.storageClass.allComponents()[component])
 
     def isComponent(self) -> bool:
         """Boolean indicating whether this `DatasetType` refers to a

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 __all__ = ["DatasetType"]
 
 from copy import deepcopy
-import logging
 import re
 
 from types import MappingProxyType
@@ -48,8 +47,6 @@ from ..configSupport import LookupKey
 
 if TYPE_CHECKING:
     from ..dimensions import Dimension, DimensionUniverse
-
-log = logging.getLogger(__name__)
 
 
 def _safeMakeMappingProxyType(data: Optional[Mapping]) -> Mapping:
@@ -154,13 +151,14 @@ class DatasetType:
             else:
                 self._parentStorageClassName = parentStorageClass
 
-        # Temporarily warn if this is a component but is missing the
-        # parent storage class. Usually implies some place not using the right
-        # API.
+        # Ensure that parent storage class is specified when we have
+        # a component and is not specified when we don't
         _, componentName = self.splitDatasetTypeName(self._name)
         if parentStorageClass is None and componentName is not None:
-            log.warning("Component dataset type '%s' constructed without parent storage class",
-                        self._name)
+            raise RuntimeError(f"Component dataset type '{self._name}' constructed without parent"
+                               " storage class")
+        if parentStorageClass is not None and componentName is None:
+            raise RuntimeError(f"Parent storage class specified by {self._name} is not a composite")
 
     def __repr__(self) -> str:
         return "DatasetType({}, {}, {})".format(self.name, self.dimensions, self._storageClassName)

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 __all__ = ["DatasetType"]
 
 from copy import deepcopy
+import logging
 import re
 
 from types import MappingProxyType
@@ -47,6 +48,8 @@ from ..configSupport import LookupKey
 
 if TYPE_CHECKING:
     from ..dimensions import Dimension, DimensionUniverse
+
+log = logging.getLogger(__name__)
 
 
 def _safeMakeMappingProxyType(data: Optional[Mapping]) -> Mapping:
@@ -81,12 +84,17 @@ class DatasetType:
     storageClass : `StorageClass` or `str`
         Instance of a `StorageClass` or name of `StorageClass` that defines
         how this `DatasetType` is persisted.
+    parentStorageClass : `StorageClass` or `str`, optional
+        Instance of a `StorageClass` or name of `StorageClass` that defines
+        how the composite parent is persisted.  Must be `None` if this
+        is not a component. Mandatory if it is a component.
     universe : `DimensionUniverse`, optional
         Set of all known dimensions, used to normalize ``dimensions`` if it
         is not already a `DimensionGraph`.
     """
 
-    __slots__ = ("_name", "_dimensions", "_storageClass", "_storageClassName")
+    __slots__ = ("_name", "_dimensions", "_storageClass", "_storageClassName",
+                 "_parentStorageClass", "_parentStorageClassName")
 
     VALID_NAME_REGEX = re.compile("^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*$")
 
@@ -112,7 +120,8 @@ class DatasetType:
 
     def __init__(self, name: str, dimensions: Union[DimensionGraph, Iterable[Dimension]],
                  storageClass: Union[StorageClass, str],
-                 *, universe: DimensionUniverse = None):
+                 *, parentStorageClass: Optional[Union[StorageClass, str]] = None,
+                 universe: Optional[DimensionUniverse] = None):
         if self.VALID_NAME_REGEX.match(name) is None:
             raise ValueError(f"DatasetType name '{name}' is invalid.")
         self._name = name
@@ -130,6 +139,28 @@ class DatasetType:
         else:
             self._storageClass = None
             self._storageClassName = storageClass
+
+        self._parentStorageClass: Optional[StorageClass] = None
+        self._parentStorageClassName: Optional[str] = None
+        if parentStorageClass is not None:
+            # Only allowed for a component dataset type
+            _, componentName = self.splitDatasetTypeName(self._name)
+            if componentName is None:
+                raise ValueError("Can not specify a parent storage class if this is not a component"
+                                 f" ({self._name})")
+            if isinstance(parentStorageClass, StorageClass):
+                self._parentStorageClass = parentStorageClass
+                self._parentStorageClassName = parentStorageClass.name
+            else:
+                self._parentStorageClassName = parentStorageClass
+
+        # Temporarily warn if this is a component but is missing the
+        # parent storage class. Usually implies some place not using the right
+        # API.
+        _, componentName = self.splitDatasetTypeName(self._name)
+        if parentStorageClass is None and componentName is not None:
+            log.warning("Component dataset type '%s' constructed without parent storage class",
+                        self._name)
 
     def __repr__(self) -> str:
         return "DatasetType({}, {}, {})".format(self.name, self.dimensions, self._storageClassName)
@@ -178,6 +209,22 @@ class DatasetType:
         if self._storageClass is None:
             self._storageClass = StorageClassFactory().getStorageClass(self._storageClassName)
         return self._storageClass
+
+    @property
+    def parentStorageClass(self) -> Optional[StorageClass]:
+        """`StorageClass` instance that defines how the composite associated
+        with this  `DatasetType` is persisted.
+
+        Note that if DatasetType was constructed with a name of a
+        StorageClass then Butler has to be initialized before using this
+        property. Can be `None` if this is not a component of a composite.
+        Must be defined if this is a component.
+        """
+        if self._parentStorageClass is None and self._parentStorageClassName is None:
+            return None
+        if self._parentStorageClass is None and self._parentStorageClassName is not None:
+            self._parentStorageClass = StorageClassFactory().getStorageClass(self._parentStorageClassName)
+        return self._parentStorageClass
 
     @staticmethod
     def splitDatasetTypeName(datasetTypeName: str) -> Tuple[str, Optional[str]]:
@@ -272,7 +319,8 @@ class DatasetType:
         """
         # The component could be a read/write or read component
         return DatasetType(self.componentTypeName(component), dimensions=self.dimensions,
-                           storageClass=self.storageClass.allComponents()[component])
+                           storageClass=self.storageClass.allComponents()[component],
+                           parentStorageClass=self.storageClass)
 
     def makeAllComponentDatasetTypes(self) -> List[DatasetType]:
         """Return all the component dataset types assocaited with this

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 __all__ = ("StorageClass", "StorageClassFactory", "StorageClassConfig")
 
 import builtins
+import copy
 import logging
 
 from typing import (
@@ -33,6 +34,7 @@ from typing import (
     Collection,
     Dict,
     List,
+    Mapping,
     Optional,
     Set,
     Sequence,
@@ -66,6 +68,8 @@ class StorageClass:
         Python type (or name of type) to associate with the `StorageClass`
     components : `dict`, optional
         `dict` mapping name of a component to another `StorageClass`.
+    readComponents : `dict`, optional
+        `dict` mapping name of a read-only component to another `StorageClass`.
     parameters : `~collections.abc.Sequence` or `~collections.abc.Set`
         Parameters understood by this `StorageClass` that can control
         reading of data from datastores.
@@ -75,6 +79,7 @@ class StorageClass:
     """
     _cls_name: str = "BaseStorageClass"
     _cls_components: Optional[Dict[str, StorageClass]] = None
+    _cls_readComponents: Optional[Dict[str, StorageClass]] = None
     _cls_parameters: Optional[Union[Set[str], Sequence[str]]] = None
     _cls_assembler: Optional[str] = None
     _cls_pytype: Optional[Union[Type, str]] = None
@@ -84,6 +89,7 @@ class StorageClass:
     def __init__(self, name: Optional[str] = None,
                  pytype: Optional[Union[Type, str]] = None,
                  components: Optional[Dict[str, StorageClass]] = None,
+                 readComponents: Optional[Dict[str, StorageClass]] = None,
                  parameters: Optional[Union[Sequence, Set]] = None,
                  assembler: Optional[str] = None):
         if name is None:
@@ -92,6 +98,8 @@ class StorageClass:
             pytype = self._cls_pytype
         if components is None:
             components = self._cls_components
+        if readComponents is None:
+            readComponents = self._cls_readComponents
         if parameters is None:
             parameters = self._cls_parameters
         if assembler is None:
@@ -112,6 +120,7 @@ class StorageClass:
             self._pytype = None
 
         self._components = components if components is not None else {}
+        self._readComponents = readComponents if readComponents is not None else {}
         self._parameters = frozenset(parameters) if parameters is not None else frozenset()
         # if the assembler is not None also set it and clear the default
         # assembler
@@ -135,6 +144,12 @@ class StorageClass:
         """Component names mapped to associated `StorageClass`
         """
         return self._components
+
+    @property
+    def readComponents(self) -> Dict[str, StorageClass]:
+        """Read-only component names mapped to associated `StorageClass`
+        """
+        return self._readComponents
 
     @property
     def parameters(self) -> Set[str]:
@@ -164,6 +179,19 @@ class StorageClass:
             return None
         self._assembler = doImport(self._assemblerClassName)
         return self._assembler
+
+    def allComponents(self) -> Mapping[str, StorageClass]:
+        """Return a mapping of all the read and read/write components
+        to the corresponding storage class.
+
+        Returns
+        -------
+        comp : `dict` of [`str`, `StorageClass`]
+            The component name to storage class mapping.
+        """
+        components = copy.copy(self.components)
+        components.update(self.readComponents)
+        return components
 
     def assembler(self) -> CompositeAssembler:
         """Return an instance of an assembler.
@@ -474,19 +502,22 @@ StorageClasses
             # Always create the storage class so we can ensure that
             # we are not trying to overwrite with a different definition
             components = None
-            if "components" in info:
-                components = {}
-                for cname, ctype in info["components"].items():
-                    if ctype not in self:
-                        processStorageClass(ctype, sconfig)
-                    components[cname] = self.getStorageClass(ctype)
 
             # Extract scalar items from dict that are needed for
             # StorageClass Constructor
             storageClassKwargs = {k: info[k] for k in ("pytype", "assembler", "parameters") if k in info}
 
-            # Fill in other items
-            storageClassKwargs["components"] = components
+            for compName in ("components", "readComponents"):
+                if compName not in info:
+                    continue
+                components = {}
+                for cname, ctype in info[compName].items():
+                    if ctype not in self:
+                        processStorageClass(ctype, sconfig)
+                    components[cname] = self.getStorageClass(ctype)
+
+                # Fill in other items
+                storageClassKwargs[compName] = components
 
             # Create the new storage class and register it
             baseClass = None
@@ -537,7 +568,7 @@ StorageClasses
         # so that a child can inherit but override one bit.
         # lists (which you get from configs) are treated as sets for this to
         # work consistently.
-        for k in ("components", "parameters"):
+        for k in ("components", "parameters", "readComponents"):
             classKey = f"_cls_{k}"
             if classKey in clsargs:
                 baseValue = getattr(baseClass, classKey, None)

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -899,7 +899,9 @@ class FileLikeDatastore(GenericBaseDatastore):
         allGetInfo = self._prepare_for_get(ref, parameters)
         refComponent = ref.datasetType.component()
 
-        if len(allGetInfo) > 1 and not refComponent:
+        isDisassembled = len(allGetInfo) > 1
+
+        if isDisassembled and not refComponent:
             # This was a disassembled dataset spread over multiple files
             # and we need to put them all back together again.
             # Read into memory and then assemble
@@ -944,7 +946,12 @@ class FileLikeDatastore(GenericBaseDatastore):
                 raise FileNotFoundError(f"Component {refComponent} not found "
                                         f"for ref {ref} in datastore {self.name}")
 
-            return self._read_artifact_into_memory(getInfo, ref, isComponent=getInfo.component is not None)
+            # Do not need the component itself if already disassembled
+            if isDisassembled:
+                isComponent = False
+            else:
+                isComponent = getInfo.component is not None
+            return self._read_artifact_into_memory(getInfo, ref, isComponent=isComponent)
 
     @transactional
     def put(self, inMemoryDataset: Any, ref: DatasetRef) -> None:

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -629,7 +629,8 @@ class FileLikeDatastore(GenericBaseDatastore):
                                                                           storageClass=storageClass),
                                                            ref.dataId)
         except KeyError as e:
-            raise DatasetTypeNotSupportedError(f"Unable to find formatter for {ref}") from e
+            raise DatasetTypeNotSupportedError(f"Unable to find formatter for {ref} in datastore "
+                                               f"{self.name}") from e
 
         # Now that we know the formatter, update the location
         location = formatter.makeUpdatedLocation(location)

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -887,11 +887,7 @@ class FileLikeDatastore(GenericBaseDatastore):
             if doDisassembly:
 
                 for component, componentStorage in ref.datasetType.storageClass.components.items():
-                    compTypeName = ref.datasetType.componentTypeName(component)
-                    compType = DatasetType(compTypeName, dimensions=ref.datasetType.dimensions,
-                                           storageClass=componentStorage)
-                    compRef = DatasetRef(compType, ref.dataId, id=ref.id, run=ref.run, conform=False)
-
+                    compRef = ref.makeComponentRef(component)
                     compLocation = predictLocation(compRef)
 
                     # Add a URI fragment to indicate this is a guess
@@ -1076,15 +1072,12 @@ class FileLikeDatastore(GenericBaseDatastore):
         if doDisassembly:
             components = ref.datasetType.storageClass.assembler().disassemble(inMemoryDataset)
             for component, componentInfo in components.items():
-                compTypeName = ref.datasetType.componentTypeName(component)
                 # Don't recurse because we want to take advantage of
                 # bulk insert -- need a new DatasetRef that refers to the
                 # same dataset_id but has the component DatasetType
                 # DatasetType does not refer to the types of components
                 # So we construct one ourselves.
-                compType = DatasetType(compTypeName, dimensions=ref.datasetType.dimensions,
-                                       storageClass=componentInfo.storageClass)
-                compRef = DatasetRef(compType, ref.dataId, id=ref.id, run=ref.run, conform=False)
+                compRef = ref.makeComponentRef(component)
                 storedInfo = self._write_in_memory_to_artifact(componentInfo.component, compRef)
                 artifacts.append((compRef, storedInfo))
         else:

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -77,28 +77,6 @@ class GenericBaseDatastore(Datastore):
         raise NotImplementedError()
 
     @abstractmethod
-    def getStoredItemInfo(self, ref: DatasetRef) -> Any:
-        """Retrieve information associated with file stored in this
-        `Datastore`.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            The dataset that is to be queried.
-
-        Returns
-        -------
-        info : `StoredDatastoreItemInfo`
-            Stored information about this file and its formatter.
-
-        Raises
-        ------
-        KeyError
-            Dataset with that id can not be found.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     def getStoredItemsInfo(self, ref: DatasetRef) -> Sequence[Any]:
         """Retrieve information associated with files stored in this
         `Datastore` associated with this dataset ref.

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -541,15 +541,6 @@ class Registry:
             if result is not None:
                 return result
 
-        # fallback to the parent if we got nothing and this was a component
-        if storage.datasetType.isComponent():
-            parentType, _ = storage.datasetType.nameAndComponent()
-            parentRef = self.findDataset(parentType, dataId, collections=collections, **kwargs)
-            if parentRef is not None:
-                # Should already conform and we know no components
-                return DatasetRef(storage.datasetType, parentRef.dataId, id=parentRef.id,
-                                  run=parentRef.run, conform=False, hasParentId=True)
-
         return None
 
     @transactional

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -140,7 +140,7 @@ class ByDimensionsDatasetRecordStorageManager(DatasetRecordStorageManager):
                                                  f"with database definition {storage.datasetType}.")
             inserted = False
         if inserted and datasetType.isComposite:
-            for component in datasetType.storageClass.components:
+            for component in datasetType.storageClass.allComponents():
                 self.register(datasetType.makeComponentDatasetType(component))
         return storage, inserted
 

--- a/python/lsst/daf/butler/tests/_datasetsHelper.py
+++ b/python/lsst/daf/butler/tests/_datasetsHelper.py
@@ -23,7 +23,7 @@ __all__ = ("DatasetTestHelper", "DatastoreTestHelper",
            "BadWriteFormatter", "BadNoWriteFormatter", "MultiDetectorFormatter")
 
 import os
-from lsst.daf.butler import DatasetType, DatasetRef
+from lsst.daf.butler import DatasetType, DatasetRef, StorageClass
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 
 
@@ -39,7 +39,13 @@ class DatasetTestHelper:
     def _makeDatasetRef(self, datasetTypeName, dimensions, storageClass, dataId, *, id=None, run=None,
                         conform=True):
         # helper for makeDatasetRef
-        datasetType = DatasetType(datasetTypeName, dimensions, storageClass)
+
+        # Pretend we have a parent if this looks like a composite
+        compositeName, componentName = DatasetType.splitDatasetTypeName(datasetTypeName)
+        parentStorageClass = StorageClass("component") if componentName else None
+
+        datasetType = DatasetType(datasetTypeName, dimensions, storageClass,
+                                  parentStorageClass=parentStorageClass)
         if id is None:
             self.id += 1
             id = self.id

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -292,3 +292,18 @@ class MetricsAssembler(CompositeAssembler):
         if use:
             inMemoryDataset.data = inMemoryDataset.data[use["slice"]]
         return inMemoryDataset
+
+    def getComponent(self, composite, componentName: str):
+        if componentName == "counter":
+            return len(composite.data)
+        return super().getComponent(composite, componentName)
+
+    @classmethod
+    def selectResponsibleComponent(cls, readComponent: str, fromComponents) -> str:
+        forwarderMap = {
+            "counter": "data",
+        }
+        forwarder = forwarderMap.get(readComponent)
+        if forwarder is not None and forwarder in fromComponents:
+            return forwarder
+        raise ValueError(f"Can not calculate read component {readComponent} from {fromComponents}")

--- a/tests/config/basic/composites.yaml
+++ b/tests/config/basic/composites.yaml
@@ -7,3 +7,5 @@ disassembled:
   StructuredCompositeTestB: true
   dummyTrue: true
   dummyFalse: false
+  StructuredCompositeReadComp: true
+  StructuredCompositeReadCompNoDisassembly: false

--- a/tests/config/basic/formatters.yaml
+++ b/tests/config/basic/formatters.yaml
@@ -1,0 +1,38 @@
+default:
+  lsst.daf.butler.tests.testFormatters.FormatterTest:
+    max: 10
+    min: 2
+    comment: Default comment
+    recipe: recipe1
+write_recipes:
+  lsst.daf.butler.tests.testFormatters.FormatterTest:
+    recipe1:
+      mode: red
+    recipe2:
+      mode: green
+StructuredDataDictYaml: lsst.daf.butler.formatters.yaml.YamlFormatter
+StructuredDataListYaml: lsst.daf.butler.formatters.yaml.YamlFormatter
+StructuredDataDictJson: lsst.daf.butler.formatters.json.JsonFormatter
+StructuredDataListJson: lsst.daf.butler.formatters.json.JsonFormatter
+StructuredDataDictPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
+StructuredDataListPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
+StructuredData: lsst.daf.butler.formatters.yaml.YamlFormatter
+StructuredDataNoComponents: lsst.daf.butler.formatters.pickle.PickleFormatter
+StructuredDataJson: lsst.daf.butler.formatters.json.JsonFormatter
+StructuredDataPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
+ThingOne: lsst.daf.butler.formatters.yaml.YamlFormatter
+datasetType.component: lsst.daf.butler.formatters.yaml.YamlFormatter
+pvi: lsst.daf.butler.formatters.pickle.PickleFormatter
+paramtest:
+  formatter: lsst.daf.butler.tests.testFormatters.FormatterTest
+  parameters:
+    max: 5
+    comment: Additional commentary
+instrument<DummyHSC>:
+  pvi: lsst.daf.butler.formatters.json.JsonFormatter
+  StructuredData: lsst.daf.butler.formatters.pickle.PickleFormatter
+  DummySC: lsst.daf.butler.formatters.yaml.YamlFormatter
+  visit+physical_filter+instrument: lsst.daf.butler.formatters.pickle.PickleFormatter
+StructuredCompositeReadComp: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
+StructuredCompositeReadCompNoDisassembly: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
+StructuredDataDataTest: lsst.daf.butler.tests.testFormatters.MetricsExampleDataFormatter

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -48,4 +48,7 @@ datastore:
       StructuredData: lsst.daf.butler.formatters.pickle.PickleFormatter
       DummySC: lsst.daf.butler.formatters.yaml.YamlFormatter
       visit+physical_filter+instrument: lsst.daf.butler.formatters.pickle.PickleFormatter
+    StructuredCompositeReadComp: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
+    StructuredCompositeReadCompNoDisassembly: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
+    StructuredDataDataTest: lsst.daf.butler.tests.testFormatters.MetricsExampleDataFormatter
   composites: !include composites.yaml

--- a/tests/config/basic/posixDatastore.yaml
+++ b/tests/config/basic/posixDatastore.yaml
@@ -12,43 +12,5 @@ datastore:
     physical_filter+: "{run:/}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
       metric33: "{run:/}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
-  formatters:
-    default:
-      lsst.daf.butler.tests.testFormatters.FormatterTest:
-        max: 10
-        min: 2
-        comment: Default comment
-        recipe: recipe1
-    write_recipes:
-      lsst.daf.butler.tests.testFormatters.FormatterTest:
-        recipe1:
-          mode: red
-        recipe2:
-          mode: green
-    StructuredDataDictYaml: lsst.daf.butler.formatters.yaml.YamlFormatter
-    StructuredDataListYaml: lsst.daf.butler.formatters.yaml.YamlFormatter
-    StructuredDataDictJson: lsst.daf.butler.formatters.json.JsonFormatter
-    StructuredDataListJson: lsst.daf.butler.formatters.json.JsonFormatter
-    StructuredDataDictPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredDataListPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredData: lsst.daf.butler.formatters.yaml.YamlFormatter
-    StructuredDataNoComponents: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredDataJson: lsst.daf.butler.formatters.json.JsonFormatter
-    StructuredDataPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
-    ThingOne: lsst.daf.butler.formatters.yaml.YamlFormatter
-    datasetType.component: lsst.daf.butler.formatters.yaml.YamlFormatter
-    pvi: lsst.daf.butler.formatters.pickle.PickleFormatter
-    paramtest:
-      formatter: lsst.daf.butler.tests.testFormatters.FormatterTest
-      parameters:
-        max: 5
-        comment: Additional commentary
-    instrument<DummyHSC>:
-      pvi: lsst.daf.butler.formatters.json.JsonFormatter
-      StructuredData: lsst.daf.butler.formatters.pickle.PickleFormatter
-      DummySC: lsst.daf.butler.formatters.yaml.YamlFormatter
-      visit+physical_filter+instrument: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredCompositeReadComp: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
-    StructuredCompositeReadCompNoDisassembly: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
-    StructuredDataDataTest: lsst.daf.butler.tests.testFormatters.MetricsExampleDataFormatter
+  formatters: !include formatters.yaml
   composites: !include composites.yaml

--- a/tests/config/basic/s3Datastore.yaml
+++ b/tests/config/basic/s3Datastore.yaml
@@ -12,23 +12,5 @@ datastore:
     physical_filter+: "{run:/}/{instrument}_{physical_filter}"
     instrument<DummyCamComp>:
       metric33: "{run:/}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"
-  formatters:
-    StructuredDataDictYaml: lsst.daf.butler.formatters.yaml.YamlFormatter
-    StructuredDataListYaml: lsst.daf.butler.formatters.yaml.YamlFormatter
-    StructuredDataDictJson: lsst.daf.butler.formatters.json.JsonFormatter
-    StructuredDataListJson: lsst.daf.butler.formatters.json.JsonFormatter
-    StructuredDataDictPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredDataListPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredData: lsst.daf.butler.formatters.yaml.YamlFormatter
-    StructuredDataNoComponents: lsst.daf.butler.formatters.pickle.PickleFormatter
-    StructuredDataJson: lsst.daf.butler.formatters.json.JsonFormatter
-    StructuredDataPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
-    ThingOne: lsst.daf.butler.formatters.yaml.YamlFormatter
-    datasetType.component: lsst.daf.butler.formatters.yaml.YamlFormatter
-    pvi: lsst.daf.butler.formatters.pickle.PickleFormatter
-    instrument<DummyHSC>:
-      pvi: lsst.daf.butler.formatters.json.JsonFormatter
-      StructuredData: lsst.daf.butler.formatters.pickle.PickleFormatter
-      DummySC: lsst.daf.butler.formatters.yaml.YamlFormatter
-      visit+physical_filter+instrument: lsst.daf.butler.formatters.pickle.PickleFormatter
+  formatters: !include formatters.yaml
   composites: !include composites.yaml

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -37,6 +37,8 @@ storageClasses:
     inheritsFrom: StructuredData
   StructuredComposite:
     inheritsFrom: StructuredData
+    parameters:
+      - slice
   StructuredCompositeTestA:
     inheritsFrom: StructuredComposite
     components:
@@ -58,3 +60,22 @@ storageClasses:
     inheritsFrom: ThingOne
     parameters:
       - param3
+  StructuredDataDataTest:
+    pytype: list
+    assembler: lsst.daf.butler.tests.ListAssembler
+    readComponents:
+      counter: Integer
+    parameters:
+      - slice
+  Integer:
+    pytype: int
+  StructuredCompositeReadComp:
+    inheritsFrom: StructuredComposite
+    components:
+      summary: StructuredDataDictYaml
+      output: StructuredDataDictYaml
+      data: StructuredDataDataTest
+    readComponents:
+      counter: Integer
+  StructuredCompositeReadCompNoDisassembly:
+    inheritsFrom: StructuredCompositeReadComp

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -119,10 +119,10 @@ class ButlerPutGetTests:
         cls.storageClassFactory.addFromConfig(cls.configFile)
 
     def assertGetComponents(self, butler, datasetRef, components, reference):
-        datasetTypeName = datasetRef.datasetType.name
+        datasetType = datasetRef.datasetType
         dataId = datasetRef.dataId
         for component in components:
-            compTypeName = DatasetType.nameWithComponent(datasetTypeName, component)
+            compTypeName = datasetType.componentTypeName(component)
             result = butler.get(compTypeName, dataId)
             self.assertEqual(result, getattr(reference, component))
 
@@ -267,10 +267,10 @@ class ButlerPutGetTests:
 
         if storageClass.isComposite():
             # Check that components can be retrieved
-            # ref.compfonents will only be populated in certain cases
+            # ref.components will only be populated in certain cases
             metricOut = butler.get(ref.datasetType.name, dataId)
-            compNameS = DatasetType.nameWithComponent(datasetTypeName, "summary")
-            compNameD = DatasetType.nameWithComponent(datasetTypeName, "data")
+            compNameS = ref.datasetType.componentTypeName("summary")
+            compNameD = ref.datasetType.componentTypeName("data")
             summary = butler.get(compNameS, dataId)
             self.assertEqual(summary, metric.summary)
             data = butler.get(compNameD, dataId)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -686,14 +686,18 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.insertDimensionData(*args)
 
         # When a DatasetType is added to the registry entries are not created
-        # for components.
+        # for components but querying them can return the components.
         datasetTypeNames = {"metric", "metric2", "metric4", "metric33", "pvi", "paramtest"}
+        components = set()
         for datasetTypeName in datasetTypeNames:
             # Create and register a DatasetType
             self.addDatasetType(datasetTypeName, dimensions, storageClass, butler.registry)
 
+            for componentName in storageClass.components:
+                components.add(DatasetType.nameWithComponent(datasetTypeName, componentName))
+
         fromRegistry = set(butler.registry.queryDatasetTypes(components=True))
-        self.assertEqual({d.name for d in fromRegistry}, datasetTypeNames)
+        self.assertEqual({d.name for d in fromRegistry}, datasetTypeNames | components)
 
         # Now that we have some dataset types registered, validate them
         butler.validateConfiguration(ignore=["test_metric_comp", "metric3", "calexp", "DummySC",

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -277,7 +277,8 @@ class ButlerPutGetTests:
             self.assertEqual(data, metric.data)
 
             compRef = butler.registry.findDataset(compNameS, dataId, collections=butler.collections)
-            self.assertTrue(compRef.hasParentId)
+            summary = butler.getDirect(compRef)
+            self.assertEqual(summary, metric.summary)
 
         # Create a Dataset type that has the same name but is inconsistent.
         inconsistentDatasetType = DatasetType(datasetTypeName, dimensions,
@@ -684,21 +685,15 @@ class ButlerTests(ButlerPutGetTests):
         for args in dimensionEntries:
             butler.registry.insertDimensionData(*args)
 
-        # When a DatasetType is added to the registry entries are created
-        # for each component. Need entries for each component in the test
-        # configuration otherwise validation won't work. The ones that
-        # are deliberately broken will be ignored later.
+        # When a DatasetType is added to the registry entries are not created
+        # for components.
         datasetTypeNames = {"metric", "metric2", "metric4", "metric33", "pvi", "paramtest"}
-        components = set()
         for datasetTypeName in datasetTypeNames:
             # Create and register a DatasetType
             self.addDatasetType(datasetTypeName, dimensions, storageClass, butler.registry)
 
-            for componentName in storageClass.components:
-                components.add(DatasetType.nameWithComponent(datasetTypeName, componentName))
-
         fromRegistry = set(butler.registry.queryDatasetTypes(components=True))
-        self.assertEqual({d.name for d in fromRegistry}, datasetTypeNames | components)
+        self.assertEqual({d.name for d in fromRegistry}, datasetTypeNames)
 
         # Now that we have some dataset types registered, validate them
         butler.validateConfiguration(ignore=["test_metric_comp", "metric3", "calexp", "DummySC",

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -279,6 +279,10 @@ class ButlerPutGetTests:
                 count = butler.get(ref.datasetType.componentTypeName("counter"), dataId)
                 self.assertEqual(count, len(data))
 
+                count = butler.get(ref.datasetType.componentTypeName("counter"), dataId,
+                                   parameters={"slice": slice(stop)})
+                self.assertEqual(count, stop)
+
             compRef = butler.registry.findDataset(compNameS, dataId, collections=butler.collections)
             summary = butler.getDirect(compRef)
             self.assertEqual(summary, metric.summary)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -267,7 +267,6 @@ class ButlerPutGetTests:
 
         if storageClass.isComposite():
             # Check that components can be retrieved
-            # ref.components will only be populated in certain cases
             metricOut = butler.get(ref.datasetType.name, dataId)
             compNameS = ref.datasetType.componentTypeName("summary")
             compNameD = ref.datasetType.componentTypeName("data")
@@ -275,6 +274,10 @@ class ButlerPutGetTests:
             self.assertEqual(summary, metric.summary)
             data = butler.get(compNameD, dataId)
             self.assertEqual(data, metric.data)
+
+            if "counter" in storageClass.readComponents:
+                count = butler.get(ref.datasetType.componentTypeName("counter"), dataId)
+                self.assertEqual(count, len(data))
 
             compRef = butler.registry.findDataset(compNameS, dataId, collections=butler.collections)
             summary = butler.getDirect(compRef)
@@ -393,7 +396,8 @@ class ButlerTests(ButlerPutGetTests):
         self.runPutGetTest(storageClass, "test_metric")
 
     def testCompositePutGetConcrete(self):
-        storageClass = self.storageClassFactory.getStorageClass("StructuredData")
+
+        storageClass = self.storageClassFactory.getStorageClass("StructuredCompositeReadCompNoDisassembly")
         butler = self.runPutGetTest(storageClass, "test_metric")
 
         # Should *not* be disassembled
@@ -414,7 +418,7 @@ class ButlerTests(ButlerPutGetTests):
         self.assertEqual(uri.fragment, "predicted", f"Checking for fragment in {uri}")
 
     def testCompositePutGetVirtual(self):
-        storageClass = self.storageClassFactory.getStorageClass("StructuredComposite")
+        storageClass = self.storageClassFactory.getStorageClass("StructuredCompositeReadComp")
         butler = self.runPutGetTest(storageClass, "test_metric_comp")
 
         # Should be disassembled

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -141,6 +141,33 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertNotEqual(DatasetType("a.b", dimensionsA, "test_b", parentStorageClass="storageA"),
                             DatasetType("a.b", dimensionsA, "test_b", parentStorageClass="storageB"))
 
+    def testParentPlaceholder(self):
+        """Test that a parent placeholder can be replaced."""
+        storageComp = StorageClass("component")
+        storageParent = StorageClass("Parent")
+        dimensions = self.universe.extract(["instrument"])
+        component = DatasetType("a.b", dimensions, storageComp,
+                                parentStorageClass=DatasetType.PlaceholderParentStorageClass)
+        self.assertIsNotNone(component.parentStorageClass)
+
+        with self.assertRaises(ValueError):
+            component.finalizeParentStorageClass("parent")
+
+        component.finalizeParentStorageClass(storageParent)
+        self.assertEqual(component.parentStorageClass, storageParent)
+
+        component = DatasetType("a.b", dimensions, storageComp,
+                                parentStorageClass=storageParent)
+
+        with self.assertRaises(ValueError):
+            # Can not replace unless a placeholder
+            component.finalizeParentStorageClass(storageComp)
+
+        datasetType = DatasetType("a", dimensions, storageParent)
+        with self.assertRaises(ValueError):
+            # Can not add parent if not component
+            datasetType.finalizeParentStorageClass(storageComp)
+
     def testHashability(self):
         """Test `DatasetType.__hash__`.
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -87,6 +87,7 @@ class DatasetTypeTestCase(unittest.TestCase):
                 full = DatasetType.nameWithComponent(name, suffix)
                 component = composite.makeComponentDatasetType(suffix)
                 self.assertEqual(component.name, full)
+                self.assertEqual(component.parentStorageClass.name, "test_StructuredData")
             for suffix in badNames:
                 full = DatasetType.nameWithComponent(name, suffix)
                 with self.subTest(full=full):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -43,7 +43,7 @@ def makeExampleMetrics(use_none=False):
     if use_none:
         array = None
     else:
-        array = [563, 234, 456.7]
+        array = [563, 234, 456.7, 105, 2054, -1045]
     return MetricsExample({"AM1": 5.2, "AM2": 30.6},
                           {"a": [1, 2, 3],
                            "b": {"blue": 5, "red": "green"}},
@@ -264,6 +264,13 @@ class DatastoreTests(DatastoreTestsBase):
                 # Retrieve a component
                 data = datastore.get(ref.makeComponentRef("data"))
                 self.assertEqual(data, metrics.data)
+
+                # On supported storage classes attempt to access a read
+                # only component
+                if "ReadComp" in sc.name:
+                    cRef = ref.makeComponentRef("counter")
+                    counter = datastore.get(cRef)
+                    self.assertEqual(counter, len(metrics.data))
 
                 datastore.remove(ref)
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -272,6 +272,9 @@ class DatastoreTests(DatastoreTestsBase):
                     counter = datastore.get(cRef)
                     self.assertEqual(counter, len(metrics.data))
 
+                    counter = datastore.get(cRef, parameters={"slice": slice(stop)})
+                    self.assertEqual(counter, stop)
+
                 datastore.remove(ref)
 
     def testRegistryCompositePutGet(self):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -555,16 +555,16 @@ class PosixDatastoreNoChecksumsTestCase(PosixDatastoreTestCase):
 
         # Configuration should have disabled checksum calculation
         datastore.put(metrics, ref)
-        info = datastore.getStoredItemInfo(ref)
-        self.assertIsNone(info.checksum)
+        infos = datastore.getStoredItemsInfo(ref)
+        self.assertIsNone(infos[0].checksum)
 
         # Remove put back but with checksums enabled explicitly
         datastore.remove(ref)
         datastore.useChecksum = True
         datastore.put(metrics, ref)
 
-        info = datastore.getStoredItemInfo(ref)
-        self.assertIsNotNone(info.checksum)
+        infos = datastore.getStoredItemsInfo(ref)
+        self.assertIsNotNone(infos[0].checksum)
 
 
 class CleanupPosixDatastoreTestCase(DatastoreTestsBase, unittest.TestCase):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -205,7 +205,71 @@ class DatastoreTests(DatastoreTestsBase):
         with self.assertRaises(FileNotFoundError):
             datastore.getURI(ref)
 
-    def testCompositePutGet(self):
+    def testDisassembly(self):
+        """Test disassembly within datastore."""
+        metrics = makeExampleMetrics()
+        if self.isEphemeral:
+            # in-memory datastore does not disassemble
+            return
+
+        # Create multiple storage classes for testing different formulations
+        # of composites. One of these will not disassemble to provide
+        # a reference.
+        storageClasses = [self.storageClassFactory.getStorageClass(sc)
+                          for sc in ("StructuredComposite",
+                                     "StructuredCompositeTestA",
+                                     "StructuredCompositeTestB",
+                                     "StructuredCompositeReadComp",
+                                     "StructuredData",  # No disassembly
+                                     "StructuredCompositeReadCompNoDisassembly",
+                                     )]
+
+        # Create the test datastore
+        datastore = self.makeDatastore()
+
+        # Dummy dataId
+        dimensions = self.universe.extract(("visit", "physical_filter"))
+        dataId = {"instrument": "dummy", "visit": 428, "physical_filter": "R"}
+
+        for i, sc in enumerate(storageClasses):
+            with self.subTest(storageClass=sc.name):
+                # Create a different dataset type each time round
+                # so that a test failure in this subtest does not trigger
+                # a cascade of tests because of file clashes
+                ref = self.makeDatasetRef(f"metric_comp_{i}", dimensions, sc, dataId,
+                                          conform=False)
+
+                disassembled = sc.name not in {"StructuredData", "StructuredCompositeReadCompNoDisassembly"}
+
+                datastore.put(metrics, ref)
+
+                baseURI, compURIs = datastore.getURIs(ref)
+                if disassembled:
+                    self.assertIsNone(baseURI)
+                    self.assertEqual(set(compURIs), {"data", "output", "summary"})
+                else:
+                    self.assertIsNotNone(baseURI)
+                    self.assertEqual(compURIs, {})
+
+                metrics_get = datastore.get(ref)
+                self.assertEqual(metrics_get, metrics)
+
+                # Retrieve the composite with read parameter
+                stop = 4
+                metrics_get = datastore.get(ref, parameters={"slice": slice(stop)})
+                self.assertEqual(metrics_get.summary, metrics.summary)
+                self.assertEqual(metrics_get.output, metrics.output)
+                self.assertEqual(metrics_get.data, metrics.data[:stop])
+
+                # Retrieve a component
+                data = datastore.get(ref.makeComponentRef("data"))
+                self.assertEqual(data, metrics.data)
+
+                datastore.remove(ref)
+
+    def testRegistryCompositePutGet(self):
+        """Tests the case where registry disassembles and puts to datastore.
+        """
         metrics = makeExampleMetrics()
         datastore = self.makeDatastore()
 
@@ -214,7 +278,8 @@ class DatastoreTests(DatastoreTestsBase):
         storageClasses = [self.storageClassFactory.getStorageClass(sc)
                           for sc in ("StructuredComposite",
                                      "StructuredCompositeTestA",
-                                     "StructuredCompositeTestB")]
+                                     "StructuredCompositeTestB",
+                                     )]
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
         dataId = {"instrument": "dummy", "visit": 428, "physical_filter": "R"}

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -70,7 +70,7 @@ class ParquetFormatterTestCase(unittest.TestCase):
         df2 = self.butler.get(self.datasetType, dataId={})
         self.assertTrue(df1.equals(df2))
         # Read just the column descriptions.
-        columns2 = self.butler.get(f"{self.datasetType.name}.columns", dataId={})
+        columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
         self.assertTrue(df1.columns.equals(columns2))
         # Read just some columns a few different ways.
         df3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "c"]})
@@ -99,7 +99,7 @@ class ParquetFormatterTestCase(unittest.TestCase):
         df2 = self.butler.get(self.datasetType, dataId={})
         self.assertTrue(df1.equals(df2))
         # Read just the column descriptions.
-        columns2 = self.butler.get(f"{self.datasetType.name}.columns", dataId={})
+        columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
         self.assertTrue(df1.columns.equals(columns2))
         # Read just some columns a few different ways.
         df3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": {"filter": "g"}})

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -39,8 +39,14 @@ class TestFileTemplates(unittest.TestCase):
         """Make a simple DatasetRef"""
         if dataId is None:
             dataId = self.dataId
+
+        # Pretend we have a parent if this looks like a composite
+        compositeName, componentName = DatasetType.splitDatasetTypeName(datasetTypeName)
+        parentStorageClass = StorageClass("component") if componentName else None
+
         datasetType = DatasetType(datasetTypeName, DimensionGraph(self.universe, names=dataId.keys()),
-                                  StorageClass(storageClassName))
+                                  StorageClass(storageClassName),
+                                  parentStorageClass=parentStorageClass)
         return DatasetRef(datasetType, dataId, id=1, run=run, conform=conform)
 
     def setUp(self):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -42,7 +42,7 @@ class TestFileTemplates(unittest.TestCase):
 
         # Pretend we have a parent if this looks like a composite
         compositeName, componentName = DatasetType.splitDatasetTypeName(datasetTypeName)
-        parentStorageClass = StorageClass("component") if componentName else None
+        parentStorageClass = DatasetType.PlaceholderParentStorageClass if componentName else None
 
         datasetType = DatasetType(datasetTypeName, DimensionGraph(self.universe, names=dataId.keys()),
                                   StorageClass(storageClassName),


### PR DESCRIPTION
This was quite a lot more code than I was expecting. There is still an issue over what to do with parameters with read-only components. For now they are sent to the component that is being used to calculate the read-only component and can't be sent to the assembler at all.