### PR TITLE
DM-25957: Remove unnecessary numpy usage

### DIFF
--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -22,9 +22,7 @@
 
 __all__ = ["makeTestRepo", "makeTestCollection", "addDatasetType", "expandUniqueId"]
 
-
-import numpy as np
-
+import random
 from lsst.daf.butler import Butler, Config, DatasetType
 
 
@@ -106,7 +104,7 @@ def makeTestCollection(repo):
     """
     # Create a "random" collection name
     # Speed matters more than cryptographic guarantees
-    collection = "test" + "".join((str(i) for i in np.random.randint(0, 10, size=8)))
+    collection = "test" + str(random.randrange(1_000_000_000))
     return Butler(butler=repo, run=collection)
 
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -30,7 +30,6 @@ import shutil
 import pickle
 import string
 import random
-import numpy as np
 
 try:
     import boto3
@@ -868,7 +867,7 @@ class FileLikeDatastoreButlerTests(ButlerTests):
         butler.registry.registerDatasetType(DatasetType("metric2", dimensions, storageClass))
         butler.registry.registerDatasetType(DatasetType("metric3", dimensions, storageClass))
 
-        dataId1 = {"instrument": "DummyCamComp", "visit": np.int64(423)}
+        dataId1 = {"instrument": "DummyCamComp", "visit": 423}
         dataId2 = {"instrument": "DummyCamComp", "visit": 423, "physical_filter": "d-r"}
         dataId3 = {"instrument": "DummyCamComp", "visit": 425}
 

--- a/tests/test_matplotlibFormatter.py
+++ b/tests/test_matplotlibFormatter.py
@@ -26,6 +26,7 @@ import unittest
 import tempfile
 import os
 import shutil
+from random import Random
 
 try:
     import matplotlib
@@ -34,7 +35,6 @@ try:
 except ImportError:
     pyplot = None
 
-import numpy as np
 from lsst.daf.butler import Butler, DatasetType
 import filecmp
 
@@ -46,10 +46,13 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 class MatplotlibFormatterTestCase(unittest.TestCase):
     """Test for MatplotlibFormatter.
     """
+    RANDOM_SEED = 10
 
     def setUp(self):
         self.root = tempfile.mkdtemp(dir=TESTDIR)
         Butler.makeRepo(self.root)
+        # Create a random image for testing
+        self.rng = Random(self.RANDOM_SEED)
 
     def tearDown(self):
         if os.path.exists(self.root):
@@ -60,7 +63,11 @@ class MatplotlibFormatterTestCase(unittest.TestCase):
         datasetType = DatasetType("test_plot", [], "Plot",
                                   universe=butler.registry.dimensions)
         butler.registry.registerDatasetType(datasetType)
-        pyplot.imshow(np.random.randn(3, 4))
+        # Does not have to be a random image
+        pyplot.imshow([self.rng.sample(range(50), 10),
+                       self.rng.sample(range(50), 10),
+                       self.rng.sample(range(50), 10),
+                       ])
         ref = butler.put(pyplot.gcf(), datasetType)
         uri = butler.getURI(ref)
         # The test after this will not work if we don't have local file


### PR DESCRIPTION
* Uses the python random number generator rather than numpy.
* Protects the one remaining numpy import