### PR TITLE
Keep time precision when exporting to YAML (DM-25885)

### DIFF
--- a/python/lsst/daf/butler/core/time_utils.py
+++ b/python/lsst/daf/butler/core/time_utils.py
@@ -27,8 +27,10 @@ import logging
 import astropy.time
 
 
-# These constants can be used by client code
-EPOCH = astropy.time.Time("1970-01-01 00:00:00", format="iso", scale="tai")
+# These constants can be used by client code.
+# EPOCH is used to construct times as read from database, its precision is
+# used by all those timestamps, set it to 1 microsecond.
+EPOCH = astropy.time.Time("1970-01-01 00:00:00", format="iso", scale="tai", precision=6)
 """Epoch for calculating time delta, this is the minimum time that can be
 stored in the database.
 """

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -43,6 +43,7 @@ except ImportError:
         """
         return cls
 
+import astropy.time
 from lsst.utils import doImport
 from lsst.daf.butler.core.utils import safeMakeDir
 from lsst.daf.butler import Butler, Config, ButlerConfig
@@ -158,9 +159,12 @@ class ButlerPutGetTests:
         butler.registry.insertDimensionData("visit_system", {"instrument": "DummyCamComp",
                                                              "id": 1,
                                                              "name": "default"})
+        visit_start = astropy.time.Time("2020-01-01 08:00:00.123456789", scale="tai")
+        visit_end = astropy.time.Time("2020-01-01 08:00:36.66", scale="tai")
         butler.registry.insertDimensionData("visit", {"instrument": "DummyCamComp", "id": 423,
                                                       "name": "fourtwentythree", "physical_filter": "d-r",
-                                                      "visit_system": 1})
+                                                      "visit_system": 1, "datetime_begin": visit_start,
+                                                      "datetime_end": visit_end})
 
         # Add a second visit for some later tests
         butler.registry.insertDimensionData("visit", {"instrument": "DummyCamComp", "id": 424,


### PR DESCRIPTION
The time is now saved as ISO string in TAI scale but with full precision
and using special tag `!butler_time/tai/iso`.