### PR TITLE
DM-26010: Move mypy execution to root directory, and run it on a directory.

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -20,5 +20,4 @@ jobs:
         run: pip install mypy
 
       - name: Change to source directory and run mypy
-        working-directory: ./python
-        run: mypy lsst
+        run: mypy python/lsst

--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,8 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
+from lsst.sconsUtils import state
 
 scripts.BasicSConstruct("daf_butler", disableCc=True)
+mypy = state.env.Command("mypy.log", "python/lsst/daf/butler",
+                         "mypy python/lsst 2>&1 | tee -a mypy.log")
+state.env.Alias("mypy", mypy)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,6 @@
 [mypy]
 warn_unused_configs = True
 warn_redundant_casts = True
-namespace_packages = True
 
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True

--- a/python/SConscript
+++ b/python/SConscript
@@ -1,6 +1,0 @@
-# -*- python -*-
-from lsst.sconsUtils import state
-mypy = state.env.Command("../mypy.log", "lsst/daf/butler",
-                         "cd python && mypy -p lsst.daf.butler 2>&1 | tee -a ../mypy.log")
-
-state.env.Alias("mypy", mypy)


### PR DESCRIPTION
This is the more common and better-supported way to run mypy, but it was previously blocked by the fact that our root (lsst) package was a namespace package.  This change should make no external difference in what mypy does right now, but I suspect it will be easier to maintain and I can already say it's much more compatible with at least some in-editor mypy integration tooling.