### PR TITLE
DM-23276: Add repr for database connection objects

### DIFF
--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -208,6 +208,15 @@ class Database(ABC):
         self._connection = connection
         self._metadata: Optional[sqlalchemy.schema.MetaData] = None
 
+    def __repr__(self) -> str:
+        # Rather than try to reproduce all the parameters used to create
+        # the object, instead report the more useful information of the
+        # connection URL.
+        uri = str(self._connection.engine.url)
+        if self.namespace:
+            uri += f"#{self.namespace}"
+        return f'{type(self).__name__}("{uri}")'
+
     @classmethod
     def makeDefaultUri(cls, root: str) -> Optional[str]:
         """Create a default connection URI appropriate for the given root

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -136,6 +136,15 @@ class DatabaseTests(ABC):
                 tables = context.addTableTuple(STATIC_TABLE_SPECS)
             self.checkStaticSchema(tables)
 
+    def testRepr(self):
+        """Test that repr does not return a generic thing."""
+        newDatabase = self.makeEmptyDatabase()
+        rep = repr(newDatabase)
+        # Check that stringification works and gives us something different
+        self.assertNotEqual(rep, str(newDatabase))
+        self.assertNotIn("object at 0x", rep, "Check default repr was not used")
+        self.assertIn("://", rep)
+
     def testDynamicTables(self):
         """Tests for `Database.ensureTableExists` and
         `Database.getExistingTable`.


### PR DESCRIPTION
Reports the connection URL rather than trying to reproduce
the exact caller parameters for the object instantiation.