### PR TITLE
Add boto3 retries, as well as higher-level backoff retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *~
 *.bck
 *.pyc
+.eggs
+*.egg-info
 version.py
 _build.*
 .cache
@@ -17,6 +19,7 @@ bin/*
 .mypy_cache/
 .idea/
 .vscode/
+.python-version
 mypy.log
 build/*
 dist/*

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,7 +8,16 @@ ignore_missing_imports = True
 [mypy-astropy.*]
 ignore_missing_imports = True
 
+[mypy-backoff]
+ignore_missing_imports = True
+
 [mypy-boto3]
+ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True
+
+[mypy-urllib3.*]
 ignore_missing_imports = True
 
 [mypy-lsst.*]

--- a/python/lsst/daf/butler/core/s3utils.py
+++ b/python/lsst/daf/butler/core/s3utils.py
@@ -81,7 +81,7 @@ def getS3Client() -> boto3.client:
 
 
 def s3CheckFileExists(path: Union[Location, ButlerURI, str], bucket: Optional[str] = None,
-                      client: Optional[boto3.cient] = None) -> Tuple[bool, int]:
+                      client: Optional[boto3.client] = None) -> Tuple[bool, int]:
     """Returns (True, filesize) if file exists in the bucket and (False, -1) if
     the file is not found.
 

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -40,10 +40,23 @@ from typing import (
     Optional,
     Type,
     Union,
+    Callable
 )
 
 # https://pypi.org/project/backoff/
-import backoff
+try:
+    import backoff
+except ImportError:
+    class Backoff():
+        @staticmethod
+        def expo() -> None:
+            return None
+
+        @staticmethod
+        def on_exception(func: Callable, *args: Any, **kwargs: Any) -> Callable:
+            return func
+
+    backoff = Backoff
 
 from lsst.daf.butler import (
     ButlerURI,

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -30,6 +30,10 @@ import os
 import pathlib
 import tempfile
 
+from botocore.exceptions import ClientError
+from http.client import ImproperConnectionState, HTTPException
+from urllib3.exceptions import RequestError, HTTPError
+
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -37,6 +41,9 @@ from typing import (
     Type,
     Union,
 )
+
+# https://pypi.org/project/backoff/
+import backoff
 
 from lsst.daf.butler import (
     ButlerURI,
@@ -56,6 +63,20 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# settings for "backoff" retry decorators.
+retryable_io_errors = (
+    # http.client
+    ImproperConnectionState, HTTPException, 
+    # urllib3.exceptions
+    RequestError, HTTPError, 
+    # built-ins
+    TimeoutError, ConnectionError)
+retryable_client_errors = (
+    # botocore.exceptions
+    ClientError, 
+    # built-ins
+    PermissionError)
+max_retry_time = 60
 
 class S3Datastore(FileLikeDatastore):
     """Basic S3 Object Storage backed Datastore.
@@ -99,6 +120,7 @@ class S3Datastore(FileLikeDatastore):
             # missing. Further discussion can make this happen though.
             raise IOError(f"Bucket {self.locationFactory.netloc} does not exist!")
 
+    @backoff.on_exception(backoff.expo, retryable_client_errors, max_time=max_retry_time)
     def _artifact_exists(self, location: Location) -> bool:
         """Check that an artifact exists in this datastore at the specified
         location.
@@ -117,6 +139,7 @@ class S3Datastore(FileLikeDatastore):
         exists, _ = s3CheckFileExists(location, client=self.client)
         return exists
 
+    @backoff.on_exception(backoff.expo, retryable_client_errors, max_time=max_retry_time)
     def _delete_artifact(self, location: Location) -> None:
         """Delete the artifact from the datastore.
 
@@ -129,6 +152,7 @@ class S3Datastore(FileLikeDatastore):
         self.client.delete_object(Bucket=location.netloc, Key=location.relativeToPathRoot)
         log.debug("Successfully deleted file: %s", location.uri)
 
+    @backoff.on_exception(backoff.expo, retryable_client_errors + retryable_io_errors, max_time=max_retry_time)
     def _read_artifact_into_memory(self, getInfo: DatastoreFileGetInformation,
                                    ref: DatasetRef, isComponent: bool = False) -> Any:
         location = getInfo.location
@@ -198,6 +222,7 @@ class S3Datastore(FileLikeDatastore):
         return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams,
                                       isComponent=isComponent)
 
+    @backoff.on_exception(backoff.expo, retryable_client_errors + retryable_io_errors, max_time=max_retry_time)
     def _write_in_memory_to_artifact(self, inMemoryDataset: Any, ref: DatasetRef) -> StoredFileInfo:
         location, formatter = self._prepare_for_put(inMemoryDataset, ref)
 

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -63,7 +63,9 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# settings for "backoff" retry decorators.
+# settings for "backoff" retry decorators. these retries are belt-and-suspenders along
+# with the retries built into Boto3, to account for semantic differences in errors between
+# S3-like providers.
 retryable_io_errors = (
     # http.client
     ImproperConnectionState, HTTPException, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pandas >= 1.0
 numpy >= 1.17
 matplotlib >= 3.0.3
 pyarrow >= 0.16
+urllib3 >= 1.25.9
 
 # These are required by lsst.utils
 psutil >= 5.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ https://github.com/lsst/sphgeom/archive/master.tar.gz
 
 # optional
 boto3 >= 1.13
+botocore >= 1.15.42
 moto >= 1.3
 pandas >= 1.0
 numpy >= 1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,15 @@ sqlalchemy >= 1.3
 https://github.com/lsst/sphgeom/archive/master.tar.gz
 
 # optional
-backoff >= 1.10.0
+backoff >= 1.10
 boto3 >= 1.13
-botocore >= 1.15.42
+botocore >= 1.15
 moto >= 1.3
 pandas >= 1.0
 numpy >= 1.17
 matplotlib >= 3.0.3
 pyarrow >= 0.16
-urllib3 >= 1.25.9
+urllib3 >= 1.25
 
 # These are required by lsst.utils
 psutil >= 5.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ sqlalchemy >= 1.3
 https://github.com/lsst/sphgeom/archive/master.tar.gz
 
 # optional
+backoff >= 1.10.0
 boto3 >= 1.13
 botocore >= 1.15.42
 moto >= 1.3


### PR DESCRIPTION
Primary purpose of this PR is to add low-level retries to the S3Datastore module. This is done in two ways:

- Botocore is imported, and a botocore.config.Config object is passed into the boto3.client() method. This allows for retries built-in to [boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html#available-retry-modes).

- The more general-purpose [`backoff`](https://pypi.org/project/backoff/) module is now used to implement retries at the level of datastore operations generally. These are higher-cost retries, but should only be attempted in the event the boto3 retry code either (a) gives up or (b) doesn't retry at all. It doesn't appear trivial to distinguish between the two cases.
  - In case (a), there will be some risk of excessive retries, though the `backoff` parameters allow only 60 seconds for retries overall, so there is low risk of jobs hanging on unrecoverable errors.
  - In case (b), we need `backoff` so that some kind of retry is attempted at all. 

All other changes are minutia.