### PR TITLE
Hotfix: Fix backoff fallback decorator

### DIFF
--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -49,8 +49,8 @@ try:
 except ImportError:
     class Backoff():
         @staticmethod
-        def expo() -> None:
-            return None
+        def expo(func: Callable, *args: Any, **kwargs: Any) -> Callable:
+            return func
 
         @staticmethod
         def on_exception(func: Callable, *args: Any, **kwargs: Any) -> Callable:


### PR DESCRIPTION
The fallback for when backoff was not present was not working properly.