### PR TITLE
DM-25985: Add saving and checking of per-manager versions

### DIFF
--- a/python/lsst/daf/butler/registry/attributes.py
+++ b/python/lsst/daf/butler/registry/attributes.py
@@ -40,7 +40,6 @@ from .interfaces import (
     ButlerAttributeExistsError,
     ButlerAttributeManager,
     StaticTablesContext,
-    VersionedExtension,
     VersionTuple
 )
 
@@ -51,7 +50,7 @@ from .interfaces import (
 _VERSION = VersionTuple(0, 1, 0)
 
 
-class DefaultButlerAttributeManager(ButlerAttributeManager, VersionedExtension):
+class DefaultButlerAttributeManager(ButlerAttributeManager):
     """An implementation of `ButlerAttributeManager` that stores attributes
     in a database table.
 

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -35,7 +35,6 @@ from lsst.daf.butler.registry.interfaces import (
     DatastoreRegistryBridge,
     DatastoreRegistryBridgeManager,
     FakeDatasetRef,
-    VersionedExtension,
     VersionTuple,
 )
 from lsst.daf.butler.registry.bridge.ephemeral import EphemeralDatastoreRegistryBridge
@@ -201,7 +200,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         self._db.delete(self._tables.dataset_location_trash, ["dataset_id", "datastore_name"], *rows)
 
 
-class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager, VersionedExtension):
+class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
     """An implementation of `DatastoreRegistryBridgeManager` that uses the same
     two tables for all non-ephemeral datastores.
 

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -37,6 +37,7 @@ from ._base import (
     makeCollectionChainTableSpec,
 )
 from ...core import ddl
+from ..interfaces import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from ..interfaces import CollectionRecord, Database, StaticTablesContext
@@ -52,14 +53,17 @@ _TABLES_SPEC = CollectionTablesTuple(
     collection_chain=makeCollectionChainTableSpec("name", sqlalchemy.String),
 )
 
+# This has to be updated on every schema change
+_VERSION = VersionTuple(0, 1, 0)
 
-class NameKeyCollectionManager(DefaultCollectionManager):
+
+class NameKeyCollectionManager(DefaultCollectionManager, VersionedExtension):
     """A `CollectionManager` implementation that uses collection names for
     primary/foreign keys and aggressively loads all collection/run records in
     the database into memory.
 
     Most of the logic, including caching policy, is implemented in the base
-    class, this class only adds customisations specific to this particular
+    class, this class only adds customizations specific to this particular
     table schema.
     """
 
@@ -105,3 +109,12 @@ class NameKeyCollectionManager(DefaultCollectionManager):
     def _getByName(self, name: str) -> Optional[CollectionRecord]:
         # Docstring inherited from DefaultCollectionManager.
         return self._records.get(name)
+
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return _VERSION
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return self._defaultSchemaDigest(self._tables)

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -37,7 +37,7 @@ from ._base import (
     makeCollectionChainTableSpec,
 )
 from ...core import ddl
-from ..interfaces import VersionedExtension, VersionTuple
+from ..interfaces import VersionTuple
 
 if TYPE_CHECKING:
     from ..interfaces import CollectionRecord, Database, StaticTablesContext
@@ -57,7 +57,7 @@ _TABLES_SPEC = CollectionTablesTuple(
 _VERSION = VersionTuple(0, 1, 0)
 
 
-class NameKeyCollectionManager(DefaultCollectionManager, VersionedExtension):
+class NameKeyCollectionManager(DefaultCollectionManager):
     """A `CollectionManager` implementation that uses collection names for
     primary/foreign keys and aggressively loads all collection/run records in
     the database into memory.

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -39,7 +39,7 @@ from ._base import (
     makeCollectionChainTableSpec,
 )
 from ...core import ddl
-from ..interfaces import CollectionRecord
+from ..interfaces import CollectionRecord, VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from ..interfaces import Database, StaticTablesContext
@@ -58,13 +58,16 @@ _TABLES_SPEC = CollectionTablesTuple(
     collection_chain=makeCollectionChainTableSpec("collection_id", sqlalchemy.BigInteger),
 )
 
+# This has to be updated on every schema change
+_VERSION = VersionTuple(0, 1, 0)
 
-class SynthIntKeyCollectionManager(DefaultCollectionManager):
+
+class SynthIntKeyCollectionManager(DefaultCollectionManager, VersionedExtension):
     """A `CollectionManager` implementation that uses synthetic primary key
     (auto-incremented integer) for collections table.
 
     Most of the logic, including caching policy, is implemented in the base
-    class, this class only adds customisations specific to this particular
+    class, this class only adds customizations specific to this particular
     table schema.
 
     Parameters
@@ -143,3 +146,12 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager):
     def _getByName(self, name: str) -> Optional[CollectionRecord]:
         # Docstring inherited from DefaultCollectionManager.
         return self._nameCache.get(name)
+
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return _VERSION
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return self._defaultSchemaDigest(self._tables)

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -39,7 +39,7 @@ from ._base import (
     makeCollectionChainTableSpec,
 )
 from ...core import ddl
-from ..interfaces import CollectionRecord, VersionedExtension, VersionTuple
+from ..interfaces import CollectionRecord, VersionTuple
 
 if TYPE_CHECKING:
     from ..interfaces import Database, StaticTablesContext
@@ -62,7 +62,7 @@ _TABLES_SPEC = CollectionTablesTuple(
 _VERSION = VersionTuple(0, 1, 0)
 
 
-class SynthIntKeyCollectionManager(DefaultCollectionManager, VersionedExtension):
+class SynthIntKeyCollectionManager(DefaultCollectionManager):
     """A `CollectionManager` implementation that uses synthetic primary key
     (auto-incremented integer) for collections table.
 

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -22,7 +22,12 @@ from lsst.daf.butler import (
     DimensionUniverse,
 )
 from lsst.daf.butler.registry import ConflictingDefinitionError
-from lsst.daf.butler.registry.interfaces import DatasetRecordStorage, DatasetRecordStorageManager
+from lsst.daf.butler.registry.interfaces import (
+    DatasetRecordStorage,
+    DatasetRecordStorageManager,
+    VersionedExtension,
+    VersionTuple
+)
 
 from .tables import makeStaticTableSpecs, addDatasetForeignKey, makeDynamicTableName, makeDynamicTableSpec
 from ._storage import ByDimensionsDatasetRecordStorage
@@ -36,7 +41,11 @@ if TYPE_CHECKING:
     from .tables import StaticDatasetTablesTuple
 
 
-class ByDimensionsDatasetRecordStorageManager(DatasetRecordStorageManager):
+# This has to be updated on every schema change
+_VERSION = VersionTuple(0, 1, 0)
+
+
+class ByDimensionsDatasetRecordStorageManager(DatasetRecordStorageManager, VersionedExtension):
     """A manager class for datasets that uses one dataset-collection table for
     each group of dataset types that share the same dimensions.
 
@@ -182,3 +191,12 @@ class ByDimensionsDatasetRecordStorageManager(DatasetRecordStorageManager):
             id=id,
             run=self._collections[row[self._collections.getRunForeignKeyName()]].name
         )
+
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return _VERSION
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return self._defaultSchemaDigest(self._static)

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -25,7 +25,6 @@ from lsst.daf.butler.registry import ConflictingDefinitionError
 from lsst.daf.butler.registry.interfaces import (
     DatasetRecordStorage,
     DatasetRecordStorageManager,
-    VersionedExtension,
     VersionTuple
 )
 
@@ -45,7 +44,7 @@ if TYPE_CHECKING:
 _VERSION = VersionTuple(0, 1, 0)
 
 
-class ByDimensionsDatasetRecordStorageManager(DatasetRecordStorageManager, VersionedExtension):
+class ByDimensionsDatasetRecordStorageManager(DatasetRecordStorageManager):
     """A manager class for datasets that uses one dataset-collection table for
     each group of dataset types that share the same dimensions.
 

--- a/python/lsst/daf/butler/registry/dimensions/caching.py
+++ b/python/lsst/daf/butler/registry/dimensions/caching.py
@@ -114,3 +114,7 @@ class CachingDimensionRecordStorage(DimensionRecordStorage):
             missing -= self._cache.keys()
             for dataId in missing:
                 self._cache[dataId] = None
+
+    def digestTables(self) -> Iterable[sqlalchemy.schema.Table]:
+        # Docstring inherited from DimensionRecordStorage.digestTables.
+        return self._nested.digestTables()

--- a/python/lsst/daf/butler/registry/dimensions/query.py
+++ b/python/lsst/daf/butler/registry/dimensions/query.py
@@ -152,3 +152,7 @@ class QueryDimensionRecordStorage(DimensionRecordStorage):
             # Given the restrictions imposed at construction, we know there's
             # nothing to actually fetch: everything we need is in the data ID.
             yield RecordClass.fromDict(dataId.byName())
+
+    def digestTables(self) -> Iterable[sqlalchemy.schema.Table]:
+        # Docstring inherited from DimensionRecordStorage.digestTables.
+        return []

--- a/python/lsst/daf/butler/registry/dimensions/skypix.py
+++ b/python/lsst/daf/butler/registry/dimensions/skypix.py
@@ -102,3 +102,7 @@ class SkyPixDimensionRecordStorage(DimensionRecordStorage):
         for dataId in dataIds:
             index = dataId[self._dimension.name]
             yield RecordClass(index, self._dimension.pixelization.pixel(index))
+
+    def digestTables(self) -> Iterable[sqlalchemy.schema.Table]:
+        # Docstring inherited from DimensionRecordStorage.digestTables.
+        return []

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -20,7 +20,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
+
+import sqlalchemy
 
 from ...core import NamedKeyDict
 from ...core.dimensions import DimensionElement, DimensionUniverse
@@ -99,4 +101,7 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager, Version
 
     def schemaDigest(self) -> Optional[str]:
         # Docstring inherited from VersionedExtension.
-        return None
+        tables: List[sqlalchemy.schema.Table] = []
+        for recStorage in self._records.values():
+            tables += recStorage.digestTables()
+        return self._defaultSchemaDigest(tables)

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -31,7 +31,6 @@ from ..interfaces import (
     StaticTablesContext,
     DimensionRecordStorageManager,
     DimensionRecordStorage,
-    VersionedExtension,
     VersionTuple
 )
 
@@ -40,7 +39,7 @@ from ..interfaces import (
 _VERSION = VersionTuple(0, 1, 0)
 
 
-class StaticDimensionRecordStorageManager(DimensionRecordStorageManager, VersionedExtension):
+class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
     """An implementation of `DimensionRecordStorageManager` for single-layer
     `Registry` and the base layers of multi-layer `Registry`.
 

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -24,10 +24,21 @@ from typing import Optional
 
 from ...core import NamedKeyDict
 from ...core.dimensions import DimensionElement, DimensionUniverse
-from ..interfaces import Database, StaticTablesContext, DimensionRecordStorageManager, DimensionRecordStorage
+from ..interfaces import (
+    Database,
+    StaticTablesContext,
+    DimensionRecordStorageManager,
+    DimensionRecordStorage,
+    VersionedExtension,
+    VersionTuple
+)
 
 
-class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
+# This has to be updated on every schema change
+_VERSION = VersionTuple(0, 1, 0)
+
+
+class StaticDimensionRecordStorageManager(DimensionRecordStorageManager, VersionedExtension):
     """An implementation of `DimensionRecordStorageManager` for single-layer
     `Registry` and the base layers of multi-layer `Registry`.
 
@@ -80,3 +91,12 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
         # Docstring inherited from DimensionRecordStorageManager.
         for storage in self._records.values():
             storage.clearCaches()
+
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return _VERSION
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return None

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -144,3 +144,7 @@ class TableDimensionRecordStorage(DimensionRecordStorage):
             compared={k: getattr(record, k) for k in record.__slots__[n:]},
         )
         return inserted
+
+    def digestTables(self) -> Iterable[sqlalchemy.schema.Table]:
+        # Docstring inherited from DimensionRecordStorage.digestTables.
+        return [self._table]

--- a/python/lsst/daf/butler/registry/interfaces/__init__.py
+++ b/python/lsst/daf/butler/registry/interfaces/__init__.py
@@ -26,3 +26,4 @@ from ._collections import *
 from ._datasets import *
 from ._bridge import *
 from ._attributes import *
+from ._versioning import *

--- a/python/lsst/daf/butler/registry/interfaces/_attributes.py
+++ b/python/lsst/daf/butler/registry/interfaces/_attributes.py
@@ -158,3 +158,14 @@ class ButlerAttributeManager(ABC):
             Corresponding attribute value.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def empty(self) -> bool:
+        """Check whether attributes set is empty.
+
+        Returns
+        -------
+        empty : `bool`
+            True if there are no any attributes defined.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_attributes.py
+++ b/python/lsst/daf/butler/registry/interfaces/_attributes.py
@@ -25,13 +25,15 @@ __all__ = [
     "ButlerAttributeExistsError",
 ]
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import (
     Iterable,
     Optional,
     Tuple,
     TYPE_CHECKING,
 )
+
+from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
     from ._database import Database, StaticTablesContext
@@ -43,7 +45,7 @@ class ButlerAttributeExistsError(RuntimeError):
     """
 
 
-class ButlerAttributeManager(ABC):
+class ButlerAttributeManager(VersionedExtension):
     """An interface for managing butler attributes in a `Registry`.
 
     Attributes are represented in registry as a set of name-value pairs, both

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -34,6 +34,7 @@ from typing import (
 
 from ...core.utils import immutable
 from ...core import DatasetRef
+from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
     from ...core import DatasetType, DimensionUniverse
@@ -212,7 +213,7 @@ class DatastoreRegistryBridge(ABC):
     """
 
 
-class DatastoreRegistryBridgeManager(ABC):
+class DatastoreRegistryBridgeManager(VersionedExtension):
     """An abstract base class that defines the interface between `Registry`
     and `Datastore` when a new `Datastore` is constructed.
 

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -28,7 +28,7 @@ __all__ = [
     "RunRecord",
 ]
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import (
     Any,
     Iterator,
@@ -41,6 +41,7 @@ import astropy.time
 from ...core import ddl, Timespan
 from ..wildcards import CollectionSearch
 from .._collectionType import CollectionType
+from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
     from ._database import Database, StaticTablesContext
@@ -241,7 +242,7 @@ class ChainedCollectionRecord(CollectionRecord):
         raise NotImplementedError()
 
 
-class CollectionManager(ABC):
+class CollectionManager(VersionedExtension):
     """An interface for managing the collections (including runs) in a
     `Registry`.
 

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -40,6 +40,7 @@ from ...core import (
     ddl,
     SimpleQuery,
 )
+from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
     from ...core import DimensionUniverse
@@ -215,7 +216,7 @@ class DatasetRecordStorage(ABC):
     """
 
 
-class DatasetRecordStorageManager(ABC):
+class DatasetRecordStorageManager(VersionedExtension):
     """An interface that manages the tables that describe datasets.
 
     `DatasetRecordStorageManager` primarily serves as a container and factory

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -28,6 +28,7 @@ from typing import Iterable, Optional, Type, TYPE_CHECKING
 import sqlalchemy
 
 from ...core import SkyPixDimension
+from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
     from ...core import (
@@ -277,7 +278,7 @@ class DimensionRecordStorage(ABC):
         raise NotImplementedError()
 
 
-class DimensionRecordStorageManager(ABC):
+class DimensionRecordStorageManager(VersionedExtension):
     """An interface for managing the dimension records in a `Registry`.
 
     `DimensionRecordStorageManager` primarily serves as a container and factory

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -265,6 +265,17 @@ class DimensionRecordStorage(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def digestTables(self) -> Iterable[sqlalchemy.schema.Table]:
+        """Return tables used for schema digest.
+
+        Returns
+        -------
+        tables : `Iterable` [ `sqlalchemy.schema.Table` ]
+            Possibly empty set of tables for schema digest calculations.
+        """
+        raise NotImplementedError()
+
 
 class DimensionRecordStorageManager(ABC):
     """An interface for managing the dimension records in a `Registry`.

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -34,6 +34,7 @@ from typing import (
 
 from ...core.ddl import TableSpec
 from ._database import Database, StaticTablesContext
+from ._versioning import VersionedExtension
 
 
 class OpaqueTableStorage(ABC):
@@ -98,7 +99,7 @@ class OpaqueTableStorage(ABC):
     """
 
 
-class OpaqueTableStorageManager(ABC):
+class OpaqueTableStorageManager(VersionedExtension):
     """An interface that manages the opaque tables in a `Registry`.
 
     `OpaqueTableStorageManager` primarily serves as a container and factory for

--- a/python/lsst/daf/butler/registry/interfaces/_versioning.py
+++ b/python/lsst/daf/butler/registry/interfaces/_versioning.py
@@ -125,7 +125,10 @@ class VersionedExtension(ABC):
         -------
         digest : `str` or `None`
             String representation of the digest of the schema, ``None`` should
-            be returned if schema digest is not to be saved or checked.
+            be returned if schema digest is not to be saved or checked. The
+            length of the returned string cannot exceed the length of the
+            "value" column of butler attributes table, currently 65535
+            characters.
 
         Notes
         -----

--- a/python/lsst/daf/butler/registry/interfaces/_versioning.py
+++ b/python/lsst/daf/butler/registry/interfaces/_versioning.py
@@ -1,0 +1,195 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = [
+    "VersionTuple",
+    "VersionedExtension",
+]
+
+from abc import ABC, abstractmethod
+import hashlib
+from typing import (
+    Iterable,
+    NamedTuple,
+    Optional,
+)
+
+import sqlalchemy
+
+
+class VersionTuple(NamedTuple):
+    """Class representing a version number.
+
+    Parameters
+    ----------
+    major, minor, patch : `int`
+        Version number components
+    """
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def fromString(cls, versionStr: str) -> VersionTuple:
+        """Extract version number from a string.
+
+        Parameters
+        ----------
+        versionStr : `str`
+            Version number in string form "X.Y.Z", all components must be
+            present.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Parsed version tuple.
+
+        Raises
+        ------
+        ValueError
+            Raised if string has an invalid format.
+        """
+        try:
+            version = tuple(int(v) for v in versionStr.split("."))
+        except ValueError as exc:
+            raise ValueError(f"Invalid version  string '{versionStr}'") from exc
+        if len(version) != 3:
+            raise ValueError(f"Invalid version  string '{versionStr}', must consist of three numbers")
+        return cls(*version)
+
+    def __str__(self) -> str:
+        """Transform version tuple into a canonical string form.
+        """
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+class VersionedExtension(ABC):
+    """Interface for extension classes with versions.
+    """
+
+    @classmethod
+    @abstractmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        """Return extension version as defined by current implementation.
+
+        This method can return ``None`` if an extension does not require
+        its version to be saved or checked.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Current extension version or ``None``.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def extensionName(cls) -> str:
+        """Return full name of the extension.
+
+        This name should match the name defined in registry configuration. It
+        is also stored in registry attributes. Default implementation returns
+        full class name.
+
+        Returns
+        -------
+        name : `str`
+            Full extension name.
+        """
+        return f"{cls.__module__}.{cls.__name__}"
+
+    @abstractmethod
+    def schemaDigest(self) -> Optional[str]:
+        """Return digest for schema piece managed by this extension.
+
+        Returns
+        -------
+        digest : `str` or `None`
+            String representation of the digest of the schema, ``None`` should
+            be returned if schema digest is not to be saved or checked.
+
+        Notes
+        -----
+        There is no exact definition of digest format, any string should work.
+        The only requirement for string contents is that it has to remain
+        stable over time if schema does not change but it should produce
+        different string for any change in the schema. In many cases default
+        implementation in `_defaultSchemaDigest` can be used as a reasonable
+        choice.
+        """
+        raise NotImplementedError()
+
+    def _defaultSchemaDigest(self, tables: Iterable[sqlalchemy.schema.Table]) -> str:
+        """Calculate digest for a schema based on list of tables schemas.
+
+        Parameters
+        ----------
+        tables : iterable [`sqlalchemy.schema.Table`]
+            Set of tables comprising the schema.
+
+        Returns
+        -------
+        digest : `str`
+            String representation of the digest of the schema.
+
+        Notes
+        -----
+        It is not specified what kind of implementation is used to calculate
+        digest string. The only requirement for that is that result should be
+        stable over time as this digest string will be stored in the database.
+        It should detect (by producing different digests) sensible changes to
+        the schema, but it also should be stable w.r.t. changes that do
+        not actually change the schema (e.g. change in the order of columns or
+        keys.) Current implementation is likely incomplete in that it does not
+        detect all possible changes (e.g. some constraints may not be included
+        into total digest).
+        """
+
+        def tableSchemaRepr(table: sqlalchemy.schema.Table) -> str:
+            """Make string representation of a single table schema.
+            """
+            tableSchemaRepr = [table.name]
+            schemaReps = []
+            for column in table.columns:
+                columnRep = f"COL,{column.name},{column.type}"
+                if column.primary_key:
+                    columnRep += ",PK"
+                if column.nullable:
+                    columnRep += ",NULL"
+                schemaReps += [columnRep]
+            for fkConstr in table.foreign_key_constraints:
+                # for foreign key we include only one side of relations into
+                # digest, other side could be managed by different extension
+                fkReps = ["FK", fkConstr.name] + [fk.column.name for fk in fkConstr.elements]
+                fkRep = ",".join(fkReps)
+                schemaReps += [fkRep]
+            # sort everything to keep it stable
+            schemaReps.sort()
+            tableSchemaRepr += schemaReps
+            return ";".join(tableSchemaRepr)
+
+        md5 = hashlib.md5()
+        tableSchemas = sorted(tableSchemaRepr(table) for table in tables)
+        for tableRepr in tableSchemas:
+            md5.update(tableRepr.encode())
+        digest = md5.hexdigest()
+        return digest

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -36,7 +36,18 @@ from typing import (
 import sqlalchemy
 
 from ..core.ddl import TableSpec, FieldSpec
-from .interfaces import Database, OpaqueTableStorageManager, OpaqueTableStorage, StaticTablesContext
+from .interfaces import (
+    Database,
+    OpaqueTableStorageManager,
+    OpaqueTableStorage,
+    StaticTablesContext,
+    VersionedExtension,
+    VersionTuple
+)
+
+
+# This has to be updated on every schema change
+_VERSION = VersionTuple(0, 1, 0)
 
 
 class ByNameOpaqueTableStorage(OpaqueTableStorage):
@@ -79,7 +90,7 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         self._db.delete(self._table, where.keys(), where)
 
 
-class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
+class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager, VersionedExtension):
     """An implementation of `OpaqueTableStorageManager` that simply creates a
     true table for each different named opaque logical table.
 
@@ -131,3 +142,12 @@ class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
             result = ByNameOpaqueTableStorage(name=name, table=table, db=self._db)
             self._storage[name] = result
         return result
+
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return _VERSION
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return self._defaultSchemaDigest([self._metaTable])

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -41,7 +41,6 @@ from .interfaces import (
     OpaqueTableStorageManager,
     OpaqueTableStorage,
     StaticTablesContext,
-    VersionedExtension,
     VersionTuple
 )
 
@@ -90,7 +89,7 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         self._db.delete(self._table, where.keys(), where)
 
 
-class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager, VersionedExtension):
+class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
     """An implementation of `OpaqueTableStorageManager` that simply creates a
     true table for each different named opaque logical table.
 

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -1059,7 +1059,7 @@ class RegistryTests(ABC):
         """Test basic functionality of attribute manager.
         """
         # number of attributes with schema versions in a fresh database
-        VERSION_COUNT = 0
+        VERSION_COUNT = 17
 
         registry = self.makeRegistry()
         attributes = registry._attributes

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -1058,8 +1058,9 @@ class RegistryTests(ABC):
     def testAttributeManager(self):
         """Test basic functionality of attribute manager.
         """
-        # number of attributes with schema versions in a fresh database
-        VERSION_COUNT = 17
+        # number of attributes with schema versions in a fresh database,
+        # 6 managers with 3 records per manager
+        VERSION_COUNT = 6 * 3
 
         registry = self.makeRegistry()
         attributes = registry._attributes

--- a/python/lsst/daf/butler/registry/versions.py
+++ b/python/lsst/daf/butler/registry/versions.py
@@ -22,28 +22,29 @@
 from __future__ import annotations
 
 __all__ = [
-    "ButlerVersionsManager", "IncompatibleVersionError", "MissingVersionError"
+    "ButlerVersionsManager",
+    "IncompatibleVersionError",
+    "MissingVersionError",
+    "MissingManagerError",
+    "ManagerMismatchError",
+    "DigestMismatchError",
 ]
 
-import hashlib
 import logging
 from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    List,
+    Any,
     Mapping,
     MutableMapping,
-    NamedTuple,
     Optional,
+    TYPE_CHECKING,
 )
 
-import sqlalchemy
+from .interfaces import VersionTuple, VersionedExtension
 
 if TYPE_CHECKING:
     from .interfaces import (
         ButlerAttributeManager,
     )
-    from ..core import Config
 
 
 _LOG = logging.getLogger(__name__)
@@ -63,50 +64,23 @@ class IncompatibleVersionError(RuntimeError):
     pass
 
 
-class VersionTuple(NamedTuple):
-    """Class representing a version number.
-
-    Parameters
-    ----------
-    major, minor, patch : `int`
-        Version number componenets
+class MissingManagerError(RuntimeError):
+    """Exception raised when manager name is missing from registry.
     """
-    major: int
-    minor: int
-    patch: int
+    pass
 
-    @classmethod
-    def fromString(cls, versionStr: str) -> VersionTuple:
-        """Extract version number from a string.
 
-        Parameters
-        ----------
-        versionStr : `str`
-            Version number in string form "X.Y.Z", all componenets must be
-            present.
+class ManagerMismatchError(RuntimeError):
+    """Exception raised when configured manager name does not match name
+    stored in the database.
+    """
+    pass
 
-        Returns
-        -------
-        version : `VersionTuple`
-            Parsed version tuple.
 
-        Raises
-        ------
-        ValueError
-            Raised if string has an invalid format.
-        """
-        try:
-            version = tuple(int(v) for v in versionStr.split("."))
-        except ValueError as exc:
-            raise ValueError(f"Invalid version  string '{versionStr}'") from exc
-        if len(version) != 3:
-            raise ValueError(f"Invalid version  string '{versionStr}', must consist of three numbers")
-        return cls(*version)
-
-    def __str__(self) -> str:
-        """Transform version tuple into a canonical string form.
-        """
-        return f"{self.major}.{self.minor}.{self.patch}"
+class DigestMismatchError(RuntimeError):
+    """Exception raised when schema digest is not equal to stored digest.
+    """
+    pass
 
 
 class VersionInfo:
@@ -138,37 +112,72 @@ class ButlerVersionsManager:
 
     Parameters
     ----------
-    versions : `dict` [`str`, `VersionInfo`]
-        Mapping of the group name to corresponding schema version and digest.
-        Group represents a piece of overall database schema, group names are
-        typically defined by configuration.
+    attributes : `ButlerAttributeManager`
+        Attribute manager instance.
+    managers : `dict` [`str`, `VersionedExtension`]
+        Mapping of extension type as defined in configuration (e.g.
+        "collections") to corresponding instance of manager.
     """
-    def __init__(self, versions: Mapping[str, VersionInfo]):
-        self._versions = versions
-        self._tablesGroups: MutableMapping[str, List[sqlalchemy.schema.Table]] = {}
+    def __init__(self, attributes: ButlerAttributeManager,
+                 managers: Mapping[str, Any]):
+        self._attributes = attributes
+        self._managers: MutableMapping[str, VersionedExtension] = {}
+        # we only care about managers implementing VersionedExtension interface
+        for name, manager in managers.items():
+            if isinstance(manager, VersionedExtension):
+                self._managers[name] = manager
+            else:
+                # All regular manages need to support versioning mechanism.
+                _LOG.warning("extension %r does not implement VersionedExtension", name)
+        self._emptyFlag: Optional[bool] = None
 
     @classmethod
-    def fromConfig(cls, schemaVersionConfig: Optional[Config]) -> ButlerVersionsManager:
-        """Make `ButlerVersionsManager` instance based on configuration.
+    def _managerConfigKey(cls, name: str) -> str:
+        """Return key used to store manager config.
 
         Parameters
         ----------
-        schemaVersionConfig : `Config` or `None`
-            Configuration object describing schema versions, typically
-            "schema_versions" sub-object of registry configuration.
+        name : `str`
+            Name of the namager type, e.g. "dimensions"
 
         Returns
         -------
-        manager : `ButlerVersionsManager`
-            New instance of the versions manager.
+        key : `str`
+            Name of the key in attributes table.
         """
-        versions = {}
-        if schemaVersionConfig:
-            for key, vdict in schemaVersionConfig.items():
-                version = VersionTuple.fromString(vdict["version"])
-                digest = vdict.get("digest")
-                versions[key] = VersionInfo(version, digest)
-        return cls(versions)
+        return f"config:registry.managers.{name}"
+
+    @classmethod
+    def _managerVersionKey(cls, extension: VersionedExtension) -> str:
+        """Return key used to store manager version.
+
+        Parameters
+        ----------
+        extension : `VersionedExtension`
+            Instance of the extension.
+
+        Returns
+        -------
+        key : `str`
+            Name of the key in attributes table.
+        """
+        return "version:" + extension.extensionName()
+
+    @classmethod
+    def _managerDigestKey(cls, extension: VersionedExtension) -> str:
+        """Return key used to store manager schema digest.
+
+        Parameters
+        ----------
+        extension : `VersionedExtension`
+            Instance of the extension.
+
+        Returns
+        -------
+        key : `str`
+            Name of the key in attributes table.
+        """
+        return "schema_digest:" + extension.extensionName()
 
     @staticmethod
     def checkCompatibility(old_version: VersionTuple, new_version: VersionTuple, update: bool) -> bool:
@@ -193,117 +202,103 @@ class ButlerVersionsManager:
         # patch difference does not matter
         return True
 
-    @staticmethod
-    def schemaDigest(tables: Iterable[sqlalchemy.schema.Table]) -> str:
-        """Calculate digest for a schema.
+    def storeManagersConfig(self) -> None:
+        """Store configured extension names in attributes table.
 
-        Parameters
-        ----------
-        tables : iterable [`sqlalchemy.schema.Table`]
-            Set of tables comprising the schema.
-
-        Returns
-        -------
-        digest : `str`
-            String representation of the digest of the schema.
-
-        Notes
-        -----
-        It is not specified what kind of implementation is used to calculate
-        digest string. The only requirement for that is that result should be
-        stable over time as this digest string will be stored in the
-        configuration and probably in the database too. It should detect (by
-        producing different digests) sensible changes to the schema, but it
-        also should be stable w.r.t. changes that do not actually change the
-        schema (e.g. change in the order of columns or keys.) Current
-        implementation is likely incomplete in that it does not detect all
-        possible changes (e.g. some constraints may not be included into
-        total digest). Digest checking is optional and can be disabled in
-        configuration if configured digest is an empty string, we should delay
-        activating that check until we have a stable implementation for this
-        method.
+        For each extension we store a record with the key
+        "config:registry.managers.{name}" and fully qualified class name as a
+        value.
         """
+        for name, extension in self._managers.items():
+            key = self._managerConfigKey(name)
+            value = extension.extensionName()
+            self._attributes.set(key, value)
+            _LOG.debug("saved manager config %s=%s", key, value)
+        self._emptyFlag = False
 
-        def tableSchemaRepr(table: sqlalchemy.schema.Table) -> str:
-            """Make string representation of a single table schema.
-            """
-            tableSchemaRepr = [table.name]
-            schemaReps = []
-            for column in table.columns:
-                columnRep = f"COL,{column.name},{column.type}"
-                if column.primary_key:
-                    columnRep += ",PK"
-                if column.nullable:
-                    columnRep += ",NULL"
-                schemaReps += [columnRep]
-            for fkConstr in table.foreign_key_constraints:
-                fkRep = f"FK,{fkConstr.name}"
-                for fk in fkConstr.elements:
-                    fkRep += f"{fk.column.name}->{fk.target_fullname}"
-                schemaReps += [fkRep]
-            schemaReps.sort()
-            tableSchemaRepr += schemaReps
-            return ";".join(tableSchemaRepr)
+    def storeManagersVersions(self) -> None:
+        """Store current manager versions in registry arttributes.
 
-        md5 = hashlib.md5()
-        tableSchemas = sorted(tableSchemaRepr(table) for table in tables)
-        for tableRepr in tableSchemas:
-            md5.update(tableRepr.encode())
-        digest = md5.hexdigest()
-        return digest
+        For each extension we store two records:
 
-    def addTable(self, group: str, table: sqlalchemy.schema.Table) -> None:
-        """Add a table to specified schema group.
-
-        Table schema added to a group will be used when calculating digest
-        for that group.
-
-        Parameters
-        ----------
-        group : `str`
-            Schema group name, e.g. "core", or " dimensions".
-        table : `sqlalchemy.schema.Table`
-            Table schema.
+            - record with the key "version:{fullExtensionName}" and version
+              number in its string format as a value,
+            - record with the key "schema_digest:{fullExtensionName}" and
+              schema digest as a value.
         """
-        self._tablesGroups.setdefault(group, []).append(table)
+        for extension in self._managers.values():
 
-    def storeVersions(self, attributes: ButlerAttributeManager) -> None:
-        """Store configured schema versions in registry arttributes.
+            version = extension.currentVersion()
+            if version:
+                key = self._managerVersionKey(extension)
+                value = str(version)
+                self._attributes.set(key, value)
+                _LOG.debug("saved manager version %s=%s", key, value)
 
-        Parameters
-        ----------
-        attributes : `ButlerAttributeManager`
-            Attribute manager instance.
+            digest = extension.schemaDigest()
+            if digest is not None:
+                key = self._managerDigestKey(extension)
+                self._attributes.set(key, digest)
+                _LOG.debug("saved manager schema digest %s=%s", key, digest)
+
+        self._emptyFlag = False
+
+    @property
+    def _attributesEmpty(self) -> bool:
+        """True if attributes table is empty.
         """
-        for key, vInfo in self._versions.items():
-            # attribute name reflects configuration path in "registry" config
-            attributes.set(f"schema_versions.{key}.version", str(vInfo.version))
-            # TODO: we could also store digest in the database but I'm not
-            # sure that digest calculation is stable enough at this point.
+        # There are existing repositories where attributes table was not
+        # filled, we don't want to force schema migration in this case yet
+        # (and we don't have tools) so we allow this as valid use case and
+        # skip all checks but print a warning.
+        if self._emptyFlag is None:
+            self._emptyFlag = self._attributes.empty()
+            if self._emptyFlag:
+                _LOG.warning("Attributes table is empty, schema may need an upgrade.")
+        return self._emptyFlag
 
-    def checkVersionDigests(self) -> None:
-        """Compare current schema digest to a configured digest.
+    def checkManagersConfig(self) -> None:
+        """Compare configured manager names with stored in database.
 
-        It calculates digest to all schema groups using tables added to each
-        group with `addTable` method. If digest is different from a configured
-        digest for the same group it generates logging warning message.
+        Raises
+        ------
+        ManagerMismatchError
+            Raised if manager names are different.
+        MissingManagerError
+            Raised if database has no stored manager name.
         """
-        for group, tables in self._tablesGroups.items():
-            if group in self._versions:
-                configDigest = self._versions[group].digest
-                if configDigest:
-                    digest = self.schemaDigest(tables)
-                    if digest != configDigest:
-                        _LOG.warning("Digest mismatch for %s schema. Configured digest: '%s', "
-                                     "actual digest '%s'.", group, configDigest, digest)
+        if self._attributesEmpty:
+            return
 
-    def checkStoredVersions(self, attributes: ButlerAttributeManager, writeable: bool) -> None:
+        missing = []
+        mismatch = []
+        for name, extension in self._managers.items():
+            key = self._managerConfigKey(name)
+            storedMgr = self._attributes.get(key)
+            _LOG.debug("found manager config %s=%s", key, storedMgr)
+            if storedMgr is None:
+                missing.append(name)
+                continue
+            if extension.extensionName() != storedMgr:
+                mismatch.append(
+                    f"{name}: configured {extension.extensionName()}, stored: {storedMgr}"
+                )
+        if missing:
+            raise MissingManagerError(
+                "Cannot find stored configuration for managers: "
+                + ", ".join(missing)
+            )
+        if mismatch:
+            raise ManagerMismatchError(
+                "Configured managers do not match registry-stored names:\n"
+                + "\n".join(missing)
+            )
+
+    def checkManagersVersions(self, writeable: bool) -> None:
         """Compare configured versions with the versions stored in database.
 
         Parameters
         ----------
-        attributes : `ButlerAttributeManager`
-            Attribute manager instance.
         writeable : `bool`
             If ``True`` then read-write access needs to be checked.
 
@@ -314,13 +309,43 @@ class ButlerVersionsManager:
         MissingVersionError
             Raised if database has no stored version for one or more groups.
         """
-        for key, vInfo in self._versions.items():
-            storedVersionStr = attributes.get(f"schema_versions.{key}.version")
-            if storedVersionStr is None:
-                raise MissingVersionError(f"Failed to read version number for group {key}")
-            storedVersion = VersionTuple.fromString(storedVersionStr)
-            if not self.checkCompatibility(storedVersion, vInfo.version, writeable):
-                raise IncompatibleVersionError(
-                    f"Configured version {vInfo.version} is not compatible with stored version "
-                    f"{storedVersion} for group {key}"
-                )
+        if self._attributesEmpty:
+            return
+
+        for extension in self._managers.values():
+            version = extension.currentVersion()
+            if version:
+                key = self._managerVersionKey(extension)
+                storedVersionStr = self._attributes.get(key)
+                _LOG.debug("found manager version %s=%s, current version %s", key, storedVersionStr, version)
+                if storedVersionStr is None:
+                    raise MissingVersionError(f"Failed to read version number {key}")
+                storedVersion = VersionTuple.fromString(storedVersionStr)
+                if not self.checkCompatibility(storedVersion, version, writeable):
+                    raise IncompatibleVersionError(
+                        f"Configured version {version} is not compatible with stored version "
+                        f"{storedVersion} for extension {extension.extensionName()}"
+                    )
+
+    def checkManagersDigests(self) -> None:
+        """Compare current schema digests with digests stored in database.
+
+        Raises
+        ------
+        DigestMismatchError
+            Raised if digests are not equal.
+        """
+        if self._attributesEmpty:
+            return
+
+        for extension in self._managers.values():
+            digest = extension.schemaDigest()
+            if digest is not None:
+                key = self._managerDigestKey(extension)
+                storedDigest = self._attributes.get(key)
+                _LOG.debug("found manager schema digest %s=%s, current digest %s", key, storedDigest, digest)
+                if storedDigest != digest:
+                    raise DigestMismatchError(
+                        f"Current schema digest '{digest}' is not the same as stored digest "
+                        f"'{storedDigest}' for extension {extension.extensionName()}"
+                    )

--- a/python/lsst/daf/butler/registry/versions.py
+++ b/python/lsst/daf/butler/registry/versions.py
@@ -127,7 +127,7 @@ class ButlerVersionsManager:
             if isinstance(manager, VersionedExtension):
                 self._managers[name] = manager
             else:
-                # All regular manages need to support versioning mechanism.
+                # All regular managers need to support versioning mechanism.
                 _LOG.warning("extension %r does not implement VersionedExtension", name)
         self._emptyFlag: Optional[bool] = None
 

--- a/python/lsst/daf/butler/tests/_dummyRegistry.py
+++ b/python/lsst/daf/butler/tests/_dummyRegistry.py
@@ -33,6 +33,7 @@ from lsst.daf.butler.registry.interfaces import (
     OpaqueTableStorageManager,
     OpaqueTableStorage,
     StaticTablesContext,
+    VersionTuple
 )
 from lsst.daf.butler.registry.bridge.ephemeral import EphemeralDatastoreRegistryBridge
 
@@ -90,6 +91,15 @@ class DummyOpaqueTableStorageManager(OpaqueTableStorageManager):
         # Docstring inherited from OpaqueTableStorageManager.
         return self._storages.setdefault(name, DummyOpaqueTableStorage(name, spec))
 
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return None
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return None
+
 
 class DummyDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
 
@@ -120,6 +130,15 @@ class DummyDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
         for name, bridge in self._bridges.items():
             if ref in bridge:
                 yield name
+
+    @classmethod
+    def currentVersion(cls) -> Optional[VersionTuple]:
+        # Docstring inherited from VersionedExtension.
+        return None
+
+    def schemaDigest(self) -> Optional[str]:
+        # Docstring inherited from VersionedExtension.
+        return None
 
 
 class DummyRegistry:


### PR DESCRIPTION
For each manager we now store its full name, version number, and schema
digest. Some control for that has been moved to a separate interface
which needs to be implemented by each manager class. Saved manager name
could be different from one specified in registry config due to
difference in module names.