### PR TITLE
DM-26160: Rewrite Location class to make proper use of ButlerURI

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -349,10 +349,14 @@ class ButlerURI:
             ButlerURI rules.
         tail : `str`
             Last `self.path` component. Tail will be empty if path ends on a
-            separator. Tail will never contain separators.
+            separator. Tail will never contain separators. It will be
+            unquoted.
         """
         head, tail = self._pathModule.split(self.path)
         headuri = self._uri._replace(path=head)
+
+        # The file part should never include quoted metacharacters
+        tail = urllib.parse.unquote(tail)
 
         # Schemeless is special in that it can be a relative path
         # We need to ensure that it stays that way. All other URIs will

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -35,6 +35,7 @@ import requests
 import tempfile
 import copy
 import logging
+import re
 
 from typing import (
     TYPE_CHECKING,
@@ -65,6 +66,9 @@ IS_POSIX = os.sep == posixpath.sep
 
 # Root path for this operating system
 OS_ROOT_PATH = Path().resolve().root
+
+# Regex for looking for URI escapes
+ESCAPES_RE = re.compile(r"%[A-F0-9]{2}")
 
 
 def os2posix(ospath: str) -> str:
@@ -218,7 +222,10 @@ class ButlerURI:
             # Since sometimes people write file:/a/b and not file:///a/b
             # we should not quote in the explicit case of file:
             if "://" not in uri and not uri.startswith("file:"):
-                uri = urllib.parse.quote(uri)
+                if ESCAPES_RE.search(uri):
+                    log.warning("Possible double encoding of %s", uri)
+                else:
+                    uri = urllib.parse.quote(uri)
             parsed = urllib.parse.urlparse(uri)
         elif isinstance(uri, urllib.parse.ParseResult):
             parsed = copy.copy(uri)

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -289,6 +289,11 @@ class ButlerURI:
         return self._uri.path
 
     @property
+    def unquoted_path(self) -> str:
+        """The path component of the URI with any URI quoting reversed."""
+        return urllib.parse.unquote(self._uri.path)
+
+    @property
     def ospath(self) -> str:
         """Path component of the URI localized to current OS."""
         raise AttributeError(f"Non-file URI ({self}) has no local OS path.")

--- a/python/lsst/daf/butler/core/repoRelocation.py
+++ b/python/lsst/daf/butler/core/repoRelocation.py
@@ -73,10 +73,12 @@ def replaceRoot(configRoot: str, butlerRoot: Optional[Union[ButlerURI, str]]) ->
         raise ValueError(f"Required to replace {BUTLER_ROOT_TAG} in '{configRoot}' "
                          "but a replacement has not been defined")
 
-    # Use absolute file path if this uses file scheme, else use unchanged
+    # Use absolute file path if this refers to a local file, else use
+    # unchanged since all other URI schemes are absolute
     uri = ButlerURI(butlerRoot)
     if not uri.scheme or uri.scheme == "file":
-        butlerRoot = os.path.abspath(uri.path)
+        # This will be a local file with URI quoting removed
+        butlerRoot = os.path.abspath(uri.ospath)
 
     assert butlerRoot is not None
     return configRoot.replace(BUTLER_ROOT_TAG, str(butlerRoot))

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -578,7 +578,7 @@ class FileLikeDatastore(GenericBaseDatastore):
         raise NotImplementedError("Must be implemented by subclasses.")
 
     @abstractmethod
-    def _extractIngestInfo(self, path: str, ref: DatasetRef, *,
+    def _extractIngestInfo(self, path: Union[str, ButlerURI], ref: DatasetRef, *,
                            formatter: Union[Formatter, Type[Formatter]],
                            transfer: Optional[str] = None) -> StoredFileInfo:
         """Relocate (if necessary) and extract `StoredFileInfo` from a
@@ -586,8 +586,8 @@ class FileLikeDatastore(GenericBaseDatastore):
 
         Parameters
         ----------
-        path : `str`
-            Path of a file to be ingested.
+        path : `str` or `ButlerURI`
+            URI or path of a file to be ingested.
         ref : `DatasetRef`
             Reference for the dataset being ingested.  Guaranteed to have
             ``dataset_id not None`.
@@ -796,14 +796,14 @@ class FileLikeDatastore(GenericBaseDatastore):
                     compLocation = predictLocation(compRef)
 
                     # Add a URI fragment to indicate this is a guess
-                    components[component] = ButlerURI(compLocation.uri + "#predicted")
+                    components[component] = ButlerURI(compLocation.uri.geturl() + "#predicted")
 
             else:
 
                 location = predictLocation(ref)
 
                 # Add a URI fragment to indicate this is a guess
-                primary = ButlerURI(location.uri + "#predicted")
+                primary = ButlerURI(location.uri.geturl() + "#predicted")
 
             return primary, components
 

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -84,11 +84,11 @@ class PosixDatastore(FileLikeDatastore):
         super().__init__(config, bridgeManager, butlerRoot)
 
         # Check that root is a valid URI for this datastore
-        root = ButlerURI(self.root)
+        root = ButlerURI(self.root, forceDirectory=True)
         if root.scheme and root.scheme != "file":
             raise ValueError(f"Root location must only be a file URI not {self.root}")
 
-        self.root = root.path
+        self.root = root.ospath
         if not os.path.isdir(self.root):
             if "create" not in self.config or not self.config["create"]:
                 raise ValueError(f"No valid root at: {self.root}")

--- a/python/lsst/daf/butler/datastores/posixDatastore.py
+++ b/python/lsst/daf/butler/datastores/posixDatastore.py
@@ -247,7 +247,7 @@ class PosixDatastore(FileLikeDatastore):
             path = pathx
         return path
 
-    def _extractIngestInfo(self, path: str, ref: DatasetRef, *,
+    def _extractIngestInfo(self, path: Union[str, ButlerURI], ref: DatasetRef, *,
                            formatter: Union[Formatter, Type[Formatter]],
                            transfer: Optional[str] = None) -> StoredFileInfo:
         # Docstring inherited from FileLikeDatastore._extractIngestInfo.

--- a/python/lsst/daf/butler/datastores/s3Datastore.py
+++ b/python/lsst/daf/butler/datastores/s3Datastore.py
@@ -304,7 +304,7 @@ class S3Datastore(FileLikeDatastore):
                                    f"within datastore ({rootUri})")
         return path
 
-    def _extractIngestInfo(self, path: str, ref: DatasetRef, *,
+    def _extractIngestInfo(self, path: Union[str, ButlerURI], ref: DatasetRef, *,
                            formatter: Union[Formatter, Type[Formatter]],
                            transfer: Optional[str] = None) -> StoredFileInfo:
         # Docstring inherited from FileLikeDatastore._extractIngestInfo.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1010,7 +1010,7 @@ class ChainedDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
     fullConfigKey = ".datastore.datastores.1.formatters"
     validationCanFail = True
-    datastoreStr = ["datastore='InMemory", "/PosixDatastore_1,", "/PosixDatastore_2'"]
+    datastoreStr = ["datastore='InMemory", "/PosixDatastore_1/,", "/PosixDatastore_2/'"]
     datastoreName = ["InMemoryDatastore@", f"PosixDatastore@{BUTLER_ROOT_TAG}/PosixDatastore_1",
                      "SecondDatastore"]
     registryStr = "/gen3.sqlite3"

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -184,30 +184,36 @@ class LocationTestCase(unittest.TestCase):
 
         self.assertEqual(loc1.path, os.path.join(root, pathInStore))
         self.assertEqual(loc1.pathInStore, pathInStore)
-        self.assertTrue(loc1.uri.startswith("file:///"))
-        self.assertTrue(loc1.uri.endswith("file.ext"))
+        self.assertTrue(loc1.uri.geturl().startswith("file:///"))
+        self.assertTrue(loc1.uri.geturl().endswith("file.ext"))
         loc1.updateExtension("fits")
-        self.assertTrue(loc1.uri.endswith("file.fits"), f"Checking 'fits' extension in {loc1.uri}")
+        self.assertTrue(loc1.uri.geturl().endswith("file.fits"),
+                        f"Checking 'fits' extension in {loc1.uri}")
         loc1.updateExtension("fits.gz")
-        self.assertTrue(loc1.uri.endswith("file.fits.gz"), f"Checking 'fits.gz' extension in {loc1.uri}")
+        self.assertEqual(loc1.uri.basename(), "file.fits.gz")
+        self.assertTrue(loc1.uri.geturl().endswith("file.fits.gz"),
+                        f"Checking 'fits.gz' extension in {loc1.uri}")
+        self.assertEqual(loc1.getExtension(), ".fits.gz")
         loc1.updateExtension(".jpeg")
-        self.assertTrue(loc1.uri.endswith("file.jpeg"), f"Checking 'jpeg' extension in {loc1.uri}")
+        self.assertTrue(loc1.uri.geturl().endswith("file.jpeg"),
+                        f"Checking 'jpeg' extension in {loc1.uri}")
         loc1.updateExtension(None)
-        self.assertTrue(loc1.uri.endswith("file.jpeg"), f"Checking unchanged extension in {loc1.uri}")
+        self.assertTrue(loc1.uri.geturl().endswith("file.jpeg"),
+                        f"Checking unchanged extension in {loc1.uri}")
         loc1.updateExtension("")
-        self.assertTrue(loc1.uri.endswith("file"), f"Checking no extension in {loc1.uri}")
+        self.assertTrue(loc1.uri.geturl().endswith("file"), f"Checking no extension in {loc1.uri}")
+        self.assertEqual(loc1.getExtension(), "")
 
     def testRelativeRoot(self):
         root = os.path.abspath(os.path.curdir)
         factory = LocationFactory(os.path.curdir)
-        print(f"Factory created: {factory}")
 
         pathInStore = "relative/path/file.ext"
         loc1 = factory.fromPath(pathInStore)
 
         self.assertEqual(loc1.path, os.path.join(root, pathInStore))
         self.assertEqual(loc1.pathInStore, pathInStore)
-        self.assertTrue(loc1.uri.startswith("file:///"))
+        self.assertEqual(loc1.uri.scheme, "file")
 
     def testQuotedRoot(self):
         """Test we can handle quoted characters."""
@@ -223,7 +229,7 @@ class LocationTestCase(unittest.TestCase):
 
             self.assertEqual(loc1.pathInStore, pathInStore)
             self.assertEqual(loc1.path, os.path.join(root, pathInStore))
-            self.assertIn("%", loc1.uri)
+            self.assertIn("%", str(loc1.uri))
             self.assertEqual(loc1.getExtension(), ".ext.gz")
 
     def testHttpLocation(self):
@@ -236,10 +242,10 @@ class LocationTestCase(unittest.TestCase):
 
         self.assertEqual(loc1.path, posixpath.join("/butler/datastore", pathInStore))
         self.assertEqual(loc1.pathInStore, pathInStore)
-        self.assertTrue(loc1.uri.startswith("https://"))
-        self.assertTrue(loc1.uri.endswith("file.ext"))
+        self.assertEqual(loc1.uri.scheme, "https")
+        self.assertEqual(loc1.uri.basename(), "file.ext")
         loc1.updateExtension("fits")
-        self.assertTrue(loc1.uri.endswith("file.fits"))
+        self.assertTrue(loc1.uri.basename(), "file.fits")
 
     def testPosix2OS(self):
         """Test round tripping of the posix to os.path conversion helpers."""

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -209,6 +209,23 @@ class LocationTestCase(unittest.TestCase):
         self.assertEqual(loc1.pathInStore, pathInStore)
         self.assertTrue(loc1.uri.startswith("file:///"))
 
+    def testQuotedRoot(self):
+        """Test we can handle quoted characters."""
+        root = "/a/b/c+1/d"
+        factory = LocationFactory(root)
+
+        pathInStore = "relative/path/file.ext.gz"
+
+        for pathInStore in ("relative/path/file.ext.gz",
+                            "relative/path+2/file.ext.gz",
+                            "relative/path+3/file#.ext.gz"):
+            loc1 = factory.fromPath(pathInStore)
+
+            self.assertEqual(loc1.pathInStore, pathInStore)
+            self.assertEqual(loc1.path, os.path.join(root, pathInStore))
+            self.assertIn("%", loc1.uri)
+            self.assertEqual(loc1.getExtension(), ".ext.gz")
+
     def testHttpLocation(self):
         root = "https://www.lsst.org/butler/datastore"
         factory = LocationFactory(root)

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -331,6 +331,18 @@ class S3URITestCase(unittest.TestCase):
         not_s3 = ButlerURI(os.path.join(self.tmpdir, "dir1", "file2.txt"))
         self.assertFalse(child.relative_to(not_s3))
 
+    def testQuoting(self):
+        """Check that quoting works."""
+        parent = ButlerURI(self.makeS3Uri("rootdir"), forceDirectory=True)
+        subpath = "rootdir/dir1+/file?.txt"
+        child = ButlerURI(self.makeS3Uri(urllib.parse.quote(subpath)))
+
+        self.assertEqual(child.relative_to(parent), "dir1+/file?.txt")
+        self.assertEqual(child.basename(), "file?.txt")
+        self.assertEqual(child.relativeToPathRoot, subpath)
+        self.assertIn("%", child.path)
+        self.assertEqual(child.unquoted_path, "/" + subpath)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -231,6 +231,12 @@ class FileURITestCase(unittest.TestCase):
         self.assertEqual(new2.relative_to(fdir), new2name, f"{new2} vs {fdir}")
         self.assertEqual(new2.relative_to(dir), new2name)
 
+        # Check for double quoting
+        plus_path = "/a/b/c+d/"
+        with self.assertLogs(level="WARNING"):
+            uri = ButlerURI(urllib.parse.quote(plus_path), forceDirectory=True)
+        self.assertEqual(uri.ospath, plus_path)
+
 
 @unittest.skipIf(not boto3, "Warning: boto3 AWS SDK not found!")
 @mock_s3


### PR DESCRIPTION
Without this we were getting inconsistencies when a datastore root was a path that had a character in it that would be escaped. This was because in some cases os.path was being used when a ButlerURI method should have been used.