### PR TITLE
DM-26318: Fix mocking of webDAV

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1215,6 +1215,9 @@ class ButlerHttpURI(ButlerURI):
         """For a dir-like URI, create the directory resource if it does not
         already exist.
         """
+        if not self.dirLike:
+            raise ValueError(f"Can not create a 'directory' for file-like URI {self}")
+
         if not self.exists():
             log.debug("Creating new directory: %s", self.geturl())
             r = self.session.request("MKCOL", self.geturl())

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1095,7 +1095,7 @@ class ButlerS3URI(ButlerURI):
             raise ValueError(f"Bucket {self.netloc} does not exist for {self}!")
 
         if not self.dirLike:
-            raise ValueError("Can not create a 'directory' for file-like URI {self}")
+            raise ValueError(f"Can not create a 'directory' for file-like URI {self}")
 
         # don't create S3 key when root is at the top-level of an Bucket
         if not self.path == "/":

--- a/tests/test_webdavutils.py
+++ b/tests/test_webdavutils.py
@@ -33,7 +33,7 @@ class WebdavUtilsTestCase(unittest.TestCase):
     """Test for the Webdav related utilities.
     """
     session = requests.Session()
-    serverRoot = "www.lsst.org"
+    serverRoot = "www.lsstnowebdav.orgx"
     wrongRoot = "www.lsstwithoutwebdav.org"
     existingfolderName = "testFolder"
     notExistingfolderName = "testFolder_not_exist"


### PR DESCRIPTION
#351 used a real domain for some tests which weren't completely mocked. This meant that things sort of worked until we had a network issue and then they didn't.