### PR TITLE
DM-26343: Use less expansive definition of extension

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -434,12 +434,25 @@ class ButlerURI:
         -------
         ext : `str`
             The file extension (including the ``.``). Can be empty string
-            if there is no file extension. Will return all file extensions
-            as a single extension such that ``file.fits.gz`` will return
-            a value of ``.fits.gz``.
+            if there is no file extension. Usually returns only the last
+            file extension unless there is a special extension modifier
+            indicating file compression, in which case the combined
+            extension (e.g. ``.fits.gz``) will be returned.
         """
+        special = {".gz", ".bz2", ".xz", ".fz"}
+
         extensions = self._pathLib(self.path).suffixes
-        return "".join(extensions)
+
+        if not extensions:
+            return ""
+
+        ext = extensions.pop()
+
+        # Multiple extensions, decide whether to include the final two
+        if extensions and ext in special:
+            ext = f"{extensions[-1]}{ext}"
+
+        return ext
 
     def join(self, path: str) -> ButlerURI:
         """Create a new `ButlerURI` with additional path components including

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -319,7 +319,10 @@ class Formatter(metaclass=ABCMeta):
         except AttributeError:
             raise NotImplementedError("No file extension registered with this formatter") from None
 
-        if default is not None:
+        # If extension is implemented as an instance property it won't return
+        # a string when called as a class propertt. Assume that
+        # the supported extensions class property is complete.
+        if default is not None and isinstance(default, str):
             supported.add(default)
 
         # Get the file name from the uri
@@ -331,6 +334,7 @@ class Formatter(metaclass=ABCMeta):
         for ext in supported:
             if file.endswith(ext):
                 return
+
         raise ValueError(f"Extension '{location.getExtension()}' on '{location}' "
                          f"is not supported by Formatter '{cls.__name__}' (supports: {supported})")
 

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -310,7 +310,6 @@ class Formatter(metaclass=ABCMeta):
         writing files.  If ``extension`` is `None` only the set of supported
         extensions will be examined.
         """
-        ext = location.getExtension()
         supported = set(cls.supportedExtensions)
 
         try:
@@ -323,9 +322,17 @@ class Formatter(metaclass=ABCMeta):
         if default is not None:
             supported.add(default)
 
-        if ext in supported:
-            return
-        raise ValueError(f"Extension '{ext}' on '{location}' is not supported by Formatter '{cls.__name__}'")
+        # Get the file name from the uri
+        file = location.uri.basename()
+
+        # Check that this file name ends with one of the supported extensions.
+        # This is less prone to confusion than asking the location for
+        # its extension and then doing a set comparison
+        for ext in supported:
+            if file.endswith(ext):
+                return
+        raise ValueError(f"Extension '{location.getExtension()}' on '{location}' "
+                         f"is not supported by Formatter '{cls.__name__}' (supports: {supported})")
 
     def predictPath(self) -> str:
         """Return the path that would be returned by write, without actually

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -21,7 +21,8 @@
 
 from __future__ import annotations
 
-__all__ = ("FormatterTest", "DoNothingFormatter", "LenientYamlFormatter", "MetricsExampleFormatter")
+__all__ = ("FormatterTest", "DoNothingFormatter", "LenientYamlFormatter", "MetricsExampleFormatter",
+           "MultipleExtensionsFormatter", "SingleExtensionFormatter")
 
 from typing import (
     TYPE_CHECKING,
@@ -69,6 +70,16 @@ class FormatterTest(Formatter):
             if "mode" not in recipes[recipeName]:
                 raise RuntimeError("'mode' is a required write recipe parameter")
         return recipes
+
+
+class SingleExtensionFormatter(DoNothingFormatter):
+    """A do nothing formatter that has a single extension registered."""
+    extension = ".fits"
+
+
+class MultipleExtensionsFormatter(SingleExtensionFormatter):
+    """A formatter that has multiple extensions registered."""
+    supportedExtensions = frozenset({".fits.gz", ".fits.fz", ".fit"})
 
 
 class LenientYamlFormatter(YamlFormatter):

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -181,6 +181,24 @@ class LocationTestCase(unittest.TestCase):
         self.assertEqual(uri, uri2)
         self.assertTrue(uri2.dirLike)
 
+    def testUriExtensions(self):
+        """Test extension extraction."""
+
+        files = (("file.fits.gz", ".fits.gz"),
+                 ("file.fits", ".fits"),
+                 ("file.fits.xz", ".fits.xz"),
+                 ("file.fits.tar", ".tar"),
+                 ("file", ""),
+                 ("flat_i_sim_1.4_blah.fits.gz", ".fits.gz"),
+                 ("flat_i_sim_1.4_blah.txt", ".txt"),
+                 ("flat_i_sim_1.4_blah.fits.fz", ".fits.fz"),
+                 ("flat_i_sim_1.4_blah.fits.txt", ".txt"),
+                 )
+
+        for file, expected in files:
+            uri = ButlerURI(f"a/b/{file}")
+            self.assertEqual(uri.getExtension(), expected)
+
     def testFileLocation(self):
         root = os.path.abspath(os.path.curdir)
         factory = LocationFactory(root)


### PR DESCRIPTION
* Change ButlerURI.getExtension to return a single extension unless that extension matches a specific set (e.g. .gz).
* Change extension validation in Formatter to check the end of the file name directly rather than trying to use the source file extension (which is an unnecessary extra step).

These changes allow "flat_i_sim_1.4_blah.fits" to be ingested as a fits file.