### PR TITLE
DM-26383: Add webdav datastore tests to daf_butler

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1399,17 +1399,19 @@ class ButlerHttpURI(ButlerURI):
         if isinstance(src, type(self)):
             if transfer == "move":
                 self.session.request("MOVE", src.geturl(), headers={"Destination": self.geturl()})
+                log.debug(f"Direct move via MOVE operation executed.")
             else:
                 self.session.request("COPY", src.geturl(), headers={"Destination": self.geturl()})
+                log.debug(f"Direct copy via COPY operation executed.")
         else:
             # Use local file and upload it
             local_src, is_temporary = src.as_local()
             f = open(local_src, "rb")
-            files = {"file": f}
-            self.session.post(self.geturl(), files=files)
+            self.session.put(self.geturl(), data=f)
             f.close()
             if is_temporary:
                 os.remove(local_src)
+            log.debug(f"Indirect copy via temporary file executed.")
 
 
 class ButlerInMemoryURI(ButlerURI):

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1241,11 +1241,12 @@ class ButlerHttpURI(ButlerURI):
     def session(self) -> requests.Session:
         """Client object to address remote resource."""
         from .webdavutils import getHttpSession, isWebdavEndpoint
-        if isWebdavEndpoint(self):
-            log.debug("%s looks like a Webdav endpoint.", self.geturl())
-            return getHttpSession()
+        baseURL = self.scheme + "://" + self.netloc
+        if isWebdavEndpoint(baseURL):
+            log.debug("%s looks like a Webdav endpoint.", baseURL)
+            return getHttpSession() 
 
-        log.debug("%s looks like a standard HTTP endpoint.", self.geturl())
+        log.debug("%s looks like a standard HTTP endpoint.", baseURL)
         return requests.Session()
 
     def exists(self) -> bool:

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1275,9 +1275,9 @@ class ButlerHttpURI(ButlerURI):
         if not self.exists():
             if self.geturl().endswith('/'):
                 diruri = ButlerURI(self.geturl()[:-1])
-                parentdir = diruri.split()[0]
+                parentdir = diruri.dirname()
             else:
-                parentdir = self.split()[0]
+                parentdir = self.dirname()
             if not parentdir.exists():
                 parentdir.mkdir()
             log.debug("Creating new directory: %s", self.geturl())

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1294,7 +1294,11 @@ class ButlerHttpURI(ButlerURI):
             raise ValueError(f"Can not create a 'directory' for file-like URI {self}")
 
         if not self.exists():
-            if not self.parent().exists():
+            # We need to test the absence of the parent directory,
+            # but also if parent URL is different from self URL,
+            # otherwise we could be stuck in a recursive loop
+            # where self == parent
+            if not self.parent().exists() and self.parent().geturl() != self.geturl():
                 self.parent().mkdir()
             log.debug("Creating new directory: %s", self.geturl())
             r = self.session.request("MKCOL", self.geturl())

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1273,6 +1273,13 @@ class ButlerHttpURI(ButlerURI):
             raise ValueError(f"Can not create a 'directory' for file-like URI {self}")
 
         if not self.exists():
+            if self.geturl().endswith('/'):
+                diruri = ButlerURI(self.geturl()[:-1])
+                parentdir = diruri.split()[0]
+            else:
+                parentdir = self.split()[0]
+            if not parentdir.exists():
+                parentdir.mkdir()
             log.debug("Creating new directory: %s", self.geturl())
             r = self.session.request("MKCOL", self.geturl())
             if r.status_code != 201:

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1244,7 +1244,7 @@ class ButlerHttpURI(ButlerURI):
         baseURL = self.scheme + "://" + self.netloc
         if isWebdavEndpoint(baseURL):
             log.debug("%s looks like a Webdav endpoint.", baseURL)
-            return getHttpSession() 
+            return getHttpSession()
 
         log.debug("%s looks like a standard HTTP endpoint.", baseURL)
         return requests.Session()

--- a/python/lsst/daf/butler/core/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri.py
@@ -1399,10 +1399,10 @@ class ButlerHttpURI(ButlerURI):
         if isinstance(src, type(self)):
             if transfer == "move":
                 self.session.request("MOVE", src.geturl(), headers={"Destination": self.geturl()})
-                log.debug(f"Direct move via MOVE operation executed.")
+                log.debug("Direct move via MOVE operation executed.")
             else:
                 self.session.request("COPY", src.geturl(), headers={"Destination": self.geturl()})
-                log.debug(f"Direct copy via COPY operation executed.")
+                log.debug("Direct copy via COPY operation executed.")
         else:
             # Use local file and upload it
             local_src, is_temporary = src.as_local()
@@ -1411,7 +1411,7 @@ class ButlerHttpURI(ButlerURI):
             f.close()
             if is_temporary:
                 os.remove(local_src)
-            log.debug(f"Indirect copy via temporary file executed.")
+            log.debug("Indirect copy via temporary file executed.")
 
 
 class ButlerInMemoryURI(ButlerURI):

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -710,6 +710,9 @@ class FileLikeDatastore(GenericBaseDatastore):
             # Work out the name we want this ingested file to have
             # inside the datastore
             tgtLocation = self._calculate_ingested_datastore_name(srcUri, ref, formatter)
+            if not tgtLocation.uri.dirname().exists():
+                log.debug("Folder %s does not exist yet.", tgtLocation.uri.dirname().geturl())
+                tgtLocation.uri.dirname().mkdir()
 
             # if we are transferring from a local file to a remote location
             # it may be more efficient to get the size and checksum of the

--- a/python/lsst/daf/butler/datastores/fileLikeDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileLikeDatastore.py
@@ -711,7 +711,7 @@ class FileLikeDatastore(GenericBaseDatastore):
             # inside the datastore
             tgtLocation = self._calculate_ingested_datastore_name(srcUri, ref, formatter)
             if not tgtLocation.uri.dirname().exists():
-                log.debug("Folder %s does not exist yet.", tgtLocation.uri.dirname().geturl())
+                log.debug("Folder %s does not exist yet.", tgtLocation.uri.dirname())
                 tgtLocation.uri.dirname().mkdir()
 
             # if we are transferring from a local file to a remote location

--- a/python/lsst/daf/butler/datastores/remoteFileDatastore.py
+++ b/python/lsst/daf/butler/datastores/remoteFileDatastore.py
@@ -136,7 +136,7 @@ class RemoteFileDatastore(FileLikeDatastore):
             log.warning("Object %s exists in datastore for ref %s", location.uri, ref)
 
         if not location.uri.dirname().exists():
-            log.debug("Folder %s does not exist yet.", location.uri.dirname().geturl())
+            log.debug("Folder %s does not exist yet.", location.uri.dirname())
             location.uri.dirname().mkdir()
 
         if self._transaction is None:

--- a/python/lsst/daf/butler/datastores/remoteFileDatastore.py
+++ b/python/lsst/daf/butler/datastores/remoteFileDatastore.py
@@ -134,6 +134,10 @@ class RemoteFileDatastore(FileLikeDatastore):
             # Eventually we should remove the check completely (it takes
             # non-zero time for network).
             log.warning("Object %s exists in datastore for ref %s", location.uri, ref)
+            
+        if not location.uri.dirname().exists():
+            log.debug("Folder %s does not exist yet.", location.uri.dirname().geturl())
+            location.uri.dirname().mkdir()
 
         if self._transaction is None:
             raise RuntimeError("Attempting to write artifact without transaction enabled")

--- a/python/lsst/daf/butler/datastores/remoteFileDatastore.py
+++ b/python/lsst/daf/butler/datastores/remoteFileDatastore.py
@@ -134,7 +134,7 @@ class RemoteFileDatastore(FileLikeDatastore):
             # Eventually we should remove the check completely (it takes
             # non-zero time for network).
             log.warning("Object %s exists in datastore for ref %s", location.uri, ref)
-            
+
         if not location.uri.dirname().exists():
             log.debug("Folder %s does not exist yet.", location.uri.dirname().geturl())
             location.uri.dirname().mkdir()

--- a/tests/config/basic/webdavDatastore.yaml
+++ b/tests/config/basic/webdavDatastore.yaml
@@ -1,8 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.webdavDatastore.WebdavDatastore
-  # http://localhost:8080 is where the local webdav server listens
-  # during Butler unit tests, so this value is required for successful testing
-  root: http://localhost:8080/butlerRoot
+  root: http://anywebdavserver/butlerRoot
   templates: !include templates.yaml
   formatters: !include formatters.yaml
   composites: !include composites.yaml

--- a/tests/config/basic/webdavDatastore.yaml
+++ b/tests/config/basic/webdavDatastore.yaml
@@ -1,6 +1,6 @@
 datastore:
   cls: lsst.daf.butler.datastores.webdavDatastore.WebdavDatastore
-  root: https://some.webdav.server/butlerRoot
+  root: http://localhost:8080/butlerRoot
   templates: !include templates.yaml
   formatters: !include formatters.yaml
   composites: !include composites.yaml

--- a/tests/config/basic/webdavDatastore.yaml
+++ b/tests/config/basic/webdavDatastore.yaml
@@ -1,5 +1,7 @@
 datastore:
   cls: lsst.daf.butler.datastores.webdavDatastore.WebdavDatastore
+  # http://localhost:8080 is where the local webdav server listens
+  # during Butler unit tests, so this value is required for successful testing
   root: http://localhost:8080/butlerRoot
   templates: !include templates.yaml
   formatters: !include formatters.yaml

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -44,8 +44,15 @@ except ImportError:
         """
         return cls
 
+try:
+    from cheroot import wsgi
+    from wsgidav.wsgidav_app import WsgiDAVApp
+except ImportError:
+    WsgiDAVApp = None
+
 import astropy.time
 from threading import Thread
+from tempfile import gettempdir
 from lsst.utils import doImport
 from lsst.daf.butler.core.utils import safeMakeDir
 from lsst.daf.butler import Butler, Config, ButlerConfig
@@ -1195,6 +1202,7 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
             unsetAwsEnvCredentials()
 
 
+@unittest.skipIf(not WsgiDAVApp, "Warning: wsgi/cheroot not found!")
 class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
     """WebdavDatastore specialization of a butler; a Webdav storage Datastore +
     a local in-memory SqlRegistry.
@@ -1274,10 +1282,6 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         uri.remove()
 
     def _serveWebdav():
-        from tempfile import gettempdir
-        from cheroot import wsgi
-        from wsgidav.wsgidav_app import WsgiDAVApp
-
         root_path = gettempdir()
 
         config = {

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1267,19 +1267,18 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
 
         if self.useTempRoot:
             self.root = self.genRoot()
-        rooturi = f"http://{self.serverName}/{self.root}"
-        config.update({"datastore": {"datastore": {"root": rooturi}}})
+        self.rooturi = f"http://{self.serverName}/{self.root}"
+        config.update({"datastore": {"datastore": {"root": self.rooturi}}})
 
         self.datastoreStr = f"datastore={self.root}"
-        self.datastoreName = [f"WebdavDatastore@{rooturi}"]
+        self.datastoreName = [f"WebdavDatastore@{self.rooturi}"]
 
-        Butler.makeRepo(rooturi, config=config, forceConfigRoot=False)
-        self.tmpConfigFile = posixpath.join(rooturi, "butler.yaml")
+
+        Butler.makeRepo(self.rooturi, config=config, forceConfigRoot=False)
+        self.tmpConfigFile = posixpath.join(self.rooturi, "butler.yaml")
 
     def tearDown(self):
-        rooturi = f"http://{self.serverName}/{self.root}"
-        uri = ButlerURI(rooturi)
-        uri.remove()
+        ButlerURI(self.rooturi).remove()
 
     def _serveWebdav():
         """Starts a local webdav-compatible HTTP server,

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1202,7 +1202,7 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
             unsetAwsEnvCredentials()
 
 
-@unittest.skipIf(not WsgiDAVApp, "Warning: wsgi/cheroot not found!")
+@unittest.skipIf(WsgiDAVApp is None, "Warning: wsgi/cheroot not found!")
 class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
     """WebdavDatastore specialization of a butler; a Webdav storage Datastore +
     a local in-memory SqlRegistry.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1273,6 +1273,9 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         self.datastoreStr = f"datastore={self.root}"
         self.datastoreName = [f"WebdavDatastore@{self.rooturi}"]
 
+        from lsst.daf.butler.core.webdavutils import isWebdavEndpoint
+        if not isWebdavEndpoint(self.rooturi):
+            raise OSError("Webdav server not running properly: cannot run tests.")
 
         Butler.makeRepo(self.rooturi, config=config, forceConfigRoot=False)
         self.tmpConfigFile = posixpath.join(self.rooturi, "butler.yaml")

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1249,6 +1249,8 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         time.sleep(3)
 
     def setUp(self):
+        os.environ["WEBDAV_AUTH_METHOD"] = "TOKEN"
+        os.environ["WEBDAV_BEARER_TOKEN"] = "XXXXXX"
 
         config = Config(self.configFile)
         uri = ButlerURI(config[".datastore.datastore.root"])

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1194,6 +1194,7 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
         if self.usingDummyCredentials:
             unsetAwsEnvCredentials()
 
+
 class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase):
     """WebdavDatastore specialization of a butler; a Webdav storage Datastore +
     a local in-memory SqlRegistry.
@@ -1243,7 +1244,7 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         cls.storageClassFactory.addFromConfig(cls.configFile)
 
         # Run a local webdav server on which tests will be run
-        t = Thread(target = cls._serveWebdav, daemon = True) 
+        t = Thread(target=cls._serveWebdav, daemon=True)
         t.start()
         # Wait for it to start
         time.sleep(3)
@@ -1271,7 +1272,7 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         rooturi = f"http://{self.serverName}/{self.root}"
         uri = ButlerURI(rooturi)
         uri.remove()
-    
+
     def _serveWebdav():
         from tempfile import gettempdir
         from cheroot import wsgi
@@ -1284,7 +1285,7 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
             "port": 8080,
             "provider_mapping": {"/": root_path},
             "http_authenticator": {
-            "domain_controller": None
+                "domain_controller": None
             },
             "simple_dc": {"user_mapping": {"*": True}},
             "verbose": 0,
@@ -1294,7 +1295,7 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         server_args = {
             "bind_addr": (config["host"], config["port"]),
             "wsgi_app": app,
-            }
+        }
         server = wsgi.Server(**server_args)
         try:
             server.start()

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1282,6 +1282,11 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         uri.remove()
 
     def _serveWebdav():
+        """Starts a local webdav-compatible HTTP server,
+        Listening on http://localhost:8080
+        This server only runs when this test class is instantiated,
+        and then shuts down. Must be started is a separate thread.
+        """
         root_path = gettempdir()
 
         config = {

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1351,12 +1351,13 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
             # shut down the server when True
             while True:
                 if stopWebdavServer():
-                    server.stop()
-                    t.join()
                     break
                 time.sleep(1)
         except KeyboardInterrupt:
             print("Caught Ctrl-C, shutting down...")
+        finally:
+            server.stop()
+            t.join()
 
     def _getfreeport():
         """

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -358,6 +358,9 @@ class S3URITestCase(unittest.TestCase):
 class WebdavURITestCase(unittest.TestCase):
 
     def setUp(self):
+        os.environ["WEBDAV_AUTH_METHOD"] = "TOKEN"
+        os.environ["WEBDAV_BEARER_TOKEN"] = "XXXXXX"
+
         serverRoot = "www.not-exists.orgx"
         existingFolderName = "existingFolder"
         existingFileName = "existingFile"

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -363,6 +363,8 @@ class WebdavURITestCase(unittest.TestCase):
         existingFileName = "existingFile"
         notExistingFileName = "notExistingFile"
 
+        self.baseURL = ButlerURI(
+            f"https://{serverRoot}")
         self.existingFileButlerURI = ButlerURI(
             f"https://{serverRoot}/{existingFolderName}/{existingFileName}")
         self.notExistingFileButlerURI = ButlerURI(
@@ -374,17 +376,8 @@ class WebdavURITestCase(unittest.TestCase):
 
         # Need to declare the options
         responses.add(responses.OPTIONS,
-                      self.existingFileButlerURI.geturl(),
-                      headers={'not': '1024'}, status=200)
-        responses.add(responses.OPTIONS,
-                      self.notExistingFileButlerURI.geturl(),
-                      headers={'not': '1024'}, status=200)
-        responses.add(responses.OPTIONS,
-                      self.notExistingFolderButlerURI.geturl(),
-                      headers={'not': '1024'}, status=200)
-        responses.add(responses.OPTIONS,
-                      self.existingFolderButlerURI.geturl(),
-                      headers={'not': '1024'}, status=200)
+                      self.baseURL.geturl(),
+                      status=200, headers={"DAV": "1,2,3"})
 
         # Used by ButlerHttpURI.exists()
         responses.add(responses.HEAD,
@@ -433,6 +426,9 @@ class WebdavURITestCase(unittest.TestCase):
         # Used by ButlerHttpURI.mkdir()
         responses.add(responses.HEAD,
                       self.existingFolderButlerURI.geturl(),
+                      status=200, headers={'Content-Length': '1024'})
+        responses.add(responses.HEAD,
+                      self.baseURL.geturl(),
                       status=200, headers={'Content-Length': '1024'})
         responses.add(responses.HEAD,
                       self.notExistingFolderButlerURI.geturl(),

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -367,7 +367,7 @@ class WebdavURITestCase(unittest.TestCase):
         notExistingFileName = "notExistingFile"
 
         self.baseURL = ButlerURI(
-            f"https://{serverRoot}")
+            f"https://{serverRoot}", forceDirectory=True)
         self.existingFileButlerURI = ButlerURI(
             f"https://{serverRoot}/{existingFolderName}/{existingFileName}")
         self.notExistingFileButlerURI = ButlerURI(
@@ -497,6 +497,15 @@ class WebdavURITestCase(unittest.TestCase):
             self.notExistingFileButlerURI.transfer_from(
                 src=self.existingFileButlerURI,
                 transfer="unsupported")
+
+    def testParent(self):
+
+        self.assertEqual(self.existingFolderButlerURI.geturl(),
+                         self.notExistingFileButlerURI.parent().geturl())
+        self.assertEqual(self.baseURL.geturl(),
+                         self.baseURL.parent().geturl())
+        self.assertEqual(self.existingFileButlerURI.parent().geturl(),
+                         self.existingFileButlerURI.dirname().geturl())
 
 
 if __name__ == "__main__":

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -355,12 +355,12 @@ class S3URITestCase(unittest.TestCase):
         self.assertEqual(child.unquoted_path, "/" + subpath)
 
 
+# Mock required environment variables during tests
+@unittest.mock.patch.dict(os.environ, {"WEBDAV_AUTH_METHOD": "TOKEN",
+                                       "WEBDAV_BEARER_TOKEN": "XXXXXX"})
 class WebdavURITestCase(unittest.TestCase):
 
     def setUp(self):
-        os.environ["WEBDAV_AUTH_METHOD"] = "TOKEN"
-        os.environ["WEBDAV_BEARER_TOKEN"] = "XXXXXX"
-
         serverRoot = "www.not-exists.orgx"
         existingFolderName = "existingFolder"
         existingFileName = "existingFile"

--- a/tests/test_webdavutils.py
+++ b/tests/test_webdavutils.py
@@ -33,7 +33,7 @@ class WebdavUtilsTestCase(unittest.TestCase):
     """Test for the Webdav related utilities.
     """
     session = requests.Session()
-    serverRoot = "www.lsstnowebdav.orgx"
+    serverRoot = "www.lsstwithwebdav.orgx"
     wrongRoot = "www.lsstwithoutwebdav.org"
     existingfolderName = "testFolder"
     notExistingfolderName = "testFolder_not_exist"


### PR DESCRIPTION
Following merged PR #351, here we're adding explicit WebdavDatastore tests. This requires starting a local webdav server against which requests are run. Adds a dependency to `wsgidav` and `cheroot` packages, for testing only. Tests are skipped if dependencies cannot be met.
Also implementing ButlerURI.parent() method, which returns the parent directory of the current ButlerURI (same as dirname() for a file-like URI).