### PR TITLE
DM-26620: Catch astropy.time warnings about dubious years

### DIFF
--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -25,6 +25,7 @@
 import unittest
 import warnings
 
+import astropy.utils.exceptions
 from astropy.time import Time, TimeDelta
 from lsst.daf.butler import time_utils
 from lsst.daf.butler.core.time_utils import astropy_to_nsec
@@ -54,8 +55,10 @@ class TimeTestCase(unittest.TestCase):
         value_max = time_utils.astropy_to_nsec(time_utils.MAX_TIME)
         self.assertEqual(value, value_max)
 
-        # Check that we do not warn inside our code for UTC in the future
-        with self.assertWarns(Warning):
+        # Astropy will give "dubious year" for UTC five years in the future
+        # so hide these expected warnings from the test output
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=astropy.utils.exceptions.AstropyWarning)
             time = Time("2101-01-01T00:00:00", format="isot", scale="utc")
 
         # unittest can't test for no warnings so we run the test and

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -23,6 +23,7 @@
 """
 
 import unittest
+import warnings
 
 from astropy.time import Time, TimeDelta
 from lsst.daf.butler import time_utils
@@ -52,6 +53,17 @@ class TimeTestCase(unittest.TestCase):
 
         value_max = time_utils.astropy_to_nsec(time_utils.MAX_TIME)
         self.assertEqual(value, value_max)
+
+        # Check that we do not warn inside our code for UTC in the future
+        with self.assertWarns(Warning):
+            time = Time("2101-01-01T00:00:00", format="isot", scale="utc")
+
+        # unittest can't test for no warnings so we run the test and
+        # trigger our own warning and count all the warnings
+        with self.assertWarns(Warning) as cm:
+            time_utils.astropy_to_nsec(time)
+            warnings.warn("deliberate")
+        self.assertEqual(str(cm.warning), "deliberate")
 
     def test_round_trip(self):
         """Test precision of round-trip conversion.

--- a/tests/test_timespan.py
+++ b/tests/test_timespan.py
@@ -24,6 +24,7 @@ import itertools
 import warnings
 
 import astropy.time
+import astropy.utils.exceptions
 
 from lsst.daf.butler import Timespan
 
@@ -131,7 +132,8 @@ class TimespanTestCase(unittest.TestCase):
 
         # Astropy will give "dubious year" for UTC five years in the future
         # so hide these expected warnings from the test output
-        with self.assertWarns(Warning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=astropy.utils.exceptions.AstropyWarning)
             ts1 = Timespan(begin=astropy.time.Time('2213-06-17 13:34:45.775000', scale='utc', format='iso'),
                            end=astropy.time.Time('2213-06-17 13:35:17.947000', scale='utc', format='iso'))
             ts2 = Timespan(begin=astropy.time.Time('2213-06-17 13:34:45.775000', scale='utc', format='iso'),

--- a/tests/test_timespan.py
+++ b/tests/test_timespan.py
@@ -21,6 +21,7 @@
 
 import unittest
 import itertools
+import warnings
 
 import astropy.time
 
@@ -124,6 +125,24 @@ class TimespanTestCase(unittest.TestCase):
         ts2 = Timespan(begin=astropy.time.Time('2013-06-17T13:34:10.775', scale='utc', format='isot'),
                        end=astropy.time.Time('2013-06-17T13:34:42.947', scale='utc', format='isot'))
         self.assertEqual(ts1, ts2, f"Compare {ts1} with {ts2}")
+
+    def testFuture(self):
+        """Check that we do not get warnings from future dates."""
+
+        # Astropy will give "dubious year" for UTC five years in the future
+        # so hide these expected warnings from the test output
+        with self.assertWarns(Warning):
+            ts1 = Timespan(begin=astropy.time.Time('2213-06-17 13:34:45.775000', scale='utc', format='iso'),
+                           end=astropy.time.Time('2213-06-17 13:35:17.947000', scale='utc', format='iso'))
+            ts2 = Timespan(begin=astropy.time.Time('2213-06-17 13:34:45.775000', scale='utc', format='iso'),
+                           end=astropy.time.Time('2213-06-17 13:35:17.947000', scale='utc', format='iso'))
+
+        # unittest can't test for no warnings so we run the test and
+        # trigger our own warning and count all the warnings
+        with self.assertWarns(Warning) as cm:
+            self.assertEqual(ts1, ts2)
+            warnings.warn("deliberate")
+        self.assertEqual(str(cm.warning), "deliberate")
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,13 +217,13 @@ class GlobToRegexTestCase(unittest.TestCase):
         """
         # test an absolute string
         patterns = globToRegex(["bar"])
-        self.assertEquals(len(patterns), 1)
+        self.assertEqual(len(patterns), 1)
         self.assertTrue(bool(re.fullmatch(patterns[0], "bar")))
         self.assertIsNone(re.fullmatch(patterns[0], "boz"))
 
         # test leading & trailing wildcard in multiple patterns
         patterns = globToRegex(["ba*", "*.fits"])
-        self.assertEquals(len(patterns), 2)
+        self.assertEqual(len(patterns), 2)
         # check the "ba*" pattern:
         self.assertTrue(bool(re.fullmatch(patterns[0], "bar")))
         self.assertTrue(bool(re.fullmatch(patterns[0], "baz")))


### PR DESCRIPTION
Any times from more than 5 years in the future will trigger
warnings when converting between UTC and TAI. Catch the places
where we are converting to TAI since those warnings are not
relevant to users (especially when they involve MAX_TIME
or simulated data from the future).