### PR TITLE
DM-26336: minor non-prototyping changes generated during query/dimensions prototyping

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: Install postgresql Python packages
         run: pip install psycopg2 testing.postgresql
 
+      - name: Install cryptography package for moto
+        run: pip install cryptography
+
       # It seems like pip install of requirements for a URL package
       # does not install those dependencies
       - name: Install sphgeom dependencies

--- a/python/lsst/daf/butler/configs/dimensions.yaml
+++ b/python/lsst/daf/butler/configs/dimensions.yaml
@@ -1,13 +1,14 @@
 dimensions:
   version: 0
   skypix:
+    # 'common' is the skypix system and level used to relate all other spatial
+    # dimensions.  Its value is a string formed by concatenating one of the
+    # other keys under the 'skypix' headerin (i.e. the name of a skypix system)
+    # with an integer level (with no zero-padding).
     common: htm7
-    htm7:
+    htm:
       class: lsst.sphgeom.HtmPixelization
-      level: 7
-    htm9:
-      class: lsst.sphgeom.HtmPixelization
-      level: 9
+      max_level: 24
 
   elements:
     instrument:

--- a/python/lsst/daf/butler/core/dimensions/config.py
+++ b/python/lsst/daf/butler/core/dimensions/config.py
@@ -76,21 +76,19 @@ def processSkyPixConfig(config: Config) -> Tuple[Dict[str, SkyPixDimension], Sky
         the universe.  This instance is also guaranteed to be a value in
         the returned ``dimensions``.
     """
-    skyPixNames = set(config.keys())
+    skyPixSysNames = set(config.keys())
     try:
-        skyPixNames.remove("common")
+        skyPixSysNames.remove("common")
     except KeyError as err:
         raise ValueError("No common skypix dimension defined in configuration.") from err
     dimensions = {}
-    for name in skyPixNames:
-        subconfig = config[name]
+    for sysName in sorted(skyPixSysNames):
+        subconfig = config[sysName]
         pixelizationClass = doImport(subconfig["class"])
-        level = subconfig.get("level", None)
-        if level is not None:
-            pixelization = pixelizationClass(level)
-        else:
-            pixelization = pixelizationClass()
-        dimensions[name] = SkyPixDimension(name, pixelization)
+        max_level = subconfig.get("max_level", 24)
+        for level in range(max_level + 1):
+            name = f"{sysName}{level}"
+            dimensions[name] = SkyPixDimension(name, pixelizationClass(level))
     try:
         common = dimensions[config["common"]]
     except KeyError as err:

--- a/python/lsst/daf/butler/core/dimensions/elements.py
+++ b/python/lsst/daf/butler/core/dimensions/elements.py
@@ -93,11 +93,11 @@ class RelatedDimensions:
             Object containing all other dimension elements.
         """
         for req in tuple(self.required):
-            other = universe.elements[req]._related
+            other = universe[req]._related
             self.required.update(other.required)
             self.dependencies.update(other.dependencies)
         for dep in self.implied:
-            other = universe.elements[dep]._related
+            other = universe[dep]._related
             self.dependencies.update(other.dependencies)
 
     required: Set[str]
@@ -232,7 +232,7 @@ class DimensionElement:
             elif targetName == self.name:
                 target = self
             else:
-                target = universe.elements.get(targetName)
+                target = universe.get(targetName)
                 if target is None:
                     try:
                         target = elementsToDo[targetName]
@@ -255,7 +255,7 @@ class DimensionElement:
         Called only by `_finish`, but may be overridden by subclasses.
         """
         self.universe = universe
-        self.universe.elements.add(self)
+        self.universe._elements.add(self)
 
     def _attachGraph(self) -> None:
         """Initialize the `graph` attribute for this element.
@@ -290,25 +290,25 @@ class DimensionElement:
 
     def __lt__(self, other: DimensionElement) -> bool:
         try:
-            return self.universe._elementIndices[self.name] < self.universe._elementIndices[other.name]
+            return self.universe.getElementIndex(self.name) < self.universe.getElementIndex(other.name)
         except KeyError:
             return NotImplemented
 
     def __le__(self, other: DimensionElement) -> bool:
         try:
-            return self.universe._elementIndices[self.name] <= self.universe._elementIndices[other.name]
+            return self.universe.getElementIndex(self.name) <= self.universe.getElementIndex(other.name)
         except KeyError:
             return NotImplemented
 
     def __gt__(self, other: DimensionElement) -> bool:
         try:
-            return self.universe._elementIndices[self.name] > self.universe._elementIndices[other.name]
+            return self.universe.getElementIndex(self.name) > self.universe.getElementIndex(other.name)
         except KeyError:
             return NotImplemented
 
     def __ge__(self, other: DimensionElement) -> bool:
         try:
-            return self.universe._elementIndices[self.name] >= self.universe._elementIndices[other.name]
+            return self.universe.getElementIndex(self.name) >= self.universe.getElementIndex(other.name)
         except KeyError:
             return NotImplemented
 
@@ -327,7 +327,7 @@ class DimensionElement:
 
         For internal use only.
         """
-        return universe.elements[name]
+        return universe[name]
 
     def __reduce__(self) -> tuple:
         return (self._unpickle, (self.universe, self.name))
@@ -468,7 +468,7 @@ class Dimension(DimensionElement):
     def _attachToUniverse(self, universe: DimensionUniverse) -> None:
         # Docstring inherited from DimensionElement._attachToUniverse.
         super()._attachToUniverse(universe)
-        universe.dimensions.add(self)
+        universe._dimensions.add(self)
 
     def _attachGraph(self) -> None:
         # Docstring inherited from DimensionElement._attachGraph.

--- a/python/lsst/daf/butler/core/dimensions/universe.py
+++ b/python/lsst/daf/butler/core/dimensions/universe.py
@@ -54,9 +54,9 @@ E = TypeVar("E", bound=DimensionElement)
 
 
 @immutable
-class DimensionUniverse(DimensionGraph):
-    """A special `DimensionGraph` that constructs and manages a complete set of
-    compatible dimensions.
+class DimensionUniverse:
+    """A parent class that represents a complete, self-consistent set of
+    dimensions and their relationships.
 
     `DimensionUniverse` is not a class-level singleton, but all instances are
     tracked in a singleton map keyed by the version number in the configuration
@@ -89,15 +89,11 @@ class DimensionUniverse(DimensionGraph):
             return self
 
         # Create the universe instance and add core attributes.
-        # We don't want any of what DimensionGraph.__new__ does, so we just go
-        # straight to object.__new__.  The C++ side of my brain is offended by
-        # this, but I think it's the right approach in Python, where we don't
-        # have the option of having multiple constructors with different roles.
         self = object.__new__(cls)
-        self.universe = self
+        assert self is not None
         self._cache = {}
-        self.dimensions = NamedValueSet()
-        self.elements = NamedValueSet()
+        self._dimensions = NamedValueSet()
+        self._elements = NamedValueSet()
 
         # Read the skypix dimensions from config.
         skyPixDimensions, self.commonSkyPix = processSkyPixConfig(config["skypix"])
@@ -128,7 +124,6 @@ class DimensionUniverse(DimensionGraph):
 
         # Add attributes for special subsets of the graph.
         self.empty = DimensionGraph(self, (), conform=False)
-        self._finish()
 
         # Set up factories for dataId packers as defined by config.
         # MyPy is totally confused by us setting attributes on self in __new__.
@@ -144,10 +139,115 @@ class DimensionUniverse(DimensionGraph):
         # version has already been constructed in the receiving process.
         self._version = version
         cls._instances[self._version] = self
+
+        # Build mappings from element to index.  These are used for
+        # topological-sort comparison operators in DimensionElement itself.
+        self._elementIndices = {
+            name: i for i, name in enumerate(self._elements.names)
+        }
+        # Same for dimension to index, sorted topologically across required
+        # and implied.  This is used for encode/decode.
+        self._dimensionIndices = {
+            name: i for i, name in enumerate(self._dimensions.names)
+        }
+
+        # Freeze internal sets so we can return them in methods without
+        # worrying about modifications.
+        self._elements.freeze()
+        self._dimensions.freeze()
         return self
 
     def __repr__(self) -> str:
         return f"DimensionUniverse({self})"
+
+    def __getitem__(self, name: str) -> DimensionElement:
+        return self._elements[name]
+
+    def get(self, name: str, default: Optional[DimensionElement] = None) -> Optional[DimensionElement]:
+        """Return the `DimensionElement` with the given name or a default.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the element.
+        default : `DimensionElement`, optional
+            Element to return if the named one does not exist.  Defaults to
+            `None`.
+
+        Returns
+        -------
+        element : `DimensionElement`
+            The named element.
+        """
+        return self._elements.get(name, default)
+
+    def getStaticElements(self) -> NamedValueSet[DimensionElement]:
+        """Return a set of all static elements in this universe.
+
+        Non-static elements that are created as needed may also exist, but
+        these are guaranteed to have no direct relationships to other elements
+        (though they may have spatial or temporal relationships).
+
+        Returns
+        -------
+        elements : `NamedValueSet` [ `DimensionElement` ]
+            A frozen set of `DimensionElement` instances.
+        """
+        return self._elements
+
+    def getStaticDimensions(self) -> NamedValueSet[Dimension]:
+        """Return a set of all static dimensions in this universe.
+
+        Non-static dimensions that are created as needed may also exist, but
+        these are guaranteed to have no direct relationships to other elements
+        (though they may have spatial or temporal relationships).
+
+        Returns
+        -------
+        dimensions : `NamedValueSet` [ `Dimension` ]
+            A frozen set of `Dimension` instances.
+        """
+        return self._dimensions
+
+    def getElementIndex(self, name: str) -> int:
+        """Return the position of the named dimension element in this
+        universe's sorting of all elements.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the element.
+
+        Returns
+        -------
+        index : `int`
+            Sorting index for this element.
+        """
+        return self._elementIndices[name]
+
+    def getDimensionIndex(self, name: str) -> int:
+        """Return the position of the named dimension in this universe's
+        sorting of all dimensions.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the dimension.
+
+        Returns
+        -------
+        index : `int`
+            Sorting index for this dimension.
+
+        Notes
+        -----
+        The dimension sort order for a universe is consistent with the element
+        order (all dimensions are elements), and either can be used to sort
+        dimensions if used consistently.  But there are also some contexts in
+        which contiguous dimension-only indices are necessary or at least
+        desirable.
+        """
+        return self._dimensionIndices[name]
 
     def extract(self, iterable: Iterable[Union[Dimension, str]]) -> DimensionGraph:
         """Construct a `DimensionGraph` from a possibly-heterogenous iterable
@@ -180,8 +280,8 @@ class DimensionUniverse(DimensionGraph):
         """Return a sorted version of the given iterable of dimension elements.
 
         The universe's sort order is topological (an element's dependencies
-        precede it), starting with skypix dimensions (which never have
-        dependencies) and then sorting lexicographically to break ties.
+        precede it), with an unspecified (but deterministic) approach to
+        breaking ties.
 
         Parameters
         ----------
@@ -196,7 +296,7 @@ class DimensionUniverse(DimensionGraph):
             A sorted list containing the same elements that were given.
         """
         s = set(elements)
-        result = [element for element in self.elements if element in s or element.name in s]
+        result = [element for element in self._elements if element in s or element.name in s]
         if reverse:
             result.reverse()
         # mypy thinks this can return DimensionElements even if all the user
@@ -227,7 +327,7 @@ class DimensionUniverse(DimensionGraph):
         See `DimensionGraph.encode` and `DimensionGraph.decode` for more
         information.
         """
-        return math.ceil(len(self.dimensions)/8)
+        return math.ceil(len(self._dimensions)/8)
 
     @classmethod
     def _unpickle(cls, version: int) -> DimensionUniverse:
@@ -262,6 +362,14 @@ class DimensionUniverse(DimensionGraph):
     """
 
     _cache: Dict[FrozenSet[str], DimensionGraph]
+
+    _dimensions: NamedValueSet[Dimension]
+
+    _elements: NamedValueSet[DimensionElement]
+
+    _dimensionIndices: Dict[str, int]
+
+    _elementIndices: Dict[str, int]
 
     _packers: Dict[str, DimensionPackerFactory]
 

--- a/python/lsst/daf/butler/core/named.py
+++ b/python/lsst/daf/butler/core/named.py
@@ -281,15 +281,15 @@ class NamedValueAbstractSet(AbstractSet[K_co]):
         raise NotImplementedError()
 
     @abstractmethod
-    def __getitem__(self, name: str) -> K_co:
+    def __getitem__(self, key: Union[str, K_co]) -> K_co:
         raise NotImplementedError()
 
-    def get(self, name: str, default: Any = None) -> Any:
+    def get(self, key: Union[str, K_co], default: Any = None) -> Any:
         """Return the element with the given name, or ``default`` if
         no such element is present.
         """
         try:
-            return self[name]
+            return self[key]
         except KeyError:
             return default
 
@@ -451,12 +451,18 @@ class NamedValueSet(NamedValueMutableSet[K]):
     def issuperset(self, other: AbstractSet[K]) -> bool:
         return self >= other
 
-    def __getitem__(self, name: str) -> K:
-        return self._dict[name]
+    def __getitem__(self, key: Union[str, K]) -> K:
+        if isinstance(key, str):
+            return self._dict[key]
+        else:
+            return self._dict[key.name]
 
-    def get(self, name: str, default: Any = None) -> Any:
+    def get(self, key: Union[str, K], default: Any = None) -> Any:
         # Docstring inherited
-        return self._dict.get(name, default)
+        if isinstance(key, str):
+            return self._dict.get(key, default)
+        else:
+            return self._dict.get(key.name, default)
 
     def __delitem__(self, name: str) -> None:
         del self._dict[name]

--- a/python/lsst/daf/butler/core/named.py
+++ b/python/lsst/daf/butler/core/named.py
@@ -489,6 +489,17 @@ class NamedValueSet(NamedValueMutableSet[K]):
         else:
             return self._dict.pop(*args)
 
+    def update(self, elements: Iterable[K]) -> None:
+        """Add multple new elements to the set.
+
+        Parameters
+        ----------
+        elements : `Iterable`
+            Elements to add.
+        """
+        for element in elements:
+            self.add(element)
+
     def copy(self) -> NamedValueSet[K]:
         """Return a new `NamedValueSet` with the same elements.
         """

--- a/python/lsst/daf/butler/core/repoTransfers.py
+++ b/python/lsst/daf/butler/core/repoTransfers.py
@@ -150,7 +150,7 @@ class RepoExport:
             records for all dimensions will be exported.
         """
         if elements is None:
-            elements = frozenset(element for element in self._registry.dimensions.elements
+            elements = frozenset(element for element in self._registry.dimensions.getStaticElements()
                                  if element.hasTable() and element.viewOf is None)
         else:
             elements = frozenset(elements)

--- a/python/lsst/daf/butler/registry/dimensions/spatial.py
+++ b/python/lsst/daf/butler/registry/dimensions/spatial.py
@@ -125,7 +125,7 @@ class SpatialDimensionRecordStorage(TableDimensionRecordStorage):
         # Docstring inherited from DimensionRecordStorage.
         if regions is not None:
             dimensions = NamedValueSet(self.element.required)
-            dimensions.add(self.element.universe.universe.commonSkyPix)
+            dimensions.add(self.element.universe.commonSkyPix)
             builder.joinTable(self._commonSkyPixOverlapTable, dimensions)
             regions[self.element] = self._table.columns[REGION_FIELD_SPEC.name]
         return super().join(builder, regions=None, timespans=timespans)

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -69,7 +69,7 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
                    universe: DimensionUniverse) -> DimensionRecordStorageManager:
         # Docstring inherited from DimensionRecordStorageManager.
         records: NamedKeyDict[DimensionElement, DimensionRecordStorage] = NamedKeyDict()
-        for element in universe.elements:
+        for element in universe.getStaticElements():
             ImplementationClass = DimensionRecordStorage.getDefaultImplementation(element)
             records[element] = ImplementationClass.initialize(db, element, context=context)
         return cls(db=db, records=records, universe=universe)

--- a/python/lsst/daf/butler/registry/queries/expressions.py
+++ b/python/lsst/daf/butler/registry/queries/expressions.py
@@ -84,8 +84,9 @@ def categorizeIdentifier(universe: DimensionUniverse, name: str) -> Tuple[Dimens
             # what they were trying to do.
             # Encourage them to clean that up and try again.
             raise RuntimeError(
-                f"Invalid reference to '{table}.{column}' in expression; please use "
-                f"'{column}' or '{column}.{universe.dimensions[column].primaryKey.name}' instead."
+                f"Invalid reference to '{table}.{column}' "  # type: ignore
+                f"in expression; please use '{column}' or "
+                f"'{column}.{universe[column].primaryKey.name}' instead."
             )
         else:
             if column not in element.RecordClass.fields.standard.names:
@@ -93,7 +94,7 @@ def categorizeIdentifier(universe: DimensionUniverse, name: str) -> Tuple[Dimens
             return element, column
     else:
         try:
-            dimension = universe.dimensions[table]
+            dimension = universe[table]
         except KeyError as err:
             raise LookupError(f"No dimension with name '{table}.") from err
         return dimension, None

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -121,15 +121,14 @@ class DimensionTestCase(unittest.TestCase):
         self.assertEqual(DimensionGraph.decode(encoded, universe=self.universe), graph)
 
     def testConfigRead(self):
-        self.assertEqual(self.universe.dimensions.names,
+        self.assertEqual(self.universe.getStaticDimensions().names,
                          {"instrument", "visit", "visit_system", "exposure", "detector",
                           "physical_filter", "abstract_filter", "subfilter", "calibration_label",
                           "skymap", "tract", "patch", "htm7", "htm9"})
 
     def testGraphs(self):
         self.checkGraphInvariants(self.universe.empty)
-        self.checkGraphInvariants(self.universe)
-        for element in self.universe.elements:
+        for element in self.universe.getStaticElements():
             self.checkGraphInvariants(element.graph)
 
     def testInstrumentDimensions(self):
@@ -185,7 +184,7 @@ class DimensionTestCase(unittest.TestCase):
 
     def testSchemaGeneration(self):
         tableSpecs = NamedKeyDict({})
-        for element in self.universe.elements:
+        for element in self.universe.getStaticElements():
             if element.hasTable and element.viewOf is None:
                 tableSpecs[element] = element.RecordClass.fields.makeTableSpec(
                     tsRepr=DatabaseTimespanRepresentation.Compound
@@ -239,7 +238,7 @@ class DimensionTestCase(unittest.TestCase):
         self.assertIs(universe1, universe2)
         self.assertIs(universe1, universe3)
         self.assertIs(universe1, universe4)
-        for element1 in universe1.elements:
+        for element1 in universe1.getStaticElements():
             element2 = pickle.loads(pickle.dumps(element1))
             self.assertIs(element1, element2)
             graph1 = element1.graph

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -124,7 +124,7 @@ class DimensionTestCase(unittest.TestCase):
         self.assertEqual(self.universe.getStaticDimensions().names,
                          {"instrument", "visit", "visit_system", "exposure", "detector",
                           "physical_filter", "abstract_filter", "subfilter", "calibration_label",
-                          "skymap", "tract", "patch", "htm7", "htm9"})
+                          "skymap", "tract", "patch"} | {f"htm{level}" for level in range(25)})
 
     def testGraphs(self):
         self.checkGraphInvariants(self.universe.empty)


### PR DESCRIPTION
These commits are the only ones worth merging now from a branch that was mostly about prototyping new code without any effort to make it work.  They're mostly improvements to the named container module, which had ABCs for its mapping class but only concrete Set class; that's now been rectified.