### PR TITLE
DM-26407: Store dimensions configuration in registry database

### DIFF
--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -7,7 +7,7 @@ Data Access Butler
 
 from .core import *
 # Import the registry subpackage directly for other symbols.
-from .registry import Registry, CollectionType, CollectionSearch, DatasetTypeRestriction
+from .registry import Registry, RegistryConfig, CollectionType, CollectionSearch, DatasetTypeRestriction
 from ._butlerConfig import *
 from ._deferredDatasetHandle import *
 from ._butler import *

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -253,7 +253,8 @@ class Butler:
     """
 
     @staticmethod
-    def makeRepo(root: str, config: Union[Config, str, None] = None, standalone: bool = False,
+    def makeRepo(root: str, config: Union[Config, str, None] = None,
+                 dimensionConfig: Union[Config, str, None] = None, standalone: bool = False,
                  createRegistry: bool = True, searchPaths: Optional[List[str]] = None,
                  forceConfigRoot: bool = True, outfile: Optional[str] = None,
                  overwrite: bool = False) -> Config:
@@ -272,6 +273,9 @@ class Butler:
             configuration will be used.  Root-dependent config options
             specified in this config are overwritten if ``forceConfigRoot``
             is `True`.
+        dimensionConfig : `Config` or `str`, optional
+            Configuration for dimensions, will be used to initialize registry
+            database. Only used when ``createRegistry`` is `True`.
         standalone : `bool`
             If True, write all expanded defaults, not just customized or
             repository-specific settings.
@@ -374,9 +378,7 @@ class Butler:
         # Create Registry and populate tables
         if createRegistry:
             registryConfig = RegistryConfig(config.get("registry"))
-            # TODO: for now DimensionConfig comes from a full config, in the
-            # future it should become separate.
-            dimensionConfig = DimensionConfig(config.get("dimensions"))
+            dimensionConfig = DimensionConfig(dimensionConfig)
             Registry.createFromConfig(registryConfig, dimensionConfig=dimensionConfig, butlerRoot=root)
         return config
 

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -62,6 +62,7 @@ from .core import (
     DatasetRef,
     DatasetType,
     Datastore,
+    DimensionConfig,
     FileDataset,
     StorageClassFactory,
     Timespan,
@@ -371,7 +372,12 @@ class Butler:
         config.dumpToUri(configURI, overwrite=overwrite)
 
         # Create Registry and populate tables
-        Registry.fromConfig(config, create=createRegistry, butlerRoot=root)
+        if createRegistry:
+            registryConfig = RegistryConfig(config.get("registry"))
+            # TODO: for now DimensionConfig comes from a full config, in the
+            # future it should become separate.
+            dimensionConfig = DimensionConfig(config.get("dimensions"))
+            Registry.createFromConfig(registryConfig, dimensionConfig=dimensionConfig, butlerRoot=root)
         return config
 
     @classmethod

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -255,9 +255,8 @@ class Butler:
     @staticmethod
     def makeRepo(root: str, config: Union[Config, str, None] = None,
                  dimensionConfig: Union[Config, str, None] = None, standalone: bool = False,
-                 createRegistry: bool = True, searchPaths: Optional[List[str]] = None,
-                 forceConfigRoot: bool = True, outfile: Optional[str] = None,
-                 overwrite: bool = False) -> Config:
+                 searchPaths: Optional[List[str]] = None, forceConfigRoot: bool = True,
+                 outfile: Optional[str] = None, overwrite: bool = False) -> Config:
         """Create an empty data repository by adding a butler.yaml config
         to a repository root directory.
 
@@ -275,7 +274,7 @@ class Butler:
             is `True`.
         dimensionConfig : `Config` or `str`, optional
             Configuration for dimensions, will be used to initialize registry
-            database. Only used when ``createRegistry`` is `True`.
+            database.
         standalone : `bool`
             If True, write all expanded defaults, not just customized or
             repository-specific settings.
@@ -284,8 +283,6 @@ class Butler:
             may be good or bad, depending on the nature of the changes).
             Future *additions* to the defaults will still be picked up when
             initializing `Butlers` to repos created with ``standalone=True``.
-        createRegistry : `bool`, optional
-            If `True` create a new Registry.
         searchPaths : `list` of `str`, optional
             Directory paths to search when calculating the full butler
             configuration.
@@ -376,10 +373,10 @@ class Butler:
         config.dumpToUri(configURI, overwrite=overwrite)
 
         # Create Registry and populate tables
-        if createRegistry:
-            registryConfig = RegistryConfig(config.get("registry"))
-            dimensionConfig = DimensionConfig(dimensionConfig)
-            Registry.createFromConfig(registryConfig, dimensionConfig=dimensionConfig, butlerRoot=root)
+        registryConfig = RegistryConfig(config.get("registry"))
+        dimensionConfig = DimensionConfig(dimensionConfig)
+        Registry.createFromConfig(registryConfig, dimensionConfig=dimensionConfig, butlerRoot=root)
+
         return config
 
     @classmethod

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -36,15 +36,13 @@ from .core import (
     ButlerURI,
     Config,
     DatastoreConfig,
-    DimensionConfig,
     StorageClassConfig,
 )
 from .registry import RegistryConfig
 from .transfers import RepoTransferFormatConfig
 
 CONFIG_COMPONENT_CLASSES = (RegistryConfig, StorageClassConfig,
-                            DatastoreConfig, DimensionConfig,
-                            RepoTransferFormatConfig)
+                            DatastoreConfig, RepoTransferFormatConfig)
 
 
 class ButlerConfig(Config):

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -59,6 +59,7 @@ def butler_import(*args, **kwargs):
 @click.command()
 @repo_argument(required=True, help=willCreateRepoHelp)
 @click.option("--seed-config", help="Path to an existing YAML config file to apply (on top of defaults).")
+@click.option("--dimension-config", help="Path to an existing YAML config file with dimension configuration.")
 @click.option("--standalone", is_flag=True, help="Include all defaults in the config file in the repo, "
               "insulating the repo from changes in package defaults.")
 @click.option("--override", is_flag=True, help="Allow values in the supplied config to override all "

--- a/python/lsst/daf/butler/configs/dimensions.yaml
+++ b/python/lsst/daf/butler/configs/dimensions.yaml
@@ -1,395 +1,394 @@
-dimensions:
-  version: 0
-  skypix:
-    # 'common' is the skypix system and level used to relate all other spatial
-    # dimensions.  Its value is a string formed by concatenating one of the
-    # other keys under the 'skypix' headerin (i.e. the name of a skypix system)
-    # with an integer level (with no zero-padding).
-    common: htm7
-    htm:
-      class: lsst.sphgeom.HtmPixelization
-      max_level: 24
+version: 0
+skypix:
+  # 'common' is the skypix system and level used to relate all other spatial
+  # dimensions.  Its value is a string formed by concatenating one of the
+  # other keys under the 'skypix' headerin (i.e. the name of a skypix system)
+  # with an integer level (with no zero-padding).
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
 
-  elements:
-    instrument:
-      doc: >
-        An entity that produces observations.  An instrument defines a set of
-        physical_filters and detectors and a numbering system for the exposures
-        and visits that represent observations with it.
-      keys:
-        -
-          name: name
-          type: string
-          length: 16
-      metadata:
-        -
-          name: visit_max
-          type: int
-          doc: >
-            Maximum value for the 'visit' field for visits associated with
-            this instrument (exclusive).
-        -
-          name: exposure_max
-          type: int
-          doc: >
-            Maximum value for the 'exposure' field for exposures associated with
-            this instrument (exclusive).
-        -
-          name: detector_max
-          type: int
-          doc: >
-            Maximum value for the 'detector' field for detectors associated with
-            this instrument (exclusive).
-        -
-          name: class_name
-          type: string
-          length: 64
-          doc: >
-            Full class name of the Instrument class associated with this
-            instrument.
-      cached: true
+elements:
+  instrument:
+    doc: >
+      An entity that produces observations.  An instrument defines a set of
+      physical_filters and detectors and a numbering system for the exposures
+      and visits that represent observations with it.
+    keys:
+      -
+        name: name
+        type: string
+        length: 16
+    metadata:
+      -
+        name: visit_max
+        type: int
+        doc: >
+          Maximum value for the 'visit' field for visits associated with
+          this instrument (exclusive).
+      -
+        name: exposure_max
+        type: int
+        doc: >
+          Maximum value for the 'exposure' field for exposures associated with
+          this instrument (exclusive).
+      -
+        name: detector_max
+        type: int
+        doc: >
+          Maximum value for the 'detector' field for detectors associated with
+          this instrument (exclusive).
+      -
+        name: class_name
+        type: string
+        length: 64
+        doc: >
+          Full class name of the Instrument class associated with this
+          instrument.
+    cached: true
 
-    band:
-      doc: >
-        A filter that is not associated with a particular instrument.  An
-        abstract filter can be used to relate similar physical filters, and
-        is typically the filter associated with coadds.
-      keys:
-        -
-          name: name
-          type: string
-          length: 32
-      view_of: physical_filter
+  band:
+    doc: >
+      A filter that is not associated with a particular instrument.  An
+      abstract filter can be used to relate similar physical filters, and
+      is typically the filter associated with coadds.
+    keys:
+      -
+        name: name
+        type: string
+        length: 32
+    view_of: physical_filter
 
-    physical_filter:
-      doc: >
-        A filter associated with a particular instrument.  physical_filters are
-        used to identify datasets that can only be associated with a single
-        observation.
-      keys:
-        -
-          name: name
-          type: string
-          length: 32
-      requires:
-        - instrument
-      implies:
-        - band
-      cached: true
+  physical_filter:
+    doc: >
+      A filter associated with a particular instrument.  physical_filters are
+      used to identify datasets that can only be associated with a single
+      observation.
+    keys:
+      -
+        name: name
+        type: string
+        length: 32
+    requires:
+      - instrument
+    implies:
+      - band
+    cached: true
 
-    subfilter:
-      doc: >
-        A mathematical division of an band. Subfilters are used to
-        model wavelength-dependent effects such as differential chromatic
-        refraction.
-      keys:
-        -
-          name: id
-          type: int
-      requires:
-        - band
-      cached: true
+  subfilter:
+    doc: >
+      A mathematical division of an band. Subfilters are used to
+      model wavelength-dependent effects such as differential chromatic
+      refraction.
+    keys:
+      -
+        name: id
+        type: int
+    requires:
+      - band
+    cached: true
 
-    detector:
-      doc: >
-        A detector associated with a particular instrument (not an observation
-        of that detector; that requires specifying an exposure or visit as
-        well).
-      keys:
-        -
-          name: id
-          type: int
-        -
-          name: full_name
-          type: string
-          length: 32
-      requires: [instrument]
-      metadata:
-        -
-          name: name_in_raft
-          type: string
-          length: 32
-        -
-          name: raft
-          type: string
-          length: 32
-          doc: >
-            A string name for a group of detectors with an instrument-dependent
-            interpretation.
-        -
-          name: purpose
-          type: string
-          length: 32
-          doc: >
-            Role of the detector; typically one of "SCIENCE", "WAVEFRONT",
-            or "GUIDE", though instruments may define additional values.
-      cached: true
+  detector:
+    doc: >
+      A detector associated with a particular instrument (not an observation
+      of that detector; that requires specifying an exposure or visit as
+      well).
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      -
+        name: name_in_raft
+        type: string
+        length: 32
+      -
+        name: raft
+        type: string
+        length: 32
+        doc: >
+          A string name for a group of detectors with an instrument-dependent
+          interpretation.
+      -
+        name: purpose
+        type: string
+        length: 32
+        doc: >
+          Role of the detector; typically one of "SCIENCE", "WAVEFRONT",
+          or "GUIDE", though instruments may define additional values.
+    cached: true
 
-    visit:
-      doc: >
-        A sequence of observations processed together, comprised of one or
-        more exposures from the same instrument with the same pointing and
-        physical_filter.
-        The visit table contains metadata that is both meaningful only for
-        science exposures and the same for all exposures in a visit.
-      keys:
-        -
-          name: id
-          type: int
-        -
-          name: name
-          type: string
-          length: 64
-      requires: [instrument]
-      implies: [physical_filter, visit_system]
-      metadata:
-        -
-          name: exposure_time
-          type: float
-          doc: >
-            The total exposure time of the visit in seconds.  This should
-            be equal to the sum of the exposure_time values for all
-            constituent exposures (i.e. it should not include time between
-            exposures).
-        -
-          name: seeing
-          type: float
-          doc: >
-            Average seeing, measured as the FWHM of the Gaussian with the same
-            effective area (arcsec).
-        -
-          name: target_name
-          type: string
-          length: 64
-          doc: Object of interest for this visit or survey field name.
-        -
-          name: observation_reason
-          type: string
-          length: 32
-          doc: >
-            The reason this visit was taken. (e.g. science,
-            filter scan, unknown, various).
-        -
-          name: science_program
-          type: string
-          length: 64
-          doc: Observing program (survey or proposal) identifier.
-        -
-          name: zenith_angle
-          type: float
-          doc: >
-            Approximate zenith angle in degrees during the visit.
-            Can only be approximate since it is continuously changing during
-            and observation and multiple visits can be combined from a
-            relatively long period.
+  visit:
+    doc: >
+      A sequence of observations processed together, comprised of one or
+      more exposures from the same instrument with the same pointing and
+      physical_filter.
+      The visit table contains metadata that is both meaningful only for
+      science exposures and the same for all exposures in a visit.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    implies: [physical_filter, visit_system]
+    metadata:
+      -
+        name: exposure_time
+        type: float
+        doc: >
+          The total exposure time of the visit in seconds.  This should
+          be equal to the sum of the exposure_time values for all
+          constituent exposures (i.e. it should not include time between
+          exposures).
+      -
+        name: seeing
+        type: float
+        doc: >
+          Average seeing, measured as the FWHM of the Gaussian with the same
+          effective area (arcsec).
+      -
+        name: target_name
+        type: string
+        length: 64
+        doc: Object of interest for this visit or survey field name.
+      -
+        name: observation_reason
+        type: string
+        length: 32
+        doc: >
+          The reason this visit was taken. (e.g. science,
+          filter scan, unknown, various).
+      -
+        name: science_program
+        type: string
+        length: 64
+        doc: Observing program (survey or proposal) identifier.
+      -
+        name: zenith_angle
+        type: float
+        doc: >
+          Approximate zenith angle in degrees during the visit.
+          Can only be approximate since it is continuously changing during
+          and observation and multiple visits can be combined from a
+          relatively long period.
 
-    exposure:
-      doc: >
-        An observation associated with a particular instrument.  All direct
-        observations are identified with an exposure, but derived datasets
-        that may be based on more than one exposure (e.g. multiple snaps) are
-        typically identified with visits instead, even for instruments that
-        don't have multiple exposures per visit.  As a result, instruments
-        that don't have multiple exposures per visit will typically have visit
-        entries that are essentially duplicates of their exposure entries.
+  exposure:
+    doc: >
+      An observation associated with a particular instrument.  All direct
+      observations are identified with an exposure, but derived datasets
+      that may be based on more than one exposure (e.g. multiple snaps) are
+      typically identified with visits instead, even for instruments that
+      don't have multiple exposures per visit.  As a result, instruments
+      that don't have multiple exposures per visit will typically have visit
+      entries that are essentially duplicates of their exposure entries.
 
-        The exposure table contains metadata entries that are relevant for
-        calibration exposures, and does not duplicate entries in visit that
-        would be the same for all exposures within a visit with the exception
-        of the exposure.group entry.
-      keys:
-        -
-          name: id
-          type: int
-        -
-          name: name
-          type: string
-          length: 64
-      requires: [instrument]
-      implies: [physical_filter]
-      metadata:
-        -
-          name: exposure_time
-          type: float
-          doc: Duration of the exposure with shutter open (seconds).
-        -
-          name: dark_time
-          type: float
-          doc: Duration of the exposure with shutter closed (seconds).
-        -
-          name: observation_type
-          type: string
-          length: 16
-          doc: The observation type of this exposure (e.g. dark, bias, science).
-        -
-          name: observation_reason
-          type: string
-          length: 32
-          doc: >
-            The reason this observation was taken. (e.g. science,
-            filter scan, unknown).
-        -
-          name: group_name
-          type: string
-          length: 64
-          doc: >
-            String group identifier associated with this exposure by the
-            acquisition system.
-        -
-          name: group_id
-          type: int
-          doc: >
-            Integer group identifier associated with this exposure by the
-            acquisition system.
-        -
-          name: target_name
-          type: string
-          length: 64
-          doc: Object of interest for this observation or survey field name.
-        -
-          name: science_program
-          type: string
-          length: 64
-          doc: >
-            Observing program (survey, proposal, engineering project)
-            identifier.
-        -
-          name: tracking_ra
-          type: float
-          doc: >
-            Tracking ICRS Right Ascension of boresight in degrees. Can be NULL
-            for observations that are not on sky.
-        -
-          name: tracking_dec
-          type: float
-          doc: >
-            Tracking ICRS Declination of boresight in degrees. Can be NULL for
-            observations that are not on sky.
-        -
-          name: sky_angle
-          type: float
-          doc: >
-            Angle of the instrument focal plane on the sky in degrees. Can
-            be NULL for observations that are not on sky, or for observations
-            where the sky angle changes during the observation.
-        -
-          name: zenith_angle
-          type: float
-          doc: >
-            Angle in degrees from the zenith at the start of the exposure.
+      The exposure table contains metadata entries that are relevant for
+      calibration exposures, and does not duplicate entries in visit that
+      would be the same for all exposures within a visit with the exception
+      of the exposure.group entry.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    implies: [physical_filter]
+    metadata:
+      -
+        name: exposure_time
+        type: float
+        doc: Duration of the exposure with shutter open (seconds).
+      -
+        name: dark_time
+        type: float
+        doc: Duration of the exposure with shutter closed (seconds).
+      -
+        name: observation_type
+        type: string
+        length: 16
+        doc: The observation type of this exposure (e.g. dark, bias, science).
+      -
+        name: observation_reason
+        type: string
+        length: 32
+        doc: >
+          The reason this observation was taken. (e.g. science,
+          filter scan, unknown).
+      -
+        name: group_name
+        type: string
+        length: 64
+        doc: >
+          String group identifier associated with this exposure by the
+          acquisition system.
+      -
+        name: group_id
+        type: int
+        doc: >
+          Integer group identifier associated with this exposure by the
+          acquisition system.
+      -
+        name: target_name
+        type: string
+        length: 64
+        doc: Object of interest for this observation or survey field name.
+      -
+        name: science_program
+        type: string
+        length: 64
+        doc: >
+          Observing program (survey, proposal, engineering project)
+          identifier.
+      -
+        name: tracking_ra
+        type: float
+        doc: >
+          Tracking ICRS Right Ascension of boresight in degrees. Can be NULL
+          for observations that are not on sky.
+      -
+        name: tracking_dec
+        type: float
+        doc: >
+          Tracking ICRS Declination of boresight in degrees. Can be NULL for
+          observations that are not on sky.
+      -
+        name: sky_angle
+        type: float
+        doc: >
+          Angle of the instrument focal plane on the sky in degrees. Can
+          be NULL for observations that are not on sky, or for observations
+          where the sky angle changes during the observation.
+      -
+        name: zenith_angle
+        type: float
+        doc: >
+          Angle in degrees from the zenith at the start of the exposure.
 
-    skymap:
-      doc: >
-        A set of tracts and patches that subdivide the sky into rectangular
-        regions with simple projections and intentional overlaps.
-      keys:
-        -
-          name: name
-          type: string
-          length: 64
-        -
-          name: hash
-          type: hash
-          nbytes: 40
-          doc: >
-            A hash of the skymap's parameters.
-      metadata:
-        - name: tract_max
-          type: int
-          doc: >
-            Maximum ID for tracts in this skymap, exclusive.
-        - name: patch_nx_max
-          type: int
-          doc: >
-            Number of patches in the x direction in each tract.
-        - name: patch_ny_max
-          type: int
-          doc: >
-            Number of patches in the y direction in each tract.
-      cached: true
+  skymap:
+    doc: >
+      A set of tracts and patches that subdivide the sky into rectangular
+      regions with simple projections and intentional overlaps.
+    keys:
+      -
+        name: name
+        type: string
+        length: 64
+      -
+        name: hash
+        type: hash
+        nbytes: 40
+        doc: >
+          A hash of the skymap's parameters.
+    metadata:
+      - name: tract_max
+        type: int
+        doc: >
+          Maximum ID for tracts in this skymap, exclusive.
+      - name: patch_nx_max
+        type: int
+        doc: >
+          Number of patches in the x direction in each tract.
+      - name: patch_ny_max
+        type: int
+        doc: >
+          Number of patches in the y direction in each tract.
+    cached: true
 
-    tract:
-      doc: >
-        A large rectangular region mapped to the sky with a single map
-        projection, associated with a particular skymap.
-      keys:
-        -
-          name: id
-          type: int
-      requires: [skymap]
+  tract:
+    doc: >
+      A large rectangular region mapped to the sky with a single map
+      projection, associated with a particular skymap.
+    keys:
+      -
+        name: id
+        type: int
+    requires: [skymap]
 
-    patch:
-      doc: >
-        A rectangular region within a tract.
-      keys:
-        -
-          name: id
-          type: int
-      requires: [skymap, tract]
-      metadata:
-        -
-          name: cell_x
-          type: int
-          nullable: false
-          doc: >
-            Which column this patch occupies in the tract's grid of patches.
-        -
-          name: cell_y
-          type: int
-          nullable: false
-          doc: >
-            Which row this patch occupies in the tract's grid of patches.
+  patch:
+    doc: >
+      A rectangular region within a tract.
+    keys:
+      -
+        name: id
+        type: int
+    requires: [skymap, tract]
+    metadata:
+      -
+        name: cell_x
+        type: int
+        nullable: false
+        doc: >
+          Which column this patch occupies in the tract's grid of patches.
+      -
+        name: cell_y
+        type: int
+        nullable: false
+        doc: >
+          Which row this patch occupies in the tract's grid of patches.
 
-    visit_detector_region:
-      doc: >
-        A many-to-many join table that provides region information for
-        visit-detector combinations.
-      requires: [visit, detector]
+  visit_detector_region:
+    doc: >
+      A many-to-many join table that provides region information for
+      visit-detector combinations.
+    requires: [visit, detector]
 
-    visit_system:
-      doc: >
-        A system of self-consistent visit definitions, within which each
-        exposure should appear at most once.
-      keys:
-        -
-          name: id
-          type: int
-        -
-          name: name
-          type: string
-          length: 32
-      requires: [instrument]
+  visit_system:
+    doc: >
+      A system of self-consistent visit definitions, within which each
+      exposure should appear at most once.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: name
+        type: string
+        length: 32
+    requires: [instrument]
 
-    visit_definition:
-      doc: >
-        A many-to-many join table that relates exposures to the visits they
-        belong to.
-      requires: [exposure, visit_system]
-      implies: [visit]
-      always_join: true
+  visit_definition:
+    doc: >
+      A many-to-many join table that relates exposures to the visits they
+      belong to.
+    requires: [exposure, visit_system]
+    implies: [visit]
+    always_join: true
 
-  topology:
-    spatial:
-      observation_regions: [visit_detector_region, visit]
-      skymap_regions: [patch, tract]
+topology:
+  spatial:
+    observation_regions: [visit_detector_region, visit]
+    skymap_regions: [patch, tract]
 
-    temporal:
-      observation_timespans: [exposure, visit]
+  temporal:
+    observation_timespans: [exposure, visit]
 
-  packers:
-    visit_detector:
-      fixed: [instrument]
-      dimensions: [instrument, visit, detector]
-      cls: lsst.daf.butler.instrument.ObservationDimensionPacker
-    exposure_detector:
-      fixed: [instrument]
-      dimensions: [instrument, exposure, detector]
-      cls: lsst.daf.butler.instrument.ObservationDimensionPacker
-    tract_patch:
-      fixed: [skymap]
-      dimensions: [skymap, tract, patch]
-      cls: lsst.skymap.packers.SkyMapDimensionPacker
-    tract_patch_band:
-      fixed: [skymap]
-      dimensions: [skymap, tract, patch, band]
-      cls: lsst.skymap.packers.SkyMapDimensionPacker
+packers:
+  visit_detector:
+    fixed: [instrument]
+    dimensions: [instrument, visit, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+  exposure_detector:
+    fixed: [instrument]
+    dimensions: [instrument, exposure, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+  tract_patch:
+    fixed: [skymap]
+    dimensions: [skymap, tract, patch]
+    cls: lsst.skymap.packers.SkyMapDimensionPacker
+  tract_patch_band:
+    fixed: [skymap]
+    dimensions: [skymap, tract, patch, band]
+    cls: lsst.skymap.packers.SkyMapDimensionPacker

--- a/python/lsst/daf/butler/configs/registry.yaml
+++ b/python/lsst/daf/butler/configs/registry.yaml
@@ -1,6 +1,6 @@
 # Default with a sqlLite registry
 registry:
-  db: 'sqlite:///:memory:'
+  db: 'sqlite:///<butlerRoot>/gen3.sqlite3'
   engines:
     sqlite: lsst.daf.butler.registry.databases.sqlite.SqliteDatabase
     postgresql: lsst.daf.butler.registry.databases.postgresql.PostgresqlDatabase

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -971,8 +971,8 @@ class RegistryTests(ABC):
         """Test basic functionality of attribute manager.
         """
         # number of attributes with schema versions in a fresh database,
-        # 6 managers with 3 records per manager
-        VERSION_COUNT = 6 * 3
+        # 6 managers with 3 records per manager, plus config for dimensions
+        VERSION_COUNT = 6 * 3 + 1
 
         registry = self.makeRegistry()
         attributes = registry._attributes

--- a/python/lsst/daf/butler/script/createRepo.py
+++ b/python/lsst/daf/butler/script/createRepo.py
@@ -22,7 +22,8 @@
 from .. import Butler, Config
 
 
-def createRepo(repo, seed_config=None, standalone=False, override=False, outfile=None):
+def createRepo(repo, seed_config=None, dimension_config=None, standalone=False,
+               override=False, outfile=None):
     """Create an empty Gen3 Butler repository.
 
     Parameters
@@ -31,6 +32,8 @@ def createRepo(repo, seed_config=None, standalone=False, override=False, outfile
         URI to the location to create the repo.
     seed_config : `str` or `None`
         Path to an existing YAML config file to apply (on top of defaults).
+    dimension_config : `str` or `None`
+        Path to an existing YAML config file with dimensions configuration.
     standalone : `bool`
         Include all the defaults in the config file in the repo if True.
         Insulates the the repo from changes to package defaults. By default
@@ -43,5 +46,5 @@ def createRepo(repo, seed_config=None, standalone=False, override=False, outfile
         write butler.yaml into the specified repo, by default False.
     """
     config = Config(seed_config) if seed_config is not None else None
-    Butler.makeRepo(repo, config=config, standalone=standalone, forceConfigRoot=not override,
-                    outfile=outfile)
+    Butler.makeRepo(repo, config=config, dimensionConfig=dimension_config, standalone=standalone,
+                    forceConfigRoot=not override, outfile=outfile)

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -73,7 +73,7 @@ def makeTestRepo(root, dataIds, *, config=None, **kwargs):
     defaults = Config()
     defaults["datastore", "cls"] = "lsst.daf.butler.datastores.inMemoryDatastore.InMemoryDatastore"
     defaults["datastore", "checksum"] = False  # In case of future changes
-    defaults["registry", "db"] = "sqlite:///:memory:"
+    defaults["registry", "db"] = "sqlite:///<butlerRoot>/gen3.sqlite3"
 
     if config:
         defaults.update(config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,5 +55,6 @@ exclude = __init__.py
 [tool:pytest]
 addopts = --flake8
 flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W503
-# The matplotlib test may not release font files
-open_files_ignore = "*.ttf"
+# The matplotlib test may not release font files.
+# Some unit tests open registry database in setUpClass.
+open_files_ignore = "*.ttf" "gen3.sqlite3"

--- a/tests/config/basic/butler-s3store.yaml
+++ b/tests/config/basic/butler-s3store.yaml
@@ -1,3 +1,2 @@
-registry: !include sqliteRegistry.yaml
 datastore: !include s3Datastore.yaml
 storageClasses: !include storageClasses.yaml

--- a/tests/config/basic/butler-webdavstore.yaml
+++ b/tests/config/basic/butler-webdavstore.yaml
@@ -1,3 +1,2 @@
-registry: !include sqliteRegistry.yaml
 datastore: !include webdavDatastore.yaml
 storageClasses: !include storageClasses.yaml

--- a/tests/config/basic/sqliteRegistry.yaml
+++ b/tests/config/basic/sqliteRegistry.yaml
@@ -1,2 +1,0 @@
-registry:
-  db: 'sqlite:///:memory:'

--- a/tests/config/dbAuth/registryConf1.yaml
+++ b/tests/config/dbAuth/registryConf1.yaml
@@ -1,4 +1,4 @@
 # test default case is unchanged, test default case infers correct
 # registry class from dialect directly
 registry:
-  expected: "sqlite:///:memory:"
+  expected: "sqlite:///<butlerRoot>/gen3.sqlite3"

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -381,13 +381,9 @@ class ButlerTests(ButlerPutGetTests):
 
     def setUp(self):
         """Create a new butler root for each test."""
-        if self.useTempRoot:
-            self.root = tempfile.mkdtemp(dir=TESTDIR)
-            Butler.makeRepo(self.root, config=Config(self.configFile))
-            self.tmpConfigFile = os.path.join(self.root, "butler.yaml")
-        else:
-            self.root = None
-            self.tmpConfigFile = self.configFile
+        self.root = tempfile.mkdtemp(dir=TESTDIR)
+        Butler.makeRepo(self.root, config=Config(self.configFile))
+        self.tmpConfigFile = os.path.join(self.root, "butler.yaml")
 
     def testConstructor(self):
         """Independent test of constructor.
@@ -1034,7 +1030,7 @@ class InMemoryDatastoreButlerTestCase(ButlerTests, unittest.TestCase):
     validationCanFail = False
     datastoreStr = ["datastore='InMemory"]
     datastoreName = ["InMemoryDatastore@"]
-    registryStr = ":memory:"
+    registryStr = "/gen3.sqlite3"
 
     def testIngest(self):
         pass
@@ -1177,7 +1173,7 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
     datastoreName = ["S3Datastore@s3://{bucketName}/{root}"]
     """The expected format of the S3Datastore string."""
 
-    registryStr = ":memory:"
+    registryStr = "/gen3.sqlite3"
     """Expected format of the Registry string."""
 
     def genRoot(self):
@@ -1204,6 +1200,10 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
             self.root = self.genRoot()
         rooturi = f"s3://{self.bucketName}/{self.root}"
         config.update({"datastore": {"datastore": {"root": rooturi}}})
+
+        # need local folder to store registry database
+        self.reg_dir = tempfile.mkdtemp(dir=TESTDIR)
+        config["registry", "db"] = f"sqlite:///{self.reg_dir}/gen3.sqlite3"
 
         # MOTO needs to know that we expect Bucket bucketname to exist
         # (this used to be the class attribute bucketName)
@@ -1233,6 +1233,9 @@ class S3DatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestCase)
         # unset any potentially set dummy credentials
         if self.usingDummyCredentials:
             unsetAwsEnvCredentials()
+
+        if self.reg_dir is not None and os.path.exists(self.reg_dir):
+            shutil.rmtree(self.reg_dir, ignore_errors=True)
 
 
 @unittest.skipIf(WsgiDAVApp is None, "Warning: wsgidav/cheroot not found!")
@@ -1270,7 +1273,7 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
     datastoreName = ["WebdavDatastore@https://{serverName}/{root}"]
     """The expected format of the WebdavDatastore string."""
 
-    registryStr = ":memory:"
+    registryStr = "/gen3.sqlite3"
     """Expected format of the Registry string."""
 
     serverThread = None
@@ -1326,6 +1329,10 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
         self.rooturi = f"http://{self.serverName}:{self.portNumber}/{self.root}"
         config.update({"datastore": {"datastore": {"root": self.rooturi}}})
 
+        # need local folder to store registry database
+        self.reg_dir = tempfile.mkdtemp(dir=TESTDIR)
+        config["registry", "db"] = f"sqlite:///{self.reg_dir}/gen3.sqlite3"
+
         self.datastoreStr = f"datastore={self.root}"
         self.datastoreName = [f"WebdavDatastore@{self.rooturi}"]
 
@@ -1341,6 +1348,9 @@ class WebdavDatastoreButlerTestCase(FileLikeDatastoreButlerTests, unittest.TestC
     def tearDown(self):
         # Clear temporary directory
         ButlerURI(self.rooturi).remove()
+
+        if self.reg_dir is not None and os.path.exists(self.reg_dir):
+            shutil.rmtree(self.reg_dir, ignore_errors=True)
 
     def _serveWebdav(self, port: int, stopWebdavServer):
         """Starts a local webdav-compatible HTTP server,

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -807,16 +807,14 @@ class ButlerTests(ButlerPutGetTests):
         if self.fullConfigKey is None:
             return
 
-        # Remove the file created in setUp
-        os.unlink(self.tmpConfigFile)
+        # create two separate directories
+        root1 = tempfile.mkdtemp(dir=self.root)
+        root2 = tempfile.mkdtemp(dir=self.root)
 
-        createRegistry = not self.useTempRoot
-        butlerConfig = Butler.makeRepo(self.root, config=Config(self.configFile),
-                                       createRegistry=createRegistry)
+        butlerConfig = Butler.makeRepo(root1, config=Config(self.configFile))
         limited = Config(self.configFile)
         butler1 = Butler(butlerConfig)
-        butlerConfig = Butler.makeRepo(self.root, standalone=True, createRegistry=False,
-                                       config=Config(self.configFile), overwrite=True)
+        butlerConfig = Butler.makeRepo(root2, standalone=True, config=Config(self.configFile))
         full = Config(self.tmpConfigFile)
         butler2 = Butler(butlerConfig)
         # Butlers should have the same configuration regardless of whether
@@ -841,7 +839,7 @@ class ButlerTests(ButlerPutGetTests):
             Butler(butlerConfig)
 
         with self.assertRaises(FileExistsError):
-            Butler.makeRepo(self.root, standalone=True, createRegistry=False,
+            Butler.makeRepo(self.root, standalone=True,
                             config=Config(self.configFile), overwrite=False)
 
     def testStringification(self):

--- a/tests/test_cliCmdCreate.py
+++ b/tests/test_cliCmdCreate.py
@@ -31,6 +31,7 @@ class CreateTest(CliCmdTestBase, unittest.TestCase):
     def defaultExpected():
         return dict(repo=None,
                     seed_config=None,
+                    dimension_config=None,
                     standalone=False,
                     override=False,
                     outfile=None)
@@ -53,11 +54,13 @@ class CreateTest(CliCmdTestBase, unittest.TestCase):
         """Test all parameters."""
         self.run_test(["create", "here",
                        "--seed-config", "foo",
+                       "--dimension-config", "/bar/dim.yaml",
                        "--standalone",
                        "--override",
                        "--outfile", "bar"],
                       self.makeExpected(repo="here",
                                         seed_config="foo",
+                                        dimension_config="/bar/dim.yaml",
                                         standalone=True,
                                         override=True,
                                         outfile="bar"))

--- a/tests/test_cliUtils.py
+++ b/tests/test_cliUtils.py
@@ -41,8 +41,8 @@ class MockerTestCase(unittest.TestCase):
         runner = LogCliRunner(env=mockEnvVar)
         result = runner.invoke(butler.cli, ["create", "repo"])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
-        Mocker.mock.assert_called_with(repo="repo", seed_config=None, standalone=False, override=False,
-                                       outfile=None)
+        Mocker.mock.assert_called_with(repo="repo", seed_config=None, dimension_config=None,
+                                       standalone=False, override=False, outfile=None)
 
 
 class ArgumentHelpGeneratorTestCase(unittest.TestCase):

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -59,7 +59,7 @@ def loadDimensionData() -> DataCoordinateSequence:
     # data and retreive it as a set of DataCoordinate objects.
     config = RegistryConfig()
     config["db"] = "sqlite://"
-    registry = Registry.fromConfig(config, create=True)
+    registry = Registry.createFromConfig(config)
     with open(DIMENSION_DATA_FILE, 'r') as stream:
         backend = YamlRepoImportBackend(stream, registry)
     backend.register()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -220,7 +220,7 @@ class PostgresqlRegistryTests(RegistryTests):
         config = self.makeRegistryConfig()
         config["db"] = self.server.url()
         config["namespace"] = namespace
-        return Registry.fromConfig(config, create=True)
+        return Registry.createFromConfig(config)
 
 
 class PostgresqlRegistryNameKeyCollMgrTestCase(PostgresqlRegistryTests, unittest.TestCase):

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -209,7 +209,7 @@ class SqliteFileRegistryTests(RegistryTests):
         _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
         config = self.makeRegistryConfig()
         config["db"] = f"sqlite:///{filename}"
-        return Registry.fromConfig(config, create=True, butlerRoot=self.root)
+        return Registry.createFromConfig(config, butlerRoot=self.root)
 
 
 class SqliteFileRegistryNameKeyCollMgrTestCase(SqliteFileRegistryTests, unittest.TestCase):
@@ -239,7 +239,7 @@ class SqliteMemoryRegistryTests(RegistryTests):
     def makeRegistry(self) -> Registry:
         config = self.makeRegistryConfig()
         config["db"] = "sqlite://"
-        return Registry.fromConfig(config, create=True)
+        return Registry.createFromConfig(config)
 
     def testRegions(self):
         """Tests for using region fields in `Registry` dimensions.

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -72,7 +72,7 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         temp = tempfile.mkdtemp(dir=TESTDIR)
         try:
             path = os.path.join(temp, 'oddConfig.py')
-            makeTestRepo(self.root, {}, outfile=path, createRegistry=False)
+            makeTestRepo(temp, {}, outfile=path)
             self.assertTrue(os.path.isfile(path))
         finally:
             shutil.rmtree(temp, ignore_errors=True)


### PR DESCRIPTION
Dimensions are now stored in registry attributes table with a key
"config:dimensions.yaml", serialized as YAML data. This change means
that we cannot use SQLite in-memory datqabase for tests that make
multiple connections (multiple Butler instances) so I had to update many
unit tests to use on-disk database instead. With this commit dimensions
are still part of full butler config but they will be separated in next
commits.

DimensionConfig is now a separate optional argument to `makeRepo`, by
default it is loaded from `dimensions.yaml`. ButlerConfig does not
include dimensions any more. `butler` CLI adds an option
--dimension-config. `dimensions.yaml` dropped top-level `dimensions`
key, and this is exactly how it is stored in database.

DimensionConfig still inherits from ConfigSubset, this is mostly for
convenience of finding defaults, though defaults loading behavior has
been overriden, it only loads first file that it finds.
