### PR TITLE
DM-25180: Add timestamp field to dataset table

### DIFF
--- a/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
@@ -215,6 +215,13 @@ def makeStaticTableSpecs(collections: Type[CollectionManager],
                         "table."
                     ),
                 ),
+                ddl.FieldSpec(
+                    name="ingest_date",
+                    dtype=sqlalchemy.TIMESTAMP,
+                    default=sqlalchemy.sql.func.now(),
+                    nullable=False,
+                    doc="Time of dataset ingestion.",
+                ),
                 # Foreign key field/constraint to run added below.
             ],
             foreignKeys=[


### PR DESCRIPTION
This was trivial to implement. The real question though seems to be whether we want the ingest time to survive an export/import cycle because I'm assuming that the insert time is not going to preserve the timestamp.