### PR TITLE
DM-27343: Test for URI existence before reporting bad file extension

### DIFF
--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -308,7 +308,15 @@ class Config(collections.abc.MutableMapping):
             content = uri.read()
             self.__initFromJson(content)
         else:
-            raise RuntimeError(f"Unhandled config file type: {uri}")
+            # This URI does not have a valid extension. It might be because
+            # we ended up with a directory and not a file. Before we complain
+            # about an extension, do an existence check.  No need to do
+            # the (possibly expensive) existence check in the default code
+            # path above because we will find out soon enough that the file
+            # is not there.
+            if not uri.exists():
+                raise FileNotFoundError(f"Config location {uri} does not exist.")
+            raise RuntimeError(f"The Config URI does not have a supported extension: {uri}")
         self.configFile = uri
 
     def __initFromYaml(self, stream):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,8 +97,16 @@ class ConfigTestCase(unittest.TestCase):
     """Tests of simple Config"""
 
     def testBadConfig(self):
-        for badArg in ([], "file.fits"):
+        for badArg in ([],  # Bad argument
+                       __file__,  # Bad file extension for existing file
+                       ):
             with self.assertRaises(RuntimeError):
+                Config(badArg)
+        for badArg in ("file.fits",  # File that does not exist with bad extension
+                       "b/c/d/",  # Directory that does not exist
+                       "file.yaml",  # Good extension for missing file
+                       ):
+            with self.assertRaises(FileNotFoundError):
                 Config(badArg)
 
     def testBasics(self):


### PR DESCRIPTION
If ButlerConfig is constructed with a directory that
does not exist, the butler.yaml will not be appended.
In that case we want to report that the directory
does not exist, not that it does not have .yaml
extension.

Only do the existence check if we know we are about to raise.
It can be an expensive check and if we pass the extension
test we will get a FileNotFoundError later.