### PR TITLE
DM-27354: Update for sphgeom pip install

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,8 @@ jobs:
         run: pip install -r requirements.txt
 
       # We have two cores so we can speed up the testing with xdist
-      - name: Install xdist and openfiles
-        run: pip install pytest-xdist pytest-openfiles
+      - name: Install pytest packages
+        run: pip install pytest pytest-flake8 pytest-xdist pytest-openfiles
 
       - name: Build and install
         run: pip install -v .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,11 +30,6 @@ jobs:
       - name: Install cryptography package for moto
         run: pip install cryptography
 
-      # It seems like pip install of requirements for a URL package
-      # does not install those dependencies
-      - name: Install sphgeom dependencies
-        run: pip install -r https://raw.githubusercontent.com/lsst/sphgeom/master/requirements.txt
-
       - name: Install dependencies
         run: pip install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml >= 5.1
 astropy >= 4.0
 click >= 7.0
 sqlalchemy >= 1.3
-https://github.com/lsst/sphgeom/archive/master.tar.gz
+git+git://github.com/lsst/sphgeom@master#egg=lsst_sphgeom
 
 # optional
 backoff >= 1.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
   pyyaml >=5.1
   sqlalchemy >= 1.03
   click >= 7.0
-  lsst_sphgeom > 0.0
+  lsst_sphgeom @ git+https://github.com/lsst/sphgeom@master
 tests_require =
   pytest >= 3.2
   flake8 >= 3.7.5


### PR DESCRIPTION
sphgeom no longer has a requirements.txt file (as of https://github.com/lsst/sphgeom/pull/30), so this PR removes the step from the build_and_test workflow that executes such a requirements.txt file.

Secondly, the install_requires dependency listing in setup.cfg now installs sphgeom from GitHub, making the sphgeom installation from a requirements.txt file unnecessary.

Note that this PR's build is expected to fail until the sphgeom PR is merged. Both PRs will need to be merged in quick succession.