### PR TITLE
DM-27374: Add ingest time support to queryDatasets

### DIFF
--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -148,7 +148,9 @@ dimensions, e.g. ``visit`` identifier is used to represent a value of
 ``visit`` dimension in registry database. Dotted identifiers are mapped to
 tables and columns in registry database, e.g. ``detector.raft`` can be used
 for accessing raft name (obviously dotted names need knowledge of database
-schema and how SQL query is built).
+schema and how SQL query is built). A simple identifier with a name
+``ingest_date`` is used to reference dataset ingest time, which can be used to
+filter query results based on that property of datasets.
 
 Unary arithmetic operators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -373,3 +375,5 @@ Few examples of valid expressions using some of the constructs:
     exposure.datetime_begin > T'58938.515'
 
     visit.datetime_end < T'mjd/58938.515/tai'
+
+    ingest_date < T'2020-11-06 21:10:00'

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -379,11 +379,14 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
         # the id and run fields from that; passing them as kwargs here tells
         # SimpleQuery to handle them whether they're constraints or results.
         # We always constraint the dataset_type_id here as well.
+        static_kwargs = {self._runKeyColumn: run}
+        if ingestDate is not None:
+            static_kwargs["ingest_date"] = SimpleQuery.Select
         query.join(
             self._static.dataset,
             id=id,
             dataset_type_id=self._dataset_type_id,
-            **{self._runKeyColumn: run}
+            **static_kwargs
         )
         # If and only if the collection is a RUN, we constrain it in the static
         # table (and also the tags or calibs table below)
@@ -401,9 +404,7 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
         # We always constrain (never retrieve) the collection from the tags
         # table.
         kwargs[self._collections.getCollectionForeignKeyName()] = collection.key
-        # select and/or constrain ingest time
-        if ingestDate is not None:
-            kwargs["ingest_date"] = SimpleQuery.Select
+        # constrain ingest time
         if isinstance(ingestDate, Timespan):
             # Tmespan is astropy Time (usually in TAI) and ingest_date is
             # TIMESTAMP, convert values to Python datetime for sqlalchemy.

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -240,6 +240,7 @@ class DatasetRecordStorage(ABC):
                id: SimpleQuery.Select.Or[Optional[int]] = SimpleQuery.Select,
                run: SimpleQuery.Select.Or[None] = SimpleQuery.Select,
                timespan: SimpleQuery.Select.Or[Optional[Timespan]] = SimpleQuery.Select,
+               ingestDate: SimpleQuery.Select.Or[Optional[Timespan]] = None,
                ) -> Optional[SimpleQuery]:
         """Return a SQLAlchemy object that represents a ``SELECT`` query for
         this `DatasetType`.
@@ -273,6 +274,12 @@ class DatasetRecordStorage(ABC):
             result columns.  If a `Timespan` instance, constrain the results to
             those whose validity ranges overlap that given timespan.  Ignored
             unless ``collection.type is CollectionType.CALIBRATION``.
+        ingestDate : `None`, `Select`, or `Timespan`
+            If `Select` include the ingest timestamp in the result columns.
+            If a `Timespan` instance, constrain the results to those whose
+            ingest times which are inside given timespan and also include
+            timestamp in the result columns. If `None` (default) then there is
+            no constraint and timestamp is not returned.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -158,7 +158,7 @@ class QueryBuilder:
             return False
         subsubqueries = []
         runKeyName = self._managers.collections.getRunForeignKeyName()
-        baseColumnNames = {"id", runKeyName} if isResult else set()
+        baseColumnNames = {"id", runKeyName, "ingest_date"} if isResult else set()
         baseColumnNames.update(datasetType.dimensions.required.names)
         for rank, collectionRecord in enumerate(collections.iter(self._managers.collections,
                                                                  collectionTypes=collectionTypes)):
@@ -175,7 +175,8 @@ class QueryBuilder:
             ssq = datasetRecordStorage.select(collection=collectionRecord,
                                               dataId=SimpleQuery.Select,
                                               id=SimpleQuery.Select if isResult else None,
-                                              run=SimpleQuery.Select if isResult else None)
+                                              run=SimpleQuery.Select if isResult else None,
+                                              ingestDate=SimpleQuery.Select if isResult else None)
             if ssq is None:
                 continue
             assert {c.name for c in ssq.columns} == baseColumnNames
@@ -225,7 +226,8 @@ class QueryBuilder:
                 ]
                 windowSelectCols = [
                     search.columns["id"].label("id"),
-                    search.columns[runKeyName].label(runKeyName)
+                    search.columns[runKeyName].label(runKeyName),
+                    search.columns["ingest_date"].label("ingest_date"),
                 ]
                 windowSelectCols += windowDataIdCols
                 assert {c.name for c in windowSelectCols} == baseColumnNames
@@ -253,6 +255,7 @@ class QueryBuilder:
                 datasetType=datasetType,
                 id=subquery.columns["id"],
                 runKey=subquery.columns[runKeyName],
+                ingestDate=subquery.columns["ingest_date"],
             )
         else:
             subquery = subquery.alias(datasetType.name)

--- a/python/lsst/daf/butler/registry/queries/_query.py
+++ b/python/lsst/daf/butler/registry/queries/_query.py
@@ -652,10 +652,14 @@ class DirectQuery(Query):
         base = self._columns.datasets
         if base is None:
             return None
+        ingestDate = base.ingestDate
+        if ingestDate is not None:
+            ingestDate = ingestDate.label("ingest_date")
         return DatasetQueryColumns(
             datasetType=base.datasetType,
             id=base.id.label("dataset_id"),
             runKey=base.runKey.label(self.managers.collections.getRunForeignKeyName()),
+            ingestDate=ingestDate,
         )
 
     @property
@@ -777,6 +781,7 @@ class MaterializedQuery(Query):
                 datasetType=self._datasetType,
                 id=self._table.columns["dataset_id"],
                 runKey=self._table.columns[self.managers.collections.getRunForeignKeyName()],
+                ingestDate=None,
             )
         else:
             return None

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -261,6 +261,11 @@ class DatasetQueryColumns:
     this dataset.
     """
 
+    ingestDate: Optional[ColumnElement]
+    """Column containing the ingest timestamp, this is not a part of
+    `DatasetRef` but it comes from the same table.
+    """
+
     def __iter__(self) -> Iterator[ColumnElement]:
         yield self.id
         yield self.runKey

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -1640,3 +1640,24 @@ class RegistryTests(ABC):
             else:
                 expected = None
             assertLookup(detector=2, timespan=timespan, expected=expected)
+
+    def testIngestTimeQuery(self):
+
+        registry = self.makeRegistry()
+        self.loadData(registry, "base.yaml")
+        self.loadData(registry, "datasets.yaml")
+
+        datasets = list(registry.queryDatasets(..., collections=...))
+        len0 = len(datasets)
+        self.assertGreater(len0, 0)
+
+        where = "ingest_date > T'2000-01-01'"
+        datasets = list(registry.queryDatasets(..., collections=..., where=where))
+        len1 = len(datasets)
+        self.assertEqual(len0, len1)
+
+        # no one will ever use this piece of software in 30 years
+        where = "ingest_date > T'2050-01-01'"
+        datasets = list(registry.queryDatasets(..., collections=..., where=where))
+        len2 = len(datasets)
+        self.assertEqual(len2, 0)


### PR DESCRIPTION
Visitor now recognizes `ingest_date` identifier and generates dialect-specific code to convert the value to nanoseconds since epoch so that time can be compared to other timestamps.