### PR TITLE
DM-27118: Add support for recreating logging configuration

### DIFF
--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -105,7 +105,7 @@ class CliLog:
             # calling this function multiple times in one program execution,
             # so do log a debug but don't log an error or fail, just make the
             # re-initialization a no-op.
-            log = logging.getLogger(__name__.partition(".")[2])
+            log = logging.getLogger(__name__)
             log.debug("Log is already initialized, returning without re-initializing.")
             return
         cls._initialized = True
@@ -297,7 +297,7 @@ class CliLog:
         """
         if cls._initialized or cls.configState:
             # Already initialized, do not touch anything.
-            log = logging.getLogger(__name__.partition(".")[2])
+            log = logging.getLogger(__name__)
             log.warning("Log is already initialized, will not replay configuration.")
             return
 

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -78,6 +78,11 @@ class CliLog:
     """The log format used when the lsst.log package is not importable and the
     log is initialized with longlog=False."""
 
+    configState = []
+    """Configuration state. Contains tuples where first item in a tuple is
+    a method and remaining items are arguments for the method.
+    """
+
     _initialized = False
     _lsstLogHandler = None
     _componentSettings = []
@@ -130,6 +135,9 @@ class CliLog:
         # also capture warnings and send them to logging
         logging.captureWarnings(True)
 
+        # remember this call
+        cls.configState.append((cls.initLog, longlog))
+
     @classmethod
     def getHandlerId(cls):
         """Get the id of the lsst.log handler added to the python logger.
@@ -167,6 +175,7 @@ class CliLog:
             logger.setLevel(componentSetting.pythonLogLevel)
         cls._setLogLevel(None, "INFO")
         cls._initialized = False
+        cls.configState = []
 
     @classmethod
     def setLogLevels(cls, logLevels):
@@ -186,6 +195,8 @@ class CliLog:
         # configure individual loggers
         for component, level in logLevels:
             cls._setLogLevel(component, level)
+            # remember this call
+            cls.configState.append((cls._setLogLevel, component, level))
 
     @classmethod
     def _setLogLevel(cls, component, level):
@@ -273,3 +284,24 @@ class CliLog:
         component levels."""
         componentSettings = cls.ComponentSettings(component)
         cls._componentSettings.append(componentSettings)
+
+    @classmethod
+    def replayConfigState(cls, configState):
+        """Re-create configuration using configuration state recorded earlier.
+
+        Parameters
+        ----------
+        configState : `list` of `tuple`
+            Tuples contain a method as first item and arguments for the method,
+            in the same format as ``cls.configState``.
+        """
+        if cls._initialized or cls.configState:
+            # Already initialized, do not touch anything.
+            log = logging.getLogger(__name__.partition(".")[2])
+            log.warning("Log is already initialized, will not replay configuration.")
+            return
+
+        # execute each one in order
+        for call in configState:
+            method, *args = call
+            method(*args)

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -58,7 +58,7 @@ from typing import (
 from lsst.utils import doImport
 
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 def safeMakeDir(directory: str) -> None:


### PR DESCRIPTION
New pipetask option for multiprocessing spawn method needs support for
transporting global state from parent to child processes. Logging
configuration is a part of this global state, this commit adds support
for recording and replaying logging configuration changes.