### PR TITLE
DM-27169: Use FilterLabel in Exposure/ExposureInfo

### DIFF
--- a/doc/lsst.daf.butler/formatters.rst
+++ b/doc/lsst.daf.butler/formatters.rst
@@ -171,12 +171,16 @@ Additionally, if the storage class refers to a composite, the datastore can be c
 Since derived components are computed and are not persisted themselves, the datastore needs to be told which component should be used to calculate this derived quantity.
 To enable this the delegate must implement `StorageClassDelegate.selectResponsibleComponent()`.
 This method is given the name of the derived component and a list of all available persisted components and must return one and only one relevant component.
-The datastore will then make a component request to the formatter associated with that component.
+The datastore will then make a component request to the `~lsst.daf.butler.Formatter` associated with that component.
 
 .. note::
 
   All delegates must support read/write components and derived components in the `StorageClassDelegate.getComponent()` implementation method.
   As a corollary, all storage classes using components must specify a delegate.
+
+.. note::
+
+   A component returned by `~StorageClassDelegate.selectResponsibleComponent()` may require a custom formatter, to support the derived component, even if it otherwise would not.
 
 Read Parameters
 ^^^^^^^^^^^^^^^

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -13,6 +13,7 @@ CoaddInputs: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 VisitInfo: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 ApCorr: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 PhotoCalib: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
+FilterLabel: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 TransmissionCurve: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Camera: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Detector: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
@@ -60,6 +61,7 @@ MetricValue:
     unsafe_dump: true
 BrighterFatterKernel: lsst.daf.butler.formatters.pickle.PickleFormatter
 StructuredDataDict: lsst.daf.butler.formatters.yaml.YamlFormatter
+# TODO: remove Filter in DM-27177
 Filter: lsst.obs.base.formatters.filter.FilterFormatter
 Stamps: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 AstropyTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -103,8 +103,13 @@ storageClasses:
     pytype: lsst.meas.algorithms.Curve
   CrosstalkCalib:
     pytype: lsst.ip.isr.CrosstalkCalib
+  # TODO: remove Filter in DM-27177
   Filter:
     pytype: lsst.afw.image.Filter
+  FilterLabel:
+    pytype: lsst.afw.image.FilterLabel
+    # To support exposure.filter; remove in DM-27177
+    delegate: lsst.obs.base.formatters.filter.FilterTranslator
   Exposure:
     pytype: lsst.afw.image.Exposure
     delegate: lsst.obs.base.exposureAssembler.ExposureAssembler
@@ -123,13 +128,16 @@ storageClasses:
       coaddInputs: CoaddInputs
       transmissionCurve: TransmissionCurve
       metadata: PropertyList
-      filter: Filter
+      # TODO: for consistency with Exposure.getFilterLabel(). Deprecate in DM-27177, remove in DM-27811.
+      filterLabel: FilterLabel
       detector: Detector
       validPolygon: Polygon
     derivedComponents:
       bbox: Box2I
       dimensions: Extent2I
       xy0: Point2I
+      # TODO: change filter to FilterLabel and make non-derived in DM-27177. This is a breaking change.
+      filter: Filter
   ExposureF:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF


### PR DESCRIPTION
This PR adds support for `FilterLabel` as a persisted form for filter information in decomposed exposures. Must be merged with lsst/afw#551. `Filter` remains both for backward-compatibility, and for consistency with the `Exposure` API (which temporarily also has `getFilter()` and `getFilterLabel()`). 

The plan for the `Exposure` class is to migrate code to using the `FilterLabel` class (through `getFilterLabel()`) on DM-27170, remove `Filter` and `getFilter()` and replace them with a new `getFilter()` that returns a `FilterLabel` on DM-27177, then remove `getFilterLabel()` on DM-27811. I propose that the components follow the same pattern to minimize user confusion.