### PR TITLE
DM-28257: allow passing a pathlib.Path

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -28,7 +28,7 @@ import copy
 import logging
 import re
 
-from pathlib import PurePath, PurePosixPath
+from pathlib import Path, PurePath, PurePosixPath
 
 __all__ = ('ButlerURI',)
 
@@ -121,12 +121,15 @@ class ButlerURI:
     _uri: urllib.parse.ParseResult
     isTemporary: bool
 
-    def __new__(cls, uri: Union[str, urllib.parse.ParseResult, ButlerURI],
+    def __new__(cls, uri: Union[str, urllib.parse.ParseResult, ButlerURI, Path],
                 root: Optional[Union[str, ButlerURI]] = None, forceAbsolute: bool = True,
                 forceDirectory: bool = False, isTemporary: bool = False) -> ButlerURI:
         parsed: urllib.parse.ParseResult
         dirLike: bool = False
         subclass: Optional[Type] = None
+
+        if isinstance(uri, Path):
+            uri = str(uri)
 
         # Record if we need to post process the URI components
         # or if the instance is already fully configured
@@ -150,7 +153,8 @@ class ButlerURI:
             # No further parsing required and we know the subclass
             subclass = type(uri)
         else:
-            raise ValueError(f"Supplied URI must be string, ButlerURI, or ParseResult but got '{uri!r}'")
+            raise ValueError("Supplied URI must be string, Path, "
+                             f"ButlerURI, or ParseResult but got '{uri!r}'")
 
         if subclass is None:
             # Work out the subclass from the URI scheme

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -33,6 +33,7 @@ import pprint
 import os
 import yaml
 import sys
+from pathlib import Path
 from yaml.representer import Representer
 import io
 from typing import Any, Dict, List, Sequence, Optional, ClassVar, IO, Tuple, Union
@@ -175,7 +176,7 @@ class Config(collections.abc.MutableMapping):
 
     Parameters
     ----------
-    other : `str` or `Config` or `dict` or `ButlerURI`
+    other : `str` or `Config` or `dict` or `ButlerURI` or `pathlib.Path`
         Other source of configuration, can be:
 
         - (`str` or `ButlerURI`) Treated as a URI to a config file. Must end
@@ -210,7 +211,7 @@ class Config(collections.abc.MutableMapping):
             self.configFile = other.configFile
         elif isinstance(other, collections.abc.Mapping):
             self.update(other)
-        elif isinstance(other, (str, ButlerURI)):
+        elif isinstance(other, (str, ButlerURI, Path)):
             # if other is a string, assume it is a file path/URI
             self.__initFromUri(other)
             self._processExplicitIncludes()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,7 @@ import os
 import contextlib
 import collections
 import itertools
+from pathlib import Path
 
 from lsst.daf.butler import ConfigSubset, Config
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
@@ -69,6 +70,10 @@ class ConfigTest(ConfigSubset):
     component = "comp"
     requiredKeys = ("item1", "item2")
     defaultConfigFile = "testconfig.yaml"
+
+
+class ConfigTestPathlib(ConfigTest):
+    defaultConfigFile = Path("testconfig.yaml")
 
 
 class ConfigTestEmpty(ConfigTest):
@@ -425,6 +430,11 @@ class ConfigSubsetTestCase(unittest.TestCase):
     def testEmpty(self):
         """Ensure that we can read an empty file."""
         c = ConfigTestEmpty(searchPaths=(self.configDir,))
+        self.assertIsInstance(c, ConfigSubset)
+
+    def testPathlib(self):
+        """Ensure that we can read an empty file."""
+        c = ConfigTestPathlib(searchPaths=(self.configDir,))
         self.assertIsInstance(c, ConfigSubset)
 
     def testDefaults(self):


### PR DESCRIPTION
This allows a `pathlib.Path` object to be passed as `config` param when initializing a Butler.