### PR TITLE
DM-28314: Initial JSON investigation

### DIFF
--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -74,9 +74,6 @@ class DatasetRef:
         not be created in new code, but are still supported for backwards
         compatibility.  New code should only pass `False` if it can guarantee
         that the dimensions are already consistent.
-    hasParentId : `bool`, optional
-        If `True` this `DatasetRef` is a component that has the ``id``
-        of the composite parent.
 
     Raises
     ------
@@ -85,19 +82,17 @@ class DatasetRef:
         provided but ``run`` is not.
     """
 
-    __slots__ = ("id", "datasetType", "dataId", "run", "hasParentId")
+    __slots__ = ("id", "datasetType", "dataId", "run",)
 
     def __init__(
         self,
         datasetType: DatasetType, dataId: DataCoordinate, *,
         id: Optional[int] = None,
         run: Optional[str] = None,
-        hasParentId: bool = False,
         conform: bool = True
     ):
         self.id = id
         self.datasetType = datasetType
-        self.hasParentId = hasParentId
         if conform:
             self.dataId = DataCoordinate.standardize(dataId, graph=datasetType.dimensions)
         else:
@@ -190,7 +185,6 @@ class DatasetRef:
         # Convert to a dict form
         as_dict: Dict[str, Any] = {"datasetType": self.datasetType.to_simple(minimal=minimal),
                                    "dataId": self.dataId.to_simple(),
-                                   "hasParentId": self.hasParentId
                                    }
 
         # Only include the id entry if it is defined
@@ -250,7 +244,7 @@ class DatasetRef:
         datasetType = DatasetType.from_simple(simple["datasetType"], universe=universe, registry=registry)
         dataId = DataCoordinate.from_simple(simple["dataId"], universe=universe)
         return cls(datasetType, dataId,
-                   id=simple["id"], run=simple["run"], hasParentId=simple["hasParentId"])
+                   id=simple["id"], run=simple["run"])
 
     to_json = to_json_generic
     from_json = classmethod(from_json_generic)
@@ -262,15 +256,14 @@ class DatasetRef:
         dataId: DataCoordinate,
         id: Optional[int],
         run: Optional[str],
-        hasParentId: bool,
     ) -> DatasetRef:
         """A custom factory method for use by `__reduce__` as a workaround for
         its lack of support for keyword arguments.
         """
-        return cls(datasetType, dataId, id=id, run=run, hasParentId=hasParentId)
+        return cls(datasetType, dataId, id=id, run=run)
 
     def __reduce__(self) -> tuple:
-        return (self._unpickle, (self.datasetType, self.dataId, self.id, self.run, self.hasParentId))
+        return (self._unpickle, (self.datasetType, self.dataId, self.id, self.run))
 
     def __deepcopy__(self, memo: dict) -> DatasetRef:
         # DatasetRef is recursively immutable; see note in @immutable
@@ -437,11 +430,11 @@ class DatasetRef:
         -------
         ref : `DatasetRef`
             A `DatasetRef` with a dataset type that corresponds to the given
-            component, with ``hasParentId=True``, and the same ID and run
+            component, and the same ID and run
             (which may be `None`, if they are `None` in ``self``).
         """
         return DatasetRef(self.datasetType.makeComponentDatasetType(name), self.dataId,
-                          id=self.id, run=self.run, hasParentId=True)
+                          id=self.id, run=self.run)
 
     datasetType: DatasetType
     """The definition of this dataset (`DatasetType`).

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -532,14 +532,7 @@ class DatasetType:
             if registry is None:
                 raise ValueError(f"Unable to convert a DatasetType name '{simple}' to DatasetType"
                                  " without a Registry")
-            datasetTypes = list(registry.queryDatasetTypes(simple))
-            if len(datasetTypes) != 1:
-                if not datasetTypes:
-                    raise RuntimeError(f"No DatasetType found in Registry with name '{simple}'")
-                else:
-                    raise RuntimeError(f"Unexpectedly got multiple DatasetTypes matching '{simple}': "
-                                       f"{datasetTypes}")
-            return datasetTypes[0]
+            return registry.getDatasetType(simple)
 
         if universe is None and registry is None:
             raise ValueError("One of universe or registry must be provided.")

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -46,6 +46,7 @@ from typing import (
 from ..storageClass import StorageClass, StorageClassFactory
 from ..dimensions import DimensionGraph
 from ..configSupport import LookupKey
+from ..json import from_json_generic, to_json_generic
 
 if TYPE_CHECKING:
     from ..dimensions import Dimension, DimensionUniverse
@@ -473,28 +474,6 @@ class DatasetType:
 
         return lookups + self.storageClass._lookupNames()
 
-    def to_json(self, minimal: bool = False) -> str:
-        """Convert this class to JSON form.
-
-        The class type is not recorded in the JSON so the JSON decoder
-        must know which class is represented.
-
-        Parameters
-        ----------
-        minimal : `bool`, optional
-            Use minimal serialization. Requires Registry to convert
-            back to a full type.
-
-        Returns
-        -------
-        json : `str`
-            The class in JSON string format.
-        """
-        # For now use the core json library to convert a dict to JSON
-        # for us.
-        import json
-        return json.dumps(self.to_simple(minimal=minimal))
-
     def to_simple(self, minimal: bool = False) -> Union[Dict, str]:
         """Convert this class to a simple python type suitable for
         serialization.
@@ -580,33 +559,8 @@ class DatasetType:
                    parentStorageClass=simple.get("parentStorageClass"),
                    universe=universe)
 
-    @classmethod
-    def from_json(cls, json_str: str,
-                  universe: Optional[DimensionUniverse] = None,
-                  registry: Optional[Registry] = None) -> DatasetType:
-        """Convert a JSON string created by `to_json` and return a
-        `DatsetType`.
-
-        Parameters
-        ----------
-        json_str : `str`
-            Representation of the dimensions in JSON format as created
-            by `to_json()`.
-        universe : `DimensionUniverse`, optional
-            The special graph of all known dimensions. Passed directly
-            to `from_simple()`.
-        registry : `lsst.daf.butler.Registry`, optional
-            Registry to use to convert simple name of a DatasetType to
-            a full `DatasetType`. Passed directly to `from_simple()`.
-
-        Returns
-        -------
-        datasetType : `DatasetType`
-            Newly-constructed object.
-        """
-        import json
-        as_dict = json.loads(json_str)
-        return cls.from_simple(as_dict, universe=universe, registry=registry)
+    to_json = to_json_generic
+    from_json = classmethod(from_json_generic)
 
     def __reduce__(self) -> Tuple[Callable, Tuple[Type[DatasetType],
                                                   Tuple[str, DimensionGraph, str, Optional[str]],

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -48,6 +48,7 @@ from ..timespan import Timespan
 from ._elements import Dimension, DimensionElement
 from ._graph import DimensionGraph
 from ._records import DimensionRecord
+from ..json import from_json_generic, to_json_generic
 
 if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
     from ._universe import DimensionUniverse
@@ -609,22 +610,6 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         assert self.hasRecords(), "pack() may only be called if hasRecords() returns True."
         return self.universe.makePacker(name, self).pack(self, returnMaxBits=returnMaxBits)
 
-    def to_json(self) -> str:
-        """Convert this class to JSON form.
-
-        The class type is not recorded in the JSON so the JSON decoder
-        must know which class is represented.
-
-        Returns
-        -------
-        json : `str`
-            The class in JSON string format.
-        """
-        # For now use the core json library to convert a dict to JSON
-        # for us.
-        import json
-        return json.dumps(self.to_simple())
-
     def to_simple(self, minimal: bool = False) -> Dict:
         """Convert this class to a simple python type suitable for
         serialization.
@@ -671,27 +656,8 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
 
         return cls.standardize(simple, universe=universe)
 
-    @classmethod
-    def from_json(cls, json_str: str, universe: DimensionUniverse) -> DataCoordinate:
-        """Convert a JSON string created by `to_json` and return a
-        `DataCoordinate`.
-
-        Parameters
-        ----------
-        json_str : `str`
-            Representation of the dimensions in JSON format as created
-            by `to_json()`.
-        universe : `DimensionUniverse`
-            The special graph of all known dimensions.
-
-        Returns
-        -------
-        dataId : `DataCoordinate`
-            Newly-constructed object.
-        """
-        import json
-        as_dict = json.loads(json_str)
-        return cls.from_simple(as_dict, universe=universe)
+    to_json = to_json_generic
+    from_json = classmethod(from_json_generic)
 
 
 DataId = Union[DataCoordinate, Mapping[str, Any]]

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -640,6 +640,9 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
             The `dict` returned by `to_simple()`.
         universe : `DimensionUniverse`
             The special graph of all known dimensions.
+        registry : `lsst.daf.butler.Registry`, optional
+            Registry from which a universe can be extracted. Can be `None`
+            if universe is provided explicitly.
 
         Returns
         -------

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -608,6 +608,76 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         assert self.hasRecords(), "pack() may only be called if hasRecords() returns True."
         return self.universe.makePacker(name, self).pack(self, returnMaxBits=returnMaxBits)
 
+    def to_json(self) -> str:
+        """Convert this class to JSON form.
+
+        The class type is not recorded in the JSON so the JSON decoder
+        must know which class is represented.
+
+        Returns
+        -------
+        json : `str`
+            The class in JSON string format.
+        """
+        # For now use the core json library to convert a dict to JSON
+        # for us.
+        import json
+        return json.dumps(self.to_simple())
+
+    def to_simple(self) -> Dict:
+        """Convert this class to a simple python type suitable for
+        serialization.
+
+        Returns
+        -------
+        as_dict : `dict`
+            The object converted to a dictionary.
+        """
+        # Convert to a dict form
+        return self.byName()
+
+    @classmethod
+    def from_simple(cls, as_dict: Dict[str, Any],
+                    universe: DimensionUniverse) -> DataCoordinate:
+        """Construct a new object from the data returned from the `to_simple`
+        method.
+
+        Parameters
+        ----------
+        as_dict : `dict` of [`str`, `Any`]
+            The `dict` returned by `to_simple()`.
+        universe : `DimensionUniverse`
+            The special graph of all known dimensions.
+
+        Returns
+        -------
+        dataId : `DataCoordinate`
+            Newly-constructed object.
+        """
+        return cls.standardize(as_dict, universe=universe)
+
+    @classmethod
+    def from_json(cls, json_str: str, universe: DimensionUniverse) -> DataCoordinate:
+        """Convert a JSON string created by `to_json` and return a
+        `DataCoordinate`.
+
+        Parameters
+        ----------
+        json_str : `str`
+            Representation of the dimensions in JSON format as created
+            by `to_json()`.
+        universe : `DimensionUniverse`
+            The special graph of all known dimensions.
+
+        Returns
+        -------
+        dataId : `DataCoordinate`
+            Newly-constructed object.
+        """
+        import json
+        as_dict = json.loads(json_str)
+        return cls.from_simple(as_dict, universe=universe)
+
 
 DataId = Union[DataCoordinate, Mapping[str, Any]]
 """A type-annotation alias for signatures that accept both informal data ID

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -31,6 +31,7 @@ from typing import (
     Dict,
     Iterable,
     Iterator,
+    List,
     Mapping,
     Optional,
     Set,
@@ -186,6 +187,77 @@ class DimensionGraph:
         """A set of the names of all dimensions in the graph (`KeysView`).
         """
         return self.dimensions.names
+
+    def to_json(self) -> str:
+        """Convert this class to JSON form.
+
+        The class type is not recorded in the JSON so the JSON decoder
+        must know which class is represented.
+
+        Returns
+        -------
+        json : `str`
+            The class in JSON string format.
+        """
+        # For now use the core json library to convert a dict to JSON
+        # for us.
+        import json
+        return json.dumps(self.to_simple())
+
+    def to_simple(self) -> List[str]:
+        """Convert this class to a simple python type suitable for
+        serialization.
+
+        Returns
+        -------
+        names : `list`
+            The names of the dimensions.
+        """
+        # Names are all we can serialize.
+        return list(self.names)
+
+    @classmethod
+    def from_simple(cls, names: List[str], universe: DimensionUniverse) -> DimensionGraph:
+        """Construct a new object from the data returned from the `to_simple`
+        method.
+
+        Parameters
+        ----------
+        names : `list` of `str`
+            The names of the dimensions.
+        universe : `DimensionUniverse`
+            The special graph of all known dimensions of which this graph will
+            be a subset.
+
+        Returns
+        -------
+        graph : `DimensionGraph`
+            Newly-constructed object.
+        """
+        return cls(names=names, universe=universe)
+
+    @classmethod
+    def from_json(cls, json_str: str, universe: DimensionUniverse) -> DimensionGraph:
+        """Convert a JSON string created by `to_json` and return a
+        `DimensionGraph`.
+
+        Parameters
+        ----------
+        json_str : `str`
+            Representation of the dimensions in JSON format as created
+            by `to_json()`.
+        universe : `DimensionUniverse`
+            The special graph of all known dimensions of which this graph will
+            be a subset.
+
+        Returns
+        -------
+        graph : `DimensionGraph`
+            Newly-constructed object.
+        """
+        import json
+        names = json.loads(json_str)
+        return cls.from_simple(names, universe)
 
     def __iter__(self) -> Iterator[Dimension]:
         """Iterate over all dimensions in the graph (and true `Dimension`

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -43,7 +43,7 @@ from typing import (
 from ..named import NamedValueAbstractSet, NamedValueSet
 from ..utils import cached_getter, immutable
 from .._topology import TopologicalSpace, TopologicalFamily
-
+from ..json import from_json_generic, to_json_generic
 
 if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
     from ._universe import DimensionUniverse
@@ -189,22 +189,6 @@ class DimensionGraph:
         """
         return self.dimensions.names
 
-    def to_json(self) -> str:
-        """Convert this class to JSON form.
-
-        The class type is not recorded in the JSON so the JSON decoder
-        must know which class is represented.
-
-        Returns
-        -------
-        json : `str`
-            The class in JSON string format.
-        """
-        # For now use the core json library to convert a dict to JSON
-        # for us.
-        import json
-        return json.dumps(self.to_simple())
-
     def to_simple(self, minimal: bool = False) -> List[str]:
         """Convert this class to a simple python type suitable for
         serialization.
@@ -255,28 +239,8 @@ class DimensionGraph:
 
         return cls(names=names, universe=universe)
 
-    @classmethod
-    def from_json(cls, json_str: str, universe: DimensionUniverse) -> DimensionGraph:
-        """Convert a JSON string created by `to_json` and return a
-        `DimensionGraph`.
-
-        Parameters
-        ----------
-        json_str : `str`
-            Representation of the dimensions in JSON format as created
-            by `to_json()`.
-        universe : `DimensionUniverse`
-            The special graph of all known dimensions of which this graph will
-            be a subset.
-
-        Returns
-        -------
-        graph : `DimensionGraph`
-            Newly-constructed object.
-        """
-        import json
-        names = json.loads(json_str)
-        return cls.from_simple(names, universe)
+    to_json = to_json_generic
+    from_json = classmethod(from_json_generic)
 
     def __iter__(self) -> Iterator[Dimension]:
         """Iterate over all dimensions in the graph (and true `Dimension`

--- a/python/lsst/daf/butler/core/dimensions/_records.py
+++ b/python/lsst/daf/butler/core/dimensions/_records.py
@@ -211,10 +211,11 @@ class DimensionRecord:
                 mapping[k] = v.to_simple(minimal=minimal)
             except AttributeError:
                 if isinstance(v, lsst.sphgeom.Region):
-                    # Match YAML serialization
-                    mapping[k] = {"cls": f"lsst.sphgeom.{type(v).__name__}",
-                                  "encoded": v.encode().hex()}
-
+                    # YAML serialization specifies the class when it
+                    # doesn't have to. This is partly for explicitness
+                    # and also history. Here use a different approach.
+                    # This code needs to be migrated to sphgeom
+                    mapping[k] = {"encoded_region": v.encode().hex()}
         definition = self.definition.to_simple(minimal=minimal)
 
         return {"definition": definition,
@@ -269,7 +270,7 @@ class DimensionRecord:
         if (ts := "timespan") in rec:
             rec[ts] = Timespan.from_simple(rec[ts], universe=universe, registry=registry)
         if (reg := "region") in rec:
-            encoded = bytes.fromhex(rec[reg]["encoded"])
+            encoded = bytes.fromhex(rec[reg]["encoded_region"])
             rec[reg] = lsst.sphgeom.Region.decode(encoded)
 
         return _reconstructDimensionRecord(definition, simple["record"])

--- a/python/lsst/daf/butler/core/json.py
+++ b/python/lsst/daf/butler/core/json.py
@@ -1,0 +1,91 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("to_json_generic", "from_json_generic")
+
+from typing import (
+    TYPE_CHECKING,
+    Optional,
+    Type,
+    TypeVar,
+)
+
+import json
+
+if TYPE_CHECKING:
+    from .dimensions import DimensionUniverse
+    from ..registry import Registry
+
+_T = TypeVar("_T")
+
+
+def to_json_generic(self: _T, minimal: bool = False) -> str:
+    """Convert this class to JSON form.
+
+    The class type is not recorded in the JSON so the JSON decoder
+    must know which class is represented.
+
+    Parameters
+    ----------
+    minimal : `bool`, optional
+        Use minimal serialization. Requires Registry to convert
+        back to a full type.
+
+    Returns
+    -------
+    json : `str`
+        The class in JSON string format.
+    """
+    # For now use the core json library to convert a dict to JSON
+    # for us.
+    return json.dumps(self.to_simple(minimal=minimal))  # type: ignore
+
+
+def from_json_generic(cls: Type[_T], json_str: str,
+                      universe: Optional[DimensionUniverse] = None,
+                      registry: Optional[Registry] = None) -> _T:
+    """Convert a JSON string created by `to_json` and return
+    something of the supplied class.
+
+    Parameters
+    ----------
+    json_str : `str`
+        Representation of the dimensions in JSON format as created
+        by `to_json()`.
+    universe : `DimensionUniverse`, optional
+        The special graph of all known dimensions. Passed directly
+        to `from_simple()`.
+    registry : `lsst.daf.butler.Registry`, optional
+        Registry to use to convert simple name of a DatasetType to
+        a full `DatasetType`. Passed directly to `from_simple()`.
+
+    Returns
+    -------
+    constructed : Any
+        Newly-constructed object.
+    """
+    simple = json.loads(json_str)
+    try:
+        return cls.from_simple(simple, universe=universe, registry=registry)  # type: ignore
+    except AttributeError as e:
+        raise AttributeError(f"JSON deserialization requires {cls} has a from_simple() class method") from e

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -141,6 +141,17 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertNotEqual(DatasetType("a.b", dimensionsA, "test_b", parentStorageClass="storageA"),
                             DatasetType("a.b", dimensionsA, "test_b", parentStorageClass="storageB"))
 
+    def testJson(self):
+        storageA = StorageClass("test_a")
+        dimensionsA = self.universe.extract(["instrument"])
+        self.assertEqual(DatasetType("a", dimensionsA, storageA,),
+                         DatasetType.from_json(DatasetType("a", dimensionsA, storageA,).to_json(),
+                                               self.universe))
+        self.assertEqual(DatasetType("a.b", dimensionsA, "test_b", parentStorageClass="parent"),
+                         DatasetType.from_json(DatasetType("a.b", dimensionsA, "test_b",
+                                                           parentStorageClass="parent").to_json(),
+                                               self.universe))
+
     def testSorting(self):
         """Can we sort a DatasetType"""
         storage = StorageClass("test_a")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -438,6 +438,11 @@ class DatasetRefTestCase(unittest.TestCase):
         s = pickle.dumps(ref)
         self.assertEqual(pickle.loads(s), ref)
 
+    def testJson(self):
+        ref = DatasetRef(self.datasetType, self.dataId, id=1, run="somerun")
+        s = ref.to_json()
+        self.assertEqual(DatasetRef.from_json(s, universe=self.universe), ref)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -451,6 +451,21 @@ class SimpleButlerTestCase(unittest.TestCase):
                     from_json = type(test_item).from_json(json_str, universe=butler.registry.dimensions)
                     self.assertEqual(from_json, test_item, msg=f"From JSON '{json_str}' using universe")
 
+    def testJsonDimensionRecords(self):
+        # Dimension Records
+        butler = self.makeButler(writeable=True)
+        butler.import_(filename=os.path.join(TESTDIR, "data", "registry", "hsc-rc2-subset.yaml"))
+
+        for dimension in ("detector", "visit"):
+            records = butler.registry.queryDimensionRecords(dimension, instrument="HSC")
+            for r in records:
+                for minimal in (True, False):
+                    json_str = r.to_json(minimal=minimal)
+                    r_json = type(r).from_json(json_str, registry=butler.registry)
+                    self.assertEqual(r_json, r)
+                    # Also check equality of each of the components as dicts
+                    self.assertEqual(r_json.toDict(), r.toDict())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_timespan.py
+++ b/tests/test_timespan.py
@@ -239,6 +239,13 @@ class TimespanTestCase(unittest.TestCase):
             warnings.warn("deliberate")
         self.assertEqual(str(cm.warning), "deliberate")
 
+    def testJson(self):
+        ts1 = Timespan(begin=astropy.time.Time('2013-06-17 13:34:45.775000', scale='tai', format='iso'),
+                       end=astropy.time.Time('2013-06-17 13:35:17.947000', scale='tai', format='iso'))
+        json_str = ts1.to_json()
+        ts_json = Timespan.from_json(json_str)
+        self.assertEqual(ts_json, ts1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This implements the simplest possible JSON support.

```
json = ref.to_json()
ref = DatasetRef.from_json(json, universe=universe)
```

A universe is required although I imagine we could make it optional if we could have a support serialization package that could be queried for a default universe to use.

To implement these I've also created `to_simple` and `from_simple` pairs for `DatasetRef`, `DatasetType`, `DimensionGraph` and `DataCoordinate` that convert the object to a dict or list and then take that and convert it back to the object.