### PR TITLE
DM-23862: Split data ID handling off from butlerTests.makeTestRepo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         run: pytest -r a -v -n 3 --open-files
 
       - name: Install documenteer
-        run: pip install 'documenteer[pipelines]<0.6'
+        run: pip install 'documenteer[pipelines]<0.7'
 
       - name: Build documentation
         working-directory: ./doc

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,13 +3,10 @@
 This configuration only affects single-package Sphinx documenation builds.
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.daf.butler
-import lsst.daf.butler.version
+from documenteer.conf.pipelinespkg import *  # noqa: F403, import *
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name="daf_butler",
-    version=lsst.daf.butler.version.__version__))
-
-extensions.append("sphinx_click.ext")  # noqa: F821
+project = "daf_butler"
+html_theme_options["logotext"] = project     # noqa: F405, unknown name
+html_title = project
+html_short_title = project
+doxylink = {}

--- a/doc/lsst.daf.butler/use-in-tests.rst
+++ b/doc/lsst.daf.butler/use-in-tests.rst
@@ -51,6 +51,25 @@ If not, the `expandUniqueId` function can recover which values are assigned to w
    >>> butlerTests.expandUniqueId(repo, {"detector": 2})
    DataCoordinate({instrument, detector}, ('FancyCam', 2))
 
+The `addDataIdValue` function defines allowed data ID values after the repository has been created.
+Unlike the data ID parameter to `makeTestRepo`, `addDataIdValue` lets you optionally specify which values are related to which.
+Any required but unspecified relationships are filled arbitrarily, so you need only give the ones your tests depend on.
+
+.. code-block:: py
+
+   from lsst.daf.butlker.tests import addDataIdValue
+
+   addDataIdValue(butler, "skymap", "map")
+   # Tract requires a skymap; can assume it's "map" because no other options.
+   # Were there more than one skymap, this would choose one unpredictably.
+   addDataIdValue(butler, "tract", 42)
+   # Explicit specification.
+   addDataIdValue(butler, "tract", 43, skymap="map")
+   # Can map dimensions in a many-to-many relationship.
+   for patch in [0, 1, 2, 3, 4, 5]:
+       addDataIdValue(butler, "patch", patch, tract=42)
+       addDataIdValue(butler, "patch", patch, tract=43)
+
 The `addDatasetType` function registers any dataset types needed by the test (e.g., "calexp").
 As with registering the data IDs, this is a prerequisite for actually reading or writing any datasets of that type during the test.
 

--- a/doc/lsst.daf.butler/use-in-tests.rst
+++ b/doc/lsst.daf.butler/use-in-tests.rst
@@ -25,35 +25,14 @@ Creating and populating a repository
 ====================================
 
 The `lsst.daf.butler.tests.makeTestRepo` function creates an in-memory repository.
-In addition to the arguments used by `~lsst.daf.butler.Butler.makeRepo`, `makeTestRepo` takes a mapping of the data ID(s) needed by the test.
-This mapping does not create any datasets itself, but instead prepares the registry so that datasets with those IDs *could* be created later.
-
-The data ID mapping takes the form of a key for each data ID dimension, and a list of possible values.
-For example:
-
-.. code-block:: py
-
-   {"instrument": ["FancyCam"],
-    "exposure": [101, 102, 103],
-    "detector": [0, 1, 2, 3],
-    "skymap": ["map"],
-    "tract": [42, 43],
-    "patch": [0, 1, 2, 3, 4, 5],
-   }
-
-To avoid creating ambiguous data IDs, values are assigned to each other in an arbitrary one-to-one fashion, rather than trying every combination (e.g., in the above example all the patches might only be assigned to tract 42).
-In many tests this is not a problem, as a single data ID is all that's needed.
-If not, the `expandUniqueId` function can recover which values are assigned to which:
-
-.. code-block:: py
-
-   >>> import lsst.daf.butler.tests as butlerTests
-   >>> butlerTests.expandUniqueId(repo, {"detector": 2})
-   DataCoordinate({instrument, detector}, ('FancyCam', 2))
+The repository is optimized for speed rather than for production processing, but otherwise is similar to `lsst.daf.butler.Butler.makeRepo`.
 
 The `addDataIdValue` function defines allowed data ID values after the repository has been created.
-Unlike the data ID parameter to `makeTestRepo`, `addDataIdValue` lets you optionally specify which values are related to which.
-Any required but unspecified relationships are filled arbitrarily, so you need only give the ones your tests depend on.
+By default, related values are assigned to each other in an arbitrary one-to-one fashion.
+This is good enough for many tests, where a single data ID is all that's needed.
+
+If you need more control (or if the assignment algorithm produces inconsistent results), `addDataIdValue` lets you specify by keyword which values are related to which.
+Any unspecified relationships are still filled arbitrarily, so you need only give the ones your tests depend on.
 
 .. code-block:: py
 

--- a/python/lsst/daf/butler/registry/dimensions/query.py
+++ b/python/lsst/daf/butler/registry/dimensions/query.py
@@ -158,11 +158,13 @@ class QueryDimensionRecordStorage(DatabaseDimensionRecordStorage):
 
     def insert(self, *records: DimensionRecord) -> None:
         # Docstring inherited from DimensionRecordStorage.insert.
-        raise TypeError(f"Cannot insert {self.element.name} records.")
+        raise TypeError(f"Cannot insert {self.element.name} records, "
+                        f"define as part of {self._viewOf} instead.")
 
     def sync(self, record: DimensionRecord) -> bool:
         # Docstring inherited from DimensionRecordStorage.sync.
-        raise TypeError(f"Cannot sync {self.element.name} records.")
+        raise TypeError(f"Cannot sync {self.element.name} records, "
+                        f"define as part of {self._viewOf} instead.")
 
     def fetch(self, dataIds: DataCoordinateIterable) -> Iterable[DimensionRecord]:
         # Docstring inherited from DimensionRecordStorage.fetch.

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -45,18 +45,20 @@ from lsst.daf.butler import (
 )
 
 
-def makeTestRepo(root, dataIds, *, config=None, **kwargs):
-    """Create an empty repository with dummy data IDs.
+def makeTestRepo(root, dataIds=None, *, config=None, **kwargs):
+    """Create an empty test repository.
 
     Parameters
     ----------
     root : `str`
         The location of the root directory for the repository.
-    dataIds : `~collections.abc.Mapping` [`str`, `iterable`]
+    dataIds : `~collections.abc.Mapping` [`str`, `iterable`], optional
         A mapping keyed by the dimensions used in the test. Each value
         is an iterable of names for that dimension (e.g., detector IDs for
         `"detector"`). Related dimensions (e.g., instruments and detectors)
-        are linked arbitrarily.
+        are linked arbitrarily. This parameter is provided for compatibility
+        with old code; newer code should make the repository, then call
+        `~lsst.daf.butler.tests.addDataIdValue`.
     config : `lsst.daf.butler.Config`, optional
         A configuration for the repository (for details, see
         `lsst.daf.butler.Butler.makeRepo`). If omitted, creates a repository
@@ -79,15 +81,9 @@ def makeTestRepo(root, dataIds, *, config=None, **kwargs):
     Notes
     -----
     This function provides a "quick and dirty" repository for simple unit
-    tests that don't depend on complex data relationships. Because it assigns
-    dimension relationships and other metadata abitrarily, it is ill-suited
+    tests that don't depend on complex data relationships. It is ill-suited
     for tests where the structure of the data matters. If you need such a
     dataset, create it directly or use a saved test dataset.
-
-    Since the values in ``dataIds`` uniquely determine the repository's
-    data IDs, the fully linked IDs can be recovered by calling
-    `expandUniqueId`, so long as no other code has inserted dimensions into
-    the repository registry.
     """
     defaults = Config()
     defaults["datastore", "cls"] = "lsst.daf.butler.datastores.inMemoryDatastore.InMemoryDatastore"
@@ -96,6 +92,9 @@ def makeTestRepo(root, dataIds, *, config=None, **kwargs):
 
     if config:
         defaults.update(config)
+
+    if not dataIds:
+        dataIds = {}
 
     # Disable config root by default so that our registry override will
     # not be ignored.

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -129,6 +129,13 @@ def makeTestCollection(repo: Butler) -> Butler:
     butler : `lsst.daf.butler.Butler`
         A Butler referring to a new collection in the repository at ``root``.
         The collection is (almost) guaranteed to be new.
+
+    Notes
+    -----
+    This function creates a single run collection that does not necessarily
+    conform to any repository conventions. It is only suitable for creating an
+    isolated test area, and not for repositories intended for real data
+    processing or analysis.
     """
     # Create a "random" collection name
     # Speed matters more than cryptographic guarantees
@@ -311,7 +318,9 @@ def expandUniqueId(butler: Butler, partialId: Mapping[str, Any]) -> DataCoordina
     -----
     This method will only work correctly if all dimensions attached to the
     target dimension (eg., "physical_filter" for "visit") are known to the
-    repository, even if they're not needed to identify a dataset.
+    repository, even if they're not needed to identify a dataset. This function
+    is only suitable for certain kinds of test repositories, and not for
+    repositories intended for real data processing or analysis.
 
     Examples
     --------
@@ -357,6 +366,12 @@ def addDataIdValue(butler: Butler, dimension: str, value: Any, **related: Any):
         The value to register for the dimension.
     **related
         Any existing dimensions to be linked to ``value``.
+
+    Notes
+    -----
+    Because this function creates filler data, it is only suitable for test
+    repositories. It should not be used for repositories intended for real data
+    processing or analysis, which have known dimension values.
 
     Examples
     --------

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -43,7 +43,7 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         # this has a prohibitive run-time cost at present
         cls.root = makeTestTempDir(TESTDIR)
 
-        cls.creatorButler = makeTestRepo(cls.root, {})
+        cls.creatorButler = makeTestRepo(cls.root)
         addDataIdValue(cls.creatorButler, "instrument", "notACam")
         addDataIdValue(cls.creatorButler, "instrument", "dummyCam")
         addDataIdValue(cls.creatorButler, "physical_filter", "k2020", band="k", instrument="notACam")

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -43,17 +43,16 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         # this has a prohibitive run-time cost at present
         cls.root = makeTestTempDir(TESTDIR)
 
+        cls.creatorButler = makeTestRepo(cls.root, {})
+        addDataIdValue(cls.creatorButler, "instrument", "notACam")
+        addDataIdValue(cls.creatorButler, "instrument", "dummyCam")
+        addDataIdValue(cls.creatorButler, "physical_filter", "k2020", band="k", instrument="notACam")
+        addDataIdValue(cls.creatorButler, "physical_filter", "l2019", instrument="dummyCam")
+        addDataIdValue(cls.creatorButler, "visit", 101, instrument="notACam", physical_filter="k2020")
+        addDataIdValue(cls.creatorButler, "visit", 102, instrument="notACam", physical_filter="k2020")
+        addDataIdValue(cls.creatorButler, "detector", 5)
         # Leave skymap/patch/tract undefined so that tests can assume
         # they're missing.
-        dataIds = {
-            # Current system can generate invalid combinations
-            # "instrument": ["notACam", "dummyCam"],
-            "instrument": ["notACam"],
-            "physical_filter": ["k2020", "l2019"],
-            "visit": [101, 102],
-            "detector": [5]
-        }
-        cls.creatorButler = makeTestRepo(cls.root, dataIds)
 
         registerMetricsExample(cls.creatorButler)
         addDatasetType(cls.creatorButler, "DataType1", {"instrument"}, "StructuredDataNoComponents")
@@ -101,20 +100,31 @@ class ButlerUtilsTestSuite(unittest.TestCase):
                                     {"instrument": "dummyCam", "detector": 5}])
 
     def testAddDataIdValue(self):
-        addDataIdValue(self.butler, "visit", 999)
+        addDataIdValue(self.butler, "visit", 1, instrument="notACam", physical_filter="k2020")
         self._checkButlerDimension({"visit", "instrument"},
-                                   "visit=999",
-                                   [{"instrument": "notACam", "visit": 999},
-                                    {"instrument": "dummyCam", "visit": 999}])
+                                   "visit=1",
+                                   [{"instrument": "notACam", "visit": 1}])
+        addDataIdValue(self.butler, "visit", 2, instrument="dummyCam", physical_filter="l2019")
+        self._checkButlerDimension({"visit", "instrument"},
+                                   "visit=2",
+                                   [{"instrument": "dummyCam", "visit": 2}])
 
         with self.assertRaises(ValueError):
             addDataIdValue(self.butler, "NotADimension", 42)
         with self.assertRaises(ValueError):
             addDataIdValue(self.butler, "detector", "nonNumeric")
+        with self.assertRaises(ValueError):
+            addDataIdValue(self.butler, "detector", 101, nonsenseField="string")
+
+        # Keywords imply different instruments
+        with self.assertRaises(RuntimeError):
+            addDataIdValue(self.butler, "exposure", 101, instrument="dummyCam", physical_filter="k2020")
 
         # No skymap defined
         with self.assertRaises(RuntimeError):
             addDataIdValue(self.butler, "tract", 42)
+        with self.assertRaises(RuntimeError):
+            addDataIdValue(self.butler, "tract", 43, skymap="map")
 
     def testAddDatasetType(self):
         # 1 for StructuredDataNoComponents, 4 for StructuredData

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -29,7 +29,7 @@ import unittest
 
 import lsst.daf.butler
 from lsst.daf.butler.tests import (makeTestRepo, makeTestCollection, addDatasetType, expandUniqueId,
-                                   MetricsExample, registerMetricsExample)
+                                   MetricsExample, registerMetricsExample, addDataIdValue)
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir, safeTestTempDir
 
 
@@ -43,8 +43,12 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         # this has a prohibitive run-time cost at present
         cls.root = makeTestTempDir(TESTDIR)
 
+        # Leave skymap/patch/tract undefined so that tests can assume
+        # they're missing.
         dataIds = {
-            "instrument": ["notACam", "dummyCam"],
+            # Current system can generate invalid combinations
+            # "instrument": ["notACam", "dummyCam"],
+            "instrument": ["notACam"],
             "physical_filter": ["k2020", "l2019"],
             "visit": [101, 102],
             "detector": [5]
@@ -80,21 +84,37 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         self.assertIn(dict(result[0]), expected)
 
     def testButlerDimensions(self):
-        self. _checkButlerDimension({"instrument"},
-                                    "instrument='notACam'",
-                                    [{"instrument": "notACam"}, {"instrument": "dummyCam"}])
-        self. _checkButlerDimension({"visit", "instrument"},
-                                    "visit=101",
-                                    [{"instrument": "notACam", "visit": 101},
-                                     {"instrument": "dummyCam", "visit": 101}])
-        self. _checkButlerDimension({"visit", "instrument"},
-                                    "visit=102",
-                                    [{"instrument": "notACam", "visit": 102},
-                                     {"instrument": "dummyCam", "visit": 102}])
-        self. _checkButlerDimension({"detector", "instrument"},
-                                    "detector=5",
-                                    [{"instrument": "notACam", "detector": 5},
-                                     {"instrument": "dummyCam", "detector": 5}])
+        self._checkButlerDimension({"instrument"},
+                                   "instrument='notACam'",
+                                   [{"instrument": "notACam"}, {"instrument": "dummyCam"}])
+        self._checkButlerDimension({"visit", "instrument"},
+                                   "visit=101",
+                                   [{"instrument": "notACam", "visit": 101},
+                                    {"instrument": "dummyCam", "visit": 101}])
+        self._checkButlerDimension({"visit", "instrument"},
+                                   "visit=102",
+                                   [{"instrument": "notACam", "visit": 102},
+                                    {"instrument": "dummyCam", "visit": 102}])
+        self._checkButlerDimension({"detector", "instrument"},
+                                   "detector=5",
+                                   [{"instrument": "notACam", "detector": 5},
+                                    {"instrument": "dummyCam", "detector": 5}])
+
+    def testAddDataIdValue(self):
+        addDataIdValue(self.butler, "visit", 999)
+        self._checkButlerDimension({"visit", "instrument"},
+                                   "visit=999",
+                                   [{"instrument": "notACam", "visit": 999},
+                                    {"instrument": "dummyCam", "visit": 999}])
+
+        with self.assertRaises(ValueError):
+            addDataIdValue(self.butler, "NotADimension", 42)
+        with self.assertRaises(ValueError):
+            addDataIdValue(self.butler, "detector", "nonNumeric")
+
+        # No skymap defined
+        with self.assertRaises(RuntimeError):
+            addDataIdValue(self.butler, "tract", 42)
 
     def testAddDatasetType(self):
         # 1 for StructuredDataNoComponents, 4 for StructuredData


### PR DESCRIPTION
This PR refactors how data IDs are handled in `lsst.daf.butler.tests` to allow more flexible, more precise, and more intuitive test environment creation. The old API is discouraged but not deprecated. The PR also includes some other minor fixes and code improvements.