### PR TITLE
DM-28527: Move special-casing of '*' and empty lists into globToRegex.

### DIFF
--- a/python/lsst/daf/butler/script/queryDatasetTypes.py
+++ b/python/lsst/daf/butler/script/queryDatasetTypes.py
@@ -57,13 +57,7 @@ def queryDatasetTypes(repo, verbose, glob, components):
         collection names.
     """
     butler = Butler(repo)
-    expression = globToRegex(glob)
-    # Only pass expression to queryDatasetTypes if there is an expression to
-    # apply; otherwise let queryDatasetTypes use its default value.
-    kwargs = {}
-    if expression:
-        kwargs["expression"] = expression
-    datasetTypes = butler.registry.queryDatasetTypes(components=components, **kwargs)
+    datasetTypes = butler.registry.queryDatasetTypes(components=components, expression=globToRegex(glob))
     info: List[Any]
     if verbose:
         table = Table(array([(d.name, str(list(d.dimensions.names)) or "None", d.storageClass.name)

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -139,13 +139,9 @@ def queryDatasets(repo, glob, collections, where, find_first, show_uri):
     butler = Butler(repo)
 
     dataset: Any = globToRegex(glob)
-    if not dataset:
-        dataset = ...
 
-    if collections and not find_first:
+    if not find_first:
         collections = globToRegex(collections)
-    elif not collections:
-        collections = ...
 
     datasets = butler.registry.queryDatasets(datasetType=dataset,
                                              collections=collections,

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -31,10 +31,7 @@ def queryDimensionRecords(repo, element, datasets, collections, where, no_check)
     # Registry.queryDimensionRecords except for ``no_check``, which is the
     # inverse of ``check``.
 
-    if collections:
-        collections = globToRegex(collections)
-    else:
-        collections = ...
+    collections = globToRegex(collections)
 
     butler = Butler(repo)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,9 +255,9 @@ class GlobToRegexTestCase(unittest.TestCase):
 
     def testStarInList(self):
         """Test that if a one of the items in the expression list is a star
-        (stand-alone) then no search terms are returned (which implies no
-        restrictions) """
-        self.assertEqual(globToRegex(["foo", "*", "bar"]), [])
+        (stand-alone) then ``...`` is returned (which implies no restrictions)
+        """
+        self.assertIs(globToRegex(["foo", "*", "bar"]), ...)
 
     def testGlobList(self):
         """Test that a list of glob strings converts as expected to a regex and


### PR DESCRIPTION
All of the command-line scripts that used globToRegex previously had to special-case the empty list it would return when '\*' or an empty input list was encountered.  But we already had a consistent sentinal value - `...` - that we used for all of these cases.  By making globToRegex return that when '*' or an empty list is encountered, we can simplify the scripts and fix DM-28527, which was due to the lack of this special-casing in queryCollections.