### PR TITLE
unpinned pinned versions in requirements.txt

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,11 @@ jobs:
       - name: Install sqlite
         run: sudo apt-get install sqlite libyaml-dev
 
+      - name: Update pip/wheel infrastructure
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel
+
       - name: Install postgresql (server)
         run: sudo apt install postgresql
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,13 +26,6 @@ jobs:
       - name: Install postgresql (server)
         run: sudo apt install postgresql
 
-      # pip is pinned because of urllib pinning because of moto bug with
-      # responses
-      - name: Update pip/wheel infrastructure
-        run: |
-          python -m pip install --upgrade pip==20.2.4
-          pip install wheel
-
       - name: Install postgresql Python packages
         run: pip install psycopg2 testing.postgresql
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,5 @@ pyarrow >= 0.16
 responses >= 0.12.0
 urllib3 >= 1.25.10
 
-# We don't use mock directly, but something else (moto?) does
-mock >= 4.0.2
-
 # These are required by lsst.utils
 psutil >= 5.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,12 +14,11 @@ pandas >= 1.0
 numpy >= 1.17
 matplotlib >= 3.0.3
 pyarrow >= 0.16
-responses == 0.12.0
-urllib3 == 1.25
+responses >= 0.12.0
+urllib3 >= 1.25.10
 
-# We don't use mock directly, but something else (moto?) does and is
-# incompatible with mock == 4.0.3.
-mock == 4.0.2
+# We don't use mock directly, but something else (moto?) does
+mock >= 4.0.2
 
 # These are required by lsst.utils
 psutil >= 5.7


### PR DESCRIPTION
- Unpinned the versions of responses, urllib3, and mock in requirements.txt
- Removed pip downgrading step in build.yaml (build_and_test GitHub action)