### PR TITLE
DM-28964: add incremental progress reporting to daf_butler

### DIFF
--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -29,6 +29,7 @@ import yaml
 
 from .cliLog import CliLog
 from .opt import log_level_option, long_log_option
+from .progress import ClickProgressHandler
 from lsst.utils import doImport
 
 
@@ -308,7 +309,8 @@ class ButlerCLI(LoaderCLI):
 @click.command(cls=ButlerCLI, context_settings=dict(help_option_names=["-h", "--help"]))
 @log_level_option()
 @long_log_option()
-def cli(log_level, long_log):
+@ClickProgressHandler.option
+def cli(log_level, long_log, progress):
     # log_level is handled by get_command and list_commands, and is called in
     # one of those functions before this is called. long_log is handled by
     # setup_logging.

--- a/python/lsst/daf/butler/cli/progress.py
+++ b/python/lsst/daf/butler/cli/progress.py
@@ -1,0 +1,75 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from __future__ import annotations
+
+__all__ = ("ClickProgressHandler",)
+
+import click
+from typing import Any, ContextManager, Iterable, Optional, TypeVar
+
+from ..core.progress import ProgressBar, ProgressHandler, Progress
+
+_T = TypeVar("_T")
+
+
+class ClickProgressHandler(ProgressHandler):
+    """A `ProgressHandler` implementation that delegates to
+    `click.progressbar`.
+
+    Parameters
+    ----------
+    **kwargs
+        Additional keyword arguments to pass to `click.progressbar`.  May not
+        include ``iterable``, ``length``, or ``label``, as these are passed
+        directly from `get_progress_bar` arguments.
+    """
+    def __init__(self, **kwargs: Any):
+        self._kwargs = kwargs
+
+    @classmethod
+    def callback(cls, ctx, params, value):
+        """A `click` callback that installs this handler as the global handler
+        for progress bars.
+
+        Should usually be called only by the `option` method.
+        """
+        if value:
+            Progress.set_handler(cls())
+        else:
+            Progress.set_handler(None)
+
+    @classmethod
+    def option(cls, cmd: Any) -> Any:
+        """A `click` command decorator that adds a ``--progress`` option
+        that installs a default-constructed instance of this progress handler.
+        """
+        return click.option("--progress/--no-progress",
+                            help="Show a progress bar for slow operations when possible.",
+                            default=False,
+                            is_flag=True,
+                            callback=cls.callback)(cmd)
+
+    def get_progress_bar(self, iterable: Optional[Iterable[_T]], desc: Optional[str],
+                         total: Optional[int], level: int) -> ContextManager[ProgressBar[_T]]:
+        # Docstring inherited.
+        return click.progressbar(iterable, length=total, label=desc, **self._kwargs)

--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -27,3 +27,5 @@ from .fileDataset import *
 from . import time_utils
 from ._topology import *
 from .timespan import *
+from .progress import Progress
+from . import progress  # most symbols are only used by handler implementors

--- a/python/lsst/daf/butler/core/progress.py
+++ b/python/lsst/daf/butler/core/progress.py
@@ -1,0 +1,367 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("Progress", "ProgressBar", "ProgressHandler")
+
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+import logging
+from typing import (
+    ClassVar,
+    Collection,
+    ContextManager,
+    Generator,
+    Iterable,
+    Iterator,
+    Optional,
+    Protocol,
+    Tuple,
+    TypeVar,
+)
+
+_T = TypeVar("_T", covariant=True)
+_K = TypeVar("_K")
+_V = TypeVar("_V", bound=Collection)
+
+
+class ProgressBar(Protocol, Iterable[_T]):
+    """A structural interface for progress bars that wrap iterables.
+
+    An object conforming to this interface can be obtained from the
+    `Progress.bar` method.
+
+    Notes
+    -----
+    This interface is intentionally defined as the intersection of the progress
+    bar objects returned by the ``click`` and ``tqdm`` packages, allowing those
+    to directly satisfy code that uses this interface.
+    """
+
+    def update(self, n: int = 1) -> None:
+        """Increment the progress bar by the given amount.
+
+        Parameters
+        ----------
+        n : `int`, optional
+            Increment the progress bar by this many steps (defaults to ``1``).
+            Note that this is a relative increment, not an absolute progress
+            value.
+        """
+        pass
+
+
+class Progress:
+    """Public interface for reporting incremental progress in the butler and
+    related tools.
+
+    This class automatically creates progress bars (or not) depending on
+    whether a handle (see `ProgressHandler`) has been installed and the given
+    name and level are enabled.  When progress reporting is not enabled, it
+    returns dummy objects that can be used just like progress bars by calling
+    code.
+
+    Parameters
+    ----------
+    name : `str`
+        Name of the process whose progress is being reported.  This is in
+        general the name of a group of progress bars, not necessarily a single
+        one, and it should have the same form as a logger name.
+    level : `int`, optional
+        A `logging` level value (defaults to `logging.INFO`).  Progress
+        reporting is enabled if a logger with ``name`` is enabled for this
+        level, and a `ProgressHandler` has been installed.
+
+    Notes
+    -----
+    The progress system inspects the level for a name using the Python built-in
+    `logging` module, and may not respect level-setting done via the
+    ``lsst.log`` interface.  But while `logging` may be necessary to control
+    progress bar visibility, the progress system can still be used together
+    with either system for actual logging.
+    """
+
+    def __init__(self, name: str, level: int = logging.INFO) -> None:
+        self._name = name
+        self._level = level
+
+    # The active handler is held in a ContextVar to isolate unit tests run
+    # by pytest-xdist.  If butler codes is ever used in a real multithreaded
+    # or asyncio application _and_ we want progress bars, we'll have to set
+    # up per-thread handlers or similar.
+    _active_handler: ClassVar[Optional[ProgressHandler]] = None
+
+    @classmethod
+    def set_handler(cls, handler: Optional[ProgressHandler]) -> None:
+        """Set the (global) progress handler to the given instance.
+
+        This should only be called in very high-level code that can be
+        reasonably confident that it will dominate its current process, e.g.
+        at the initialization of a command-line script or Jupyter notebook.
+
+        Parameters
+        ----------
+        handler : `ProgressHandler` or `None`
+            Object that will handle all progress reporting.  May be set to
+            `None` to disable progress reporting.
+        """
+        cls._active_handler = handler
+
+    def is_enabled(self) -> bool:
+        """Check whether this process should report progress.
+
+        Returns
+        -------
+        enabled : `bool`
+            `True` if there is a `ProgressHandler` set and a logger with the
+            same name and level as ``self`` is enabled.
+        """
+        if self._active_handler is not None:
+            logger = logging.getLogger(self._name)
+            if logger.isEnabledFor(self._level):
+                return True
+        return False
+
+    def bar(
+        self,
+        iterable: Optional[Iterable[_T]] = None,
+        desc: Optional[str] = None,
+        total: Optional[int] = None,
+    ) -> ContextManager[ProgressBar[_T]]:
+        """Return a new progress bar context manager.
+
+        Parameters
+        ----------
+        iterable : `Iterable`, optional
+            An arbitrary Python iterable that will be iterated over when the
+            returned `ProgressBar` is.  If not provided, whether the progress
+            bar is iterable is handler-defined, but it may be updated manually.
+        desc: `str`, optional
+            A user-friendly description for this progress bar; usually appears
+            next to it.  If not provided, ``self.name`` is used (which is not
+            usually a user-friendly string, but may be appropriate for
+            debug-level progress).
+        total : `int`, optional
+            The total number of steps in this progress bar.  If not provided,
+            ``len(iterable)`` is used.  If that does not work, whether the
+            progress bar works at all is handler-defined, and hence this mode
+            should not be relied upon.
+
+        Returns
+        -------
+        bar : `ContextManager` [ `ProgressBar` ]
+            A context manager that returns an object satisfying the
+            `ProgressBar` interface when it is entered.
+        """
+        if self.is_enabled():
+            if desc is None:
+                desc = self._name
+            handler = self._active_handler
+            assert handler, "Guaranteed by `is_enabled` check above."
+            return handler.get_progress_bar(iterable, desc=desc, total=total, level=self._level)
+        return _NullProgressBar.context(iterable)
+
+    def wrap(
+        self,
+        iterable: Iterable[_T],
+        desc: Optional[str] = None,
+        total: Optional[int] = None,
+    ) -> Generator[_T, None, None]:
+        """Iterate over an object while reporting progress.
+
+        Parameters
+        ----------
+        iterable : `Iterable`
+            An arbitrary Python iterable to iterate over.
+        desc: `str`, optional
+            A user-friendly description for this progress bar; usually appears
+            next to it.  If not provided, ``self.name`` is used (which is not
+            usually a user-friendly string, but may be appropriate for
+            debug-level progress).
+        total : `int`, optional
+            The total number of steps in this progress bar.  If not provided,
+            ``len(iterable)`` is used.  If that does not work, whether the
+            progress bar works at all is handler-defined, and hence this mode
+            should not be relied upon.
+
+        Yields
+        ------
+        element
+            The same objects that iteration over ``iterable`` would yield.
+        """
+        with self.bar(iterable, desc=desc, total=total) as bar:
+            yield from bar
+
+    def iter_chunks(
+        self,
+        chunks: Collection[_V],
+        desc: Optional[str] = None,
+        total: Optional[int] = None,
+        skip_scalar: bool = True,
+    ) -> Generator[_V, None, None]:
+        """Wrap iteration over chunks of elements in a progress bar.
+
+        Parameters
+        ----------
+        chunks : `Collection`
+            A sized iterable whose elements are themselves both iterable and
+            sized (i.e. ``len(item)`` works).  If ``total`` is not provided,
+            this may not be a single-pass iteration, because an initial pass to
+            estimate the total number of elements is required.
+        desc: `str`, optional
+            A user-friendly description for this progress bar; usually appears
+            next to it.  If not provided, ``self.name`` is used (which is not
+            usually a user-friendly string, but may be appropriate for
+            debug-level progress).
+        total : `int`, optional
+            The total number of steps in this progress bar; defaults to the
+            sum of the lengths of the chunks.
+        skip_scalar: `bool`, optional
+            If `True` and there are zero or one chunks, do not report progress.
+
+        Yields
+        ------
+        chunk
+            The same objects that iteration over ``chunks`` would yield.
+        """
+        if skip_scalar and len(chunks) <= 1:
+            yield from chunks
+        else:
+            if total is None:
+                total = sum(len(c) for c in chunks)
+            with self.bar(desc=desc, total=total) as bar:  # type: ignore
+                for chunk in chunks:
+                    yield chunk
+                    bar.update(len(chunk))
+
+    def iter_item_chunks(
+        self,
+        items: Collection[Tuple[_K, _V]],
+        desc: Optional[str] = None,
+        total: Optional[int] = None,
+        skip_scalar: bool = True,
+    ) -> Generator[Tuple[_K, _V], None, None]:
+        """Wrap iteration over chunks of items in a progress bar.
+
+        Parameters
+        ----------
+        items : `Iterable`
+            A sized iterable whose elements are (key, value) tuples, where the
+            values are themselves both iterable and sized (i.e. ``len(item)``
+            works).  If ``total`` is not provided, this may not be a
+            single-pass iteration, because an initial pass to estimate the
+            total number of elements is required.
+        desc: `str`, optional
+            A user-friendly description for this progress bar; usually appears
+            next to it.  If not provided, ``self.name`` is used (which is not
+            usually a user-friendly string, but may be appropriate for
+            debug-level progress).
+        total : `int`, optional
+            The total number of values in this progress bar; defaults to the
+            sum of the lengths of the chunks.
+        skip_scalar: `bool`, optional
+            If `True` and there are zero or one items, do not report progress.
+
+        Yields
+        ------
+        chunk
+            The same items that iteration over ``chunks`` would yield.
+        """
+        if skip_scalar and len(items) <= 1:
+            yield from items
+        else:
+            if total is None:
+                total = sum(len(v) for _, v in items)
+            with self.bar(desc=desc, total=total) as bar:  # type: ignore
+                for key, chunk in items:
+                    yield key, chunk
+                    bar.update(len(chunk))
+
+
+class ProgressHandler(ABC):
+    """An interface for objects that can create progress bars.
+    """
+
+    @abstractmethod
+    def get_progress_bar(self, iterable: Optional[Iterable[_T]], desc: str,
+                         total: Optional[int], level: int) -> ContextManager[ProgressBar[_T]]:
+        """Create a new progress bar.
+
+        Parameters
+        ----------
+        iterable : `Iterable` or `None`
+            An arbitrary Python iterable that will be iterated over when the
+            returned `ProgressBar` is.  If `None`, whether the progress bar is
+            iterable is handler-defined, but it may be updated manually.
+        desc: `str`
+            A user-friendly description for this progress bar; usually appears
+            next to it
+        total : `int` or `None`
+            The total number of steps in this progress bar.  If `None``,
+            ``len(iterable)`` should be used.  If that does not work, whether
+            the progress bar works at all is handler-defined.
+        level : `int`
+            A `logging` level value (defaults to `logging.INFO`) associated
+            with the process reporting progress.  Handlers are not responsible
+            for disabling progress reporting on levels, but may utilize level
+            information to annotate them differently.
+        """
+        raise NotImplementedError()
+
+
+class _NullProgressBar(Iterable[_T]):
+    """A trivial implementation of `ProgressBar` that does nothing but pass
+    through its iterable's elements.
+
+    Parameters
+    ----------
+    iterable : `Iterable` or `None`
+        An arbitrary Python iterable that will be iterated over when ``self``
+        is.
+    """
+
+    def __init__(self, iterable: Optional[Iterable[_T]]):
+        self._iterable = iterable
+
+    @classmethod
+    @contextmanager
+    def context(cls, iterable: Optional[Iterable[_T]]) -> Generator[_NullProgressBar[_T], None, None]:
+        """Return a trivial context manager that wraps an instance of this
+        class.
+
+        This context manager doesn't actually do anything other than allow this
+        do-nothing implementation to be used in `Progress.bar`.
+
+        Parameters
+        ----------
+        iterable : `Iterable` or `None`
+            An arbitrary Python iterable that will be iterated over when the
+            returned object is.
+        """
+        yield cls(iterable)
+
+    def __iter__(self) -> Iterator[_T]:
+        assert self._iterable is not None, "Cannot iterate over progress bar initialized without iterable."
+        return iter(self._iterable)
+
+    def update(self, n: int = 1) -> None:
+        pass

--- a/python/lsst/daf/butler/core/progress.py
+++ b/python/lsst/daf/butler/core/progress.py
@@ -141,6 +141,24 @@ class Progress:
                 return True
         return False
 
+    def at(self, level: int) -> Progress:
+        """Return a copy of this progress interface with a different level.
+
+        Parameters
+        ----------
+        level : `int`
+            A `logging` level value.  Progress reporting is enabled if a logger
+            with ``name`` is enabled for this level, and a `ProgressHandler`
+            has been installed.
+
+        Returns
+        -------
+        progress : `Progress`
+            A new `Progress` object with the same name as ``self`` and the
+            given ``level``.
+        """
+        return Progress(self._name, level)
+
     def bar(
         self,
         iterable: Optional[Iterable[_T]] = None,

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -65,6 +65,7 @@ from lsst.daf.butler import (
     FormatterFactory,
     Location,
     LocationFactory,
+    Progress,
     StorageClass,
     StoredFileInfo,
 )
@@ -889,7 +890,8 @@ class FileDatastore(GenericBaseDatastore):
     def _finishIngest(self, prepData: Datastore.IngestPrepData, *, transfer: Optional[str] = None) -> None:
         # Docstring inherited from Datastore._finishIngest.
         refsAndInfos = []
-        for dataset in prepData.datasets:
+        progress = Progress("lsst.daf.butler.datastores.FileDatastore.ingest", level=logging.DEBUG)
+        for dataset in progress.wrap(prepData.datasets, desc="Ingesting dataset files"):
             # Do ingest as if the first dataset ref is associated with the file
             info = self._extractIngestInfo(dataset.path, dataset.refs[0], formatter=dataset.formatter,
                                            transfer=transfer)
@@ -1670,7 +1672,8 @@ class FileDatastore(GenericBaseDatastore):
             if not directoryUri.exists():
                 raise FileNotFoundError(f"Export location {directory} does not exist")
 
-        for ref in refs:
+        progress = Progress("lsst.daf.butler.datastores.FileDatastore.export", level=logging.DEBUG)
+        for ref in progress.wrap(refs, "Exporting dataset files"):
             fileLocations = self._get_dataset_locations_info(ref)
             if not fileLocations:
                 raise FileNotFoundError(f"Could not retrieve dataset {ref}.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,6 @@ convention = numpy
 # Our docstyle documents __init__ at the class level (D107)
 # We allow methods to inherit docstrings and this is not compatible with D102.
 # Docstring at the very first line is not required
-# D205 and D400 both complain if the first sentence of the docstring does not
-# fit on one line.
-add-ignore = D107, D105, D102, D100, D205, D400
+# D200, D205 and D400 all complain if the first sentence of the docstring does
+# not fit on one line.
+add-ignore = D107, D105, D102, D100, D200, D205, D400

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,209 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from contextlib import contextmanager
+import logging
+import unittest
+
+import click
+
+from lsst.daf.butler.core.progress import Progress, ProgressHandler
+from lsst.daf.butler.cli.utils import clickResultMsg
+from lsst.daf.butler.cli.progress import ClickProgressHandler
+
+
+class MockProgressBar:
+    """Mock implementation of `ProgressBar` that remembers the status it
+    would report in a list.
+
+    Both the initial 0 and the end-of-iterable size are reported.
+
+    Parameters
+    ----------
+    iterable : `Iterable`, optional
+        Iterable to wrap, or `None`.
+    """
+    def __init__(self, iterable):
+        self._iterable = iterable
+        self._current = 0
+        self.reported = [self._current]
+        MockProgressBar.last = self
+
+    last = None
+    """Last instance of this class that was constructed, for test code that
+    cannot access it directly via other means.
+    """
+
+    def __iter__(self):
+        for element in self._iterable:
+            yield element
+            self._current += 1
+            self.reported.append(self._current)
+
+    def update(self, n: int = 1) -> None:
+        self._current += n
+        self.reported.append(self._current)
+
+
+class MockProgressHandler(ProgressHandler):
+    """A `ProgressHandler` implementation that returns `MockProgressBar`
+    instances.
+    """
+    @contextmanager
+    def get_progress_bar(self, iterable, desc, total, level):
+        yield MockProgressBar(iterable)
+
+
+class ClickProgressHandlerTestCase(unittest.TestCase):
+    """Test enabling and disabling progress in click commands.
+
+    It looks like click's testing harness doesn't ever actually let its
+    progress bar generate output, so the best we can do is check that using it
+    doesn't raise exceptions, and see if it looks like we're doing something
+    based on what our own progress-object state is.
+    """
+
+    def setUp(self):
+        # Set up a mock handler by default.  Tests of click behavior will
+        # rely on this when they check that inside a click command we never
+        # end up with that mock.
+        self.logger = logging.getLogger("test_progress")
+        self.logger.setLevel(logging.INFO)
+        Progress.set_handler(MockProgressHandler())
+        self.runner = click.testing.CliRunner()
+
+    def tearDown(self):
+        MockProgressHandler.last = None
+        Progress.set_handler(None)
+        self.logger.setLevel(logging.NOTSET)
+
+    def get_cmd(self, level, enabled):
+        """Return a click command that uses a progress bar and tests that it
+        is or not enabled, as given.
+        """
+
+        @click.command()
+        @ClickProgressHandler.option
+        def cmd(progress):
+            p = Progress("test_progress", level=level)
+            with p.bar(range(5), desc="testing!") as bar:
+                self.assertFalse(isinstance(bar, MockProgressBar))
+                r = list(bar)
+            self.assertEqual(r, list(range(5)))
+            self.assertEqual(enabled, p.is_enabled())
+
+        return cmd
+
+    def test_click_disabled_by_default(self):
+        """Test that progress is disabled by default in click commands.
+        """
+        result = self.runner.invoke(
+            self.get_cmd(logging.INFO, enabled=False),
+            [],
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+    def test_click_enabled(self):
+        """Test turning on progress in click commands.
+        """
+        result = self.runner.invoke(
+            self.get_cmd(logging.INFO, enabled=True),
+            ["--progress"],
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+    def test_click_disabled_globally(self):
+        """Test turning on progress in click commands.
+        """
+        result = self.runner.invoke(
+            self.get_cmd(logging.INFO, enabled=False),
+            ["--no-progress"],
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+    def test_click_disabled_by_log_level(self):
+        """Test that progress reports below the current log level are disabled,
+        even if progress is globally enabled.
+        """
+        result = self.runner.invoke(
+            self.get_cmd(logging.DEBUG, enabled=False),
+            ["--progress"],
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+
+class MockedProgressHandlerTestCase(unittest.TestCase):
+    """Test that the interface layer for progress reporting works by using
+    mock handler and progress bar objects.
+    """
+
+    def setUp(self):
+        self.logger = logging.getLogger("test_progress")
+        self.logger.setLevel(logging.INFO)
+        Progress.set_handler(MockProgressHandler())
+        self.progress = Progress("test_progress")
+
+    def tearDown(self):
+        MockProgressHandler.last = None
+        Progress.set_handler(None)
+        self.logger.setLevel(logging.NOTSET)
+
+    def test_bar_iterable(self):
+        """Test using `Progress.bar` to wrap an iterable.
+        """
+        iterable = list(range(5))
+        with self.progress.bar(iterable) as bar:
+            r = list(bar)
+        self.assertEqual(r, iterable)
+        self.assertEqual(iterable + [len(iterable)], bar.reported)
+
+    def test_bar_update(self):
+        """Test using `Progress.bar` with manual updates.
+        """
+        with self.progress.bar(total=10) as bar:
+            for i in range(5):
+                bar.update(2)
+        self.assertEqual(list(range(0, 12, 2)), bar.reported)
+
+    def test_iter_chunks(self):
+        """Test using `Progress.iter_chunks`.
+        """
+        iterable = [list(range(2)), list(range(3))]
+        seen = []
+        for chunk in self.progress.iter_chunks(iterable):
+            seen.extend(chunk)
+        self.assertEqual(seen, iterable[0] + iterable[1])
+        self.assertEqual(MockProgressBar.last.reported, [0, 2, 5])
+
+    def test_iter_item_chunks(self):
+        """Test using `Progress.iter_item_chunks`.
+        """
+        mapping = {"x": list(range(2)), "y": list(range(3))}
+        seen = {}
+        for key, chunk in self.progress.iter_item_chunks(mapping.items()):
+            seen[key] = chunk
+        self.assertEqual(seen, mapping)
+        self.assertEqual(MockProgressBar.last.reported, [0, 2, 5])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This creates an abstract interface to allow at least daf_butler and some downstream middleware code to report progress in a way that would let higher-level tools show progress bars.  It also makes a start at letting click-based command-line tools actually show those progress bars, but that's disabled by default as I'm not sure how it interacts with logging.

I haven't actually instrumented too many points in `daf_butler` - just a few known hot spots, like datastore transfers and loops over `expandDataId` in` Registry` - and there may not be much more we can do there, because we've actually done a pretty good job of vectorizing things, and that means a lot of slow operations are single commands from our perspective (and there's no way to e.g. get incremental progress on a query from the database).  But if the middleware pundits are happy with the approach I've taken here, I'll go ahead and instrument at least `BaseSkyMap.register`, `RawIngestTask`, and `ConvertRepoTask` (on this ticket), where we certainly have lots of loops that would benefit from this kind of reporting.