### PR TITLE
DM-28717: Allow for Stamps formatter to handle bbox

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -186,8 +186,12 @@ storageClasses:
     pytype: lsst.verify.Measurement
   Stamps:
     pytype: lsst.meas.algorithms.Stamps
+    parameters:
+      - bbox
   BrightStarStamps:
     pytype: lsst.meas.algorithms.brightStarStamps.BrightStarStamps
+    parameters:
+      - bbox
   AstropyTable:
     pytype: astropy.table.Table
   AstropyQTable:


### PR DESCRIPTION
One of four PRs for [DM-28717](https://jira.lsstcorp.org/browse/DM-28717), the others being afw, obs_base and meas_algorithms.