### PR TITLE
DM-29106: allow Datastore to "forget" datasets and add a new Butler method to use it.

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1160,6 +1160,49 @@ class Butler:
         ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwds)
         return self.datastore.exists(ref)
 
+    def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
+        """Remove one or more `~CollectionType.RUN` collections and the
+        datasets within them.
+
+        Parameters
+        ----------
+        names : `Iterable` [ `str` ]
+            The names of the collections to remove.
+        unstore : `bool`, optional
+            If `True` (default), delete datasets from all datastores in which
+            they are present, and attempt to rollback the registry deletions if
+            datastore deletions fail (which may not always be possible).  If
+            `False`, datastore records for these datasets are still removed,
+            but any artifacts (e.g. files) will not be.
+
+        Raises
+        ------
+        TypeError
+            Raised if one or more collections are not of type
+            `~CollectionType.RUN`.
+        """
+        if not self.isWriteable():
+            raise TypeError("Butler is read-only.")
+        names = list(names)
+        refs: List[DatasetRef] = []
+        for name in names:
+            collectionType = self.registry.getCollectionType(name)
+            if collectionType is not CollectionType.RUN:
+                raise TypeError(f"The collection type of '{name}' is {collectionType.name}, not RUN.")
+            refs.extend(self.registry.queryDatasets(..., collections=name, findFirst=True))
+        with self.registry.transaction():
+            if unstore:
+                for ref in refs:
+                    if self.datastore.exists(ref):
+                        self.datastore.trash(ref)
+            else:
+                self.datastore.forget(refs)
+            for name in names:
+                self.registry.removeCollection(name)
+        if unstore:
+            # Point of no return for removing artifacts
+            self.datastore.emptyTrash()
+
     def pruneCollection(self, name: str, purge: bool = False, unstore: bool = False) -> None:
         """Remove a collection and possibly prune datasets within it.
 

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -787,9 +787,13 @@ class Butler:
             if allowUnresolved:
                 return DatasetRef(datasetType, dataId)
             else:
+                if collections is None:
+                    collections = self.registry.defaults.collections
                 raise LookupError(f"Dataset {datasetType.name} with data ID {dataId} "
                                   f"could not be found in collections {collections}.")
         if idNumber is not None and idNumber != ref.id:
+            if collections is None:
+                collections = self.registry.defaults.collections
             raise ValueError(f"DatasetRef.id provided ({idNumber}) does not match "
                              f"id ({ref.id}) in registry in collections {collections}.")
         return ref

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -646,6 +646,23 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
+    def forget(self, refs: Iterable[DatasetRef]) -> None:
+        """Indicate to the Datastore that it should remove all records of the
+        given datasets, without actually deleting them.
+
+        Parameters
+        ----------
+        refs : `Iterable` [ `DatasetRef` ]
+            References to the datasets being forgotten.
+
+        Notes
+        -----
+        Asking a datastore to forget a `DatasetRef` it does not hold should be
+        a silent no-op, not an error.
+        """
+        raise NotImplementedError("Must be implemented by subclass")
+
+    @abstractmethod
     def trash(self, datasetRef: DatasetRef, ignore_errors: bool = True) -> None:
         """Indicate to the Datastore that a Dataset can be moved to the trash.
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -551,6 +551,10 @@ class ChainedDatastore(Datastore):
         self.trash(ref, ignore_errors=False)
         self.emptyTrash(ignore_errors=False)
 
+    def forget(self, refs: Iterable[DatasetRef]) -> None:
+        for datastore in tuple(self.datastores):
+            datastore.forget(refs)
+
     def trash(self, ref: DatasetRef, ignore_errors: bool = True) -> None:
         log.debug("Trashing %s", ref)
 

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1573,6 +1573,13 @@ class FileDatastore(GenericBaseDatastore):
                             f"of {self.name}"
                         ) from e
 
+    @transactional
+    def forget(self, refs: Iterable[DatasetRef]) -> None:
+        # Docstring inherited.
+        refs = list(refs)
+        self.bridge.forget(refs)
+        self._table.delete(["dataset_id"], *[{"dataset_id": ref.getCheckedId()} for ref in refs])
+
     def validateConfiguration(self, entities: Iterable[Union[DatasetRef, DatasetType, StorageClass]],
                               logFailures: bool = False) -> None:
         """Validate some of the configuration for this datastore.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -328,6 +328,8 @@ class FileDatastore(GenericBaseDatastore):
         location : `Location`
             Location of the artifact associated with this datastore.
         """
+        if location.pathInStore.isabs():
+            raise RuntimeError(f"Cannot delete artifact with absolute uri {location.uri}.")
         log.debug("Deleting file: %s", location.uri)
         location.uri.remove()
         log.debug("Successfully deleted file: %s", location.uri)
@@ -442,6 +444,9 @@ class FileDatastore(GenericBaseDatastore):
         can_remove : `Bool`
             True if the artifact can be safely removed.
         """
+        # Can't ever delete absolute URIs.
+        if location.pathInStore.isabs():
+            return False
 
         # Get all entries associated with this path
         allRefs = self._registered_refs_per_artifact(location.pathInStore)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -394,7 +394,7 @@ class FileDatastore(GenericBaseDatastore):
 
     def removeStoredItemInfo(self, ref: DatasetIdRef) -> None:
         # Docstring inherited from GenericBaseDatastore
-        self._table.delete(dataset_id=ref.id)
+        self._table.delete(["dataset_id"], {"dataset_id": ref.id})
 
     def _get_dataset_locations_info(self, ref: DatasetIdRef) -> List[Tuple[Location, StoredFileInfo]]:
         r"""Find all the `Location`\ s  of the requested dataset in the
@@ -1568,7 +1568,10 @@ class FileDatastore(GenericBaseDatastore):
                                     ref.id, location.uri, self.name, e)
                         continue
                     else:
-                        raise FileNotFoundError(err_msg)
+                        raise FileNotFoundError(
+                            f"Error removing dataset {ref.id} ({location.uri}) from internal registry "
+                            f"of {self.name}"
+                        ) from e
 
     def validateConfiguration(self, entities: Iterable[Union[DatasetRef, DatasetType, StorageClass]],
                               logFailures: bool = False) -> None:

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -462,6 +462,13 @@ class InMemoryDatastore(GenericBaseDatastore):
             raise AssertionError(f"Unexpectedly got no URI for in-memory datastore for {ref}")
         return primary
 
+    def forget(self, refs: Iterable[DatasetRef]) -> None:
+        # Docstring inherited.
+        refs = list(refs)
+        self._bridge.forget(refs)
+        for ref in refs:
+            self.removeStoredItemInfo(ref)
+
     def trash(self, ref: DatasetRef, ignore_errors: bool = False) -> None:
         """Indicate to the Datastore that a dataset can be removed.
 

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -387,7 +387,7 @@ class Registry:
             keyword arguments are column names and values are the values they
             must have.
         """
-        self._managers.opaque[tableName].delete(**where)
+        self._managers.opaque[tableName].delete(where.keys(), where)
 
     def registerCollection(self, name: str, type: CollectionType = CollectionType.TAGGED,
                            doc: Optional[str] = None) -> None:

--- a/python/lsst/daf/butler/registry/bridge/ephemeral.py
+++ b/python/lsst/daf/butler/registry/bridge/ephemeral.py
@@ -54,6 +54,9 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Docstring inherited from DatastoreRegistryBridge
         self._datasetIds.update(ref.getCheckedId() for ref in refs)
 
+    def forget(self, refs: Iterable[DatasetIdRef]) -> None:
+        self._datasetIds.difference_update(ref.id for ref in refs)
+
     def moveToTrash(self, refs: Iterable[DatasetIdRef]) -> None:
         # Docstring inherited from DatastoreRegistryBridge
         self._trashedIds.update(ref.getCheckedId() for ref in refs)

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -148,6 +148,11 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Docstring inherited from DatastoreRegistryBridge
         self._db.insert(self._tables.dataset_location, *self._refsToRows(refs))
 
+    def forget(self, refs: Iterable[DatasetIdRef]) -> None:
+        # Docstring inherited from DatastoreRegistryBridge
+        rows = self._refsToRows(self.check(refs))
+        self._db.delete(self._tables.dataset_location, ["datastore_name", "dataset_id"], *rows)
+
     def moveToTrash(self, refs: Iterable[DatasetIdRef]) -> None:
         # Docstring inherited from DatastoreRegistryBridge
         # TODO: avoid self.check() call via queries like

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -134,6 +134,26 @@ class DatastoreRegistryBridge(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def forget(self, refs: Iterable[DatasetIdRef]) -> None:
+        """Remove dataset location information without any attempt to put it
+        in the trash while waiting for external deletes.
+
+        This should be used only to implement `Datastore.forget`, or in cases
+        where deleting the actual datastore artifacts cannot fail.
+
+        Parameters
+        ----------
+        refs : `Iterable` of `DatasetIdRef`
+            References to the datasets.
+
+        Raises
+        ------
+        AmbiguousDatasetError
+            Raised if ``any(ref.id is None for ref in refs)``.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def moveToTrash(self, refs: Iterable[DatasetIdRef]) -> None:
         """Move dataset location information to trash.
 

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1396,7 +1396,7 @@ class Database(ABC):
         *rows
             Positional arguments are the keys of rows to be deleted, as
             dictionaries mapping column name to value.  The keys in all
-            dictionaries must exactly the names in ``columns``.
+            dictionaries must be exactly the names in ``columns``.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -28,6 +28,7 @@ __all__ = ["OpaqueTableStorageManager", "OpaqueTableStorage"]
 from abc import ABC, abstractmethod
 from typing import (
     Any,
+    Iterable,
     Iterator,
     Optional,
 )
@@ -81,16 +82,19 @@ class OpaqueTableStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def delete(self, **where: Any) -> None:
+    def delete(self, columns: Iterable[str], *rows: dict) -> None:
         """Remove records from an opaque table.
 
         Parameters
         ----------
-        **where
-            Additional keyword arguments are interpreted as equality
-            constraints that restrict the deleted rows (combined with AND);
-            keyword arguments are column names and values are the values they
-            must have.
+        columns: `~collections.abc.Iterable` of `str`
+            The names of columns that will be used to constrain the rows to
+            be deleted; these will be combined via ``AND`` to form the
+            ``WHERE`` clause of the delete query.
+        *rows
+            Positional arguments are the keys of rows to be deleted, as
+            dictionaries mapping column name to value.  The keys in all
+            dictionaries must be exactly the names in ``columns``.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -29,6 +29,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    Iterable,
     Iterator,
     Optional,
 )
@@ -84,9 +85,9 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         for row in self._db.query(sql):
             yield dict(row)
 
-    def delete(self, **where: Any) -> None:
+    def delete(self, columns: Iterable[str], *rows: dict) -> None:
         # Docstring inherited from OpaqueTableStorage.
-        self._db.delete(self._table, where.keys(), where)
+        self._db.delete(self._table, columns, *rows)
 
 
 class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):

--- a/python/lsst/daf/butler/tests/_dummyRegistry.py
+++ b/python/lsst/daf/butler/tests/_dummyRegistry.py
@@ -63,13 +63,16 @@ class DummyOpaqueTableStorage(OpaqueTableStorage):
             if all(d[k] == v for k, v in where.items()):
                 yield d
 
-    def delete(self, **where: Any):
+    def delete(self, columns: Iterable[str], *rows: dict):
         # Docstring inherited from OpaqueTableStorage.
-        kept = []
-        for d in self._rows:
-            if not all(d[k] == v for k, v in where.items()):
-                kept.append(d)
-        self._rows = kept
+        kept_rows = []
+        for table_row in self._rows:
+            for where_row in rows:
+                if all(table_row[k] == v for k, v in where_row.items()):
+                    break
+                else:
+                    kept_rows.append(table_row)
+        self._rows = kept_rows
 
 
 class DummyOpaqueTableStorageManager(OpaqueTableStorageManager):

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,4 +66,6 @@ convention = numpy
 # Our docstyle documents __init__ at the class level (D107)
 # We allow methods to inherit docstrings and this is not compatible with D102.
 # Docstring at the very first line is not required
-add-ignore = D107, D105, D102, D100
+# D205 and D400 both complain if the first sentence of the docstring does not
+# fit on one line.
+add-ignore = D107, D105, D102, D100, D205, D400

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -64,7 +64,7 @@ from lsst.daf.butler import FileDataset
 from lsst.daf.butler import CollectionSearch, CollectionType
 from lsst.daf.butler import ButlerURI
 from lsst.daf.butler import script
-from lsst.daf.butler.registry import MissingCollectionError, OrphanedRecordError
+from lsst.daf.butler.registry import MissingCollectionError
 from lsst.daf.butler.core.repoRelocation import BUTLER_ROOT_TAG
 from lsst.daf.butler.core._butlerUri.s3utils import (setAwsEnvCredentials,
                                                      unsetAwsEnvCredentials)
@@ -584,26 +584,6 @@ class ButlerTests(ButlerPutGetTests):
         ref1 = butler.put(metric, datasetType, {"instrument": "Cam1", "physical_filter": "Cam1-G"}, run=run1)
         ref2 = butler.put(metric, datasetType, {"instrument": "Cam1", "physical_filter": "Cam1-G"}, run=run2)
         ref3 = butler.put(metric, datasetType, {"instrument": "Cam1", "physical_filter": "Cam1-R1"}, run=run1)
-
-        # Add a new dataset type and delete it
-        tmpName = "prune_collections_disposable"
-        tmpDatasetType = self.addDatasetType(tmpName, dimensions, storageClass,
-                                             butler.registry)
-        tmpFromRegistry = butler.registry.getDatasetType(tmpName)
-        self.assertEqual(tmpDatasetType, tmpFromRegistry)
-        butler.registry.removeDatasetType(tmpName)
-        with self.assertRaises(KeyError):
-            butler.registry.getDatasetType(tmpName)
-        # Removing a second time is fine
-        butler.registry.removeDatasetType(tmpName)
-
-        # Component removal is not allowed
-        with self.assertRaises(ValueError):
-            butler.registry.removeDatasetType(DatasetType.nameWithComponent(tmpName, "component"))
-
-        # Try and fail to delete a datasetType that is associated with data
-        with self.assertRaises(OrphanedRecordError):
-            butler.registry.removeDatasetType(datasetType.name)
 
         # Try to delete a RUN collection without purge, or with purge and not
         # unstore.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -967,6 +967,42 @@ class FileDatastoreButlerTests(ButlerTests):
                 self.assertEqual(list(importButler.registry.queryDimensionRecords("skymap")),
                                  [importButler.registry.dimensions["skymap"].RecordClass(**skymapRecord)])
 
+    def testRemoveRuns(self):
+        storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
+        butler = Butler(self.tmpConfigFile, writeable=True)
+        # Load registry data with dimensions to hang datasets off of.
+        registryDataDir = os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
+        butler.import_(filename=os.path.join(registryDataDir, "base.yaml"))
+        # Add some RUN-type collection.
+        run1 = "run1"
+        butler.registry.registerRun(run1)
+        run2 = "run2"
+        butler.registry.registerRun(run2)
+        # put a dataset in each
+        metric = makeExampleMetrics()
+        dimensions = butler.registry.dimensions.extract(["instrument", "physical_filter"])
+        datasetType = self.addDatasetType("prune_collections_test_dataset", dimensions, storageClass,
+                                          butler.registry)
+        ref1 = butler.put(metric, datasetType, {"instrument": "Cam1", "physical_filter": "Cam1-G"}, run=run1)
+        ref2 = butler.put(metric, datasetType, {"instrument": "Cam1", "physical_filter": "Cam1-G"}, run=run2)
+        uri1 = butler.getURI(ref1, collections=[run1])
+        uri2 = butler.getURI(ref2, collections=[run2])
+        # Remove from both runs with different values for unstore.
+        butler.removeRuns([run1], unstore=True)
+        butler.removeRuns([run2], unstore=False)
+        # Should be nothing in registry for either one, and datastore should
+        # not think either exists.
+        with self.assertRaises(MissingCollectionError):
+            butler.registry.getCollectionType(run1)
+        with self.assertRaises(MissingCollectionError):
+            butler.registry.getCollectionType(run2)
+        self.assertFalse(butler.datastore.exists(ref1))
+        self.assertFalse(butler.datastore.exists(ref2))
+        # The ref we unstored should be gone according to the URI, but the
+        # one we forgot should still be around.
+        self.assertFalse(uri1.exists())
+        self.assertTrue(uri2.exists())
+
 
 class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
     """PosixDatastore specialization of a butler"""


### PR DESCRIPTION
This is nominally ready for review, but it raises questions about the future that we should probably resolve before merging:

 - Is it okay that I'm introducing `Butler.removeRuns` and sort of abandoning `Butler.pruneCollection` with this ticket (see https://community.lsst.org/t/simplifying-and-limiting-deletion-in-gen3-butler-repos/4808)?

 - Is it sufficiently easy/important to make forget-rather-than-unstore automatic for absolute-URL ingests that I should just do it here, or is that a separate ticket?