### PR TITLE
DM-25965: Add ButlerURI.abspath() method

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -84,7 +84,7 @@ from .core.repoRelocation import BUTLER_ROOT_TAG
 from .core.utils import transactional, getClassOf
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._butlerConfig import ButlerConfig
-from .registry import Registry, RegistryConfig, RegistryDefaults, CollectionType
+from .registry import Registry, RegistryConfig, RegistryDefaults, CollectionType, ConflictingDefinitionError
 from .registry.wildcards import CollectionSearch
 from .transfers import RepoExportContext
 
@@ -1433,6 +1433,11 @@ class Butler:
             # associated with `dataset`.
             resolvedRefs: List[DatasetRef] = []
             for ref in dataset.refs:
+                if ref.dataId in groupedData[ref.datasetType]:
+                    raise ConflictingDefinitionError(f"Ingest conflict. Dataset {dataset.path} has same"
+                                                     " DataId as other ingest dataset"
+                                                     f" {groupedData[ref.datasetType][ref.dataId][0].path} "
+                                                     f" ({ref.dataId})")
                 groupedData[ref.datasetType][ref.dataId] = (dataset, resolvedRefs)
 
         # Now we can bulk-insert into Registry for each DatasetType.

--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -621,6 +621,17 @@ class ButlerURI:
         """
         return True
 
+    def abspath(self) -> ButlerURI:
+        """Return URI using an absolute path.
+
+        Returns
+        -------
+        abs : `ButlerURI`
+            Absolute URI. For non-schemeless URIs this always returns itself.
+            Schemeless URIs are upgraded to file URIs.
+        """
+        return self
+
     def _as_local(self) -> Tuple[str, bool]:
         """Return the location of the (possibly remote) resource as local file.
 

--- a/python/lsst/daf/butler/core/_butlerUri/file.py
+++ b/python/lsst/daf/butler/core/_butlerUri/file.py
@@ -104,24 +104,6 @@ class ButlerFileURI(ButlerURI):
         """
         return self.ospath, False
 
-    def _force_to_file(self) -> ButlerFileURI:
-        """Force a schemeless URI to a file URI and returns a new URI.
-
-        Returns
-        -------
-        file : `ButlerFileURI`
-            A copy of the URI using file scheme. If already a file scheme
-            the copy will be identical.
-
-        Raises
-        ------
-        ValueError
-            Raised if this URI is schemeless and relative path and so can
-            not be forced to file absolute path without context.
-        """
-        # This is always a file scheme so always return copy
-        return copy.copy(self)
-
     def relative_to(self, other: ButlerURI) -> Optional[str]:
         """Return the relative path from this URI to the other URI.
 
@@ -177,7 +159,7 @@ class ButlerFileURI(ButlerURI):
         # forcing to file is fine.
         # Use a cast to convince mypy that other has to be a ButlerFileURI
         # in order to get to this part of the code.
-        return self._force_to_file().relative_to(cast(ButlerFileURI, other)._force_to_file())
+        return self.abspath().relative_to(cast(ButlerFileURI, other).abspath())
 
     def read(self, size: int = -1) -> bytes:
         """Return the entire content of the file as bytes."""

--- a/python/lsst/daf/butler/core/_butlerUri/schemeless.py
+++ b/python/lsst/daf/butler/core/_butlerUri/schemeless.py
@@ -68,28 +68,27 @@ class ButlerSchemelessURI(ButlerFileURI):
         """
         return os.path.isabs(self.ospath)
 
-    def _force_to_file(self) -> ButlerFileURI:
-        """Force a schemeless URI to a file URI and returns a new URI.
+    def abspath(self) -> ButlerURI:
+        """Force a schemeless URI to a file URI.
 
         This will include URI quoting of the path.
 
         Returns
         -------
         file : `ButlerFileURI`
-            A copy of the URI using file scheme. If already a file scheme
-            the copy will be identical.
+            A new URI using file scheme.
 
-        Raises
-        ------
-        ValueError
-            Raised if this URI is schemeless and relative path and so can
-            not be forced to file absolute path without context.
+        Notes
+        -----
+        The current working directory will be used to convert this scheme-less
+        URI to an absolute path.
         """
-        if not self.isabs():
-            raise RuntimeError(f"Internal error: Can not force {self} to absolute file URI")
-        uri = self._uri._replace(scheme="file", path=urllib.parse.quote(os2posix(self.path)))
-        # mypy really wants a ButlerFileURI to be returned here
-        return ButlerURI(uri, forceDirectory=self.dirLike)  # type: ignore
+        # Convert this URI to a string so that any fragments will be
+        # processed correctly by the ButlerURI constructor.  We provide
+        # the options that will force the code below in _fixupPathUri to
+        # return a file URI from a scheme-less one.
+        return ButlerURI(str(self), forceAbsolute=True, forceDirectory=self.isdir(),
+                         isTemporary=self.isTemporary)
 
     @classmethod
     def _fixupPathUri(cls, parsed: urllib.parse.ParseResult, root: Optional[Union[str, ButlerURI]] = None,

--- a/python/lsst/daf/butler/core/fileDataset.py
+++ b/python/lsst/daf/butler/core/fileDataset.py
@@ -31,7 +31,7 @@ from typing import (
     Union,
 )
 
-
+from ._butlerUri import ButlerURI
 from .datasets import DatasetRef
 from .formatter import FormatterParameter
 
@@ -46,8 +46,8 @@ class FileDataset:
     """Registry information about the dataset. (`list` of `DatasetRef`).
     """
 
-    path: str
-    """Path to the dataset (`str`).
+    path: Union[str, ButlerURI]
+    """Path to the dataset (`str` or `ButlerURI`).
 
     If the dataset was exported with ``transfer=None`` (i.e. in-place),
     this is relative to the datastore root (only datastores that have a
@@ -72,4 +72,4 @@ class FileDataset:
         # Sort on path alone
         if not isinstance(other, type(self)):
             return NotImplemented
-        return self.path < other.path
+        return str(self.path) < str(other.path)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -687,13 +687,13 @@ class FileDatastore(GenericBaseDatastore):
 
         return transfer
 
-    def _pathInStore(self, path: str) -> Optional[str]:
+    def _pathInStore(self, path: Union[str, ButlerURI]) -> Optional[str]:
         """Return path relative to datastore root
 
         Parameters
         ----------
-        path : `str`
-            Path to dataset. Can be absolute. If relative assumed to
+        path : `str` or `ButlerURI`
+            Path to dataset. Can be absolute URI. If relative assumed to
             be relative to the datastore. Returns path in datastore
             or raises an exception if the path it outside.
 
@@ -707,12 +707,13 @@ class FileDatastore(GenericBaseDatastore):
         pathUri = ButlerURI(path, forceAbsolute=False)
         return pathUri.relative_to(self.root)
 
-    def _standardizeIngestPath(self, path: str, *, transfer: Optional[str] = None) -> str:
+    def _standardizeIngestPath(self, path: Union[str, ButlerURI], *,
+                               transfer: Optional[str] = None) -> Union[str, ButlerURI]:
         """Standardize the path of a to-be-ingested file.
 
         Parameters
         ----------
-        path : `str`
+        path : `str` or `ButlerURI`
             Path of a file to be ingested.
         transfer : `str`, optional
             How (and whether) the dataset should be added to the datastore.
@@ -723,8 +724,9 @@ class FileDatastore(GenericBaseDatastore):
 
         Returns
         -------
-        path : `str`
-            New path in what the datastore considers standard form.
+        path : `str` or `ButlerURI`
+            New path in what the datastore considers standard form. If an
+            absolute URI was given that will be returned unchanged.
 
         Notes
         -----

--- a/python/lsst/daf/butler/transfers/_yaml.py
+++ b/python/lsst/daf/butler/transfers/_yaml.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 __all__ = ["YamlRepoExportBackend", "YamlRepoImportBackend"]
 
-import os
 from datetime import datetime
 from typing import (
     Any,
@@ -55,6 +54,7 @@ from ..core import (
     FileDataset,
     Timespan,
 )
+from ..core._butlerUri import ButlerURI
 from ..core.utils import iterable
 from ..core.named import NamedValueSet
 from ..registry import CollectionType, Registry
@@ -369,7 +369,7 @@ class YamlRepoImportBackend(RepoImportBackend):
             for sliceForFileDataset, fileDataset in zip(slices, records):
                 fileDataset.refs = resolvedRefs[sliceForFileDataset]
                 if directory is not None:
-                    fileDataset.path = os.path.join(directory, fileDataset.path)
+                    fileDataset.path = ButlerURI(directory, forceDirectory=True).join(fileDataset.path)
                 fileDatasets.append(fileDataset)
         # Ingest everything into the datastore at once.
         if datastore is not None and fileDatasets:

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -218,8 +218,8 @@ class FileURITestCase(unittest.TestCase):
         src.write(b"Some content")
         self.assertTrue(src.exists())
 
-        # Use the internal API to force to a file
-        file = src._force_to_file()
+        # abspath always returns a file scheme
+        file = src.abspath()
         self.assertTrue(file.exists())
         self.assertIn("???", file.ospath)
         self.assertNotIn("???", file.path)
@@ -264,7 +264,7 @@ class FileURITestCase(unittest.TestCase):
         self.assertTrue(new2.ospath.endswith(new2name))
         self.assertEqual(new.read(), new2.read())
 
-        fdir = dir._force_to_file()
+        fdir = dir.abspath()
         self.assertNotIn("???", fdir.path)
         self.assertIn("???", fdir.ospath)
         self.assertEqual(fdir.scheme, "file")


### PR DESCRIPTION
This is now very lightweight since URIs are immutable.
Forces scheme-less URIs to file URIs.