### PR TITLE
DM-29440: Do not use Path.resolve to determine posix root

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri/utils.py
+++ b/python/lsst/daf/butler/core/_butlerUri/utils.py
@@ -40,8 +40,13 @@ from typing import (
 # Determine if the path separator for the OS looks like POSIX
 IS_POSIX = os.sep == posixpath.sep
 
-# Root path for this operating system
-OS_ROOT_PATH = Path().resolve().root
+# Root path for this operating system. This can use getcwd which
+# can fail in some situations so in the default case assume that
+# posix means posix and only determine explicitly in the non-posix case.
+if IS_POSIX:
+    OS_ROOT_PATH = posixpath.sep
+else:
+    OS_ROOT_PATH = Path().resolve().root
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
If we know it's posix we know that the answer is /