### PR TITLE
DM-28636: Make data ID expansion in ingest sometimes optional.

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1463,9 +1463,12 @@ class Butler:
         allResolvedRefs: List[DatasetRef] = []
         for datasetType, groupForType in progress.iter_item_chunks(groupedData.items(),
                                                                    desc="Bulk-inserting datasets by type"):
-            refs = self.registry.insertDatasets(datasetType,
-                                                dataIds=groupForType.keys(),
-                                                run=run)
+            refs = self.registry.insertDatasets(
+                datasetType,
+                dataIds=groupForType.keys(),
+                run=run,
+                expand=self.datastore.needs_expanded_data_ids(transfer, datasetType),
+            )
             # Append those resolved DatasetRefs to the new lists we set up for
             # them.
             for ref, (_, resolvedRefs) in zip(refs, groupForType.values()):

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -822,3 +822,27 @@ class Datastore(metaclass=ABCMeta):
             on `DatasetType` name or `StorageClass`.
         """
         raise NotImplementedError("Must be implemented by subclass")
+
+    def needs_expanded_data_ids(
+        self,
+        transfer: Optional[str],
+        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+    ) -> bool:
+        """Test whether this datastore needs expanded data IDs to ingest.
+
+        Parameters
+        ----------
+        transfer : `str` or `None`
+            Transfer mode for ingest.
+        entity, optional
+            Object representing what will be ingested.  If not provided (or not
+            specific enough), `True` may be returned even if expanded data
+            IDs aren't necessary.
+
+        Returns
+        -------
+        needed : `bool`
+            If `True`, expanded data IDs may be needed.  `False` only if
+            expansion definitely isn't necessary.
+        """
+        return True

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -663,3 +663,18 @@ class ChainedDatastore(Datastore):
                 keys.update(p.getLookupKeys())
 
         return keys
+
+    def needs_expanded_data_ids(
+        self,
+        transfer: Optional[str],
+        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+    ) -> bool:
+        # Docstring inherited.
+        # We can't safely use `self.datastoreConstraints` with `entity` to
+        # check whether a child datastore would even want to ingest this
+        # dataset, because we don't want to filter out datastores that might
+        # need an expanded data ID based in incomplete information (e.g. we
+        # pass a StorageClass, but the constraint dispatches on DatasetType).
+        # So we pessimistically check if any datastore would need an expanded
+        # data ID for this transfer mode.
+        return any(datastore.needs_expanded_data_ids(transfer) for datastore in self.datastores)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1788,3 +1788,15 @@ class FileDatastore(GenericBaseDatastore):
                     hasher.update(chunk)
 
         return hasher.hexdigest()
+
+    def needs_expanded_data_ids(
+        self,
+        transfer: Optional[str],
+        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+    ) -> bool:
+        # Docstring inherited.
+        # This _could_ also use entity to inspect whether the filename template
+        # involves placeholders other than the required dimensions for its
+        # dataset type, but that's not necessary for correctness; it just
+        # enables more optimizations (perhaps only in theory).
+        return transfer not in ("direct", None)

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -585,3 +585,11 @@ class InMemoryDatastore(GenericBaseDatastore):
     def getLookupKeys(self) -> Set[LookupKey]:
         # Docstring is inherited from base class
         return self.constraints.getLookupKeys()
+
+    def needs_expanded_data_ids(
+        self,
+        transfer: Optional[str],
+        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+    ) -> bool:
+        # Docstring inherited.
+        return False


### PR DESCRIPTION
This would be better with a bit more work, but it already speeds up gen2to3 conversion (with direct or in-place) transfers a lot.