### PR TITLE
DM-27412: Rework daf.butler.tests.makeTestCollection

### DIFF
--- a/doc/lsst.daf.butler/use-in-tests.rst
+++ b/doc/lsst.daf.butler/use-in-tests.rst
@@ -68,9 +68,10 @@ Individual tests can be partly isolated using the `lsst.daf.butler.tests.makeTes
 Once a test collection is created, datasets can be read or written as usual:
 
 .. code-block:: py
-   :emphasize-lines: 1, 4
+   :emphasize-lines: 2, 5
 
-   butler = butlerTests.makeTestCollection(repo)
+   # Assuming self is a unittest.TestCase object
+   butler = butlerTests.makeTestCollection(repo, uniqueId=self.id())
 
    exposure = makeTestExposure()  # user-defined code
    butler.put(exposure, "calexp", dataId)

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -115,7 +115,7 @@ def makeTestRepo(root: str,
     return butler
 
 
-def makeTestCollection(repo: Butler) -> Butler:
+def makeTestCollection(repo: Butler, uniqueId: Optional[str] = None) -> Butler:
     """Create a read/write Butler to a fresh collection.
 
     Parameters
@@ -123,6 +123,9 @@ def makeTestCollection(repo: Butler) -> Butler:
     repo : `lsst.daf.butler.Butler`
         A previously existing Butler to a repository, such as that returned by
         `~lsst.daf.butler.Butler.makeRepo` or `makeTestRepo`.
+    uniqueId : `str`, optional
+        A collection ID guaranteed by external code to be unique across all
+        calls to ``makeTestCollection`` for the same repository.
 
     Returns
     -------
@@ -137,9 +140,11 @@ def makeTestCollection(repo: Butler) -> Butler:
     isolated test area, and not for repositories intended for real data
     processing or analysis.
     """
-    # Create a "random" collection name
-    # Speed matters more than cryptographic guarantees
-    collection = "test" + str(random.randrange(1_000_000_000))
+    if not uniqueId:
+        # Create a "random" collection name
+        # Speed matters more than cryptographic guarantees
+        uniqueId = str(random.randrange(1_000_000_000))
+    collection = "test_" + uniqueId
     return Butler(butler=repo, run=collection)
 
 

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -65,7 +65,8 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         removeTestTempDir(cls.root)
 
     def setUp(self):
-        self.butler = makeTestCollection(self.creatorButler)
+        # TestCase.id() is unique for each test method
+        self.butler = makeTestCollection(self.creatorButler, uniqueId=self.id())
 
     def testButlerValid(self):
         self.butler.validateConfiguration()


### PR DESCRIPTION
This PR alters `makeTestCollection` to support an externally provided test ID.