### PR TITLE
DM-30147: Add cache_ok flag to type decorator classes

### DIFF
--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -99,6 +99,8 @@ class Base64Bytes(sqlalchemy.TypeDecorator):
 
     impl = sqlalchemy.Text
 
+    cache_ok = True
+
     def __init__(self, nbytes: int, *args: Any, **kwargs: Any):
         length = 4*ceil(nbytes/3) if self.impl == sqlalchemy.String else None
         super().__init__(*args, length=length, **kwargs)
@@ -153,6 +155,8 @@ class AstropyTimeNsecTai(sqlalchemy.TypeDecorator):
 
     impl = sqlalchemy.BigInteger
 
+    cache_ok = True
+
     def process_bind_param(self, value: Optional[astropy.time.Time], dialect: sqlalchemy.engine.Dialect
                            ) -> Optional[int]:
         if value is None:
@@ -179,6 +183,8 @@ class GUID(sqlalchemy.TypeDecorator):
     """
 
     impl = sqlalchemy.CHAR
+
+    cache_ok = True
 
     def load_dialect_impl(self, dialect: sqlalchemy.Dialect) -> sqlalchemy.TypeEngine:
         if dialect.name == 'postgresql':

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -192,6 +192,8 @@ class _RangeTimespanType(sqlalchemy.TypeDecorator):
 
     impl = sqlalchemy.dialects.postgresql.INT8RANGE
 
+    cache_ok = True
+
     def process_bind_param(self, value: Optional[Timespan],
                            dialect: sqlalchemy.engine.Dialect
                            ) -> Optional[psycopg2.extras.NumericRange]:


### PR DESCRIPTION
New feature was added to sqlalchemy and it generates warning by default
if this flag is not set excplicitly.