### PR TITLE
DM-30140: Allow trash to take iterable of dataset refs

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright 2016-2019 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
-Copyright 2018-2019 Association of Universities for Research in Astronomy
-Copyright 2015, 2018-2019 The Trustees of Princeton University
+Copyright 2016-2021 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+Copyright 2018-2021 Association of Universities for Research in Astronomy
+Copyright 2015, 2018-2021 The Trustees of Princeton University
 Copyright 2020 University of Washington

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -718,20 +718,22 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def trash(self, datasetRef: DatasetRef, ignore_errors: bool = True) -> None:
+    def trash(self, ref: Union[DatasetRef, Iterable[DatasetRef]], ignore_errors: bool = True) -> None:
         """Indicate to the Datastore that a Dataset can be moved to the trash.
 
         Parameters
         ----------
-        datasetRef : `DatasetRef`
-            Reference to the required Dataset.
+        ref : `DatasetRef` or iterable thereof
+            Reference(s) to the required Dataset.
         ignore_errors : `bool`, optional
-            Determine whether errors should be ignored.
+            Determine whether errors should be ignored. When multiple
+            refs are being trashed there will be no per-ref check.
 
         Raises
         ------
         FileNotFoundError
-            When Dataset does not exist.
+            When Dataset does not exist and errors are not ignored. Only
+            checked if a single ref is supplied (and not in a list).
 
         Notes
         -----

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1578,7 +1578,7 @@ class FileDatastore(GenericBaseDatastore):
             log.debug("Doing multi-dataset trash in datastore %s", self.name)
             # Assumed to be an iterable of refs so bulk mode enabled.
             try:
-                self._move_to_trash_in_registry(ref)
+                self.bridge.moveToTrash(ref)
             except Exception as e:
                 if ignore_errors:
                     log.warning("Unexpected issue moving multiple datasets to trash: %s", e)
@@ -1610,7 +1610,7 @@ class FileDatastore(GenericBaseDatastore):
 
         # Mark dataset as trashed
         try:
-            self._move_to_trash_in_registry([ref])
+            self.bridge.moveToTrash([ref])
         except Exception as e:
             if ignore_errors:
                 log.warning(f"Attempted to mark dataset ({ref}) to be trashed in datastore {self.name} "

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1572,25 +1572,21 @@ class FileDatastore(GenericBaseDatastore):
         self._register_datasets(artifacts)
 
     @transactional
-    def trash(self, ref: DatasetRef, ignore_errors: bool = True) -> None:
-        """Indicate to the datastore that a dataset can be removed.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Reference to the required Dataset.
-        ignore_errors : `bool`
-            If `True` return without error even if something went wrong.
-            Problems could occur if another process is simultaneously trying
-            to delete.
-
-        Raises
-        ------
-        FileNotFoundError
-            Attempt to remove a dataset that does not exist.
-        """
+    def trash(self, ref: Union[DatasetRef, Iterable[DatasetRef]], ignore_errors: bool = True) -> None:
         # Get file metadata and internal metadata
-        log.debug("Trashing %s in datastore %s", ref, self.name)
+        if not isinstance(ref, DatasetRef):
+            log.debug("Doing multi-dataset trash in datastore %s", self.name)
+            # Assumed to be an iterable of refs so bulk mode enabled.
+            try:
+                self._move_to_trash_in_registry(ref)
+            except Exception as e:
+                if ignore_errors:
+                    log.warning("Unexpected issue moving multiple datasets to trash: %s", e)
+                else:
+                    raise
+            return
+
+        log.debug("Trashing dataset %s in datastore %s", ref, self.name)
 
         fileLocations = self._get_dataset_locations_info(ref)
 
@@ -1614,7 +1610,7 @@ class FileDatastore(GenericBaseDatastore):
 
         # Mark dataset as trashed
         try:
-            self._move_to_trash_in_registry(ref)
+            self._move_to_trash_in_registry([ref])
         except Exception as e:
             if ignore_errors:
                 log.warning(f"Attempted to mark dataset ({ref}) to be trashed in datastore {self.name} "

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -132,24 +132,6 @@ class GenericBaseDatastore(Datastore):
         self.bridge.insert(registryRefs.values())
         self.addStoredItemInfo(expandedRefs, expandedItemInfos)
 
-    def _move_to_trash_in_registry(self, refs: Iterable[DatasetRef]) -> None:
-        """Tell registry that these datasets and associated components
-        are to be trashed.
-
-        Parameters
-        ----------
-        ref : iterable of `DatasetRef`
-            Datasets to mark for removal from registry.
-
-        Notes
-        -----
-        Dataset is not removed from internal stored item info table.
-        """
-        # Note that a ref can point to component dataset refs that
-        # have been deleted already from registry but are still in
-        # the python object. moveToTrash will deal with that.
-        self.bridge.moveToTrash(refs)
-
     def _post_process_get(self, inMemoryDataset: Any, readStorageClass: StorageClass,
                           assemblerParams: Optional[Mapping[str, Any]] = None,
                           isComponent: bool = False) -> Any:

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -132,14 +132,14 @@ class GenericBaseDatastore(Datastore):
         self.bridge.insert(registryRefs.values())
         self.addStoredItemInfo(expandedRefs, expandedItemInfos)
 
-    def _move_to_trash_in_registry(self, ref: DatasetRef) -> None:
-        """Tell registry that this dataset and associated components
+    def _move_to_trash_in_registry(self, refs: Iterable[DatasetRef]) -> None:
+        """Tell registry that these datasets and associated components
         are to be trashed.
 
         Parameters
         ----------
-        ref : `DatasetRef`
-            Dataset to mark for removal from registry.
+        ref : iterable of `DatasetRef`
+            Datasets to mark for removal from registry.
 
         Notes
         -----
@@ -148,7 +148,7 @@ class GenericBaseDatastore(Datastore):
         # Note that a ref can point to component dataset refs that
         # have been deleted already from registry but are still in
         # the python object. moveToTrash will deal with that.
-        self.bridge.moveToTrash([ref])
+        self.bridge.moveToTrash(refs)
 
     def _post_process_get(self, inMemoryDataset: Any, readStorageClass: StorageClass,
                           assemblerParams: Optional[Mapping[str, Any]] = None,

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -42,12 +42,12 @@ from typing import (
     Union,
 )
 
-from lsst.daf.butler import DatasetId, StoredDatastoreItemInfo, StorageClass, ButlerURI
+from lsst.daf.butler import DatasetId, DatasetRef, StoredDatastoreItemInfo, StorageClass, ButlerURI
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
 from .genericDatastore import GenericBaseDatastore
 
 if TYPE_CHECKING:
-    from lsst.daf.butler import (Config, DatasetRef, DatasetType,
+    from lsst.daf.butler import (Config, DatasetType,
                                  LookupKey)
     from lsst.daf.butler.registry.interfaces import DatasetIdRef, DatastoreRegistryBridgeManager
 
@@ -483,20 +483,21 @@ class InMemoryDatastore(GenericBaseDatastore):
         for ref in refs:
             self.removeStoredItemInfo(ref)
 
-    def trash(self, ref: DatasetRef, ignore_errors: bool = False) -> None:
+    def trash(self, ref: Union[DatasetRef, Iterable[DatasetRef]], ignore_errors: bool = False) -> None:
         """Indicate to the Datastore that a dataset can be removed.
 
         Parameters
         ----------
-        ref : `DatasetRef`
-            Reference to the required Dataset.
+        ref : `DatasetRef` or iterable thereof
+            Reference to the required Dataset(s).
         ignore_errors: `bool`, optional
             Indicate that errors should be ignored.
 
         Raises
         ------
         FileNotFoundError
-            Attempt to remove a dataset that does not exist.
+            Attempt to remove a dataset that does not exist. Only relevant
+            if a single dataset ref is given.
 
         Notes
         -----
@@ -504,6 +505,10 @@ class InMemoryDatastore(GenericBaseDatastore):
         since all internal changes are isolated to solely this process and
         the registry only changes rows associated with this process.
         """
+        if not isinstance(ref, DatasetRef):
+            log.debug("Bulk trashing of datasets in datastore %s", self.name)
+            self._move_to_trash_in_registry(ref)
+            return
 
         log.debug("Trash %s in datastore %s", ref, self.name)
 
@@ -512,7 +517,7 @@ class InMemoryDatastore(GenericBaseDatastore):
             self._get_dataset_info(ref)
 
             # Move datasets to trash table
-            self._move_to_trash_in_registry(ref)
+            self._move_to_trash_in_registry([ref])
         except Exception as e:
             if ignore_errors:
                 log.warning("Error encountered moving dataset %s to trash in datastore %s: %s",
@@ -544,6 +549,9 @@ class InMemoryDatastore(GenericBaseDatastore):
             for ref, _ in trashed:
                 try:
                     realID, _ = self._get_dataset_info(ref)
+                except FileNotFoundError:
+                    # Dataset already removed so ignore it
+                    continue
                 except Exception as e:
                     if ignore_errors:
                         log.warning("Emptying trash in datastore %s but encountered an "

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -507,7 +507,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         """
         if not isinstance(ref, DatasetRef):
             log.debug("Bulk trashing of datasets in datastore %s", self.name)
-            self._move_to_trash_in_registry(ref)
+            self.bridge.moveToTrash(ref)
             return
 
         log.debug("Trash %s in datastore %s", ref, self.name)
@@ -517,7 +517,7 @@ class InMemoryDatastore(GenericBaseDatastore):
             self._get_dataset_info(ref)
 
             # Move datasets to trash table
-            self._move_to_trash_in_registry([ref])
+            self.bridge.moveToTrash([ref])
         except Exception as e:
             if ignore_errors:
                 log.warning("Error encountered moving dataset %s to trash in datastore %s: %s",


### PR DESCRIPTION
This is much much faster than calling trash on each ref separately. Also remove the existence check since if we are asking for a dataset to be trashed it is not really that important if the dataset has already disappeared and that could just be caused by someone else pruning a collection in parallel.