### PR TITLE
DM-30200: (HotFix) Include "-" in globToRegex exemptions

### DIFF
--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -433,7 +433,7 @@ def globToRegex(expressions: Union[str, EllipsisType, None,
     if not expressions or "*" in expressions:
         return Ellipsis
 
-    nomagic = re.compile(r"^[\w/\.]+$", re.ASCII)
+    nomagic = re.compile(r"^[\w/\.\-]+$", re.ASCII)
 
     # Try not to convert simple string to a regex.
     results: List[Union[str, Pattern]] = []


### PR DESCRIPTION
"-" is only magic if "[" is present.