### PR TITLE
DM-30335: Add special flag to support put on execution butler

### DIFF
--- a/doc/changes/DM-30335.misc.rst
+++ b/doc/changes/DM-30335.misc.rst
@@ -1,0 +1,3 @@
+Add a Butler configuration for an execution butler that has pre-defined registry entries but no datastore records.
+
+The `Butler.put()` will return the pre-existing dataset ref but will still fail if a datastore record is found.

--- a/doc/changes/datastore/DM-30335.api.rst
+++ b/doc/changes/datastore/DM-30335.api.rst
@@ -1,0 +1,2 @@
+A new method ``Datastore.knows()`` has been added to allow a user to ask the datastore whether it knows about a specific dataset but without requiring a check to see if the artifact itself exists.
+Use ``Datastore.exists()`` to check that the datastore knows about a dataset and the artifact exists.

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -339,6 +339,24 @@ class Datastore(metaclass=ABCMeta):
         self._transaction = self._transaction.parent
 
     @abstractmethod
+    def knows(self, ref: DatasetRef) -> bool:
+        """Check if the dataset is known to the datastore.
+
+        Does not check for existence of any artifact.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            Reference to the required dataset.
+
+        Returns
+        -------
+        exists : `bool`
+            `True` if the dataset is known to the datastore.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def exists(self, datasetRef: DatasetRef) -> bool:
         """Check if the dataset exists in the datastore.
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -230,6 +230,27 @@ class ChainedDatastore(Datastore):
         chainName = ", ".join(str(ds) for ds in self.datastores)
         return chainName
 
+    def knows(self, ref: DatasetRef) -> bool:
+        """Check if the dataset is known to any of the datastores.
+
+        Does not check for existence of any artifact.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            Reference to the required dataset.
+
+        Returns
+        -------
+        exists : `bool`
+            `True` if the dataset is known to the datastore.
+        """
+        for datastore in self.datastores:
+            if datastore.knows(ref):
+                log.debug("%s known to datastore %s", ref, datastore.name)
+                return True
+        return False
+
     def exists(self, ref: DatasetRef) -> bool:
         """Check if the dataset exists in one of the datastores.
 

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1146,6 +1146,26 @@ class FileDatastore(GenericBaseDatastore):
         return self._post_process_get(result, getInfo.readStorageClass, getInfo.assemblerParams,
                                       isComponent=isComponent)
 
+    def knows(self, ref: DatasetRef) -> bool:
+        """Check if the dataset is known to the datastore.
+
+        Does not check for existence of any artifact.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            Reference to the required dataset.
+
+        Returns
+        -------
+        exists : `bool`
+            `True` if the dataset is known to the datastore.
+        """
+        fileLocations = self._get_dataset_locations_info(ref)
+        if fileLocations:
+            return True
+        return False
+
     def exists(self, ref: DatasetRef) -> bool:
         """Check if the dataset exists in the datastore.
 

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -239,6 +239,24 @@ class InMemoryDatastore(GenericBaseDatastore):
 
         return realID, storedItemInfo
 
+    def knows(self, ref: DatasetRef) -> bool:
+        """Check if the dataset is known to the datastore.
+
+        This datastore does not distinguish dataset existence from knowledge
+        of a dataset.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            Reference to the required dataset.
+
+        Returns
+        -------
+        exists : `bool`
+            `True` if the dataset is known to the datastore.
+        """
+        return self.exists(ref)
+
     def exists(self, ref: DatasetRef) -> bool:
         """Check if the dataset exists in the datastore.
 


### PR DESCRIPTION
`allow_put_of_predefined_dataset` can be set to `True` to allow a put to work even if the registry thinks it knows about the entry. The put will still fail if datastore knows about the dataset.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
