### PR TITLE
DM-30372: Ensure all managers are listed in butler.yaml file in makeRepo

### DIFF
--- a/doc/changes/DM-30372.bugfix.rst
+++ b/doc/changes/DM-30372.bugfix.rst
@@ -1,0 +1,4 @@
+Fix butler repository creation when a seed config has specified a registry manager override.
+
+Previously only that manager was recorded rather than the full set.
+We always require a full set to be recorded to prevent breakage of a butler when a default changes.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -388,7 +388,7 @@ class Butler:
             # allowed to change anymore.  Note that in the standalone=True
             # branch, _everything_ in the config is expanded, so there's no
             # need to special case this.
-            Config.updateParameters(RegistryConfig, config, full, toCopy=("managers",), overwrite=False)
+            Config.updateParameters(RegistryConfig, config, full, toMerge=("managers",), overwrite=False)
         configURI: Union[str, ButlerURI]
         if outfile is not None:
             # When writing to a separate location we must include


### PR DESCRIPTION
Previously overriding a manager in a seed would only record that one manager.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
