### PR TITLE
DM-30685: Issue warning if lookup key dimension is not known to universe

### DIFF
--- a/doc/changes/DM-30685.misc.rst
+++ b/doc/changes/DM-30685.misc.rst
@@ -1,0 +1,2 @@
+If an unrecognized dimension is used as a look up key in a configuration file (using the ``+`` syntax) a warning is used suggesting a possible typo rather than a confusing `KeyError`.
+This is no longer a fatal error and the key will be treated as a name.


### PR DESCRIPTION
Previously a confusing KeyError would be issued with the unknown key.
Now replace this with a warning message suggesting that there might be a typo
but still continue on without stopping.

This is mainly motivated by the presence of physical_filter in the
fileDatastore file template. Since this is in a default configuration
it affects all users, even those that define their own universe.

DM-26190 may give us the real fix for the fileDatastore problem.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
