### PR TITLE
DM-30743: Defer creation of temporary datastore cache directory

### DIFF
--- a/doc/changes/DM-30743-bugfix.rst
+++ b/doc/changes/DM-30743-bugfix.rst
@@ -1,0 +1,2 @@
+Stop writing a temporary datastore cache directory every time a ``Butler`` object was instantiated.
+Now only create one when one is requested.

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -55,6 +55,9 @@ log = logging.getLogger(__name__)
 class DatastoreCacheManagerConfig(ConfigSubset):
     """Configuration information for `DatastoreCacheManager`."""
 
+    component = "cached"
+    requiredKeys = ("cacheable",)
+
 
 class AbstractDatastoreCacheManager(ABC):
     """An abstract base class for managing caching in a Datastore.


### PR DESCRIPTION
Previously we always created it every single time someone instantiated
a Butler!

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
