### PR TITLE
DM-30771: Allow components to be missing in datastore trust mode

### DIFF
--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -584,6 +584,20 @@ class FileDatastore(GenericBaseDatastore):
 
         if len(fileLocations) > 1:
             disassembled = True
+
+            # If trust is involved it is possible that there will be
+            # components listed here that do not exist in the datastore.
+            # Explicitly check for file artifact existence and filter out any
+            # that are missing.
+            if self.trustGetRequest:
+                fileLocations = [loc for loc in fileLocations if loc[0].uri.exists()]
+
+                # For now complain only if we have no components at all. One
+                # component is probably a problem but we can punt that to the
+                # assembler.
+                if not fileLocations:
+                    raise FileNotFoundError(f"None of the component files for dataset {ref} exist.")
+
         else:
             disassembled = False
 


### PR DESCRIPTION
When disassembling a composite we can't assume that all components
will exist. In trust mode assume that any components found means
that these should be passed on to the assembler.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
