### PR TITLE
DM-30784: Fixes to transfer_from to correctly filter out missing datasets and register dataset types

### DIFF
--- a/doc/changes/DM-30784.bugfix.rst
+++ b/doc/changes/DM-30784.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``Butler.transfer_from()`` such that it registers any missing dataset types and also skips any datasets that do not have associated datastore artifacts.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1864,7 +1864,10 @@ class FileDatastore(GenericBaseDatastore):
             id_to_ref = {ref.id: ref for ref in refs if ref.id in missing_ids}
 
             for missing in missing_ids:
-                expected = self._get_expected_dataset_locations_info(id_to_ref[missing])
+                # Ask the source datastore where the missing artifacts
+                # should be.  An execution butler might not know about the
+                # artifacts even if they are there.
+                expected = source_datastore._get_expected_dataset_locations_info(id_to_ref[missing])
 
                 # Not all components can be guaranteed to exist so this
                 # list has to filter those by checking to see if the

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1200,7 +1200,17 @@ class FileDatastore(GenericBaseDatastore):
         if not fileLocations:
             if not self.trustGetRequest:
                 return False
-            fileLocations = self._get_expected_dataset_locations_info(ref)
+
+            # When we are guessing a dataset location we can not check
+            # for the existence of every component since we can not
+            # know if every component was written. Instead we check
+            # for the existence of any of the expected locations.
+            for location, _ in self._get_expected_dataset_locations_info(ref):
+                if self._artifact_exists(location):
+                    return True
+            return False
+
+        # All listed artifacts must exist.
         for location, _ in fileLocations:
             if not self._artifact_exists(location):
                 return False

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -160,7 +160,7 @@ class QueryDatasets:
         self.datasets = self.butler.registry.queryDatasets(datasetType=glob,
                                                            collections=collections,
                                                            where=where,
-                                                           findFirst=find_first)
+                                                           findFirst=find_first).expanded()
 
     def getTables(self):
         """Get the datasets as a list of astropy tables.
@@ -175,7 +175,8 @@ class QueryDatasets:
             if not self.showUri:
                 tables[datasetRef.datasetType.name].add(datasetRef)
             else:
-                primaryURI, componentURIs = self.butler.getURIs(datasetRef, collections=datasetRef.run)
+                primaryURI, componentURIs = self.butler.getURIs(datasetRef, collections=datasetRef.run,
+                                                                predict=True)
                 if primaryURI:
                     tables[datasetRef.datasetType.name].add(datasetRef, primaryURI)
                 for name, uri in componentURIs.items():


### PR DESCRIPTION
Turns out that I had forgotten a rather critical filter and was transferring all datasets, even those that had not file artifact. This is now fixed. This PR also adds dataset type registration.


## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
