### PR TITLE
DM-30316: Support rewriting of sqlite registry

### DIFF
--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -114,6 +114,7 @@ class ButlerConfig(Config):
         configFile = butlerConfig.configFile
         if configFile is not None:
             uri = ButlerURI(configFile)
+            self.configFile = uri
             self.configDir = uri.dirname()
 
         # A Butler config contains defaults defined by each of the component


### PR DESCRIPTION
This branch supports sqlite registry rewriting. The registry rewriting itself is in lsst-dm/daf_butler_migrate#3

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
