### PR TITLE
DM-30718: Do not recreate DataCoordinate on butler.get if given a DataCoordinate

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -736,19 +736,14 @@ class Butler:
                                 dimensionName, newDataId[dimensionName], str(values))
                     continue
 
-                # Build up a WHERE expression -- use single quotes
-                def quote(s: Any) -> str:
-                    if isinstance(s, str):
-                        return f"'{s}'"
-                    else:
-                        return s
-
-                where = " AND ".join(f"{dimensionName}.{k} = {quote(v)}"
-                                     for k, v in values.items())
+                # Build up a WHERE expression
+                bind = {k: v for k, v in values.items()}
+                where = " AND ".join(f"{dimensionName}.{k} = {k}"
+                                     for k in bind)
 
                 # Hopefully we get a single record that matches
                 records = set(self.registry.queryDimensionRecords(dimensionName, dataId=newDataId,
-                                                                  where=where, **kwds))
+                                                                  where=where, bind=bind, **kwds))
 
                 if len(records) != 1:
                     if len(records) > 1:

--- a/python/lsst/daf/butler/_deferredDatasetHandle.py
+++ b/python/lsst/daf/butler/_deferredDatasetHandle.py
@@ -56,7 +56,7 @@ class DeferredDatasetHandle:
             It defaults to None. If the value is not None,  this dict will
             be merged with the parameters dict used to construct the
             `DeferredDatasetHandle` class.
-        kwargs : `dict`
+        **kwargs
             This argument is deprecated and only exists to support legacy
             gen2 butler code during migration. It is completely ignored
             and will be removed in the future.

--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -401,7 +401,7 @@ class ButlerURI:
         forceDirectory : `bool`
             Parameter passed to ButlerURI constructor to force this
             new URI to be dir-like.
-        kwargs : `dict`
+        **kwargs
             Components of a `urllib.parse.ParseResult` that should be
             modified for the newly-created `ButlerURI`.
 

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -134,7 +134,7 @@ class DatastoreTransaction:
             Function to undo this event.
         args : `tuple`
             Positional arguments to `undoFunc`.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to `undoFunc`.
         """
         self._log.append(self.Event(name, undoFunc, args, kwargs))

--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -82,9 +82,9 @@ class SchemaValidationError(ValidationError):
             the decorated function.
         """
         def decorate(func: Callable) -> Callable:
-            def decorated(self: Any, config: Config, *args: Any, **kwds: Any) -> Any:
+            def decorated(self: Any, config: Config, *args: Any, **kwargs: Any) -> Any:
                 try:
-                    return func(self, config, *args, **kwds)
+                    return func(self, config, *args, **kwargs)
                 except caught as err:
                     raise cls(message.format(config=str(config), err=err))
             return decorated
@@ -287,7 +287,7 @@ class FieldSpec:
 
     @classmethod
     @SchemaValidationError.translate(KeyError, "Missing key {err} in column config '{config}'.")
-    def fromConfig(cls, config: Config, **kwds: Any) -> FieldSpec:
+    def fromConfig(cls, config: Config, **kwargs: Any) -> FieldSpec:
         """Create a `FieldSpec` from a subset of a `SchemaConfig`.
 
         Parameters
@@ -295,7 +295,7 @@ class FieldSpec:
         config: `Config`
             Configuration describing the column.  Nested configuration keys
             correspond to `FieldSpec` attributes.
-        kwds
+        **kwargs
             Additional keyword arguments that provide defaults for values
             not present in config.
 
@@ -314,7 +314,7 @@ class FieldSpec:
             raise SchemaValidationError(f"Invalid field type string: '{config['type']}'.")
         if not config["name"].islower():
             raise SchemaValidationError(f"Column name '{config['name']}' is not all lowercase.")
-        self = cls(name=config["name"], dtype=dtype, **kwds)
+        self = cls(name=config["name"], dtype=dtype, **kwargs)
         self.length = config.get("length", self.length)
         self.nbytes = config.get("nbytes", self.nbytes)
         if self.length is not None and self.nbytes is not None:

--- a/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
+++ b/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
@@ -367,7 +367,7 @@ class _DataCoordinateCollectionBase(DataCoordinateIterable):
 
         Returns
         -------
-        kwargs : `dict`
+        **kwargs
             A dict with `hasFull`, `hasRecords`, and `check` keys, associated
             with the appropriate values for a `subset` operation with the given
             dimensions.

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -710,7 +710,7 @@ class FormatterFactory:
             ``instrument`` value for the data ID.
         args : `tuple`
             Positional arguments to use pass to the object constructor.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to pass to object constructor.
 
         Returns
@@ -740,7 +740,7 @@ class FormatterFactory:
             ``instrument`` value for the data ID.
         args : `tuple`
             Positional arguments to use pass to the object constructor.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to pass to object constructor.
 
         Returns
@@ -768,7 +768,7 @@ class FormatterFactory:
         overwrite : `bool`, optional
             If `True` an existing entry will be replaced by the new value.
             Default is `False`.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to always pass to object constructor when
             retrieved.
 

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -168,7 +168,7 @@ class MappingFactory:
             Items with `None` value are skipped.
         args : `tuple`
             Positional arguments to use pass to the object constructor.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to pass to object constructor.
 
         Returns
@@ -207,7 +207,7 @@ class MappingFactory:
             Items with `None` value are skipped.
         args : `tuple`
             Positional arguments to use pass to the object constructor.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to pass to object constructor.
 
         Returns
@@ -239,7 +239,7 @@ class MappingFactory:
             If `True`, an existing entry will be overwritten.  This option
             is expected to be used to simplify test suites.
             Default is `False`.
-        kwargs : `dict`
+        **kwargs
             Keyword arguments to always pass to object constructor when
             retrieved.
 

--- a/python/lsst/daf/butler/core/serverModels.py
+++ b/python/lsst/daf/butler/core/serverModels.py
@@ -226,7 +226,7 @@ class QueryBaseModel(BaseModel):
 
         Returns
         -------
-        kwargs : `dict`
+        **kwargs
             The keword arguments stored in the model. `None` is converted
             to an empty dict. Returns empty dict if the ``keyword_args``
             property is not defined.

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -215,7 +215,7 @@ def getInstanceOf(typeOrName: Union[Type, str], *args: Any, **kwargs: Any) -> An
         A string describing the Python class to load or a Python type.
     args : `tuple`
         Positional arguments to use pass to the object constructor.
-    kwargs : `dict`
+    **kwargs
         Keyword arguments to pass to object constructor.
 
     Returns

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -982,13 +982,13 @@ class Registry(ABC):
         Parameters
         ----------
         dataId : `DataCoordinate` or `dict`, optional
-            Data ID to be expanded; augmented and overridden by ``kwds``.
+            Data ID to be expanded; augmented and overridden by ``kwargs``.
         graph : `DimensionGraph`, optional
             Set of dimensions for the expanded ID.  If `None`, the dimensions
-            will be inferred from the keys of ``dataId`` and ``kwds``.
-            Dimensions that are in ``dataId`` or ``kwds`` but not in ``graph``
-            are silently ignored, providing a way to extract and expand a
-            subset of a data ID.
+            will be inferred from the keys of ``dataId`` and ``kwargs``.
+            Dimensions that are in ``dataId`` or ``kwargs`` but not in
+            ``graph`` are silently ignored, providing a way to extract and
+            ``graph`` expand a subset of a data ID.
         records : `Mapping` [`str`, `DimensionRecord`], optional
             Dimension record data to use before querying the database for that
             data, keyed by element name.

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -345,7 +345,7 @@ class CollectionManager(VersionedExtension):
         constraint: `bool`, optional
             If `False` (`True` is default), add a field that can be joined to
             the run primary key, but do not add a foreign key constraint.
-        **kwds
+        **kwargs
             Additional keyword arguments are forwarded to the `ddl.FieldSpec`
             constructor (only the ``name`` and ``dtype`` arguments are
             otherwise provided).

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -746,7 +746,7 @@ class Database(ABC):
         return []
 
     def _convertFieldSpec(self, table: str, spec: ddl.FieldSpec, metadata: sqlalchemy.MetaData,
-                          **kwds: Any) -> sqlalchemy.schema.Column:
+                          **kwargs: Any) -> sqlalchemy.schema.Column:
         """Convert a `FieldSpec` to a `sqlalchemy.schema.Column`.
 
         Parameters
@@ -758,7 +758,7 @@ class Database(ABC):
         metadata : `sqlalchemy.MetaData`
             SQLAlchemy representation of the DDL schema this field's table is
             being added to.
-        **kwds
+        **kwargs
             Additional keyword arguments to forward to the
             `sqlalchemy.schema.Column` constructor.  This is provided to make
             it easier for derived classes to delegate to ``super()`` while
@@ -778,10 +778,10 @@ class Database(ABC):
                                             metadata=metadata))
         assert spec.doc is None or isinstance(spec.doc, str), f"Bad doc for {table}.{spec.name}."
         return sqlalchemy.schema.Column(*args, nullable=spec.nullable, primary_key=spec.primaryKey,
-                                        comment=spec.doc, server_default=spec.default, **kwds)
+                                        comment=spec.doc, server_default=spec.default, **kwargs)
 
     def _convertForeignKeySpec(self, table: str, spec: ddl.ForeignKeySpec, metadata: sqlalchemy.MetaData,
-                               **kwds: Any) -> sqlalchemy.schema.ForeignKeyConstraint:
+                               **kwargs: Any) -> sqlalchemy.schema.ForeignKeyConstraint:
         """Convert a `ForeignKeySpec` to a
         `sqlalchemy.schema.ForeignKeyConstraint`.
 
@@ -794,7 +794,7 @@ class Database(ABC):
         metadata : `sqlalchemy.MetaData`
             SQLAlchemy representation of the DDL schema this constraint is
             being added to.
-        **kwds
+        **kwargs
             Additional keyword arguments to forward to the
             `sqlalchemy.schema.ForeignKeyConstraint` constructor.  This is
             provided to make it easier for derived classes to delegate to
@@ -848,7 +848,7 @@ class Database(ABC):
         raise NotImplementedError(f"Database {self} does not support exclusion constraints.")
 
     def _convertTableSpec(self, name: str, spec: ddl.TableSpec, metadata: sqlalchemy.MetaData,
-                          **kwds: Any) -> sqlalchemy.schema.Table:
+                          **kwargs: Any) -> sqlalchemy.schema.Table:
         """Convert a `TableSpec` to a `sqlalchemy.schema.Table`.
 
         Parameters
@@ -858,7 +858,7 @@ class Database(ABC):
         metadata : `sqlalchemy.MetaData`
             SQLAlchemy representation of the DDL schema this table is being
             added to.
-        **kwds
+        **kwargs
             Additional keyword arguments to forward to the
             `sqlalchemy.schema.Table` constructor.  This is provided to make it
             easier for derived classes to delegate to ``super()`` while making
@@ -914,7 +914,7 @@ class Database(ABC):
         args.extend(self._convertExclusionConstraintSpec(name, excl, metadata) for excl in spec.exclusion)
 
         assert spec.doc is None or isinstance(spec.doc, str), f"Bad doc for {name}."
-        return sqlalchemy.schema.Table(name, metadata, *args, comment=spec.doc, info=spec, **kwds)
+        return sqlalchemy.schema.Table(name, metadata, *args, comment=spec.doc, info=spec, **kwargs)
 
     def ensureTableExists(self, name: str, spec: ddl.TableSpec) -> sqlalchemy.schema.Table:
         """Ensure that a table with the given name and specification exists,
@@ -1531,7 +1531,7 @@ class Database(ABC):
         return self._connection.execute(sql, *rows).rowcount
 
     def query(self, sql: sqlalchemy.sql.FromClause,
-              *args: Any, **kwds: Any) -> sqlalchemy.engine.ResultProxy:
+              *args: Any, **kwargs: Any) -> sqlalchemy.engine.ResultProxy:
         """Run a SELECT query against the database.
 
         Parameters
@@ -1541,7 +1541,7 @@ class Database(ABC):
         *args
             Additional positional arguments are forwarded to
             `sqlalchemy.engine.Connection.execute`.
-        **kwds
+        **kwargs
             Additional keyword arguments are forwarded to
             `sqlalchemy.engine.Connection.execute`.
 
@@ -1556,7 +1556,7 @@ class Database(ABC):
         classes.
         """
         # TODO: should we guard against non-SELECT queries here?
-        return self._connection.execute(sql, *args, **kwds)
+        return self._connection.execute(sql, *args, **kwargs)
 
     origin: int
     """An integer ID that should be used as the default for any datasets,

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -361,6 +361,7 @@ class SimpleButlerTestCase(unittest.TestCase):
             ({"detector.full_name": "Ab"}, {"instrument": "Cam1", "physical_filter": "Cam1-G"}),
             ({"full_name": "Ab"}, {"instrument": "Cam1", "physical_filter": "Cam1-G"}),
             (None, {"full_name": "Ab", "instrument": "Cam1", "physical_filter": "Cam1-G"}),
+            (None, {"detector": "Ab", "instrument": "Cam1", "physical_filter": "Cam1-G"}),
             ({"name_in_raft": "b", "raft": "A"}, {"instrument": "Cam1", "physical_filter": "Cam1-G"}),
             ({"name_in_raft": "b"}, {"raft": "A", "instrument": "Cam1", "physical_filter": "Cam1-G"}),
             (None, {"name_in_raft": "b", "raft": "A", "instrument": "Cam1", "physical_filter": "Cam1-G"}),


### PR DESCRIPTION
Previously a fully expanded DataCoordinate would be turned into a minimalist dict before converting it back to a DataCoordinate in an attempt to handle the detector/exposure record specifications in dataIds.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
