### PR TITLE
DM-30124: Use native timestamp comparison for ingest_date

### DIFF
--- a/doc/changes/DM-30124.bugfix.md
+++ b/doc/changes/DM-30124.bugfix.md
@@ -1,0 +1,6 @@
+Fix handling of ingest_date timestamps.
+
+Previously there was an inconsistency between ingest_date database-native UTC
+handling and astropy Time used for time literals which resulted in 37 second
+difference. This updates makes consistent use of database-native time
+functions to resolve this issue.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -229,8 +229,8 @@ Here are few examples for checking containment in a time range:
 .. code-block:: sql
 
     -- using literals for both timestamp and time range
-    T'2020-01-01' IN (T'2019-01-01', '2020-01-01')
-    (T'2020-01-01', T'2020-02-01') NOT IN (T'2019-01-01', '2020-01-01')
+    T'2020-01-01' IN (T'2019-01-01', T'2020-01-01')
+    (T'2020-01-01', T'2020-02-01') NOT IN (T'2019-01-01', T'2020-01-01')
 
     -- using identifiers for each timestamp in a time range
     T'2020-01-01' IN (interval.begin, interval.end)
@@ -255,7 +255,7 @@ OVERLAPS operator
 ^^^^^^^^^^^^^^^^^
 
 The ``OVERLAPS`` operator checks for overlapping time ranges or regions, its
-argument have to have consistent types. Like with ``IN`` operator time ranges
+arguments have to have consistent types. Like with ``IN`` operator time ranges
 can be represented with a tuple of two timestamps (literals or identifiers) or
 with a single identifier. Regions can only be used as identifiers.
 ``OVERLAPS`` syntax is similar to ``IN`` but it does not require  parentheses
@@ -266,7 +266,7 @@ Few examples of the syntax:
 
 .. code-block:: sql
 
-    (T'2020-01-01', T'2022-01-01') OVERLAPS (T'2019-01-01', '2021-01-01')
+    (T'2020-01-01', T'2022-01-01') OVERLAPS (T'2019-01-01', T'2021-01-01')
     (interval.begin, interval.end) OVERLAPS interval_2
     interval_1 OVERLAPS interval_2
 

--- a/python/lsst/daf/butler/registry/queries/expressions/convert.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/convert.py
@@ -576,7 +576,7 @@ class TimeBinaryOperator:
         ----------
         *args : `ScalarWhereClauseConverter`
             Instances which represent time objects, their type can be one of
-            `Time` or `datetime`. If coercion happens that `Time` objects can
+            `Time` or `datetime`. If coercion happens, then `Time` objects can
             only be literals, not expressions.
 
         Returns
@@ -588,7 +588,7 @@ class TimeBinaryOperator:
         """
 
         def _coerce(arg: ScalarWhereClauseConverter) -> ScalarWhereClauseConverter:
-            """Coerce singe ScalarWhereClauseConverter to datetime literal.
+            """Coerce single ScalarWhereClauseConverter to datetime literal.
             """
             if arg.dtype is not datetime:
                 assert arg.value is not None, "Cannot coerce non-literals"

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,109 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from sqlalchemy.schema import Column
+from sqlalchemy.dialects import postgresql, sqlite
+
+from lsst.daf.butler.registry.queries.expressions import convertExpressionToSql, ParserYacc
+from lsst.daf.butler.registry.queries._structs import QueryColumns
+from lsst.daf.butler import DimensionUniverse
+from lsst.daf.butler.core import NamedKeyDict, TimespanDatabaseRepresentation
+
+
+class FakeDatasetRecordStorageManager:
+    ingestDate = Column("ingest_date")
+
+
+class ConvertExpressionToSqlTestCase(unittest.TestCase):
+    """A test case for convertExpressionToSql method
+    """
+
+    def setUp(self):
+        self.universe = DimensionUniverse()
+
+    def test_simple(self):
+        """Test with a trivial expression"""
+
+        parser = ParserYacc()
+        tree = parser.parse("1 > 0")
+        self.assertIsNotNone(tree)
+
+        columns = QueryColumns()
+        elements = NamedKeyDict()
+        column_element = convertExpressionToSql(
+            tree, self.universe, columns, elements, {},
+            TimespanDatabaseRepresentation.Compound
+        )
+        self.assertEqual(str(column_element.compile()), ":param_1 > :param_2")
+        self.assertEqual(str(column_element.compile(compile_kwargs={"literal_binds": True})), "1 > 0")
+
+    def test_time(self):
+        """Test with a trivial expression including times"""
+
+        parser = ParserYacc()
+        tree = parser.parse("T'1970-01-01 00:00/tai' < T'2020-01-01 00:00/tai'")
+        self.assertIsNotNone(tree)
+
+        columns = QueryColumns()
+        elements = NamedKeyDict()
+        column_element = convertExpressionToSql(
+            tree, self.universe, columns, elements, {},
+            TimespanDatabaseRepresentation.Compound
+        )
+        self.assertEqual(str(column_element.compile()), ":param_1 < :param_2")
+        self.assertEqual(str(column_element.compile(compile_kwargs={"literal_binds": True})),
+                         "0 < 1577836800000000000")
+
+    def test_ingest_date(self):
+        """Test with an expression including ingest_date which is native UTC"""
+
+        parser = ParserYacc()
+        tree = parser.parse("ingest_date < T'2020-01-01 00:00/utc'")
+        self.assertIsNotNone(tree)
+
+        columns = QueryColumns()
+        columns.datasets = FakeDatasetRecordStorageManager()
+        elements = NamedKeyDict()
+        column_element = convertExpressionToSql(
+            tree, self.universe, columns, elements, {},
+            TimespanDatabaseRepresentation.Compound
+        )
+
+        # render it, needs specific dialect to convert column to expression
+        dialect = postgresql.dialect()
+        self.assertEqual(str(column_element.compile(dialect=dialect)),
+                         "ingest_date < TIMESTAMP %(param_1)s")
+        self.assertEqual(str(column_element.compile(dialect=dialect,
+                                                    compile_kwargs={"literal_binds": True})),
+                         "ingest_date < TIMESTAMP '2020-01-01 00:00:00.000000'")
+
+        dialect = sqlite.dialect()
+        self.assertEqual(str(column_element.compile(dialect=dialect)),
+                         "datetime(ingest_date) < datetime(?)")
+        self.assertEqual(str(column_element.compile(dialect=dialect,
+                                                    compile_kwargs={"literal_binds": True})),
+                         "datetime(ingest_date) < datetime('2020-01-01 00:00:00.000000')")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Do not convert ingest_date to nanoseconds, instead use native time
functions for all operations. This requires some time literals to be
converted from astropy Time to datetime. The change implies that we
cannot use ingest_date with other TAI-based timestamp columns in the
same sub-expression. If we need that feature then ingest_date needs to
be migrated to TAI nanoseconds.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
