### PR TITLE
DM-30977: Add python log handler to store LogRecord as they come in

### DIFF
--- a/doc/changes/DM-30977.feature.rst
+++ b/doc/changes/DM-30977.feature.rst
@@ -1,0 +1,5 @@
+* Add class representing a collection of log records (``ButlerLogRecords``).
+* Allow this class to be stored and retrieved from a Butler datastore.
+* Add special log handler to allow JSON log records to be stored.
+* Add ``--log-file`` option to command lines to redirect log output to file.
+* Add ``--no-log-tty`` to disable log output to terminal.

--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -29,7 +29,7 @@ import traceback
 import yaml
 
 from .cliLog import CliLog
-from .opt import log_level_option, long_log_option
+from .opt import log_level_option, long_log_option, log_file_option
 from .progress import ClickProgressHandler
 from lsst.utils import doImport
 
@@ -152,7 +152,8 @@ class LoaderCLI(click.MultiCommand, abc.ABC):
 
         Subcommands may further configure the log settings."""
         if isinstance(ctx, click.Context):
-            CliLog.initLog(longlog=ctx.params.get(long_log_option.name(), False))
+            CliLog.initLog(longlog=ctx.params.get(long_log_option.name(), False),
+                           log_file=ctx.params.get(log_file_option.name(), None))
             if log_level_option.name() in ctx.params:
                 CliLog.setLogLevels(ctx.params[log_level_option.name()])
         else:
@@ -316,8 +317,9 @@ class ButlerCLI(LoaderCLI):
 @click.command(cls=ButlerCLI, context_settings=dict(help_option_names=["-h", "--help"]))
 @log_level_option()
 @long_log_option()
+@log_file_option()
 @ClickProgressHandler.option
-def cli(log_level, long_log, progress):
+def cli(log_level, long_log, log_file, progress):
     # log_level is handled by get_command and list_commands, and is called in
     # one of those functions before this is called. long_log is handled by
     # setup_logging.

--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -153,7 +153,7 @@ class LoaderCLI(click.MultiCommand, abc.ABC):
         Subcommands may further configure the log settings."""
         if isinstance(ctx, click.Context):
             CliLog.initLog(longlog=ctx.params.get(long_log_option.name(), False),
-                           log_file=ctx.params.get(log_file_option.name(), None))
+                           log_file=ctx.params.get(log_file_option.name(), ()))
             if log_level_option.name() in ctx.params:
                 CliLog.setLogLevels(ctx.params[log_level_option.name()])
         else:

--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -29,7 +29,7 @@ import traceback
 import yaml
 
 from .cliLog import CliLog
-from .opt import log_level_option, long_log_option, log_file_option
+from .opt import log_level_option, long_log_option, log_file_option, log_tty_option
 from .progress import ClickProgressHandler
 from lsst.utils import doImport
 
@@ -153,6 +153,7 @@ class LoaderCLI(click.MultiCommand, abc.ABC):
         Subcommands may further configure the log settings."""
         if isinstance(ctx, click.Context):
             CliLog.initLog(longlog=ctx.params.get(long_log_option.name(), False),
+                           log_tty=ctx.params.get(log_tty_option.name(), True),
                            log_file=ctx.params.get(log_file_option.name(), ()))
             if log_level_option.name() in ctx.params:
                 CliLog.setLogLevels(ctx.params[log_level_option.name()])
@@ -318,8 +319,9 @@ class ButlerCLI(LoaderCLI):
 @log_level_option()
 @long_log_option()
 @log_file_option()
+@log_tty_option()
 @ClickProgressHandler.option
-def cli(log_level, long_log, log_file, progress):
+def cli(log_level, long_log, log_file, log_tty, progress):
     # log_level is handled by get_command and list_commands, and is called in
     # one of those functions before this is called. long_log is handled by
     # setup_logging.

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -85,7 +85,7 @@ class CliLog:
     that need to be closed on reset."""
 
     @classmethod
-    def initLog(cls, longlog, log_file=()):
+    def initLog(cls, longlog: bool, log_tty: bool = True, log_file=()):
         """Initialize logging. This should only be called once per program
         execution. After the first call this will log a warning and return.
 
@@ -96,6 +96,9 @@ class CliLog:
         ----------
         longlog : `bool`
             If True, make log messages appear in long format, by default False.
+        log_tty : `bool`
+            Control whether a default stream handler is enabled that logs
+            to the terminal.
         log_file : `tuple` of `str`
             Path to files to write log records. If path ends in ``.json`` the
             records will be written in JSON format. Else they will be written
@@ -124,7 +127,9 @@ class CliLog:
             # MDC is set via ButlerMDC, rather than in lsst.log.
             lsstLog.usePythonLogging()
 
-        if longlog:
+        if not log_tty:
+            logging.basicConfig(force=True, handlers=[logging.NullHandler()])
+        elif longlog:
 
             # Want to create our own Formatter so that we can get high
             # precision timestamps. This requires we attach our own

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -85,7 +85,7 @@ class CliLog:
     that need to be closed on reset."""
 
     @classmethod
-    def initLog(cls, longlog, log_file=None):
+    def initLog(cls, longlog, log_file=()):
         """Initialize logging. This should only be called once per program
         execution. After the first call this will log a warning and return.
 
@@ -96,10 +96,10 @@ class CliLog:
         ----------
         longlog : `bool`
             If True, make log messages appear in long format, by default False.
-        log_file : `str`
-            Path to file to write log records. If ends in ``.json`` the
+        log_file : `tuple` of `str`
+            Path to files to write log records. If path ends in ``.json`` the
             records will be written in JSON format. Else they will be written
-            in text format. If `None` no log file will be created. Records
+            in text format. If empty no log file will be created. Records
             will be appended to this file if it exists.
         """
         if cls._initialized:
@@ -154,9 +154,9 @@ class CliLog:
         ButlerMDC.add_mdc_log_record_factory()
 
         # Set up the file logger
-        if log_file:
-            handler = logging.FileHandler(log_file)
-            if log_file.endswith(".json"):
+        for file in log_file:
+            handler = logging.FileHandler(file)
+            if file.endswith(".json"):
                 formatter = JsonFormatter()
             else:
                 if longlog:

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -27,8 +27,7 @@ try:
 except ModuleNotFoundError:
     lsstLog = None
 
-from lsst.daf.butler import ButlerMDC
-from ..core.logging import JsonFormatter
+from ..core.logging import JsonLogFormatter, ButlerMDC
 
 
 class PrecisionLogFormatter(logging.Formatter):
@@ -162,7 +161,7 @@ class CliLog:
         for file in log_file:
             handler = logging.FileHandler(file)
             if file.endswith(".json"):
-                formatter = JsonFormatter()
+                formatter = JsonLogFormatter()
             else:
                 if longlog:
                     formatter = PrecisionLogFormatter(fmt=cls.pylog_longLogFmt, style="{")

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -28,7 +28,7 @@ except ModuleNotFoundError:
     lsstLog = None
 
 from lsst.daf.butler import ButlerMDC
-from ..core.logging import MDCDict, JsonFormatter
+from ..core.logging import JsonFormatter
 
 
 class PrecisionLogFormatter(logging.Formatter):
@@ -151,15 +151,7 @@ class CliLog:
         # to the records. By default this is only used for long-log
         # but always enable it for when someone adds a new handler
         # that needs it.
-        old_factory = logging.getLogRecordFactory()
-
-        def record_factory(*args, **kwargs):
-            record = old_factory(*args, **kwargs)
-            # Make sure we send a copy of the global dict in the record.
-            record.MDC = MDCDict(ButlerMDC._MDC)
-            return record
-
-        logging.setLogRecordFactory(record_factory)
+        ButlerMDC.add_mdc_log_record_factory()
 
         # Set up the file logger
         if log_file:
@@ -200,6 +192,8 @@ class CliLog:
             logger = logging.getLogger(componentSetting.component)
             logger.setLevel(componentSetting.pythonLogLevel)
         cls._setLogLevel(None, "INFO")
+
+        ButlerMDC.restore_log_record_factory()
 
         # Remove the FileHandler we may have attached.
         root = logging.getLogger()

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -172,7 +172,7 @@ class CliLog:
             cls._fileHandlers.append(handler)
 
         # remember this call
-        cls.configState.append((cls.initLog, longlog, log_file))
+        cls.configState.append((cls.initLog, longlog, log_tty, log_file))
 
     @classmethod
     def resetLog(cls):

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -122,6 +122,11 @@ log_file_option = MWOptionDecorator("--log-file",
                                     " JSON log records will be written, else formatted text log records"
                                     " will be written. This file can exist and records will be appended.")
 
+log_tty_option = MWOptionDecorator("--log-tty/--no-log-tty",
+                                   default=True,
+                                   help="Log to terminal (default). If false logging to terminal is"
+                                   " disabled.")
+
 options_file_option = MWOptionDecorator("--options-file", "-@",
                                         expose_value=False,  # This option should not be forwarded
                                         help=unwrap("""URI to YAML file containing overrides

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -115,9 +115,11 @@ long_log_option = MWOptionDecorator("--long-log",
 
 log_file_option = MWOptionDecorator("--log-file",
                                     default=None,
+                                    multiple=True,
+                                    callback=split_commas,
                                     type=MWPath(file_okay=True, dir_okay=False, writable=True),
-                                    help="File to write log messages. If the path ends with '.json' then JSON"
-                                    " log records will be written, else formatted text log records"
+                                    help="File(s) to write log messages. If the path ends with '.json' then"
+                                    " JSON log records will be written, else formatted text log records"
                                     " will be written. This file can exist and records will be appended.")
 
 options_file_option = MWOptionDecorator("--options-file", "-@",

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -23,7 +23,7 @@
 import click
 from functools import partial
 
-from ..utils import MWOptionDecorator, split_commas, split_kv, unwrap, yaml_presets
+from ..utils import MWOptionDecorator, MWPath, split_commas, split_kv, unwrap, yaml_presets
 from lsst.daf.butler.registry import CollectionType
 
 
@@ -113,6 +113,12 @@ long_log_option = MWOptionDecorator("--long-log",
                                     help="Make log messages appear in long format.",
                                     is_flag=True)
 
+log_file_option = MWOptionDecorator("--log-file",
+                                    default=None,
+                                    type=MWPath(file_okay=True, dir_okay=False, writable=True),
+                                    help="File to write log messages. If the path ends with '.json' then JSON"
+                                    " log records will be written, else formatted text log records"
+                                    " will be written. This file can exist and records will be appended.")
 
 options_file_option = MWOptionDecorator("--options-file", "-@",
                                         expose_value=False,  # This option should not be forwarded

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -73,3 +73,4 @@ AstropyTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter
 AstropyQTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter
 ExtendedPsf: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 HealSparseMap: lsst.pipe.tasks.healSparseMapping.HealSparseMapFormatter
+ButlerLogRecords: lsst.daf.butler.formatters.logs.ButlerLogRecordsFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -260,3 +260,5 @@ storageClasses:
     parameters:
       - pixels
       - degrade_nside
+  ButlerLogRecords:
+    pytype: lsst.daf.butler.ButlerLogRecords

--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -30,4 +30,7 @@ from ._topology import *
 from .timespan import *
 from .progress import Progress
 from . import progress  # most symbols are only used by handler implementors
-from .logging import *
+# Only import the VERBOSE constant and ButlerLogRecords
+# VERBOSE is useful for log messages and ButlerLogRecords is the
+# fundamental type stored in datastores.
+from .logging import VERBOSE, ButlerLogRecords

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -488,7 +488,7 @@ class Datastore(metaclass=ABCMeta):
         instead of `_finishIngest`.
         """
         raise NotImplementedError(
-            "Datastore does not support direct file-based ingest."
+            f"Datastore {self} does not support direct file-based ingest."
         )
 
     def _finishIngest(self, prepData: IngestPrepData, *, transfer: Optional[str] = None) -> None:
@@ -518,7 +518,7 @@ class Datastore(metaclass=ABCMeta):
         directly.
         """
         raise NotImplementedError(
-            "Datastore does not support direct file-based ingest."
+            f"Datastore {self} does not support direct file-based ingest."
         )
 
     def ingest(self, *datasets: FileDataset, transfer: Optional[str] = None) -> None:

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -312,4 +312,4 @@ class JsonFormatter(Formatter):
 
     def format(self, record: LogRecord) -> str:
         butler_record = ButlerLogRecord.from_record(record)
-        return butler_record.json()
+        return butler_record.json(exclude_unset=True, exclude_defaults=True)

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 __all__ = ("VERBOSE", "ButlerMDC", "ButlerLogRecords", "ButlerLogRecordHandler",
-           "ButlerLogRecord", "JsonFormatter")
+           "ButlerLogRecord", "JsonLogFormatter")
 
 import logging
 import datetime
@@ -492,7 +492,7 @@ class ButlerLogRecordHandler(StreamHandler):
         self.records.append(record)
 
 
-class JsonFormatter(Formatter):
+class JsonLogFormatter(Formatter):
     """Format a `LogRecord` in JSON format."""
 
     def format(self, record: LogRecord) -> str:

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -25,6 +25,7 @@ __all__ = ("VERBOSE", "ButlerMDC", "ButlerLogRecords", "ButlerLogRecordHandler")
 
 import logging
 import datetime
+import traceback
 from typing import List, Union, Optional, ClassVar, Iterable, Iterator, Dict
 
 from logging import LogRecord, StreamHandler
@@ -126,6 +127,7 @@ class ButlerLogRecord(BaseModel):
     funcName: Optional[str]
     process: int
     processName: str
+    exc_info: Optional[str]
     MDC: Dict[str, str]
 
     class Config:
@@ -159,6 +161,14 @@ class ButlerLogRecord(BaseModel):
         # every system is using the same time.
         record_dict["asctime"] = datetime.datetime.fromtimestamp(record.created,
                                                                  tz=datetime.timezone.utc)
+
+        # Sometimes exception information is included so must be
+        # extracted.
+        if record.exc_info:
+            etype = record.exc_info[0]
+            evalue = record.exc_info[1]
+            tb = record.exc_info[2]
+            record_dict["exc_info"] = "\n".join(traceback.format_exception(etype, evalue, tb))
 
         return cls(**record_dict)
 

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -359,6 +359,7 @@ class ButlerLogRecords(BaseModel):
         # A stream of records with one record per line.
         records = [ButlerLogRecord.parse_raw(first_line)]
         for line in stream:
+            line = line.rstrip()
             if line:  # Filter out blank lines.
                 records.append(ButlerLogRecord.parse_raw(line))
 

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -247,8 +247,14 @@ class ButlerLogRecords(BaseModel):
     def __setitem__(self, index: int, value: Record) -> None:
         self.__root__[index] = self._validate_record(value)
 
-    def __getitem__(self, index: int) -> ButlerLogRecord:
-        return self.__root__[index]
+    def __getitem__(self, index: Union[slice, int]) -> Union[ButlerLogRecords, ButlerLogRecord]:
+        # Handles slices and returns a new collection in that
+        # case.
+        item = self.__root__[index]
+        if isinstance(item, list):
+            return type(self)(__root__=item)
+        else:
+            return item
 
     def __reversed__(self) -> Iterator[ButlerLogRecord]:
         return self.__root__.__reversed__()

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -25,7 +25,7 @@ __all__ = ("VERBOSE", "ButlerMDC", "ButlerLogRecords", "ButlerLogRecordHandler")
 
 import logging
 import datetime
-from typing import List, Union, Optional, ClassVar, Iterable, Iterator
+from typing import List, Union, Optional, ClassVar, Iterable, Iterator, Dict
 
 from logging import LogRecord, StreamHandler
 from pydantic import BaseModel, ValidationError
@@ -126,6 +126,7 @@ class ButlerLogRecord(BaseModel):
     funcName: Optional[str]
     process: int
     processName: str
+    MDC: Dict[str, str]
 
     class Config:
         """Pydantic model configuration."""
@@ -148,6 +149,10 @@ class ButlerLogRecord(BaseModel):
         record_dict = {k: getattr(record, k) for k in simple}
 
         record_dict["message"] = record.getMessage()
+
+        # MDC -- ensure the contents are copied to prevent any confusion
+        # over the MDC global being updated later.
+        record_dict["MDC"] = dict(getattr(record, "MDC", {}))
 
         # Always use UTC because in distributed systems we can't be sure
         # what timezone localtime is and it's easier to compare logs if

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -32,6 +32,8 @@ from typing import List, Union, Optional, ClassVar, Iterable, Iterator, Dict, IO
 from logging import LogRecord, StreamHandler, Formatter
 from pydantic import BaseModel, ValidationError
 
+from .utils import isplit
+
 VERBOSE = (logging.INFO + logging.DEBUG) // 2
 """Verbose log level"""
 
@@ -354,7 +356,7 @@ class ButlerLogRecords(BaseModel):
         # Filter out blank lines -- mypy is confused by the newline
         # argument to split().
         newline = "\n" if isinstance(serialized, str) else b"\n"
-        records = [ButlerLogRecord.parse_raw(line) for line in serialized.split(newline)  # type: ignore
+        records = [ButlerLogRecord.parse_raw(line) for line in isplit(serialized, newline)  # type: ignore
                    if line]
         return cls.from_records(records)
 

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -30,7 +30,7 @@ import traceback
 from typing import List, Union, Optional, ClassVar, Iterable, Iterator, Dict, IO
 
 from logging import LogRecord, StreamHandler, Formatter
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from .utils import isplit
 
@@ -407,7 +407,7 @@ class ButlerLogRecords(BaseModel):
         elif isinstance(record, LogRecord):
             record = ButlerLogRecord.from_record(record)
         else:
-            raise ValidationError(f"Can only append item of type {type(record)}")
+            raise ValueError(f"Can only append item of type {type(record)}")
         return record
 
     def insert(self, index: int, value: Record) -> None:

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -223,6 +223,10 @@ class ButlerLogRecord(BaseModel):
 
         as_dict = self.dict()
 
+        # Special case MDC content. Convert it to an MDCDict
+        # so that missing items do not break formatting.
+        as_dict["MDC"] = MDCDict(as_dict["MDC"])
+
         as_dict["asctime"] = as_dict["asctime"].isoformat()
         formatted = log_format.format(**as_dict)
         return formatted

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -313,7 +313,7 @@ class ButlerLogRecords(BaseModel):
     def __reversed__(self) -> Iterator[ButlerLogRecord]:
         return self.__root__.__reversed__()
 
-    def __delitem__(self, index: int) -> None:
+    def __delitem__(self, index: Union[slice, int]) -> None:
         del self.__root__[index]
 
     def __str__(self) -> str:

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -26,6 +26,7 @@ __all__ = (
     "getFullTypeName",
     "getInstanceOf",
     "immutable",
+    "isplit",
     "iterable",
     "safeMakeDir",
     "Singleton",
@@ -445,3 +446,32 @@ def globToRegex(expressions: Union[str, EllipsisType, None,
             res = re.compile(fnmatch.translate(e))
         results.append(res)
     return results
+
+
+T = TypeVar('T', str, bytes)
+
+
+def isplit(string: T, sep: T) -> Iterator[T]:
+    """Split a string or bytes by separator returning a generator.
+
+    Parameters
+    ----------
+    string : `str` or `bytes`
+        The string to split into substrings.
+    sep : `str` or `bytes`
+        The separator to use to split the string. Must be the same
+        type as ``string``. Must always be given.
+
+    Yields
+    ------
+    subset : `str` or `bytes`
+        The next subset extracted from the input until the next separator.
+    """
+    begin = 0
+    while True:
+        end = string.find(sep, begin)
+        if end == -1:
+            yield string[begin:]
+            return
+        yield string[begin:end]
+        begin = end + 1

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -139,4 +139,4 @@ class ButlerLogRecordsFormatter(JsonFormatter):
         Exception
             The object could not be serialized.
         """
-        return inMemoryDataset.json().encode()
+        return inMemoryDataset.json(exclude_unset=True, exclude_defaults=True).encode()

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -27,7 +27,7 @@ from typing import (
     Type,
 )
 
-from lsst.daf.butler import ButlerLogRecords
+from lsst.daf.butler.core.logging import ButlerLogRecords
 from .json import JsonFormatter
 
 

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -1,0 +1,83 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ("ButlerLogRecordsFormatter", )
+
+from typing import (
+    Any,
+    Optional,
+    Type,
+)
+
+from lsst.daf.butler import ButlerLogRecords
+from .json import JsonFormatter
+
+
+class ButlerLogRecordsFormatter(JsonFormatter):
+    """Read and write log records in JSON format.
+
+    This is a naive implementation that treats everything as a pydantic.
+    model.  In the future this may be changed to be able to read
+    ``ButlerLogRecord`` one at time from the file and return a subset
+    of records given some filtering parameters.
+    """
+
+    def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
+        """Read the bytes object as a python object.
+
+        Parameters
+        ----------
+        serializedDataset : `bytes`
+            Bytes object to unserialize.
+        pytype : `class`, optional
+            Not used by this implementation.
+
+        Returns
+        -------
+        inMemoryDataset : `object`
+            The requested data as a Python object or None if the string could
+            not be read.
+        """
+        if pytype is None:
+            pytype = ButlerLogRecords
+        elif not issubclass(pytype, ButlerLogRecords):
+            raise RuntimeError(f"Python type {pytype} does not seem to be a ButlerLogRecords type")
+        return pytype.parse_raw(serializedDataset)
+
+    def _toBytes(self, inMemoryDataset: Any) -> bytes:
+        """Write the in memory dataset to a bytestring.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to serialize
+
+        Returns
+        -------
+        serializedDataset : `bytes`
+            bytes representing the serialized dataset.
+
+        Raises
+        ------
+        Exception
+            The object could not be serialized.
+        """
+        return inMemoryDataset.json().encode()

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -27,7 +27,7 @@ from typing import (
     Type,
 )
 
-from lsst.daf.butler import ButlerLogRecords, ButlerLogRecord
+from lsst.daf.butler import ButlerLogRecords
 from .json import JsonFormatter
 
 
@@ -36,7 +36,7 @@ class ButlerLogRecordsFormatter(JsonFormatter):
 
     This is a naive implementation that treats everything as a pydantic.
     model.  In the future this may be changed to be able to read
-    ``ButlerLogRecord`` one at time from the file and return a subset
+    `ButlerLogRecord` one at time from the file and return a subset
     of records given some filtering parameters.
     """
 
@@ -92,19 +92,7 @@ class ButlerLogRecordsFormatter(JsonFormatter):
         elif not issubclass(pytype, ButlerLogRecords):
             raise RuntimeError(f"Python type {pytype} does not seem to be a ButlerLogRecords type")
 
-        if not serializedDataset:
-            # No records to return
-            return pytype.from_records([])
-
-        if serializedDataset.startswith(b"["):
-            return pytype.parse_raw(serializedDataset)
-
-        if not serializedDataset.startswith(b"{"):
-            raise RuntimeError(f"These bytes do not look like JSON -- starts with '{serializedDataset[0]}'")
-
-        # Filter out blank lines.
-        records = [ButlerLogRecord.parse_raw(line) for line in serializedDataset.split(b"\n") if line]
-        return pytype.from_records(records)
+        return pytype.from_raw(serializedDataset)
 
     def _toBytes(self, inMemoryDataset: Any) -> bytes:
         """Write the in memory dataset to a bytestring.

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -67,22 +67,7 @@ class ButlerLogRecordsFormatter(JsonFormatter):
         elif not issubclass(pytype, ButlerLogRecords):
             raise RuntimeError(f"Python type {pytype} does not seem to be a ButlerLogRecords type")
 
-        with open(path, "r") as fd:
-            first = fd.readline()
-            if first.startswith("["):
-                # This is a ButlerLogRecords serialization.
-                all = first + fd.read()
-                return pytype.parse_raw(all)
-
-            # A stream of records with one record per line.
-            if not first.startswith("{"):
-                raise RuntimeError(f"Unrecognized JSON log format. First lines is '{first}'")
-            records = [ButlerLogRecord.parse_raw(first)]
-            for line in fd:
-                if line:  # Filter out blank lines.
-                    records.append(ButlerLogRecord.parse_raw(line))
-
-            return pytype.from_records(records)
+        return pytype.from_file(path)
 
     def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
         """Read the bytes object as a python object.
@@ -101,7 +86,7 @@ class ButlerLogRecordsFormatter(JsonFormatter):
             The requested data as a Python object or None if the string could
             not be read.
         """
-        # Duplicates some of the logic from readFile above.
+        # Duplicates some of the logic from ButlerLogRecords.from_file
         if pytype is None:
             pytype = ButlerLogRecords
         elif not issubclass(pytype, ButlerLogRecords):

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -170,8 +170,9 @@ class CliLogTestBase():
 
         with self.runner.isolated_filesystem():
             for longlog in (True, False):
-                # The click test does not capture logging emitted from lsst.log
-                # so use subprocess to run the test instead.
+                # The pytest log handler interferes with the log configuration
+                # settings set up by initLog -- therefore test by using
+                # a subprocess.
                 if longlog:
                     args = ("butler", "--log-level", "DEBUG", "--long-log", "create", "here")
                 else:

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -199,7 +199,7 @@ class CliLogTestBase():
                                     msg=f"did not find lines starting with module in: \n{output.getvalue()}")
 
     def testFileLogging(self):
-        """Test --file-log option."""
+        """Test --log-file option."""
         with self.runner.isolated_filesystem():
             for i, suffix in enumerate([".json", ".log"]):
                 # Get a temporary file name and immediately close it

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -229,6 +229,26 @@ class CliLogTestBase():
 
                 self.assertGreater(len(records), 5)
 
+    def testLogTty(self):
+        """Verify that log output to terminal can be suppressed."""
+
+        with self.runner.isolated_filesystem():
+            for log_tty in (True, False):
+                # The pytest log handler interferes with the log configuration
+                # settings set up by initLog -- therefore test by using
+                # a subprocess.
+                if log_tty:
+                    args = ("butler", "--log-level", "DEBUG", "--log-tty", "create", "here")
+                else:
+                    args = ("butler", "--log-level", "DEBUG", "--no-log-tty", "create", "here2")
+                result = subprocess.run(args, capture_output=True)
+
+                output = result.stderr.decode()
+                if log_tty:
+                    self.assertIn("DEBUG", output)
+                else:
+                    self.assertNotIn("DEBUG", output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -37,7 +37,7 @@ import tempfile
 from lsst.daf.butler.cli.butler import cli as butlerCli
 from lsst.daf.butler.cli.cliLog import CliLog
 from lsst.daf.butler.cli.utils import clickResultMsg, command_test_env, LogCliRunner
-from lsst.daf.butler import ButlerLogRecords
+from lsst.daf.butler.core.logging import ButlerLogRecords
 try:
     import lsst.log as lsstLog
 except ModuleNotFoundError:

--- a/tests/test_logFormatter.py
+++ b/tests/test_logFormatter.py
@@ -29,7 +29,7 @@ import tempfile
 from logging import FileHandler
 
 from lsst.daf.butler import Butler, DatasetType, FileDataset, DatasetRef
-from lsst.daf.butler import ButlerLogRecordHandler, JsonFormatter
+from lsst.daf.butler.core.logging import ButlerLogRecordHandler, JsonLogFormatter
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
@@ -80,7 +80,7 @@ class ButlerLogRecordsFormatterTestCase(unittest.TestCase):
                                           delete=False)
 
         handler = FileHandler(tmp.name)
-        handler.setFormatter(JsonFormatter())
+        handler.setFormatter(JsonLogFormatter())
         log.addHandler(handler)
 
         log.info("An INFO message")

--- a/tests/test_logFormatter.py
+++ b/tests/test_logFormatter.py
@@ -1,0 +1,70 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for ButlerLogRecordsFormatter.
+"""
+
+import unittest
+import os
+import logging
+
+from lsst.daf.butler import Butler, DatasetType, ButlerLogRecordHandler
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class ButlerLogRecordsFormatterTestCase(unittest.TestCase):
+    """Test for ButlerLogRecords put/get."""
+
+    def setUp(self):
+        self.root = makeTestTempDir(TESTDIR)
+        Butler.makeRepo(self.root)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def testButlerLogRecordsFormatter(self):
+        butler = Butler(self.root, run="testrun")
+        datasetType = DatasetType("test_logs", [], "ButlerLogRecords",
+                                  universe=butler.registry.dimensions)
+
+        butler.registry.registerDatasetType(datasetType)
+
+        handler = ButlerLogRecordHandler()
+
+        log = logging.getLogger(self.id())
+        log.setLevel(logging.INFO)
+        log.addHandler(handler)
+
+        log.info("An INFO message")
+        log.debug("A DEBUG message")
+        log.warning("A WARNING message")
+
+        ref = butler.put(handler.records, datasetType)
+        records = butler.getDirect(ref)
+
+        self.assertEqual(records, handler.records)
+        self.assertEqual(len(records), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -281,6 +281,9 @@ class TestJsonLogging(unittest.TestCase):
         log.info("A message")
         log.warning("A warning")
 
+        # Add a blank line to the stream to check the parser ignores it.
+        print(file=stream)
+
         # Rewind the stream and pull messages out of it.
         stream.seek(0)
         records = ButlerLogRecords.from_stream(stream)
@@ -288,8 +291,14 @@ class TestJsonLogging(unittest.TestCase):
         self.assertEqual(records[0].message, "A message")
         self.assertEqual(records[1].levelname, "WARNING")
 
-        # Now read from the file.
+        # Now read from the file. Add two blank lines to test the parser
+        # will filter them out.
         file_handler.close()
+
+        with open(filename, "a") as fd:
+            print(file=fd)
+            print(file=fd)
+
         file_records = ButlerLogRecords.from_file(filename)
         self.assertEqual(file_records, records)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,66 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import logging
+
+from lsst.daf.butler import ButlerLogRecordHandler, ButlerLogRecords, VERBOSE
+
+
+class LoggingTestCase(unittest.TestCase):
+    """Test we can capture log messages."""
+
+    def testRecordCapture(self):
+        handler = ButlerLogRecordHandler()
+
+        log = logging.getLogger(self.id())
+        log.setLevel(VERBOSE)
+        log.addHandler(handler)
+
+        test_messages = (
+            (logging.INFO, "This is a log message", True),
+            (logging.WARNING, "This is a warning message", True),
+            (logging.DEBUG, "This debug message should not be stored", False),
+            (VERBOSE, "A verbose message should appear", True),
+        )
+
+        for level, message, _ in test_messages:
+            log.log(level, message)
+
+        expected = [info for info in test_messages if info[2]]
+
+        self.assertEqual(len(handler.records), len(expected))
+
+        for given, record in zip(expected, handler.records):
+            self.assertEqual(given[0], record.levelno)
+            self.assertEqual(given[1], record.message)
+
+        # Check that we can serialize the records
+        json = handler.records.json()
+
+        records = ButlerLogRecords.parse_raw(json)
+        for original_record, new_record in zip(handler.records, records):
+            self.assertEqual(new_record, original_record)
+        self.assertEqual(str(records), str(handler.records))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -25,11 +25,11 @@ import logging
 import tempfile
 from logging import StreamHandler, FileHandler
 
-from lsst.daf.butler import (
+from lsst.daf.butler.core.logging import (
     ButlerLogRecordHandler,
     ButlerLogRecords,
     VERBOSE,
-    JsonFormatter,
+    JsonLogFormatter,
     ButlerLogRecord,
     ButlerMDC,
 )
@@ -263,7 +263,7 @@ class TestJsonLogging(unittest.TestCase):
         log.setLevel(logging.INFO)
 
         # Log to a stream and also to a file.
-        formatter = JsonFormatter()
+        formatter = JsonLogFormatter()
 
         stream = io.StringIO()
         stream_handler = StreamHandler(stream)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -70,6 +70,33 @@ class LoggingTestCase(unittest.TestCase):
             self.assertEqual(new_record, original_record)
         self.assertEqual(str(records), str(self.handler.records))
 
+    def testButlerLogRecords(self):
+
+        self.log.setLevel(logging.INFO)
+
+        n_messages = 10
+        message = "Message #%d"
+        for counter in range(n_messages):
+            self.log.info(message, counter)
+
+        records = self.handler.records
+        self.assertEqual(len(records), n_messages)
+
+        # Test slicing.
+        start = 2
+        end = 6
+        subset = records[start:end]
+        self.assertIsInstance(subset, ButlerLogRecords)
+        self.assertEqual(len(subset), end - start)
+        self.assertIn(f"#{start}", subset[0].message)
+
+        # Test slice for deleting
+        initial_length = len(subset)
+        start_del = 1
+        end_del = 3
+        del subset[start_del:end_del]
+        self.assertEqual(len(subset), initial_length - (end_del - start_del))
+
     def testExceptionInfo(self):
 
         self.log.setLevel(logging.DEBUG)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -255,6 +255,17 @@ class LoggingTestCase(unittest.TestCase):
         self.assertEqual(self.handler.records[-1].format(fmt), "x")
         self.assertEqual(self.handler.records[-1].format("{message}"), f"Message {i}")
 
+        # MDC context manager
+        fmt = "x{MDC[LABEL]} - {message}"
+        ButlerMDC.MDC("LABEL", "original")
+        with ButlerMDC.set_mdc({"LABEL": "test"}):
+            i += 1
+            self.log.info("Message %d", i)
+        self.assertEqual(self.handler.records[-1].format(fmt), f"xtest - Message {i}")
+        i += 1
+        self.log.info("Message %d", i)
+        self.assertEqual(self.handler.records[-1].format(fmt), f"xoriginal - Message {i}")
+
 
 class TestJsonLogging(unittest.TestCase):
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -213,6 +213,25 @@ class LoggingTestCase(unittest.TestCase):
         # But can be optional on a record that didn't set it.
         self.assertEqual(self.handler.records[0].format(fmt), "x")
 
+        # Set an extra MDC entry and include all content.
+        extra = "extra"
+        ButlerMDC.MDC("EXTRA", extra)
+
+        i += 1
+        self.log.info("Message %d", i)
+        formatted = self.handler.records[-1].format("x{MDC} - {message}")
+        self.assertIn(f"EXTRA={extra}", formatted)
+        self.assertIn("LABEL=dataId", formatted)
+        self.assertIn(f"Message {i}", formatted)
+
+        # Clear the MDC and ensure that it does not continue to appear
+        # in messages.
+        ButlerMDC.MDCRemove("LABEL")
+        i += 1
+        self.log.info("Message %d", i)
+        self.assertEqual(self.handler.records[-1].format(fmt), "x")
+        self.assertEqual(self.handler.records[-1].format("{message}"), f"Message {i}")
+
 
 class TestJsonLogging(unittest.TestCase):
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -105,6 +105,29 @@ class LoggingTestCase(unittest.TestCase):
                 if not trim:
                     self.assertIn("...", str(cm.exception))
 
+    def testRecordsFormatting(self):
+
+        self.log.setLevel(logging.DEBUG)
+        self.log.debug("debug message")
+        self.log.warning("warning message")
+        self.log.critical("critical message")
+        self.log.log(VERBOSE, "verbose message")
+
+        self.assertEqual(len(self.handler.records), 4)
+
+        format_default = str(self.handler.records)
+
+        # Set the format for these records.
+        self.handler.records.set_log_format("{levelname}")
+        format_override = str(self.handler.records)
+
+        self.assertNotEqual(format_default, format_override)
+        self.assertEqual(format_override, "DEBUG\nWARNING\nCRITICAL\nVERBOSE")
+
+        # Reset the log format and it should match the original text.
+        self.handler.records.set_log_format(None)
+        self.assertEqual(str(self.handler.records), format_default)
+
     def testButlerLogRecords(self):
         """Test the list-like methods of ButlerLogRecords."""
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -109,7 +109,8 @@ class TestJsonLogging(unittest.TestCase):
 
         # Rewind the stream and pull messages out of it.
         stream.seek(0)
-        records = [ButlerLogRecord.parse_raw(line) for line in stream]
+        records = ButlerLogRecords.from_stream(stream)
+        self.assertIsInstance(records[0], ButlerLogRecord)
         self.assertEqual(records[0].message, "A message")
         self.assertEqual(records[1].levelname, "WARNING")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,7 @@ import unittest
 from lsst.daf.butler.core.utils import findFileResources, getFullTypeName, globToRegex, iterable, Singleton
 from lsst.daf.butler import Formatter, Registry
 from lsst.daf.butler import NamedKeyDict, NamedValueSet, StorageClass
-
+from lsst.daf.butler.core.utils import isplit
 
 TESTDIR = os.path.dirname(__file__)
 
@@ -216,6 +216,18 @@ class TestButlerUtils(unittest.TestCase):
 
         for item, typeName in tests:
             self.assertEqual(getFullTypeName(item), typeName)
+
+    def testIsplit(self):
+        # Test compatibility with str.split
+        seps = ("\n", " ", "d")
+        input_str = "ab\ncd ef\n"
+
+        for sep in seps:
+            for input in (input_str, input_str.encode()):
+                test_sep = sep.encode() if isinstance(input, bytes) else sep
+                isp = list(isplit(input, sep=test_sep))
+                ssp = input.split(test_sep)
+                self.assertEqual(isp, ssp)
 
 
 class FindFileResourcesTestCase(unittest.TestCase):


### PR DESCRIPTION
These records can then be serialized in butler datastore.  This is assuming that lsst/log#55 is merged which will also need changes in daf_butler for initializing logging such that we no longer forward everything to lsst.log. Will need changes to ctrl_mpexec as well.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
