### PR TITLE
PREOPS-579: Add method to check for deterministic dataset ID support.

### DIFF
--- a/python/lsst/daf/butler/registries/remote.py
+++ b/python/lsst/daf/butler/registries/remote.py
@@ -266,6 +266,10 @@ class RemoteRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError()
 
+    def supportsIdGenerationMode(self, mode: DatasetIdGenEnum) -> bool:
+        # Docstring inherited from lsst.daf.butler.registry.Registry
+        raise NotImplementedError()
+
     def findDataset(self, datasetType: Union[DatasetType, str], dataId: Optional[DataId] = None, *,
                     collections: Any = None, timespan: Optional[Timespan] = None,
                     **kwargs: Any) -> Optional[DatasetRef]:

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -390,6 +390,10 @@ class SqlRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return self._managers.datasets[name].datasetType
 
+    def supportsIdGenerationMode(self, mode: DatasetIdGenEnum) -> bool:
+        # Docstring inherited from lsst.daf.butler.registry.Registry
+        return self._managers.datasets.supportsIdGenerationMode(mode)
+
     def findDataset(self, datasetType: Union[DatasetType, str], dataId: Optional[DataId] = None, *,
                     collections: Any = None, timespan: Optional[Timespan] = None,
                     **kwargs: Any) -> Optional[DatasetRef]:

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -603,6 +603,23 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def supportsIdGenerationMode(self, mode: DatasetIdGenEnum) -> bool:
+        """Test whether the given dataset ID generation mode is supported by
+        `insertDatasets`.
+
+        Parameters
+        ----------
+        mode : `DatasetIdGenEnum`
+            Enum value for the mode to test.
+
+        Returns
+        -------
+        supported : `bool`
+            Whether the given mode is supported.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def findDataset(self, datasetType: Union[DatasetType, str], dataId: Optional[DataId] = None, *,
                     collections: Any = None, timespan: Optional[Timespan] = None,
                     **kwargs: Any) -> Optional[DatasetRef]:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -27,6 +27,7 @@ from lsst.daf.butler import (
 )
 from lsst.daf.butler.registry import ConflictingDefinitionError, OrphanedRecordError
 from lsst.daf.butler.registry.interfaces import (
+    DatasetIdGenEnum,
     DatasetRecordStorage,
     DatasetRecordStorageManager,
     VersionTuple
@@ -350,6 +351,12 @@ class ByDimensionsDatasetRecordStorageManager(ByDimensionsDatasetRecordStorageMa
     _autoincrement: bool = True
     _idColumnType: type = sqlalchemy.BigInteger
 
+    @classmethod
+    def supportsIdGenerationMode(cls, mode: DatasetIdGenEnum) -> bool:
+        # Docstring inherited from DatasetRecordStorageManager.
+        # MyPy seems confused about enum value types here.
+        return mode is mode.UNIQUE  # type: ignore
+
 
 class ByDimensionsDatasetRecordStorageManagerUUID(ByDimensionsDatasetRecordStorageManagerBase):
     """Implementation of ByDimensionsDatasetRecordStorageManagerBase which uses
@@ -359,3 +366,8 @@ class ByDimensionsDatasetRecordStorageManagerUUID(ByDimensionsDatasetRecordStora
     _recordStorageType: Type[ByDimensionsDatasetRecordStorage] = ByDimensionsDatasetRecordStorageUUID
     _autoincrement: bool = False
     _idColumnType: type = ddl.GUID
+
+    @classmethod
+    def supportsIdGenerationMode(cls, mode: DatasetIdGenEnum) -> bool:
+        # Docstring inherited from DatasetRecordStorageManager.
+        return True

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -423,6 +423,24 @@ class DatasetRecordStorageManager(VersionedExtension):
 
     @classmethod
     @abstractmethod
+    def supportsIdGenerationMode(cls, mode: DatasetIdGenEnum) -> bool:
+        """Test whether the given dataset ID generation mode is supported by
+        `insert`.
+
+        Parameters
+        ----------
+        mode : `DatasetIdGenEnum`
+            Enum value for the mode to test.
+
+        Returns
+        -------
+        supported : `bool`
+            Whether the given mode is supported.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    @abstractmethod
     def addDatasetForeignKey(cls, tableSpec: ddl.TableSpec, *,
                              name: str = "dataset", constraint: bool = True, onDelete: Optional[str] = None,
                              **kwargs: Any) -> ddl.FieldSpec:


### PR DESCRIPTION
This functionality is really DM-30344, and it turns out I didn't need it for the main goal of this ticket, but it's not worth the effort to move it to another branch and separate it (or really its obs_base counterpart) from the functionality I do need.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
