### PR TITLE
DM-31120: Switch all logging to python

### DIFF
--- a/doc/changes/DM-31120.other.rst
+++ b/doc/changes/DM-31120.other.rst
@@ -1,0 +1,2 @@
+Switch logging such that all logging messages are now forwarded to Python ``logging`` from ``lsst.log``.
+Previously all Python ``logging`` messages were being forwarded to ``lsst.log``.


### PR DESCRIPTION
Now lsst.log messages are forwarded to python.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
