### PR TITLE
DM-31337: Allow skipping calibration collections

### DIFF
--- a/doc/changes/DM-31337.feature.md
+++ b/doc/changes/DM-31337.feature.md
@@ -1,0 +1,4 @@
+Registry methods that previously could raise an exception when searching in
+calibrations collections now have an improved logic that skip those
+collections if they were not given explicitly but only appeared in chained
+collections.

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -143,6 +143,7 @@ class QueryBuilder:
             collections = CollectionSearch.fromExpression(collections)
         else:
             collections = CollectionQuery.fromExpression(collections)
+        explicitCollections = frozenset(collections.explicitNames())
         # If we are searching all collections with no constraints, loop over
         # RUN collections only, because that will include all datasets.
         collectionTypes: AbstractSet[CollectionType]
@@ -163,7 +164,9 @@ class QueryBuilder:
         for rank, collectionRecord in enumerate(collections.iter(self._managers.collections,
                                                                  collectionTypes=collectionTypes)):
             if collectionRecord.type is CollectionType.CALIBRATION:
-                if datasetType.isCalibration():
+                # If collection name was provided explicitly then say sorry,
+                # otherwise collection is a part of chained one and we skip it.
+                if datasetType.isCalibration() and collectionRecord.name in explicitCollections:
                     raise NotImplementedError(
                         f"Query for dataset type '{datasetType.name}' in CALIBRATION-type collection "
                         f"'{collectionRecord.name}' is not yet supported."

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -489,6 +489,11 @@ class CollectionSearch(BaseModel, Sequence[str]):
                     includeChains=includeChains,
                 )
 
+    def explicitNames(self) -> Iterator[str]:
+        """Iterate over collection names that were specified explicitly.
+        """
+        yield from self.__root__
+
     def __iter__(self) -> Iterator[str]:  # type: ignore
         yield from self.__root__
 
@@ -657,6 +662,12 @@ class CollectionQuery:
                         flattenChains=flattenChains,
                         includeChains=includeChains,
                     )
+
+    def explicitNames(self) -> Iterator[str]:
+        """Iterate over collection names that were specified explicitly.
+        """
+        if isinstance(self._search, CollectionSearch):
+            yield from self._search.explicitNames()
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, CollectionQuery):


### PR DESCRIPTION
QueryBuilder joinDataset() method now has an improved logic for handling
calibration collections. If calibration collection name was not specified
explicitly but appeared inside chained collection then that collection is
silently skipped instead of raising NotImplementedError.


## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
