### PR TITLE
DM-31344: Fix some logic for ButlerURI.relative_to()

### DIFF
--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -612,6 +612,14 @@ class ButlerURI:
             Returns `None` if there is no parent child relationship.
             Scheme and netloc must match.
         """
+        # Scheme-less absolute other is treated as if it's a file scheme.
+        # Scheme-less relative other can only return non-None if self
+        # is also scheme-less relative and that is handled specifically
+        # in a subclass.
+        if not other.scheme and other.isabs():
+            other = other.abspath()
+
+        # Scheme-less self is handled elsewhere.
         if self.scheme != other.scheme or self.netloc != other.netloc:
             return None
 

--- a/python/lsst/daf/butler/core/_butlerUri/file.py
+++ b/python/lsst/daf/butler/core/_butlerUri/file.py
@@ -34,7 +34,6 @@ __all__ = ('ButlerFileURI',)
 
 from typing import (
     TYPE_CHECKING,
-    cast,
     Iterator,
     List,
     Optional,
@@ -103,63 +102,6 @@ class ButlerFileURI(ButlerURI):
             Always returns `False` (this is not a temporary file).
         """
         return self.ospath, False
-
-    def relative_to(self, other: ButlerURI) -> Optional[str]:
-        """Return the relative path from this URI to the other URI.
-
-        Parameters
-        ----------
-        other : `ButlerURI`
-            URI to use to calculate the relative path. Must be a parent
-            of this URI.
-
-        Returns
-        -------
-        subpath : `str`
-            The sub path of this URI relative to the supplied other URI.
-            Returns `None` if there is no parent child relationship.
-            Scheme and netloc must match but for file URIs schemeless
-            is also used. If this URI is a relative URI but the other is
-            absolute, it is assumed to be in the parent completely unless it
-            starts with ".." (in which case the path is combined and tested).
-            If both URIs are relative, the relative paths are compared
-            for commonality.
-
-        Notes
-        -----
-        By definition a relative path will be relative to the enclosing
-        absolute parent URI. It will be returned unchanged if it does not
-        use a parent directory specification.
-        """
-        # We know self is a file so check the other. Anything other than
-        # file or schemeless means by definition these have no paths in common
-        if other.scheme and other.scheme != "file":
-            return None
-
-        # for case where both URIs are relative use the normal logic
-        # where a/b/c.txt and a/b/ returns c.txt.
-        if not self.isabs() and not other.isabs():
-            return super().relative_to(other)
-
-        # if we have a relative path convert it to absolute
-        # relative to the supplied parent.  This is solely to handle
-        # the case where the relative path includes ".." but somehow
-        # then goes back inside the directory of the parent
-        if not self.isabs():
-            childUri = other.join(self.path)
-            return childUri.relative_to(other)
-
-        # By this point if the schemes are identical we can use the
-        # base class implementation.
-        if self.scheme == other.scheme:
-            return super().relative_to(other)
-
-        # if one is schemeless and the other is not the base implementation
-        # will fail so we need to fix that -- they are both absolute so
-        # forcing to file is fine.
-        # Use a cast to convince mypy that other has to be a ButlerFileURI
-        # in order to get to this part of the code.
-        return self.abspath().relative_to(cast(ButlerFileURI, other).abspath())
 
     def read(self, size: int = -1) -> bytes:
         """Return the entire content of the file as bytes."""

--- a/python/lsst/daf/butler/core/_butlerUri/schemeless.py
+++ b/python/lsst/daf/butler/core/_butlerUri/schemeless.py
@@ -141,7 +141,7 @@ class ButlerSchemelessURI(ButlerFileURI):
             root = os.path.abspath(os.path.curdir)
         elif isinstance(root, ButlerURI):
             if root.scheme and root.scheme != "file":
-                raise RuntimeError(f"The override root must be a file URI not {root.scheme}")
+                raise ValueError(f"The override root must be a file URI not {root.scheme}")
             root = os.path.abspath(root.ospath)
 
         # this is a local OS file path which can support tilde expansion.

--- a/python/lsst/daf/butler/core/_butlerUri/schemeless.py
+++ b/python/lsst/daf/butler/core/_butlerUri/schemeless.py
@@ -90,6 +90,60 @@ class ButlerSchemelessURI(ButlerFileURI):
         return ButlerURI(str(self), forceAbsolute=True, forceDirectory=self.isdir(),
                          isTemporary=self.isTemporary)
 
+    def relative_to(self, other: ButlerURI) -> Optional[str]:
+        """Return the relative path from this URI to the other URI.
+
+        Parameters
+        ----------
+        other : `ButlerURI`
+            URI to use to calculate the relative path.
+
+        Returns
+        -------
+        subpath : `str`
+            The sub path of this URI relative to the supplied other URI.
+            Returns `None` if there is no parent child relationship.
+            If this URI is a relative URI but the other is
+            absolute, it is assumed to be in the parent completely unless it
+            starts with ".." (in which case the path is combined and tested).
+            If both URIs are relative, the relative paths are compared
+            for commonality.
+
+        Notes
+        -----
+        By definition a relative path will be relative to the enclosing
+        absolute parent URI. It will be returned unchanged if it does not
+        use a parent directory specification.
+        """
+        # In some scenarios below a new derived child URI needs to be created
+        # to convert from scheme-less to absolute URI.
+        child = None
+
+        if not self.isabs() and not other.isabs():
+            # Both are schemeless relative. Use parent implementation
+            # rather than trying to convert both to file: first since schemes
+            # match.
+            pass
+        elif not self.isabs() and other.isabs():
+            # Append child to other. This can account for .. in child path.
+            child = other.join(self.path)
+        elif self.isabs() and not other.isabs():
+            # Finding common paths is not possible if the parent is
+            # relative and the child is absolute.
+            return None
+        elif self.isabs() and other.isabs():
+            # Both are absolute so convert schemeless to file
+            # if necessary.
+            child = self.abspath()
+            if not other.scheme:
+                other = other.abspath()
+        else:
+            raise RuntimeError(f"Unexpected combination of {child}.relative_to({other}).")
+
+        if child is None:
+            return super().relative_to(other)
+        return child.relative_to(other)
+
     @classmethod
     def _fixupPathUri(cls, parsed: urllib.parse.ParseResult, root: Optional[Union[str, ButlerURI]] = None,
                       forceAbsolute: bool = False,

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -78,6 +78,12 @@ class FileURITestCase(unittest.TestCase):
         self.assertEqual(uri, uri2)
         self.assertEqual(id(uri), id(uri2))
 
+        with self.assertRaises(ValueError):
+            # Scheme-less URIs are not allowed to support non-file roots
+            # at the present time. This may change in the future to become
+            # equivalent to ButlerURI.join()
+            ButlerURI("a/b.txt", root=ButlerURI("s3://bucket/a/b/"))
+
     def testExtension(self):
         file = ButlerURI(os.path.join(self.tmpdir, "test.txt"))
         self.assertEqual(file.updatedExtension(None), file)

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -290,10 +290,10 @@ class FileURITestCase(unittest.TestCase):
 
         # Test that children relative to schemeless and file schemes
         # still return the same unquoted name
-        self.assertEqual(fnew2.relative_to(fdir), new2name)
-        self.assertEqual(fnew2.relative_to(dir), new2name)
-        self.assertEqual(new2.relative_to(fdir), new2name, f"{new2} vs {fdir}")
-        self.assertEqual(new2.relative_to(dir), new2name)
+        self.assertEqual(fnew2.relative_to(fdir), new2name, f"{fnew2}.relative_to({fdir})")
+        self.assertEqual(fnew2.relative_to(dir), new2name, f"{fnew2}.relative_to({dir})")
+        self.assertEqual(new2.relative_to(fdir), new2name, f"{new2}.relative_to({fdir})")
+        self.assertEqual(new2.relative_to(dir), new2name, f"{new2}.relative_to({dir})")
 
         # Check for double quoting
         plus_path = "/a/b/c+d/"

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -103,11 +103,11 @@ class FileURITestCase(unittest.TestCase):
         self.assertEqual(child.relative_to(parent), "dir1/file.txt")
 
         not_child = ButlerURI("/a/b/dir1/file.txt")
-        self.assertFalse(not_child.relative_to(parent))
+        self.assertIsNone(not_child.relative_to(parent))
         self.assertFalse(not_child.isdir())
 
         not_directory = ButlerURI(os.path.join(self.tmpdir, "dir1", "file2.txt"))
-        self.assertFalse(child.relative_to(not_directory))
+        self.assertIsNone(child.relative_to(not_directory))
 
         # Relative URIs
         parent = ButlerURI("a/b/", forceAbsolute=False)
@@ -124,7 +124,7 @@ class FileURITestCase(unittest.TestCase):
         self.assertEqual(child.relative_to(parent), "e/f/g.txt")
 
         child = ButlerURI("../e/f/g.txt", forceAbsolute=False)
-        self.assertFalse(child.relative_to(parent))
+        self.assertIsNone(child.relative_to(parent))
 
         child = ButlerURI("../c/e/f/g.txt", forceAbsolute=False)
         self.assertEqual(child.relative_to(parent), "e/f/g.txt")

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -129,6 +129,29 @@ class FileURITestCase(unittest.TestCase):
         child = ButlerURI("../c/e/f/g.txt", forceAbsolute=False)
         self.assertEqual(child.relative_to(parent), "e/f/g.txt")
 
+        # Test non-file root with relative path.
+        child = ButlerURI("e/f/g.txt", forceAbsolute=False)
+        parent = ButlerURI("s3://hello/a/b/c/")
+        self.assertEqual(child.relative_to(parent), "e/f/g.txt")
+
+        # Test with different netloc
+        child = ButlerURI("http://my.host/a/b/c.txt")
+        parent = ButlerURI("http://other.host/a/")
+        self.assertIsNone(child.relative_to(parent), f"{child}.relative_to({parent})")
+
+        # Schemeless absolute child.
+        # Schemeless absolute URI is constructed using root= parameter.
+        parent = ButlerURI("file:///a/b/c/")
+        child = ButlerURI("d/e.txt", root=parent)
+        self.assertEqual(child.relative_to(parent), "d/e.txt", f"{child}.relative_to({parent})")
+
+        parent = ButlerURI("c/", root="/a/b/")
+        self.assertEqual(child.relative_to(parent), "d/e.txt", f"{child}.relative_to({parent})")
+
+        # Absolute schemeless child with relative parent will always fail.
+        parent = ButlerURI("d/e.txt", forceAbsolute=False)
+        self.assertIsNone(child.relative_to(parent), f"{child}.relative_to({parent})")
+
     def testParents(self):
         """Test of splitting and parent walking."""
         parent = ButlerURI(self.tmpdir, forceDirectory=True, forceAbsolute=True)


### PR DESCRIPTION
Rewrites the ButlerURI.relative_to() code for scheme-less URIs so that it works correctly with S3 URIs.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
