### PR TITLE
DM-31398: Handle absolute URIs in datastore with transfer=None export

### DIFF
--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2057,8 +2057,10 @@ class FileDatastore(GenericBaseDatastore):
             pathInStore = location.pathInStore.path
             if transfer is None:
                 # TODO: do we also need to return the readStorageClass somehow?
-                # We will use the path in store directly
-                pass
+                # We will use the path in store directly. If this is an
+                # absolute URI, preserve it.
+                if location.pathInStore.isabs():
+                    pathInStore = str(location.uri)
             elif transfer == "direct":
                 # Use full URIs to the remote store in the export
                 pathInStore = str(location.uri)


### PR DESCRIPTION
Previously this worked for local file systems because uri.path
returns an absolute path and the system didn't notice the
bad logic. At IDF storing uri.path for an absolute URI gives
the path component "/CALIB/..." and drops the scheme and bucket
name. Now correctly trap an absolute URI with None transfer
mode.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
