### PR TITLE
DM-31507 Modify data-structures to aid ref counting

### DIFF
--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -237,7 +237,9 @@ class CategorizedWildcard:
                 raise TypeError(f"Object '{element!r}' returned by coercion function is still unrecognized.")
             if coerceUnrecognized is not None:
                 try:
-                    process(coerceUnrecognized(element), alreadyCoerced=True)
+                    # This should be safe but flake8 cant tell that the
+                    # function will be re-declared next function call
+                    process(coerceUnrecognized(element), alreadyCoerced=True)  # noqa: F821
                 except Exception as err:
                     raise TypeError(f"Could not coerce expression element '{element!r}'.") from err
             else:
@@ -254,6 +256,7 @@ class CategorizedWildcard:
                 if not allowAny:
                     raise TypeError("This expression may not be unconstrained.")
                 return Ellipsis
+        del process
         return self
 
     def makeWhereExpression(self, column: sqlalchemy.sql.ColumnElement


### PR DESCRIPTION
It is desirable that variables get cleaned up when they go out of
scope, meaning that their ref count must go to zero. Some objects
kept closures or circular references which means they must be
cleaned by the garbage collector which can happen at unpredictable
times. Make these objects able to be dropped with reference counting.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
