### PR TITLE
DM-31520: Allow butler collection-chain to have comma-separated children

### DIFF
--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -504,7 +504,7 @@ def transfer_datasets(**kwargs):
 @click.command(cls=ButlerCommand)
 @repo_argument(required=True)
 @click.argument("parent", required=True, nargs=1)
-@click.argument("children", required=False, nargs=-1)
+@click.argument("children", required=False, nargs=-1, callback=split_commas)
 @click.option("--doc", default="",
               help="Documentation string associated with this collection. "
               "Only relevant if the collection is newly created.")
@@ -526,11 +526,16 @@ def collection_chain(**kwargs):
     PARENT is the name of the chained collection to create or modify. If the
     collection already exists the chain associated with it will be updated.
 
-    CHILDREN are the collections to be used to modify the chain. The exact
-    usage depends on the MODE option. When the MODE is 'pop' the CHILDREN
-    should be integer indices indicating collections to be removed from
-    the current chain.
+    CHILDREN are the collections to be used to modify the chain. The supplied
+    values will be split on comma. The exact usage depends on the MODE option.
+    For example,
 
+    $ butler collection-chain REPO PARENT child1,child2 child3
+
+    will result in three children being included in the chain.
+
+    When the MODE is 'pop' the CHILDREN should be integer indices indicating
+    collections to be removed from the current chain.
     MODE 'pop' can take negative integers to indicate removal relative to the
     end of the chain, but when doing that '--' must be given to indicate the
     end of the options specification.

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -208,6 +208,7 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
             # Add a couple more run collections for chain testing
             registry1.registerRun("run2")
             registry1.registerRun("run3")
+            registry1.registerRun("run4")
 
             self.assertChain(["--mode", "pop", "chain1"],
                              "[run1, chain2]")
@@ -224,11 +225,11 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
             self.assertChain(["--mode", "pop", "chain1", "1", "3"],
                              "[chain2, run1]")
 
-            self.assertChain(["--mode", "redefine", "chain1", "chain2", "run2", "run3", "--flatten"],
-                             "[calibration1, run1, run2, run3]")
+            self.assertChain(["--mode", "redefine", "chain1", "chain2", "run2", "run3,run4", "--flatten"],
+                             "[calibration1, run1, run2, run3, run4]")
 
             self.assertChain(["--mode", "pop", "chain1", "--", "-1", "-3"],
-                             "[calibration1, run2]")
+                             "[calibration1, run1, run3]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This simplifies the movement of options for pipetask which do
include commas.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
