### PR TITLE
DM-31542: Enable compression for all the Exposure formatters

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/writeRecipes.yaml
+++ b/python/lsst/daf/butler/configs/datastores/writeRecipes.yaml
@@ -1,4 +1,4 @@
-lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter:
+lsst.obs.base.formatters.fitsExposure.StandardFitsImageFormatterBase: &StandardFitsImageFormatterBase
   # No compression
   noCompression: &noCompression
     image: &noCompressionOptions
@@ -42,3 +42,11 @@ lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter:
   # Set the default
   default:
     <<: *lossless
+lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter:
+  <<: *StandardFitsImageFormatterBase
+lsst.obs.base.formatters.fitsExposure.FitsImageFormatter:
+  <<: *StandardFitsImageFormatterBase
+lsst.obs.base.formatters.fitsExposure.FitsMaskFormatter:
+  <<: *StandardFitsImageFormatterBase
+lsst.obs.base.formatters.fitsExposure.FitsMaskedImageFormatter:
+  <<: *StandardFitsImageFormatterBase


### PR DESCRIPTION
With the reorganization of the FitsExposureFormatter
the compression options were no longer being applied to Image,
Variance or Mask components. This change ensures that all
the formatters support compression.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
