### PR TITLE
DM-30178: Preparing for sqlalchemy 2 API changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,41 +15,69 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: 3.8
-
-      - name: Install sqlite
-        run: sudo apt-get install sqlite libyaml-dev
+          channels: conda-forge,defaults
+          channel-priority: strict
+          show-channel-urls: true
 
       - name: Update pip/wheel infrastructure
+        shell: bash -l {0}
         run: |
-          python -m pip install --upgrade pip
-          pip install wheel
+          conda install -y -q pip wheel
+
+      - name: Install sqlite
+        shell: bash -l {0}
+        run: |
+          conda install -y -q sqlite
 
       - name: Install postgresql (server)
         run: sudo apt install postgresql
 
       - name: Install postgresql Python packages
-        run: pip install psycopg2 testing.postgresql
+        shell: bash -l {0}
+        run: |
+          conda install -y -q psycopg2
+          pip install testing.postgresql
 
       - name: Install cryptography package for moto
-        run: pip install cryptography
+        shell: bash -l {0}
+        run: |
+          conda install -y -q cryptography
 
       - name: Install WebDAV packages for testing
-        run: pip install cheroot wsgidav
+        shell: bash -l {0}
+        run: |
+          pip install cheroot wsgidav
 
       - name: Install dependencies
+        shell: bash -l {0}
         run: |
           pip install -r requirements.txt
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages
-        run: pip install pytest pytest-flake8 pytest-xdist pytest-openfiles
+        shell: bash -l {0}
+        run: |
+          conda install -y -q \
+            flake8 \
+            pytest pytest-flake8 pytest-xdist pytest-openfiles
+
+      - name: List installed packages
+        shell: bash -l {0}
+        run: |
+          conda list
+          pip list -v
 
       - name: Build and install
-        run: pip install -v .
+        shell: bash -l {0}
+        run: |
+          pip install -v .
 
       - name: Run tests
-        run: pytest -r a -v -n 3 --open-files
+        shell: bash -l {0}
+        env:
+          SQLALCHEMY_WARN_20: 1
+        run: |
+          pytest -r a -v -n 3 --open-files

--- a/python/lsst/daf/butler/core/simpleQuery.py
+++ b/python/lsst/daf/butler/core/simpleQuery.py
@@ -126,7 +126,7 @@ class SimpleQuery:
         sql : `sqlalchemy.sql.Select`
             A SQLAlchemy object representing the full query.
         """
-        result = sqlalchemy.sql.select(self.columns)
+        result = sqlalchemy.sql.select(*self.columns)
         if self._from is not None:
             result = result.select_from(self._from)
         if self.where:

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -1014,7 +1014,7 @@ class SqlRegistry(Registry):
             query = storage.select(collectionRecord)
             if query is None:
                 continue
-            for row in self._db.query(query.combine()):
+            for row in self._db.query(query.combine()).mappings():
                 dataId = DataCoordinate.fromRequiredValues(
                     storage.datasetType.dimensions,
                     tuple(row[name] for name in storage.datasetType.dimensions.required.names)

--- a/python/lsst/daf/butler/registry/attributes.py
+++ b/python/lsst/daf/butler/registry/attributes.py
@@ -82,7 +82,7 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
 
     def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
         # Docstring inherited from ButlerAttributeManager.
-        sql = sqlalchemy.sql.select([self._table.columns.value]).where(
+        sql = sqlalchemy.sql.select(self._table.columns.value).where(
             self._table.columns.name == name
         )
         row = self._db.query(sql).fetchone()
@@ -115,16 +115,16 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
 
     def items(self) -> Iterable[Tuple[str, str]]:
         # Docstring inherited from ButlerAttributeManager.
-        sql = sqlalchemy.sql.select([
+        sql = sqlalchemy.sql.select(
             self._table.columns.name,
             self._table.columns.value,
-        ])
+        )
         for row in self._db.query(sql):
             yield row[0], row[1]
 
     def empty(self) -> bool:
         # Docstring inherited from ButlerAttributeManager.
-        sql = sqlalchemy.sql.select([sqlalchemy.sql.func.count()]).select_from(self._table)
+        sql = sqlalchemy.sql.select(sqlalchemy.sql.func.count()).select_from(self._table)
         row = self._db.query(sql).fetchone()
         return row[0] == 0
 

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -173,7 +173,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Docstring inherited from DatastoreRegistryBridge
         byId = {ref.getCheckedId(): ref for ref in refs}
         sql = sqlalchemy.sql.select(
-            [self._tables.dataset_location.columns.dataset_id]
+            self._tables.dataset_location.columns.dataset_id
         ).select_from(
             self._tables.dataset_location
         ).where(
@@ -241,18 +241,18 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         if record_column is not None:
             # Some helper subqueries
             items_not_in_trash = join_records(
-                sqlalchemy.sql.select([records_table._table.columns[record_column]]),
+                sqlalchemy.sql.select(records_table._table.columns[record_column]),
                 self._tables.dataset_location,
             ).alias("items_not_in_trash")
             items_in_trash = join_records(
-                sqlalchemy.sql.select([records_table._table.columns[record_column]]),
+                sqlalchemy.sql.select(records_table._table.columns[record_column]),
                 self._tables.dataset_location_trash,
             ).alias("items_in_trash")
 
             # A query for paths that are referenced by datasets in the trash
             # and datasets not in the trash.
             items_to_preserve = sqlalchemy.sql.select(
-                [items_in_trash.columns[record_column]]
+                items_in_trash.columns[record_column]
             ).select_from(
                 items_not_in_trash.join(
                     items_in_trash,
@@ -337,7 +337,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
     def findDatastores(self, ref: DatasetRef) -> Iterable[str]:
         # Docstring inherited from DatastoreRegistryBridge
         sql = sqlalchemy.sql.select(
-            [self._tables.dataset_location.columns.datastore_name]
+            self._tables.dataset_location.columns.datastore_name
         ).select_from(
             self._tables.dataset_location
         ).where(

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -183,7 +183,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
             )
         )
         for row in self._db.query(sql).fetchall():
-            yield byId[row["dataset_id"]]
+            yield byId[row.dataset_id]
 
     @contextmanager
     def emptyTrash(self, records_table: Optional[OpaqueTableStorage] = None,
@@ -261,7 +261,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
                 )
             )
             preserved = {row[record_column]
-                         for row in self._db.query(items_to_preserve).fetchall()}
+                         for row in self._db.query(items_to_preserve).mappings()}
 
         # Convert results to a tuple of id+info and a record of the artifacts
         # that should not be deleted from datastore. The id+info tuple is
@@ -343,7 +343,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
         ).where(
             self._tables.dataset_location.columns.dataset_id == ref.getCheckedId()
         )
-        for row in self._db.query(sql).fetchall():
+        for row in self._db.query(sql).mappings():
             yield row[self._tables.dataset_location.columns.datastore_name]
         for name, bridge in self._ephemeral.items():
             if ref in bridge:

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -229,7 +229,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Run query, transform results into a list of dicts that we can later
         # use to delete.
         rows = [dict(**row, datastore_name=self.datastoreName)
-                for row in self._db.query(info_in_trash).fetchall()]
+                for row in self._db.query(info_in_trash).mappings()]
 
         # It is possible for trashed refs to be linked to artifacts that
         # are still associated with refs that are not to be trashed. We

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -281,7 +281,7 @@ class DefaultChainedCollectionRecord(ChainedCollectionRecord):
             self._table.columns.position
         )
         return CollectionSearch.fromExpression(
-            [manager[row[self._table.columns.child]].name for row in self._db.query(sql)]
+            [manager[row._mapping[self._table.columns.child]].name for row in self._db.query(sql)]
         )
 
 
@@ -331,7 +331,7 @@ class DefaultCollectionManager(Generic[K], CollectionManager):
         records = []
         chains = []
         TimespanReprClass = self._db.getTimespanRepresentation()
-        for row in self._db.query(sql).fetchall():
+        for row in self._db.query(sql).mappings():
             collection_id = row[self._tables.collection.columns[self._collectionIdName]]
             name = row[self._tables.collection.columns.name]
             type = CollectionType(row["type"])

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -271,9 +271,9 @@ class DefaultChainedCollectionRecord(ChainedCollectionRecord):
 
     def _load(self, manager: CollectionManager) -> CollectionSearch:
         # Docstring inherited from ChainedCollectionRecord.
-        sql = sqlalchemy.sql.select([
+        sql = sqlalchemy.sql.select(
             self._table.columns.child,
-        ]).select_from(
+        ).select_from(
             self._table
         ).where(
             self._table.columns.parent == self.key
@@ -322,7 +322,7 @@ class DefaultCollectionManager(Generic[K], CollectionManager):
     def refresh(self) -> None:
         # Docstring inherited from CollectionManager.
         sql = sqlalchemy.sql.select(
-            list(self._tables.collection.columns) + list(self._tables.run.columns)
+            *(list(self._tables.collection.columns) + list(self._tables.run.columns))
         ).select_from(
             self._tables.collection.join(self._tables.run, isouter=True)
         )
@@ -440,7 +440,7 @@ class DefaultCollectionManager(Generic[K], CollectionManager):
     def getDocumentation(self, key: Any) -> Optional[str]:
         # Docstring inherited from CollectionManager.
         sql = sqlalchemy.sql.select(
-            [self._tables.collection.columns.doc]
+            self._tables.collection.columns.doc
         ).select_from(
             self._tables.collection
         ).where(

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager, closing
 from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Tuple, Type, Union
 
 import psycopg2
+import sqlalchemy
 import sqlalchemy.dialects.postgresql
 
 from ..interfaces import Database
@@ -75,7 +76,7 @@ class PostgresqlDatabase(Database):
             if namespace is None:
                 namespace = connection.execute("SELECT current_schema();").scalar()
             query = "SELECT COUNT(*) FROM pg_extension WHERE extname='btree_gist';"
-            if not connection.execute(query).scalar():
+            if not connection.execute(sqlalchemy.text(query)).scalar():
                 raise RuntimeError(
                     "The Butler PostgreSQL backend requires the btree_gist extension. "
                     "As extensions are enabled per-database, this may require an administrator to run "
@@ -114,7 +115,7 @@ class PostgresqlDatabase(Database):
     def _lockTables(self, tables: Iterable[sqlalchemy.schema.Table] = ()) -> None:
         # Docstring inherited.
         for table in tables:
-            self._connection.execute(f"LOCK TABLE {table.key} IN EXCLUSIVE MODE")
+            self._connection.execute(sqlalchemy.text(f"LOCK TABLE {table.key} IN EXCLUSIVE MODE"))
 
     def isWriteable(self) -> bool:
         return self._writeable
@@ -167,7 +168,7 @@ class PostgresqlDatabase(Database):
                 for column in table.columns
                 if column.name not in table.primary_key}
         query = query.on_conflict_do_update(constraint=table.primary_key, set_=data)
-        self._connection.execute(query, *rows)
+        self._connection.execute(query, rows)
 
     def ensure(self, table: sqlalchemy.schema.Table, *rows: dict) -> int:
         # Docstring inherited.
@@ -178,7 +179,7 @@ class PostgresqlDatabase(Database):
         # we don't care which constraint is violated or specify which columns
         # to update.
         query = sqlalchemy.dialects.postgresql.dml.insert(table).on_conflict_do_nothing()
-        return self._connection.execute(query, *rows).rowcount
+        return self._connection.execute(query, rows).rowcount
 
 
 class _RangeTimespanType(sqlalchemy.TypeDecorator):

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -113,11 +113,11 @@ class PostgresqlDatabase(Database):
                     cursor.execute("SET TIME ZONE 0")
             yield
 
-    def _lockTables(self, tables: Iterable[sqlalchemy.schema.Table] = ()) -> None:
+    def _lockTables(self, connection: sqlalchemy.engine.Connection,
+                    tables: Iterable[sqlalchemy.schema.Table] = ()) -> None:
         # Docstring inherited.
-        with self._connection() as connection:
-            for table in tables:
-                connection.execute(sqlalchemy.text(f"LOCK TABLE {table.key} IN EXCLUSIVE MODE"))
+        for table in tables:
+            connection.execute(sqlalchemy.text(f"LOCK TABLE {table.key} IN EXCLUSIVE MODE"))
 
     def isWriteable(self) -> bool:
         return self._writeable

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -54,7 +54,7 @@ def _onSqlite3Begin(connection: sqlalchemy.engine.Connection) -> sqlalchemy.engi
     # own that does, and tell SQLite to try to acquire a lock as soon as we
     # start a transaction (this should lead to more blocking and fewer
     # deadlocks).
-    connection.execute("BEGIN IMMEDIATE")
+    connection.execute(sqlalchemy.text("BEGIN IMMEDIATE"))
     return connection
 
 
@@ -388,7 +388,7 @@ class SqliteDatabase(Database):
                 # a transaction.  The main-table insertion can take care of
                 # returnIds for us.
                 with self.transaction():
-                    self._connection.execute(autoincr.table.insert(), *rowsForAutoincrTable)
+                    self._connection.execute(autoincr.table.insert(), rowsForAutoincrTable)
                     return super().insert(table, *rows, returnIds=returnIds)
             else:
                 # Caller did not pass autoincrement key values on the first
@@ -427,7 +427,7 @@ class SqliteDatabase(Database):
             raise NotImplementedError(
                 "replace does not support compound primary keys with autoincrement fields."
             )
-        self._connection.execute(_Replace(table), *rows)
+        self._connection.execute(_Replace(table), rows)
 
     def ensure(self, table: sqlalchemy.schema.Table, *rows: dict) -> int:
         self.assertTableWriteable(table, f"Cannot ensure into read-only table {table}.")
@@ -437,7 +437,7 @@ class SqliteDatabase(Database):
             raise NotImplementedError(
                 "ensure does not support compound primary keys with autoincrement fields."
             )
-        return self._connection.execute(_Ensure(table), *rows).rowcount
+        return self._connection.execute(_Ensure(table), rows).rowcount
 
     filename: Optional[str]
     """Name of the file this database is connected to (`str` or `None`).

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -269,7 +269,8 @@ class SqliteDatabase(Database):
         else:
             return "SQLite3@:memory:"
 
-    def _lockTables(self, tables: Iterable[sqlalchemy.schema.Table] = ()) -> None:
+    def _lockTables(self, connection: sqlalchemy.engine.Connection,
+                    tables: Iterable[sqlalchemy.schema.Table] = ()) -> None:
         # Docstring inherited.
         # Our SQLite database always acquires full-database locks at the
         # beginning of a transaction, so there's no need to acquire table-level

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -184,7 +184,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         byName = {}
         byId: Dict[DatasetId, ByDimensionsDatasetRecordStorage] = {}
         c = self._static.dataset_type.columns
-        for row in self._db.query(self._static.dataset_type.select()).fetchall():
+        for row in self._db.query(self._static.dataset_type.select()).mappings():
             name = row[c.name]
             dimensions = self._dimensions.loadDimensionGraph(row[c.dimensions_key])
             calibTableName = row[c.calibration_association_table]
@@ -304,7 +304,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         ).where(
             self._static.dataset.columns.id == id
         )
-        row = self._db.query(sql).fetchone()
+        row = self._db.query(sql).mappings().fetchone()
         if row is None:
             return None
         recordsForType = self._byId.get(row[self._static.dataset.columns.dataset_type_id])

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -297,10 +297,8 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
     def getDatasetRef(self, id: DatasetId) -> Optional[DatasetRef]:
         # Docstring inherited from DatasetRecordStorageManager.
         sql = sqlalchemy.sql.select(
-            [
-                self._static.dataset.columns.dataset_type_id,
-                self._static.dataset.columns[self._collections.getRunForeignKeyName()],
-            ]
+            self._static.dataset.columns.dataset_type_id,
+            self._static.dataset.columns[self._collections.getRunForeignKeyName()],
         ).select_from(
             self._static.dataset
         ).where(

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
@@ -287,7 +287,7 @@ class CollectionSummaryManager:
         # rows.  This will never include CHAINED collections or collections
         # with no datasets.
         summaries: Dict[Any, CollectionSummary] = {}
-        for row in self._db.query(sql):
+        for row in self._db.query(sql).mappings():
             # Collection key should never be None/NULL; it's what we join on.
             # Extract that and then turn it into a collection name.
             collectionKey = row[self._collectionKeyName]

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
@@ -282,7 +282,7 @@ class CollectionSummaryManager:
                 ),
                 isouter=True,
             )
-        sql = sqlalchemy.sql.select(columns).select_from(fromClause)
+        sql = sqlalchemy.sql.select(*columns).select_from(fromClause)
         # Run the query and construct CollectionSummary objects from the result
         # rows.  This will never include CHAINED collections or collections
         # with no datasets.

--- a/python/lsst/daf/butler/registry/dimensions/governor.py
+++ b/python/lsst/daf/butler/registry/dimensions/governor.py
@@ -87,7 +87,7 @@ class BasicGovernorDimensionRecordStorage(GovernorDimensionRecordStorage):
         # Docstring inherited from GovernorDimensionRecordStorage.
         RecordClass = self._dimension.RecordClass
         sql = sqlalchemy.sql.select(
-            [self._table.columns[name] for name in RecordClass.fields.standard.names]
+            *[self._table.columns[name] for name in RecordClass.fields.standard.names]
         ).select_from(self._table)
         cache: Dict[str, DimensionRecord] = {}
         for row in self._db.query(sql):

--- a/python/lsst/daf/butler/registry/dimensions/governor.py
+++ b/python/lsst/daf/butler/registry/dimensions/governor.py
@@ -91,7 +91,7 @@ class BasicGovernorDimensionRecordStorage(GovernorDimensionRecordStorage):
         ).select_from(self._table)
         cache: Dict[str, DimensionRecord] = {}
         for row in self._db.query(sql):
-            record = RecordClass(**dict(row))
+            record = RecordClass(**row._asdict())
             cache[getattr(record, self._dimension.primaryKey.name)] = record
         self._cache = cache
 

--- a/python/lsst/daf/butler/registry/dimensions/query.py
+++ b/python/lsst/daf/butler/registry/dimensions/query.py
@@ -128,7 +128,8 @@ class QueryDimensionRecordStorage(DatabaseDimensionRecordStorage):
             # as SelectableDimensionRecordStorage.fetch will do.
             # Instead, we add DISTINCT in join() only.
             self._query = sqlalchemy.sql.select(
-                columns, distinct=True
+                *columns
+            ).distinct(
             ).select_from(
                 targetTable
             ).alias(

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -288,7 +288,7 @@ class _DimensionGraphStorage:
         be called explicitly.
         """
         dimensionNamesByKey: Dict[int, Set[str]] = defaultdict(set)
-        for row in self._db.query(self._definitionTable.select()):
+        for row in self._db.query(self._definitionTable.select()).mappings():
             key = row[self._definitionTable.columns.dimension_graph_id]
             dimensionNamesByKey[key].add(row[self._definitionTable.columns.dimension_name])
         keysByGraph: Dict[DimensionGraph, int] = {self._universe.empty: 0}

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -640,7 +640,7 @@ class _SkyPixOverlapStorage:
             sysCol = self._summaryTable.columns.skypix_system
             lvlCol = self._summaryTable.columns.skypix_level
             query = sqlalchemy.sql.select(
-                [gvCol, sysCol, lvlCol],
+                gvCol, sysCol, lvlCol,
             ).select_from(
                 self._summaryTable
             ).where(
@@ -784,7 +784,7 @@ class _SkyPixOverlapStorage:
             if governorValues is not Ellipsis:
                 summaryWhere.append(gvCol.in_(list(governorValues)))
             summaryQuery = sqlalchemy.sql.select(
-                [gvCol]
+                gvCol
             ).select_from(
                 self._summaryTable
             ).where(
@@ -812,7 +812,7 @@ class _SkyPixOverlapStorage:
                 self._overlapTable.columns[self._governor.element.name].in_(list(governorValues))
             )
         overlapQuery = sqlalchemy.sql.select(
-            columns
+            *columns
         ).select_from(
             self._overlapTable
         ).where(

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -206,7 +206,7 @@ class TableDimensionRecordStorage(DatabaseDimensionRecordStorage):
         query.join(self._table)
         dataIds.constrain(query, lambda name: self._fetchColumns[name])
         for row in self._db.query(query.combine()):
-            values = dict(row)
+            values = row._asdict()
             if self.element.temporal is not None:
                 values[TimespanDatabaseRepresentation.NAME] = TimespanReprClass.extract(values)
             yield RecordClass(**values)

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -650,7 +650,7 @@ class _SkyPixOverlapStorage:
             skypix: Dict[str, NamedKeyDict[SkyPixSystem, List[int]]] = {
                 gv: NamedKeyDict() for gv in grouped.keys()
             }
-            for summaryRow in self._db.query(query):
+            for summaryRow in self._db.query(query).mappings():
                 system = self.element.universe.skypix[summaryRow[sysCol]]
                 skypix[summaryRow[gvCol]].setdefault(system, []).append(summaryRow[lvlCol])
             if replace:
@@ -790,7 +790,7 @@ class _SkyPixOverlapStorage:
             ).where(
                 sqlalchemy.sql.and_(*summaryWhere)
             )
-            materializedGovernorValues = {row[gvCol] for row in self._db.query(summaryQuery)}
+            materializedGovernorValues = {row._mapping[gvCol] for row in self._db.query(summaryQuery)}
             if governorValues is Ellipsis:
                 missingGovernorValues = self._governor.values - materializedGovernorValues
             else:

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1171,7 +1171,7 @@ class Database(ABC):
                 # how many rows we get back.
                 toSelect.add(next(iter(keys.keys())))
             selectSql = sqlalchemy.sql.select(
-                [table.columns[k].label(k) for k in toSelect]
+                *[table.columns[k].label(k) for k in toSelect]
             ).select_from(table).where(
                 sqlalchemy.sql.and_(*[table.columns[k] == v for k, v in keys.items()])
             )

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1175,7 +1175,7 @@ class Database(ABC):
             ).select_from(table).where(
                 sqlalchemy.sql.and_(*[table.columns[k] == v for k, v in keys.items()])
             )
-            fetched = list(self._connection.execute(selectSql).fetchall())
+            fetched = list(self._connection.execute(selectSql).mappings())
             if len(fetched) != 1:
                 return len(fetched), None, None
             existing = fetched[0]

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1349,7 +1349,7 @@ class Database(ABC):
                         names = select.columns.keys()
                 self._connection.execute(table.insert().from_select(names, select))
             else:
-                self._connection.execute(table.insert(), *rows)
+                self._connection.execute(table.insert(), rows)
             return None
         else:
             sql = table.insert()
@@ -1490,7 +1490,7 @@ class Database(ABC):
             whereTerms = [table.columns[name] == sqlalchemy.sql.bindparam(name) for name in columns]
             if whereTerms:
                 sql = sql.where(sqlalchemy.sql.and_(*whereTerms))
-            return self._connection.execute(sql, *rows).rowcount
+            return self._connection.execute(sql, rows).rowcount
         else:
             # One of the columns has changing values but any others are
             # fixed. In this case we can use an IN operator and be more
@@ -1565,7 +1565,7 @@ class Database(ABC):
         sql = table.update().where(
             sqlalchemy.sql.and_(*[table.columns[k] == sqlalchemy.sql.bindparam(v) for k, v in where.items()])
         )
-        return self._connection.execute(sql, *rows).rowcount
+        return self._connection.execute(sql, rows).rowcount
 
     def query(self, sql: sqlalchemy.sql.FromClause,
               *args: Any, **kwargs: Any) -> sqlalchemy.engine.ResultProxy:

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -116,10 +116,10 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
             for clause in _batch_in_clauses(**where):
                 sql_where = sql.where(clause)
                 for row in self._db.query(sql_where):
-                    yield dict(row)
+                    yield row._asdict()
         else:
             for row in self._db.query(sql):
-                yield dict(row)
+                yield row._asdict()
 
     def delete(self, columns: Iterable[str], *rows: dict) -> None:
         # Docstring inherited from OpaqueTableStorage.

--- a/python/lsst/daf/butler/registry/queries/_builder.py
+++ b/python/lsst/daf/butler/registry/queries/_builder.py
@@ -248,12 +248,12 @@ class QueryBuilder:
                     ).label("rownum")
                 )
                 window = sqlalchemy.sql.select(
-                    windowSelectCols
+                    *windowSelectCols
                 ).select_from(search).alias(
                     f"{datasetType.name}_window"
                 )
                 subquery = sqlalchemy.sql.select(
-                    [window.columns[name].label(name) for name in baseColumnNames]
+                    *[window.columns[name].label(name) for name in baseColumnNames]
                 ).select_from(
                     window
                 ).where(

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -630,12 +630,12 @@ class DatabaseTests(ABC):
             # Give Side2 a chance to create a connection
             await asyncio.sleep(1.0)
             with db1.transaction(lock=lock):
-                names1 = {row["name"] for row in db1.query(tables1.a.select())}
+                names1 = {row.name for row in db1.query(tables1.a.select())}
                 # Give Side2 a chance to insert (which will be blocked if
                 # we've acquired a lock).
                 await asyncio.sleep(2.0)
                 db1.insert(tables1.a, {"name": "a1"})
-                names2 = {row["name"] for row in db1.query(tables1.a.select())}
+                names2 = {row.name for row in db1.query(tables1.a.select())}
             return names1, names2
 
         async def side2() -> None:
@@ -872,7 +872,7 @@ class DatabaseTests(ABC):
         self.assertEqual(
             [row[TimespanReprClass.NAME] is None for row in aRows],
             [
-                row["f"] for row in db.query(
+                row.f for row in db.query(
                     sqlalchemy.sql.select(
                         aRepr.isNull().label("f")
                     ).order_by(
@@ -885,7 +885,7 @@ class DatabaseTests(ABC):
         self.assertEqual(
             [False for row in bRows],
             [
-                row["f"] for row in db.query(
+                row.f for row in db.query(
                     sqlalchemy.sql.select(
                         bRepr.isNull().label("f")
                     ).order_by(
@@ -921,7 +921,7 @@ class DatabaseTests(ABC):
                     (aRepr > rhsRepr).label("greater_than"),
                 ).select_from(aTable)
                 queried = {
-                    row["lhs"]: (row["overlaps"], row["contains"], row["less_than"], row["greater_than"])
+                    row.lhs: (row.overlaps, row.contains, row.less_than, row.greater_than)
                     for row in db.query(sql)
                 }
                 self.assertEqual(expected, queried)
@@ -956,8 +956,7 @@ class DatabaseTests(ABC):
             lhsSubquery.join(rhsSubquery, onclause=sqlalchemy.sql.literal(True))
         )
         queried = {
-            (row["lhs"], row["rhs"]): (row["overlaps"], row["contains"],
-                                       row["less_than"], row["greater_than"])
+            (row.lhs, row.rhs): (row.overlaps, row.contains, row.less_than, row.greater_than)
             for row in db.query(sql)}
         self.assertEqual(expected, queried)
         # Test relationship expressions between in-database timespans and
@@ -982,7 +981,7 @@ class DatabaseTests(ABC):
                     (aRepr > rhs).label("greater_than"),
                 ).select_from(aTable)
                 queried = {
-                    row["lhs"]: (row["contains"], row["less_than"], row["greater_than"])
+                    row.lhs: (row.contains, row.less_than, row.greater_than)
                     for row in db.query(sql)
                 }
                 self.assertEqual(expected, queried)

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -261,7 +261,7 @@ class DatabaseTests(ABC):
             # Check that the inserted rows are present.
             self.assertCountEqual(
                 [{"a_name": "a1", "b_id": bId} for bId in bIds[:2]],
-                [dict(row) for row in newDatabase.query(table1.select())]
+                [row._asdict() for row in newDatabase.query(table1.select())]
             )
             # Create another one via a read-only connection to the database.
             # We _do_ allow temporary table modifications in read-only
@@ -296,7 +296,7 @@ class DatabaseTests(ABC):
                     # Check that the inserted rows are present.
                     self.assertCountEqual(
                         [{"a_name": "a2", "b_id": bId} for bId in bIds[1:]],
-                        [dict(row) for row in existingReadOnlyDatabase.query(table2.select())]
+                        [row._asdict() for row in existingReadOnlyDatabase.query(table2.select())]
                     )
                     # Drop the temporary table from the read-only DB.  It's
                     # unspecified whether attempting to use it after this
@@ -338,11 +338,11 @@ class DatabaseTests(ABC):
         region = ConvexPolygon((UnitVector3d(1, 0, 0), UnitVector3d(0, 1, 0), UnitVector3d(0, 0, 1)))
         row = {"name": "a1", "region": region}
         db.insert(tables.a, row)
-        self.assertEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row])
+        self.assertEqual([r._asdict() for r in db.query(tables.a.select())], [row])
         # Insert multiple autoincrement rows but do not try to get the IDs
         # back immediately.
         db.insert(tables.b, {"name": "b1", "value": 10}, {"name": "b2", "value": 20})
-        results = [dict(r) for r in db.query(tables.b.select().order_by("id")).fetchall()]
+        results = [r._asdict() for r in db.query(tables.b.select().order_by("id"))]
         self.assertEqual(len(results), 2)
         for row in results:
             self.assertIn(row["name"], ("b1", "b2"))
@@ -352,9 +352,9 @@ class DatabaseTests(ABC):
         rows = [{"name": "b3", "value": 30}, {"name": "b4", "value": 40}]
         ids = db.insert(tables.b, *rows, returnIds=True)
         results = [
-            dict(r) for r in db.query(
+            r._asdict() for r in db.query(
                 tables.b.select().where(tables.b.columns.id > results[1]["id"])
-            ).fetchall()
+            )
         ]
         expected = [dict(row, id=id) for row, id in zip(rows, ids)]
         self.assertCountEqual(results, expected)
@@ -365,7 +365,7 @@ class DatabaseTests(ABC):
         rows = [{"origin": db.origin, "b_id": results[0]["id"]},
                 {"origin": db.origin, "b_id": None}]
         ids = db.insert(tables.c, *rows, returnIds=True)
-        results = [dict(r) for r in db.query(tables.c.select()).fetchall()]
+        results = [r._asdict() for r in db.query(tables.c.select())]
         expected = [dict(row, id=id) for row, id in zip(rows, ids)]
         self.assertCountEqual(results, expected)
         self.assertTrue(all(result["id"] is not None for result in results))
@@ -374,7 +374,7 @@ class DatabaseTests(ABC):
         # Insert into it.
         rows = [{"c_origin": db.origin, "c_id": id, "a_name": "a1"} for id in ids]
         db.insert(d, *rows)
-        results = [dict(r) for r in db.query(d.select()).fetchall()]
+        results = [r._asdict() for r in db.query(d.select())]
         self.assertCountEqual(rows, results)
         # Insert multiple rows into a table with an autoincrement+origin
         # primary key (this is especially tricky for SQLite, but good to test
@@ -385,14 +385,14 @@ class DatabaseTests(ABC):
                  {"id": 700, "origin": 60, "b_id": None},
                  {"id": 1, "origin": 60, "b_id": None}]
         db.insert(tables.c, *rows2)
-        results = [dict(r) for r in db.query(tables.c.select()).fetchall()]
+        results = [r._asdict() for r in db.query(tables.c.select())]
         self.assertCountEqual(results, expected + rows2)
         self.assertTrue(all(result["id"] is not None for result in results))
 
         # Define 'SELECT COUNT(*)' query for later use.
         count = sqlalchemy.sql.select(sqlalchemy.sql.func.count())
         # Get the values we inserted into table b.
-        bValues = [dict(r) for r in db.query(tables.b.select()).fetchall()]
+        bValues = [r._asdict() for r in db.query(tables.b.select())]
         # Remove two row from table b by ID.
         n = db.delete(tables.b, ["id"], {"id": bValues[0]["id"]}, {"id": bValues[1]["id"]})
         self.assertEqual(n, 2)
@@ -431,7 +431,7 @@ class DatabaseTests(ABC):
         self.assertEqual(n, 1)
         sql = sqlalchemy.sql.select(tables.a.columns.name, tables.a.columns.region).select_from(tables.a)
         self.assertCountEqual(
-            [dict(r) for r in db.query(sql).fetchall()],
+            [r._asdict() for r in db.query(sql)],
             [{"name": "a1", "region": None}, {"name": "a2", "region": region}]
         )
 
@@ -445,32 +445,32 @@ class DatabaseTests(ABC):
         values, inserted = db.sync(tables.b, keys={"name": "b1"}, extra={"value": 10}, returning=["id"])
         self.assertTrue(inserted)
         self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
-                         [dict(r) for r in db.query(tables.b.select()).fetchall()])
+                         [r._asdict() for r in db.query(tables.b.select())])
         # Repeat that operation, which should do nothing but return the
         # requested values.
         values, inserted = db.sync(tables.b, keys={"name": "b1"}, extra={"value": 10}, returning=["id"])
         self.assertFalse(inserted)
         self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
-                         [dict(r) for r in db.query(tables.b.select()).fetchall()])
+                         [r._asdict() for r in db.query(tables.b.select())])
         # Repeat the operation without the 'extra' arg, which should also just
         # return the existing row.
         values, inserted = db.sync(tables.b, keys={"name": "b1"}, returning=["id"])
         self.assertFalse(inserted)
         self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
-                         [dict(r) for r in db.query(tables.b.select()).fetchall()])
+                         [r._asdict() for r in db.query(tables.b.select())])
         # Repeat the operation with a different value in 'extra'.  That still
         # shouldn't be an error, because 'extra' is only used if we really do
         # insert.  Also drop the 'returning' argument.
         _, inserted = db.sync(tables.b, keys={"name": "b1"}, extra={"value": 20})
         self.assertFalse(inserted)
         self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
-                         [dict(r) for r in db.query(tables.b.select()).fetchall()])
+                         [r._asdict() for r in db.query(tables.b.select())])
         # Repeat the operation with the correct value in 'compared' instead of
         # 'extra'.
         _, inserted = db.sync(tables.b, keys={"name": "b1"}, compared={"value": 10})
         self.assertFalse(inserted)
         self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
-                         [dict(r) for r in db.query(tables.b.select()).fetchall()])
+                         [r._asdict() for r in db.query(tables.b.select())])
         # Repeat the operation with an incorrect value in 'compared'; this
         # should raise.
         with self.assertRaises(DatabaseConflictError):
@@ -483,7 +483,7 @@ class DatabaseTests(ABC):
             _, inserted = rodb.sync(tables.b, keys={"name": "b1"})
             self.assertFalse(inserted)
             self.assertEqual([{"id": values["id"], "name": "b1", "value": 10}],
-                             [dict(r) for r in rodb.query(tables.b.select()).fetchall()])
+                             [r._asdict() for r in rodb.query(tables.b.select())])
             with self.assertRaises(ReadOnlyDatabaseError):
                 rodb.sync(tables.b, keys={"name": "b2"}, extra={"value": 20})
         # Repeat the operation with a different value in 'compared' and ask to
@@ -491,7 +491,7 @@ class DatabaseTests(ABC):
         _, updated = db.sync(tables.b, keys={"name": "b1"}, compared={"value": 20}, update=True)
         self.assertEqual(updated, {"value": 10})
         self.assertEqual([{"id": values["id"], "name": "b1", "value": 20}],
-                         [dict(r) for r in db.query(tables.b.select()).fetchall()])
+                         [r._asdict() for r in db.query(tables.b.select())])
 
     def testReplace(self):
         """Tests for `Database.replace`.
@@ -504,25 +504,25 @@ class DatabaseTests(ABC):
         region = ConvexPolygon((UnitVector3d(1, 0, 0), UnitVector3d(0, 1, 0), UnitVector3d(0, 0, 1)))
         row1 = {"name": "a1", "region": region}
         db.replace(tables.a, row1)
-        self.assertEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1])
+        self.assertEqual([r._asdict() for r in db.query(tables.a.select())], [row1])
         # Insert another row without a region.
         row2 = {"name": "a2", "region": None}
         db.replace(tables.a, row2)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2])
         # Use replace to re-insert both of those rows again, which should do
         # nothing.
         db.replace(tables.a, row1, row2)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2])
         # Replace row1 with a row with no region, while reinserting row2.
         row1a = {"name": "a1", "region": None}
         db.replace(tables.a, row1a, row2)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1a, row2])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1a, row2])
         # Replace both rows, returning row1 to its original state, while adding
         # a new one.  Pass them in in a different order.
         row2a = {"name": "a2", "region": region}
         row3 = {"name": "a3", "region": None}
         db.replace(tables.a, row3, row2a, row1)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2a, row3])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2a, row3])
 
     def testEnsure(self):
         """Tests for `Database.ensure`.
@@ -535,27 +535,27 @@ class DatabaseTests(ABC):
         region = ConvexPolygon((UnitVector3d(1, 0, 0), UnitVector3d(0, 1, 0), UnitVector3d(0, 0, 1)))
         row1 = {"name": "a1", "region": region}
         self.assertEqual(db.ensure(tables.a, row1), 1)
-        self.assertEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1])
+        self.assertEqual([r._asdict() for r in db.query(tables.a.select())], [row1])
         # Insert another row without a region.
         row2 = {"name": "a2", "region": None}
         self.assertEqual(db.ensure(tables.a, row2), 1)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2])
         # Use ensure to re-insert both of those rows again, which should do
         # nothing.
         self.assertEqual(db.ensure(tables.a, row1, row2), 0)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2])
         # Attempt to insert row1's key with no region, while
         # reinserting row2.  This should also do nothing.
         row1a = {"name": "a1", "region": None}
         self.assertEqual(db.ensure(tables.a, row1a, row2), 0)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2])
         # Attempt to insert new rows for both existing keys, this time also
         # adding a new row.  Pass them in in a different order.  Only the new
         # row should be added.
         row2a = {"name": "a2", "region": region}
         row3 = {"name": "a3", "region": None}
         self.assertEqual(db.ensure(tables.a, row3, row2a, row1a), 1)
-        self.assertCountEqual([dict(r) for r in db.query(tables.a.select()).fetchall()], [row1, row2, row3])
+        self.assertCountEqual([r._asdict() for r in db.query(tables.a.select())], [row1, row2, row3])
 
     def testTransactionNesting(self):
         """Test that transactions can be nested with the behavior in the
@@ -582,7 +582,7 @@ class DatabaseTests(ABC):
                     # an exception.
                     db.insert(tables.a, {"name": "a1"})
         self.assertCountEqual(
-            [dict(r) for r in db.query(tables.a.select()).fetchall()],
+            [r._asdict() for r in db.query(tables.a.select())],
             [{"name": "a1", "region": None}, {"name": "a2", "region": None}],
         )
         # Second test: error recovery via implicit savepoint=True, when the
@@ -605,7 +605,7 @@ class DatabaseTests(ABC):
                         # raising an exception.
                         db.insert(tables.a, {"name": "a1"})
         self.assertCountEqual(
-            [dict(r) for r in db.query(tables.a.select()).fetchall()],
+            [r._asdict() for r in db.query(tables.a.select())],
             [{"name": "a1", "region": None}, {"name": "a2", "region": None}, {"name": "a3", "region": None}],
         )
 
@@ -630,12 +630,12 @@ class DatabaseTests(ABC):
             # Give Side2 a chance to create a connection
             await asyncio.sleep(1.0)
             with db1.transaction(lock=lock):
-                names1 = {row["name"] for row in db1.query(tables1.a.select()).fetchall()}
+                names1 = {row["name"] for row in db1.query(tables1.a.select())}
                 # Give Side2 a chance to insert (which will be blocked if
                 # we've acquired a lock).
                 await asyncio.sleep(2.0)
                 db1.insert(tables1.a, {"name": "a1"})
-                names2 = {row["name"] for row in db1.query(tables1.a.select()).fetchall()}
+                names2 = {row["name"] for row in db1.query(tables1.a.select())}
             return names1, names2
 
         async def side2() -> None:
@@ -795,8 +795,8 @@ class DatabaseTests(ABC):
         # Test basic round-trip through database.
         self.assertEqual(
             aRows,
-            [convertRowFromSelect(dict(row))
-             for row in db.query(aTable.select().order_by(aTable.columns.id)).fetchall()]
+            [convertRowFromSelect(row._asdict())
+             for row in db.query(aTable.select().order_by(aTable.columns.id))]
         )
         # Create another table B with a not-null timespan and (if the database
         # supports it), an exclusion constraint.  Use ensureTableExists this
@@ -831,8 +831,8 @@ class DatabaseTests(ABC):
         # Test basic round-trip through database.
         self.assertEqual(
             bRows,
-            [convertRowFromSelect(dict(row))
-             for row in db.query(bTable.select().order_by(bTable.columns.id)).fetchall()]
+            [convertRowFromSelect(row._asdict())
+             for row in db.query(bTable.select().order_by(bTable.columns.id))]
         )
         # Test that we can't insert timespan=None into this table.
         with self.assertRaises(sqlalchemy.exc.IntegrityError):
@@ -878,7 +878,7 @@ class DatabaseTests(ABC):
                     ).order_by(
                         aTable.columns.id
                     )
-                ).fetchall()
+                )
             ]
         )
         bRepr = TimespanReprClass.fromSelectable(bTable)
@@ -891,7 +891,7 @@ class DatabaseTests(ABC):
                     ).order_by(
                         bTable.columns.id
                     )
-                ).fetchall()
+                )
             ]
         )
         # Test relationships expressions that relate in-database timespans to
@@ -922,7 +922,7 @@ class DatabaseTests(ABC):
                 ).select_from(aTable)
                 queried = {
                     row["lhs"]: (row["overlaps"], row["contains"], row["less_than"], row["greater_than"])
-                    for row in db.query(sql).fetchall()
+                    for row in db.query(sql)
                 }
                 self.assertEqual(expected, queried)
         # Test relationship expressions that relate in-database timespans to
@@ -958,7 +958,7 @@ class DatabaseTests(ABC):
         queried = {
             (row["lhs"], row["rhs"]): (row["overlaps"], row["contains"],
                                        row["less_than"], row["greater_than"])
-            for row in db.query(sql).fetchall()}
+            for row in db.query(sql)}
         self.assertEqual(expected, queried)
         # Test relationship expressions between in-database timespans and
         # Python-literal instantaneous times.
@@ -983,6 +983,6 @@ class DatabaseTests(ABC):
                 ).select_from(aTable)
                 queried = {
                     row["lhs"]: (row["contains"], row["less_than"], row["greater_than"])
-                    for row in db.query(sql).fetchall()
+                    for row in db.query(sql)
                 }
                 self.assertEqual(expected, queried)

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -248,7 +248,7 @@ class DatabaseTests(ABC):
             newDatabase.insert(
                 table1,
                 select=sqlalchemy.sql.select(
-                    [static.a.columns.name.label("a_name"), static.b.columns.id.label("b_id")]
+                    static.a.columns.name.label("a_name"), static.b.columns.id.label("b_id")
                 ).select_from(
                     static.a.join(static.b, onclause=sqlalchemy.sql.literal(True))
                 ).where(
@@ -282,7 +282,7 @@ class DatabaseTests(ABC):
                     existingReadOnlyDatabase.insert(
                         table2,
                         select=sqlalchemy.sql.select(
-                            [static.a.columns.name, static.b.columns.id]
+                            static.a.columns.name, static.b.columns.id
                         ).select_from(
                             static.a.join(static.b, onclause=sqlalchemy.sql.literal(True))
                         ).where(
@@ -390,7 +390,7 @@ class DatabaseTests(ABC):
         self.assertTrue(all(result["id"] is not None for result in results))
 
         # Define 'SELECT COUNT(*)' query for later use.
-        count = sqlalchemy.sql.select([sqlalchemy.sql.func.count()])
+        count = sqlalchemy.sql.select(sqlalchemy.sql.func.count())
         # Get the values we inserted into table b.
         bValues = [dict(r) for r in db.query(tables.b.select()).fetchall()]
         # Remove two row from table b by ID.
@@ -429,7 +429,7 @@ class DatabaseTests(ABC):
         region = ConvexPolygon((UnitVector3d(1, 0, 0), UnitVector3d(0, 1, 0), UnitVector3d(0, 0, 1)))
         n = db.update(tables.a, {"name": "k"}, {"k": "a2", "region": region})
         self.assertEqual(n, 1)
-        sql = sqlalchemy.sql.select([tables.a.columns.name, tables.a.columns.region]).select_from(tables.a)
+        sql = sqlalchemy.sql.select(tables.a.columns.name, tables.a.columns.region).select_from(tables.a)
         self.assertCountEqual(
             [dict(r) for r in db.query(sql).fetchall()],
             [{"name": "a1", "region": None}, {"name": "a2", "region": region}]
@@ -874,7 +874,7 @@ class DatabaseTests(ABC):
             [
                 row["f"] for row in db.query(
                     sqlalchemy.sql.select(
-                        [aRepr.isNull().label("f")]
+                        aRepr.isNull().label("f")
                     ).order_by(
                         aTable.columns.id
                     )
@@ -887,7 +887,7 @@ class DatabaseTests(ABC):
             [
                 row["f"] for row in db.query(
                     sqlalchemy.sql.select(
-                        [bRepr.isNull().label("f")]
+                        bRepr.isNull().label("f")
                     ).order_by(
                         bTable.columns.id
                     )
@@ -913,13 +913,13 @@ class DatabaseTests(ABC):
                             lhsRow[TimespanReprClass.NAME] > rhsRow[TimespanReprClass.NAME],
                         )
                 rhsRepr = TimespanReprClass.fromLiteral(rhsRow[TimespanReprClass.NAME])
-                sql = sqlalchemy.sql.select([
+                sql = sqlalchemy.sql.select(
                     aTable.columns.id.label("lhs"),
                     aRepr.overlaps(rhsRepr).label("overlaps"),
                     aRepr.contains(rhsRepr).label("contains"),
                     (aRepr < rhsRepr).label("less_than"),
                     (aRepr > rhsRepr).label("greater_than"),
-                ]).select_from(aTable)
+                ).select_from(aTable)
                 queried = {
                     row["lhs"]: (row["overlaps"], row["contains"], row["less_than"], row["greater_than"])
                     for row in db.query(sql).fetchall()
@@ -946,14 +946,12 @@ class DatabaseTests(ABC):
         lhsRepr = TimespanReprClass.fromSelectable(lhsSubquery)
         rhsRepr = TimespanReprClass.fromSelectable(rhsSubquery)
         sql = sqlalchemy.sql.select(
-            [
-                lhsSubquery.columns.id.label("lhs"),
-                rhsSubquery.columns.id.label("rhs"),
-                lhsRepr.overlaps(rhsRepr).label("overlaps"),
-                lhsRepr.contains(rhsRepr).label("contains"),
-                (lhsRepr < rhsRepr).label("less_than"),
-                (lhsRepr > rhsRepr).label("greater_than"),
-            ]
+            lhsSubquery.columns.id.label("lhs"),
+            rhsSubquery.columns.id.label("rhs"),
+            lhsRepr.overlaps(rhsRepr).label("overlaps"),
+            lhsRepr.contains(rhsRepr).label("contains"),
+            (lhsRepr < rhsRepr).label("less_than"),
+            (lhsRepr > rhsRepr).label("greater_than"),
         ).select_from(
             lhsSubquery.join(rhsSubquery, onclause=sqlalchemy.sql.literal(True))
         )
@@ -977,12 +975,12 @@ class DatabaseTests(ABC):
                             lhsRow[TimespanReprClass.NAME] > t,
                         )
                 rhs = sqlalchemy.sql.literal(t, type_=ddl.AstropyTimeNsecTai)
-                sql = sqlalchemy.sql.select([
+                sql = sqlalchemy.sql.select(
                     aTable.columns.id.label("lhs"),
                     aRepr.contains(rhs).label("contains"),
                     (aRepr < rhs).label("less_than"),
                     (aRepr > rhs).label("greater_than"),
-                ]).select_from(aTable)
+                ).select_from(aTable)
                 queried = {
                     row["lhs"]: (row["contains"], row["less_than"], row["greater_than"])
                     for row in db.query(sql).fetchall()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -54,7 +54,7 @@ def _startServer(root):
     """
     server = testing.postgresql.Postgresql(base_dir=root)
     engine = sqlalchemy.engine.create_engine(server.url())
-    engine.execute("CREATE EXTENSION btree_gist;")
+    engine.execute(sqlalchemy.text("CREATE EXTENSION btree_gist;"))
     return server
 
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -175,17 +175,17 @@ class PostgresqlDatabaseTestCase(unittest.TestCase, DatabaseTests):
         # half-open ranges and PostgreSQL operators on ranges.
         def subquery(alias: str) -> sqlalchemy.sql.FromClause:
             return sqlalchemy.sql.select(
-                [tbl.columns.id.label("id"), tbl.columns.timespan.label("timespan")]
+                tbl.columns.id.label("id"), tbl.columns.timespan.label("timespan")
             ).select_from(
                 tbl
             ).alias(alias)
         sq1 = subquery("sq1")
         sq2 = subquery("sq2")
-        query = sqlalchemy.sql.select([
+        query = sqlalchemy.sql.select(
             sq1.columns.id.label("n1"),
             sq2.columns.id.label("n2"),
             sq1.columns.timespan.overlaps(sq2.columns.timespan).label("overlaps"),
-        ])
+        )
 
         # `columns` is deprecated since 1.4, but
         # `selected_columns` method did not exist in 1.3.

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -168,7 +168,7 @@ class PostgresqlDatabaseTestCase(unittest.TestCase, DatabaseTests):
         # Test basic round-trip through database.
         self.assertEqual(
             rows,
-            [dict(row) for row in db.query(tbl.select().order_by(tbl.columns.id)).fetchall()]
+            [row._asdict() for row in db.query(tbl.select().order_by(tbl.columns.id))]
         )
 
         # Test that Timespan's Python methods are consistent with our usage of

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -201,7 +201,7 @@ class PostgresqlDatabaseTestCase(unittest.TestCase, DatabaseTests):
                                     category=sqlalchemy.exc.SAWarning)
             dbResults = {
                 (row[columns.n1], row[columns.n2]): row[columns.overlaps]
-                for row in db.query(query)
+                for row in db.query(query).mappings()
             }
 
         pyResults = {

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -54,7 +54,8 @@ def _startServer(root):
     """
     server = testing.postgresql.Postgresql(base_dir=root)
     engine = sqlalchemy.engine.create_engine(server.url())
-    engine.execute(sqlalchemy.text("CREATE EXTENSION btree_gist;"))
+    with engine.begin() as connection:
+        connection.execute(sqlalchemy.text("CREATE EXTENSION btree_gist;"))
     return server
 
 


### PR DESCRIPTION
Trying to make our code compatible with sqlalchemy 2 by enabling `SQLALCHEMY_WARN_20=1`, running all unit tests and watching for warnings. Here are the changes so far (which are still compatible with 1.4):
- `select()` takes columns as positional arguments instead of a list
- `Row` conversion to `dict` works differently
- `row[name]` is replaced with `row.name` or `row._mapping[name]` (or `RowCursor.mappings()` in some cases)
- `connection.execute()` takes parameters as a dict or list of dicts, not as keyword argument
- `Engine.execute()` is deprecated, have to to use `Connection.execute()`
- related to previous item, some changes to connection/transaction handling are needed in our code

With all these changes the unit tests are now warning-free. Our unit tests probably/likely don't have 100% coverage so I also searched the code for known patterns, still there is a chance that I missed some cases that need fixing. Jenkins is happy with our current 1.4 version so hopefully nothing is broken.

I did not enable [`future=True`](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine) flag yet, not sure if we want it at this point. Our code still tries to support sqlalchemy 1.3, if we drop that support then enabling `future=True` is probably the right thing to do.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
