### PR TITLE
DM-31548: Add reverse-lookup index for skypix overlap tables.

### DIFF
--- a/doc/changes/DM-31548.perf
+++ b/doc/changes/DM-31548.perf
@@ -1,0 +1,1 @@
+Add indexes to make certain spatial join queries much more efficient.

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -50,7 +50,7 @@ from ..interfaces import (
 
 
 # This has to be updated on every schema change
-_VERSION = VersionTuple(6, 0, 0)
+_VERSION = VersionTuple(6, 0, 1)
 
 
 class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -441,6 +441,12 @@ class _SkyPixOverlapStorage:
                 # (more columns added below)
             ],
             unique=set(),
+            indexes={
+                # This index has the same fields as the PK, in a different
+                # order, to facilitate queries that know skypix_index and want
+                # to find the other element.
+                ("skypix_system", "skypix_level", "skypix_index",) + tuple(element.graph.required.names),
+            },
             foreignKeys=[
                 # Foreign key to summary table.  This makes sure we don't
                 # materialize any overlaps without remembering that we've done


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [x] create migration script