### PR TITLE
DM-31700: Fix parquet formatter failure on zero-index tables

### DIFF
--- a/doc/changes/DM-31700.bugfix.rst
+++ b/doc/changes/DM-31700.bugfix.rst
@@ -1,0 +1,3 @@
+Fix parquet formatter error when reading tables with no indices.
+
+Previously, this would cause butler.get to fail to read valid parquet tables. 

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -59,7 +59,7 @@ class _ParquetLoader:
         self.file = pq.ParquetFile(path)
         self.md = json.loads(self.file.metadata.metadata[b"pandas"])
         indexes = self.md["column_indexes"]
-        if len(indexes) == 1:
+        if len(indexes) <= 1:
             self.columns = pd.Index(
                 name for name in self.file.metadata.schema.names if not name.startswith("__")
             )


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
