### PR TITLE
DM-30266 Modify serialization of some objects

### DIFF
--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -69,6 +69,31 @@ class SerializedDatasetType(BaseModel):
     parentStorageClass: Optional[StrictStr] = None
     isCalibration: StrictBool = False
 
+    @classmethod
+    def direct(cls, *, name: str, storageClass: Optional[str] = None,
+               dimensions: Optional[Dict] = None,
+               parentStorageClass: Optional[str] = None, isCalibration: bool = False
+               ) -> SerializedDatasetType:
+        """Construct a `SerializedDatasetType` directly without validators.
+
+        This differs from PyDantics construct method in that the arguments are
+        explicitly what the model requires, and it will recurse through
+        members, constructing them from their corresponding `direct` methods.
+
+        This method should only be called when the inputs are trusted.
+        """
+        node = SerializedDatasetType.__new__(cls)
+        setter = object.__setattr__
+        setter(node, 'name', name)
+        setter(node, 'storageClass', storageClass)
+        setter(node, 'dimensions',
+               dimensions if dimensions is None else SerializedDimensionGraph.direct(**dimensions))
+        setter(node, 'parentStorageClass', parentStorageClass)
+        setter(node, 'isCalibration', isCalibration)
+        setter(node, '__fields_set__', {'name', 'storageClass', 'dimensions', 'parentStorageClass',
+                                        'isCalibration'})
+        return node
+
 
 class DatasetType:
     r"""A named category of Datasets.

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -73,6 +73,25 @@ class SerializedDataCoordinate(BaseModel):
     dataId: Dict[str, DataIdValue]
     records: Optional[Dict[str, SerializedDimensionRecord]] = None
 
+    @classmethod
+    def direct(cls, *, dataId: Dict[str, DataIdValue], records: Dict[str, Dict]) -> SerializedDataCoordinate:
+        """Construct a `SerializedDataCoordinate` directly without validators.
+
+        This differs from the pydantic "construct" method in that the arguments
+        are explicitly what the model requires, and it will recurse through
+        members, constructing them from their corresponding `direct` methods.
+
+        This method should only be called when the inputs are trusted.
+        """
+        node = SerializedDataCoordinate.__new__(cls)
+        setter = object.__setattr__
+        setter(node, 'dataId', dataId)
+        setter(node, 'records',
+               records if records is None else
+               {k: SerializedDimensionRecord.direct(**v) for k, v in records.items()})
+        setter(node, '__fields_set__', {'dataId', 'records'})
+        return node
+
 
 def _intersectRegions(*args: Region) -> Optional[Region]:
     """Return the intersection of several regions.

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -58,6 +58,21 @@ class SerializedDimensionGraph(BaseModel):
 
     names: List[str]
 
+    @classmethod
+    def direct(cls, *, names: List[str]) -> SerializedDimensionGraph:
+        """Construct a `SerializedDimensionGraph` directly without validators.
+
+        This differs from the pydantic "construct" method in that the arguments
+        are explicitly what the model requires, and it will recurse through
+        members, constructing them from their corresponding `direct` methods.
+
+        This method should only be called when the inputs are trusted.
+        """
+        node = SerializedDimensionGraph.__new__(cls)
+        object.__setattr__(node, 'names', names)
+        object.__setattr__(node, '__fields_set__', {'names'})
+        return node
+
 
 @immutable
 class DimensionGraph:

--- a/tests/test_quantum.py
+++ b/tests/test_quantum.py
@@ -19,17 +19,92 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+from typing import Tuple, Iterable
 import unittest
 
-from lsst.daf.butler import Quantum, DimensionUniverse, NamedKeyDict, StorageClass, DatasetType, DatasetRef
+from lsst.daf.butler import (Quantum,
+                             DimensionUniverse,
+                             NamedKeyDict,
+                             StorageClass,
+                             DatasetType,
+                             DatasetRef,
+                             SerializedQuantum,
+                             DataCoordinate,
+                             DimensionRecordsAccumulator)
+from lsst.sphgeom import Circle
 
 """Tests for Quantum.
 """
 
 
+class MockTask:
+    pass
+
+
 class QuantumTestCase(unittest.TestCase):
     """Test for Quantum.
     """
+
+    def _buildFullQuantum(self, taskName, addRecords=False) -> Tuple[Quantum, Iterable[DatasetType]]:
+        universe = DimensionUniverse()
+        datasetTypeNameInit = "test_ds_init"
+        datasetTypeNameInput = "test_ds_input"
+        datasetTypeNameOutput = "test_ds_output"
+
+        storageClass = StorageClass("testref_StructuredData")
+
+        instrument = universe['instrument']
+        instrumentRecord = instrument.RecordClass(name="test")
+
+        band = universe['band']
+        bandRecord = band.RecordClass(name="r")
+
+        physical_filter = universe['physical_filter']
+        physical_filter_record = physical_filter.RecordClass(name='r', instrument='test')
+
+        visit_system = universe['visit_system']
+        visit_system_record = visit_system.RecordClass(id=9, instrument='test', name='test_visit_system')
+
+        visit = universe['visit']
+        region = Circle()
+        hashed = hash(visit).to_bytes(30, 'little')
+        visit_record_42 = visit.RecordClass(id=42, instrument='test', name='test_visit', region=region,
+                                            hash=hashed)
+        visit_record_42 = visit.RecordClass(id=43, instrument='test', name='test_visit', region=region,
+                                            hash=hashed)
+
+        records42 = {instrument: instrumentRecord, band: bandRecord,
+                     physical_filter: physical_filter_record,
+                     visit_system: visit_system_record, visit: visit_record_42}
+
+        records43 = {instrument: instrumentRecord, band: bandRecord,
+                     physical_filter: physical_filter_record,
+                     visit_system: visit_system_record, visit: visit_record_42}
+
+        dataId42 = DataCoordinate.standardize(dict(instrument='test', visit=42),  # type: ignore
+                                              universe=universe)
+        dataId43 = DataCoordinate.standardize(dict(instrument='test', visit=43),  # type: ignore
+                                              universe=universe)
+
+        if addRecords:
+            dataId42 = dataId42.expanded(records42)  # type: ignore
+            dataId43 = dataId43.expanded(records43)  # type: ignore
+
+        datasetTypeInit = DatasetType(datasetTypeNameInit, universe.extract(("instrument", "visit")),
+                                      storageClass)
+        datasetTypeInput = DatasetType(datasetTypeNameInput, universe.extract(("instrument", "visit")),
+                                       storageClass)
+        datasetTypeOutput = DatasetType(datasetTypeNameOutput, universe.extract(("instrument", "visit")),
+                                        storageClass)
+        predictedInputs = {datasetTypeInput: [DatasetRef(datasetTypeInput, dataId42),
+                                              DatasetRef(datasetTypeInput, dataId43)]}
+        outputs = {datasetTypeOutput: [DatasetRef(datasetTypeOutput, dataId42),
+                                       DatasetRef(datasetTypeOutput, dataId43)]}
+        initInputs = {datasetTypeInit: DatasetRef(datasetTypeInit, dataId42)}
+
+        return Quantum(taskName=taskName, inputs=predictedInputs, outputs=outputs,
+                       initInputs=initInputs), [datasetTypeInit, datasetTypeInput, datasetTypeOutput]
 
     def testConstructor(self):
         """Test of constructor.
@@ -44,19 +119,46 @@ class QuantumTestCase(unittest.TestCase):
         self.assertEqual(quantum.outputs, {})
         self.assertIsNone(quantum.dataId)
 
-        universe = DimensionUniverse()
-        instrument = "DummyCam"
-        datasetTypeName = "test_ds"
-        storageClass = StorageClass("testref_StructuredData")
-        datasetType = DatasetType(datasetTypeName, universe.extract(("instrument", "visit")), storageClass)
-        predictedInputs = {datasetType: [DatasetRef(datasetType, dict(instrument=instrument, visit=42)),
-                                         DatasetRef(datasetType, dict(instrument=instrument, visit=43))]}
-        outputs = {datasetType: [DatasetRef(datasetType, dict(instrument=instrument, visit=42)),
-                                 DatasetRef(datasetType, dict(instrument=instrument, visit=43))]}
+        quantum, (_, datasetTypeInput, datasetTypeOutput) = self._buildFullQuantum(taskName)
+        self.assertEqual(len(quantum.inputs[datasetTypeInput]), 2)
+        self.assertEqual(len(quantum.outputs[datasetTypeOutput]), 2)
 
-        quantum = Quantum(taskName=taskName, inputs=predictedInputs, outputs=outputs)
-        self.assertEqual(len(quantum.inputs[datasetType]), 2)
-        self.assertEqual(len(quantum.outputs[datasetType]), 2)
+    def testSerialization(self):
+        taskName = f"{MockTask.__module__}.{MockTask.__qualname__}"
+        # from simple w/o records
+        quantum, _ = self._buildFullQuantum(taskName)
+        serialized = quantum.to_simple()
+        self.assertEqual(quantum, quantum.from_simple(serialized, DimensionUniverse()))
+
+        # from simple w/ records
+        quantum, _ = self._buildFullQuantum(taskName, addRecords=True)
+        serialized = quantum.to_simple()
+        self.assertEqual(quantum, quantum.from_simple(serialized, DimensionUniverse()))
+
+        # verify direct works
+        jsonVersion = json.loads(serialized.json())
+        fromDirect = SerializedQuantum.direct(**jsonVersion)
+        self.assertEqual(fromDirect, serialized)
+
+        # verify direct with records works
+        quantum, _ = self._buildFullQuantum(taskName, addRecords=True)
+        serialized = quantum.to_simple()
+        jsonVersion = json.loads(serialized.json())
+        fromDirect = SerializedQuantum.direct(**jsonVersion)
+        self.assertEqual(fromDirect, serialized)
+
+        # verify the simple accumulator works
+        accumulator = DimensionRecordsAccumulator()
+        quantum, _ = self._buildFullQuantum(taskName, addRecords=True)
+        serialized = quantum.to_simple(accumulator)
+        # verify the accumulator was populated
+        recordMapping = accumulator.makeSerializedDimensionRecordMapping()
+        self.assertGreater(len(recordMapping), 0)
+        # verify the dimension records were not written out
+        self.assertEqual(serialized.dimensionRecords, None)
+        serialized.dimensionRecords = accumulator.makeSerializedDimensionRecordMapping()  # type: ignore
+
+        self.assertEqual(quantum, quantum.from_simple(serialized, universe=DimensionUniverse()))
 
 
 if __name__ == "__main__":

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -27,6 +27,7 @@ from typing import Any
 import unittest
 import uuid
 import re
+import json
 
 try:
     import numpy as np
@@ -585,6 +586,10 @@ class SimpleButlerTestCase(unittest.TestCase):
                     json_str = r.to_json(minimal=minimal)
                     r_json = type(r).from_json(json_str, registry=butler.registry)
                     self.assertEqual(r_json, r)
+                    # check with direct method
+                    simple = r.to_simple()
+                    fromDirect = type(simple).direct(**json.loads(json_str))
+                    self.assertEqual(simple, fromDirect)
                     # Also check equality of each of the components as dicts
                     self.assertEqual(r_json.toDict(), r.toDict())
 


### PR DESCRIPTION
Add/Modify serialization of some objects to support a new serialized
format of QuantumGraphs. In particular this introduces a new method
on some objects to support direct construction if the inputs are
already trusted, skipping validation steps.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
