### PR TITLE
DM-29531: Update IsrCalib so it can serve as StorageClass for subclasses

### DIFF
--- a/doc/changes/DM-29531.misc.rst
+++ b/doc/changes/DM-29531.misc.rst
@@ -1,0 +1,1 @@
+Add formatter and storageClass information for IsrCalib.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -27,6 +27,7 @@ ExposureCatalog: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 ObjectMaskCatalog: lsst.pipe.tasks.objectMasks.RegionFileFormatter
 DataFrame: lsst.daf.butler.formatters.parquet.ParquetFormatter
 Defects: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
+IsrCalib: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 QECurve: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 CrosstalkCalib: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 PhotonTransferCurveDataset: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -110,6 +110,8 @@ storageClasses:
     pytype: lsst.daf.base.PropertySet
   PropertyList:
     pytype: lsst.daf.base.PropertyList
+  IsrCalib:
+    pytype: lsst.ip.isr.IsrCalib
   Defects:
     pytype: lsst.ip.isr.Defects
   QECurve:


### PR DESCRIPTION
Add formatter and storageClass information for IsrCalib.


## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
