### PR TITLE
DM-31785: Improve efficiency of butler.transfer_from

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
         env:
           SQLALCHEMY_WARN_20: 1
         run: |
-          pytest -r a -v -n 3 --open-files --cov=./ --cov-report=xml --cov-branch
+          pytest -r a -v -n 3 --open-files --cov=lsst.daf.butler --cov=tests --cov-report=xml --cov-report=term --cov-branch
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Build and install
         shell: bash -l {0}
         run: |
-          pip install -v .
+          pip install -v -e .
 
       - name: Run tests
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ LSST Data Access framework described in [DMTN-056](https://dmtn-056.lsst.io).
 This is a **Python 3 only** package (we assume Python 3.8 or higher).
 
 ADASS paper: [Abstracting the Storage and Retrieval of Image Data at the LSST](https://ui.adsabs.harvard.edu/abs/2019ASPC..523..653J/abstract).
+
+[![codecov](https://codecov.io/gh/lsst/daf_butler/branch/master/graph/badge.svg?token=2BUBL8R9RH)](https://codecov.io/gh/lsst/daf_butler)

--- a/doc/changes/DM-31785.perf.rst
+++ b/doc/changes/DM-31785.perf.rst
@@ -1,0 +1,3 @@
+Made 20x speed improvement for ``Butler.transfer_from``.
+The main slow down is asking the datastore whether a file artifact exists.
+This is now parallelized and the result is cached for later.

--- a/doc/changes/DM-31826.bugfix.rst
+++ b/doc/changes/DM-31826.bugfix.rst
@@ -1,0 +1,1 @@
+Fix problem in ButlerURI where transferring a file from one URI to another would overwrite the existing file even if they were the same actual file (for example because of soft links in the directory hierarchy).

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1858,8 +1858,10 @@ class Butler:
         # purged, we have to ask for the (predicted) URI and check
         # existence explicitly. Execution butler is set up exactly like
         # this with no datastore records.
+        artifact_existence: Dict[ButlerURI, bool] = {}
         if skip_missing:
-            dataset_existence = source_butler.datastore.mexists(source_refs)
+            dataset_existence = source_butler.datastore.mexists(source_refs,
+                                                                artifact_existence=artifact_existence)
             source_refs = [ref for ref, exists in dataset_existence.items() if exists]
             filtered_count = len(source_refs)
             log.log(VERBOSE, "%d datasets removed because the artifact does not exist. Now have %d.",
@@ -1934,7 +1936,8 @@ class Butler:
             # Ask the datastore to transfer. The datastore has to check that
             # the source datastore is compatible with the target datastore.
             self.datastore.transfer_from(source_butler.datastore, source_refs,
-                                         local_refs=transferred_refs, transfer=transfer)
+                                         local_refs=transferred_refs, transfer=transfer,
+                                         artifact_existence=artifact_existence)
 
         return transferred_refs
 

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1815,7 +1815,9 @@ class Butler:
             import always uses unique.
         skip_missing : `bool`
             If `True`, datasets with no datastore artifact associated with
-            them are not transferred.
+            them are not transferred. If `False` a registry entry will be
+            created even if no datastore record is created (and so will
+            look equivalent to the dataset being unstored).
 
         Returns
         -------
@@ -1844,7 +1846,8 @@ class Butler:
         if not isinstance(source_refs, collections.abc.Collection):
             source_refs = list(source_refs)
 
-        log.info("Transferring %d datasets into %s", len(source_refs), str(self))
+        original_count = len(source_refs)
+        log.info("Transferring %d datasets into %s", original_count, str(self))
 
         if id_gen_map is None:
             id_gen_map = {}
@@ -1856,7 +1859,11 @@ class Butler:
         # existence explicitly. Execution butler is set up exactly like
         # this with no datastore records.
         if skip_missing:
-            source_refs = [ref for ref in source_refs if source_butler.datastore.exists(ref)]
+            dataset_existence = source_butler.datastore.mexists(source_refs)
+            source_refs = [ref for ref, exists in dataset_existence.items() if exists]
+            filtered_count = len(source_refs)
+            log.log(VERBOSE, "%d datasets removed because the artifact does not exist. Now have %d.",
+                    original_count - filtered_count, filtered_count)
 
         # Importing requires that we group the refs by dataset type and run
         # before doing the import.

--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -62,6 +62,11 @@ ESCAPES_RE = re.compile(r"%[A-F0-9]{2}")
 # Precomputed escaped hash
 ESCAPED_HASH = urllib.parse.quote("#")
 
+# Maximum number of worker threads for parallelized operations.
+# If greater than 10, be aware that this number has to be consistent
+# with connection pool sizing (for example in urllib3).
+MAX_WORKERS = 10
+
 
 class ButlerURI:
     """Convenience wrapper around URI parsers.
@@ -670,11 +675,7 @@ class ButlerURI:
         """
         import concurrent.futures
 
-        # The max worker count here must not exceed the max connection pools
-        # in whatever system is doing the network connection. The default
-        # is 10 for urllib3.
-        max_workers = 10
-        exists_executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        exists_executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS)
 
         def wrapper(uri: ButlerURI) -> Tuple[ButlerURI, bool]:
             try:

--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -22,6 +22,7 @@
 from __future__ import annotations
 
 import contextlib
+import concurrent.futures
 import urllib.parse
 import posixpath
 import copy
@@ -673,8 +674,6 @@ class ButlerURI:
         existence : `dict` of [`ButlerURI`, `bool`]
             Mapping of original URI to boolean indicating existence.
         """
-        import concurrent.futures
-
         exists_executor = concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS)
 
         def wrapper(uri: ButlerURI) -> Tuple[ButlerURI, bool]:

--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -41,6 +41,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Dict,
     Optional,
     Tuple,
     Type,
@@ -652,6 +653,23 @@ class ButlerURI:
             `True` if the resource exists.
         """
         raise NotImplementedError()
+
+    @classmethod
+    def mexists(cls, uris: Iterable[ButlerURI]) -> Dict[ButlerURI, bool]:
+        """Check for existence of multiple URIs at once.
+
+        Parameters
+        ----------
+        uris : iterable of `ButlerURI`
+            The URIs to test.
+
+        Returns
+        -------
+        existence : `dict` of [`ButlerURI`, `bool`]
+            Mapping of original URI to boolean indicating existence.
+        """
+        # None asyncio
+        return {uri: uri.exists() for uri in uris}
 
     def remove(self) -> None:
         """Remove the resource."""

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -356,6 +356,25 @@ class Datastore(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
+    def mexists(self, refs: Iterable[DatasetRef]) -> Dict[DatasetRef, bool]:
+        """Check the existence of multiple datasets at once.
+
+        Parameters
+        ----------
+        refs : iterable of `DatasetRef`
+            The datasets to be checked.
+
+        Returns
+        -------
+        existence : `dict` of [`DatasetRef`, `bool`]
+            Mapping from dataset to boolean indicating existence.
+        """
+        existence: Dict[DatasetRef, bool] = {}
+        # Non-optimized default.
+        for ref in refs:
+            existence[ref] = self.exists(ref)
+        return existence
+
     @abstractmethod
     def exists(self, datasetRef: DatasetRef) -> bool:
         """Check if the dataset exists in the datastore.

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -356,13 +356,18 @@ class Datastore(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def mexists(self, refs: Iterable[DatasetRef]) -> Dict[DatasetRef, bool]:
+    def mexists(self, refs: Iterable[DatasetRef],
+                artifact_existence: Optional[Dict[ButlerURI, bool]] = None) -> Dict[DatasetRef, bool]:
         """Check the existence of multiple datasets at once.
 
         Parameters
         ----------
         refs : iterable of `DatasetRef`
             The datasets to be checked.
+        artifact_existence : `dict` of [`ButlerURI`, `bool`], optional
+            Mapping of datastore artifact to existence. Updated by this
+            method with details of all artifacts tested. Can be `None`
+            if the caller is not interested.
 
         Returns
         -------
@@ -623,7 +628,8 @@ class Datastore(metaclass=ABCMeta):
 
     def transfer_from(self, source_datastore: Datastore, refs: Iterable[DatasetRef],
                       local_refs: Optional[Iterable[DatasetRef]] = None,
-                      transfer: str = "auto") -> None:
+                      transfer: str = "auto",
+                      artifact_existence: Optional[Dict[ButlerURI, bool]] = None) -> None:
         """Transfer dataset artifacts from another datastore to this one.
 
         Parameters
@@ -649,6 +655,10 @@ class Datastore(metaclass=ABCMeta):
             data store choose the most natural option for itself.
             If the source location and transfer location are identical the
             transfer mode will be ignored.
+        artifact_existence : `dict` of [`ButlerURI`, `bool`], optional
+            Mapping of datastore artifact to existence. Updated by this
+            method with details of all artifacts tested. Can be `None`
+            if the caller is not interested.
 
         Raises
         ------

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 __all__ = (
     "allSlots",
+    "chunk_iterable",
     "getClassOf",
     "getFullTypeName",
     "getInstanceOf",
@@ -40,6 +41,7 @@ import os
 import builtins
 import fnmatch
 import functools
+import itertools
 import logging
 import time
 import re
@@ -54,6 +56,7 @@ from typing import (
     Mapping,
     Optional,
     Pattern,
+    Tuple,
     Type,
     TypeVar,
     TYPE_CHECKING,
@@ -534,3 +537,27 @@ def time_this(log: Optional[logging.Logger] = None, msg: Optional[str] = None,
         # caller (1 is this file, 2 is contextlib, 3 is user)
         log.log(level, msg + "%sTook %.4f seconds", *args,
                 ": " if msg else "", end - start, stacklevel=3)
+
+
+def chunk_iterable(data: Iterable[Any], chunk_size: int = 1_000) -> Iterator[Tuple[Any, ...]]:
+    """Return smaller chunks of an iterable.
+
+    Parameters
+    ----------
+    data : iterable of anything
+        The iterable to be chunked. Can be a mapping, in which case
+        the keys are returned in chunks.
+    chunk_size : int, optional
+        The largest chunk to return. Can be smaller and depends on the
+        number of elements in the iterator. Defaults to 1_000.
+
+    Yields
+    ------
+    chunk : `tuple`
+        The contents of a chunk of the iterator as a `tuple`. A tuple is
+        preferred over an iterator since it is more convenient to tell it is
+        empty and the caller knows it can be sized and indexed.
+    """
+    it = iter(data)
+    while (chunk := tuple(itertools.islice(it, chunk_size))):
+        yield chunk

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -251,6 +251,30 @@ class ChainedDatastore(Datastore):
                 return True
         return False
 
+    def mexists(self, refs: Iterable[DatasetRef]) -> Dict[DatasetRef, bool]:
+        """Check the existence of multiple datasets at once.
+
+        Parameters
+        ----------
+        refs : iterable of `DatasetRef`
+            The datasets to be checked.
+
+        Returns
+        -------
+        existence : `dict` of [`DatasetRef`, `bool`]
+            Mapping from dataset to boolean indicating existence in any
+            of the child datastores.
+        """
+        dataset_existence: Dict[DatasetRef, bool] = {}
+        for datastore in self.datastores:
+            dataset_existence.update(datastore.mexists(refs))
+
+            # For next datastore no point asking about ones we know
+            # exist already. No special exemption for ephemeral datastores.
+            refs = [ref for ref, exists in dataset_existence.items() if not exists]
+
+        return dataset_existence
+
     def exists(self, ref: DatasetRef) -> bool:
         """Check if the dataset exists in one of the datastores.
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -251,13 +251,18 @@ class ChainedDatastore(Datastore):
                 return True
         return False
 
-    def mexists(self, refs: Iterable[DatasetRef]) -> Dict[DatasetRef, bool]:
+    def mexists(self, refs: Iterable[DatasetRef],
+                artifact_existence: Optional[Dict[ButlerURI, bool]] = None) -> Dict[DatasetRef, bool]:
         """Check the existence of multiple datasets at once.
 
         Parameters
         ----------
         refs : iterable of `DatasetRef`
             The datasets to be checked.
+        artifact_existence : `dict` of [`ButlerURI`, `bool`], optional
+            Mapping of datastore artifact to existence. Updated by this
+            method with details of all artifacts tested. Can be `None`
+            if the caller is not interested.
 
         Returns
         -------

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -272,7 +272,7 @@ class ChainedDatastore(Datastore):
         """
         dataset_existence: Dict[DatasetRef, bool] = {}
         for datastore in self.datastores:
-            dataset_existence.update(datastore.mexists(refs))
+            dataset_existence.update(datastore.mexists(refs, artifact_existence=artifact_existence))
 
             # For next datastore no point asking about ones we know
             # exist already. No special exemption for ephemeral datastores.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2071,7 +2071,7 @@ class FileDatastore(GenericBaseDatastore):
         # directly in the target datastore, which seems unlikely to be useful
         # since at any moment the source datastore could delete the file.
         if transfer in ("direct", "split"):
-            raise ValueError("Can not transfer from a source datastore using direct mode since"
+            raise ValueError(f"Can not transfer from a source datastore using {transfer} mode since"
                              " those files are controlled by the other datastore.")
 
         # Empty existence lookup if none given.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1352,10 +1352,8 @@ class FileDatastore(GenericBaseDatastore):
             if log.isEnabledFor(VERBOSE):
                 n_results = len(chunk_result)
                 n_checked += n_results
-                n_found = 0
-                for found in chunk_result.values():
-                    if found:
-                        n_found += 1
+                # Can treat the booleans as 0, 1 integers and sum them.
+                n_found = sum(chunk_result.values())
                 n_found_total += n_found
                 log.log(VERBOSE, "Number of datasets found in datastore for chunk %d:%d = %d/%d"
                         " (running total: %d/%d out of %d)",

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1315,6 +1315,7 @@ class FileDatastore(GenericBaseDatastore):
         dataset_existence: Dict[DatasetRef, bool] = {}
         refs = list(refs)
         n_refs = len(refs)
+        log.log(VERBOSE, "Checking for the existence of artifacts for %d datasets in datastore", n_refs)
         n_found_total = 0
         n_checked = 0
         for i in range(0, n_refs, chunk_size):
@@ -1369,9 +1370,8 @@ class FileDatastore(GenericBaseDatastore):
                 for missing in missing_ids:
                     dataset_existence[id_to_ref[missing]] = False
             else:
-                log.log(VERBOSE,
-                        "%d out of %d datasets were not known to datastore during initial existence check.",
-                        len(missing_ids), len(requested_ids))
+                log.debug("%d out of %d datasets were not known to datastore during initial existence check.",
+                          len(missing_ids), len(requested_ids))
 
                 # Construct data structure identical to that returned
                 # by _get_stored_records_associated_with_refs() but using

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2146,7 +2146,7 @@ class FileDatastore(GenericBaseDatastore):
                                                                        artifact_existence=artifact_existence)
 
                 # Now go through the records and propagate the ones that exist.
-                location_factory = self.locationFactory
+                location_factory = source_datastore.locationFactory
                 for missing, record_list in records.items():
                     # Skip completely if the ref does not exist.
                     ref = id_to_ref[missing]

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1311,6 +1311,27 @@ class FileDatastore(GenericBaseDatastore):
         existence : `dict` of [`DatasetRef`, `bool`]
             Mapping from dataset to boolean indicating existence.
         """
+        chunk_size = 1000
+        dataset_existence: Dict[DatasetRef, bool] = {}
+        refs = list(refs)
+        for i in range(0, len(refs), chunk_size):
+            log.info("Processing chunk: %d:%d", i, i + chunk_size)
+            dataset_existence.update(self._mexists(refs[i:i + chunk_size]))
+        return dataset_existence
+
+    def _mexists(self, refs: Iterable[DatasetRef]) -> Dict[DatasetRef, bool]:
+        """Check the existence of multiple datasets at once.
+
+        Parameters
+        ----------
+        refs : iterable of `DatasetRef`
+            The datasets to be checked.
+
+        Returns
+        -------
+        existence : `dict` of [`DatasetRef`, `bool`]
+            Mapping from dataset to boolean indicating existence.
+        """
         # Need a mapping of dataset_id to dataset ref since the API
         # works with dataset_id
         id_to_ref = {ref.getCheckedId(): ref for ref in refs}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ astropy >= 4.0
 click >7.0
 sqlalchemy >= 1.3
 git+git://github.com/lsst/sphgeom@master#egg=lsst_sphgeom
+git+git://github.com/lsst/utils@master#egg=lsst_utils
 pydantic
 httpx
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
   sqlalchemy >= 1.03
   click >= 7.0
   lsst_sphgeom @ git+https://github.com/lsst/sphgeom@master
+  lsst_utils @ git+https://github.com/lsst/utils@master
   deprecated >= 1.2
 tests_require =
   pytest >= 3.2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import os.path
-import errno
-import urllib.request
 from setuptools import setup
 
 
@@ -10,53 +8,6 @@ with open("./python/lsst/daf/butler/version.py", "w") as f:
     print(f"""
 __all__ = ("__version__", )
 __version__ = '{version}'""", file=f)
-
-# The purpose of this setup.py is to build enough of the system to
-# allow testing. Not to distribute on PyPI.
-# One impediment is the dependency on lsst.utils.
-# if that package is missing we download the two files we need
-# and include them in our distribution
-urls = {}
-try:
-    import lsst.utils  # noqa: F401
-except ImportError:
-    urls = {"doImport.py":
-            "https://raw.githubusercontent.com/lsst/utils/master/python/lsst/utils/doImport.py",
-            "tests.py":
-            "https://raw.githubusercontent.com/lsst/utils/master/python/lsst/utils/tests.py"}
-
-if urls:
-    utils_dir = "python/lsst/utils"
-    if not os.path.exists(utils_dir):
-        try:
-            os.makedirs(utils_dir)
-        except OSError as e:
-            # Don't fail if directory exists due to race
-            if e.errno != errno.EEXIST:
-                raise e
-    failed = False
-    for file, url in urls.items():
-        outpath = os.path.join(utils_dir, file)
-        # Do not redownload if the file is there
-        if os.path.exists(outpath):
-            continue
-        try:
-            contents = urllib.request.urlopen(url).read()
-            print(f"Successfully read from {url}: {len(contents)} bytes ({type(contents)})")
-            if isinstance(contents, bytes):
-                contents = contents.decode()
-        except Exception as e:
-            print(f"Unable to download url {url}: {e}")
-            failed = True
-        else:
-            with open(outpath, "w") as fh:
-                print(contents, file=fh)
-    # Write a simple __init__.py
-    if not failed:
-        init_path = os.path.join(utils_dir, "__init__.py")
-        if not os.path.exists(init_path):
-            with open(init_path, "w") as fh:
-                print("from .doImport import *", file=fh)
 
 # read the contents of our README file
 this_directory = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ version = "0.1.0"
 with open("./python/lsst/daf/butler/version.py", "w") as f:
     print(f"""
 __all__ = ("__version__", )
-__version__='{version}'""", file=f)
+__version__ = '{version}'""", file=f)
 
 # The purpose of this setup.py is to build enough of the system to
 # allow testing. Not to distribute on PyPI.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -685,9 +685,10 @@ class ButlerTests(ButlerPutGetTests):
             butler.pruneCollection(run2, pruge=True, unstore=True)
         self.assertCountEqual(set(butler.registry.queryDatasets(..., collections=...)),
                               [ref1, ref2, ref3])
-        self.assertTrue(butler.datastore.exists(ref1))
-        self.assertTrue(butler.datastore.exists(ref2))
-        self.assertTrue(butler.datastore.exists(ref3))
+        existence = butler.datastore.mexists([ref1, ref2, ref3])
+        self.assertTrue(existence[ref1])
+        self.assertTrue(existence[ref2])
+        self.assertTrue(existence[ref3])
         # Try to delete CHAINED and TAGGED collections with purge; should not
         # work.
         with self.assertRaises(TypeError):
@@ -701,9 +702,10 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.getCollectionType(tag1)
         self.assertCountEqual(set(butler.registry.queryDatasets(..., collections=...)),
                               [ref1, ref2, ref3])
-        self.assertTrue(butler.datastore.exists(ref1))
-        self.assertTrue(butler.datastore.exists(ref2))
-        self.assertTrue(butler.datastore.exists(ref3))
+        existence = butler.datastore.mexists([ref1, ref2, ref3])
+        self.assertTrue(existence[ref1])
+        self.assertTrue(existence[ref2])
+        self.assertTrue(existence[ref3])
         # Add the tagged collection back in, and remove it with unstore=True.
         # This should remove ref3 only from the datastore.
         butler.registry.registerCollection(tag1, type=CollectionType.TAGGED)
@@ -713,9 +715,10 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.getCollectionType(tag1)
         self.assertCountEqual(set(butler.registry.queryDatasets(..., collections=...)),
                               [ref1, ref2, ref3])
-        self.assertTrue(butler.datastore.exists(ref1))
-        self.assertTrue(butler.datastore.exists(ref2))
-        self.assertFalse(butler.datastore.exists(ref3))
+        existence = butler.datastore.mexists([ref1, ref2, ref3])
+        self.assertTrue(existence[ref1])
+        self.assertTrue(existence[ref2])
+        self.assertFalse(existence[ref3])
         # Delete the chain with unstore=False.  The datasets should not be
         # affected at all.
         butler.pruneCollection(chain1)
@@ -723,9 +726,10 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.getCollectionType(chain1)
         self.assertCountEqual(set(butler.registry.queryDatasets(..., collections=...)),
                               [ref1, ref2, ref3])
-        self.assertTrue(butler.datastore.exists(ref1))
-        self.assertTrue(butler.datastore.exists(ref2))
-        self.assertFalse(butler.datastore.exists(ref3))
+        existence = butler.datastore.mexists([ref1, ref2, ref3])
+        self.assertTrue(existence[ref1])
+        self.assertTrue(existence[ref2])
+        self.assertFalse(existence[ref3])
         # Redefine and then delete the chain with unstore=True.  Only ref1
         # should be unstored (ref3 has already been unstored, but otherwise
         # would be now).
@@ -736,9 +740,10 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.getCollectionType(chain1)
         self.assertCountEqual(set(butler.registry.queryDatasets(..., collections=...)),
                               [ref1, ref2, ref3])
-        self.assertFalse(butler.datastore.exists(ref1))
-        self.assertTrue(butler.datastore.exists(ref2))
-        self.assertFalse(butler.datastore.exists(ref3))
+        existence = butler.datastore.mexists([ref1, ref2, ref3])
+        self.assertFalse(existence[ref1])
+        self.assertTrue(existence[ref2])
+        self.assertFalse(existence[ref3])
         # Remove run1.  This removes ref1 and ref3 from the registry (they're
         # already gone from the datastore, which is fine).
         butler.pruneCollection(run1, purge=True, unstore=True)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1742,9 +1742,12 @@ class PosixDatastoreTransfers(unittest.TestCase):
                 self.assertEqual(new_metric, metric)
 
         # Now transfer them to the second butler
-        transferred = self.target_butler.transfer_from(self.source_butler, source_refs,
-                                                       id_gen_map=id_gen_map)
+        with self.assertLogs(level=logging.DEBUG) as cm:
+            transferred = self.target_butler.transfer_from(self.source_butler, source_refs,
+                                                           id_gen_map=id_gen_map)
         self.assertEqual(len(transferred), n_expected)
+        log_output = ";".join(cm.output)
+        self.assertIn("found in datastore for chunk", log_output)
 
         # Do the transfer twice to ensure that it will do nothing extra.
         # Only do this if purge=True because it does not work for int

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -270,7 +270,14 @@ class FileURITestCase(unittest.TestCase):
         self.assertEqual(u, j)
         self.assertFalse(j.dirLike)
         self.assertFalse(j.isdir())
-        self.assertFalse(d.join("not-there.yaml").exists())
+        not_there = d.join("not-there.yaml")
+        self.assertFalse(not_there.exists())
+
+        bad = ButlerURI("resource://bad.module/not.yaml")
+        multi = ButlerURI.mexists([u, bad, not_there])
+        self.assertTrue(multi[u])
+        self.assertFalse(multi[bad])
+        self.assertFalse(multi[not_there])
 
     def testEscapes(self):
         """Special characters in file paths"""


### PR DESCRIPTION
* Add `datastore.mexists()` and `ButlerURI.mexists()`
* Use parallel queries of object store.
* Cache result of initial check for registry entries and reuse for check inside datastore.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
