### PR TITLE
DM-31826: Make ButlerURI.transfer_from check for identical in and out files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           conda install -y -q \
             flake8 \
-            pytest pytest-flake8 pytest-xdist pytest-openfiles
+            pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov
 
       - name: List installed packages
         shell: bash -l {0}
@@ -80,4 +80,8 @@ jobs:
         env:
           SQLALCHEMY_WARN_20: 1
         run: |
-          pytest -r a -v -n 3 --open-files
+          pytest -r a -v -n 3 --open-files --cov=./ --cov-report=xml --cov-branch
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v2
+        with:
+          file: ./coverage.xml

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -242,8 +242,12 @@ class ButlerPutGetTests:
 
                     for preserve_path in (True, False):
                         destination = root_uri.join(f"artifacts/{preserve_path}_{counter}/")
+                        # Use copy so that we can test that overwrite
+                        # protection works (using "auto" for File URIs would
+                        # use hard links and subsequent transfer would work
+                        # because it knows they are the same file).
                         transferred = butler.retrieveArtifacts([ref], destination,
-                                                               preserve_path=preserve_path)
+                                                               preserve_path=preserve_path, transfer="copy")
                         self.assertGreater(len(transferred), 0)
                         artifacts = list(ButlerURI.findFileResources([destination]))
                         self.assertEqual(set(transferred), set(artifacts))

--- a/tests/test_cliCmdRetrieveArtifacts.py
+++ b/tests/test_cliCmdRetrieveArtifacts.py
@@ -87,9 +87,14 @@ class CliRetrieveArtifactsTest(unittest.TestCase, ButlerTestHelper):
         runner = LogCliRunner()
         with runner.isolated_filesystem():
             destdir = "tmp2/"
-            # Force hardlink
+            # Force hardlink -- if this fails assume that it is because
+            # hardlinks are not supported (/tmp and TESTDIR are on
+            # different file systems) and skip the test. There are other
+            # tests for the command line itself.
             result = runner.invoke(cli, ["retrieve-artifacts", self.root, destdir, "--transfer", "hardlink"])
-            self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+            if result.exit_code != 0:
+                raise unittest.SkipTest("hardlink not supported between these directories for this test:"
+                                        f" {clickResultMsg(result)}")
 
             # Running again should pass because hard links are the same
             # file.

--- a/tests/test_cliCmdRetrieveArtifacts.py
+++ b/tests/test_cliCmdRetrieveArtifacts.py
@@ -83,11 +83,25 @@ class CliRetrieveArtifactsTest(unittest.TestCase, ButlerTestHelper):
             artifacts = self.find_files(destdir)
             self.assertEqual(len(artifacts), 3, f"Expected 3 artifacts: {artifacts}")
 
+    def testOverwriteLink(self):
+        runner = LogCliRunner()
+        with runner.isolated_filesystem():
+            destdir = "tmp2/"
+            # Force hardlink
+            result = runner.invoke(cli, ["retrieve-artifacts", self.root, destdir, "--transfer", "hardlink"])
+            self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+            # Running again should pass because hard links are the same
+            # file.
+            result = runner.invoke(cli, ["retrieve-artifacts", self.root, destdir])
+            self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
     def testClobber(self):
         runner = LogCliRunner()
         with runner.isolated_filesystem():
             destdir = "tmp2/"
-            result = runner.invoke(cli, ["retrieve-artifacts", self.root, destdir])
+            # Force copy so we can ensure that overwrite tests will trigger.
+            result = runner.invoke(cli, ["retrieve-artifacts", self.root, destdir, "--transfer", "copy"])
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
             # Running again should fail


### PR DESCRIPTION
Sometimes even if the URIs are different they point to the same
file. This must be checked to ensure we don't delete the file
by mistake. If they are identical the transfer is assumed
to have succeeded.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
