### PR TITLE
DM-31941: Allow datastore.trash to remove unknown files and ingest to overwrite

### DIFF
--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -902,8 +902,13 @@ class FileDatastore(GenericBaseDatastore):
                 checksum = self.computeChecksum(srcUri) if self.useChecksum else None
                 have_sized = True
 
-            # transfer the resource to the destination
-            tgtLocation.uri.transfer_from(srcUri, transfer=transfer, transaction=self._transaction)
+            # Transfer the resource to the destination.
+            # Allow overwrite of an existing file. This matches the behavior
+            # of datastore.put() in that it trusts that registry would not
+            # be asking to overwrite unless registry thought that the
+            # overwrite was allowed.
+            tgtLocation.uri.transfer_from(srcUri, transfer=transfer, transaction=self._transaction,
+                                          overwrite=True)
 
         if tgtLocation is None:
             # This means we are using direct mode

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1902,6 +1902,53 @@ class FileDatastore(GenericBaseDatastore):
         # the cache will simply be refilled.
         self.cacheManager.remove_from_cache(ref)
 
+        # If we are in trust mode there will be nothing to move to
+        # the trash table and we will have to try to delete the file
+        # immediately.
+        if self.trustGetRequest:
+            # Try to keep the logic below for a single file trash.
+            if isinstance(ref, DatasetRef):
+                refs = {ref}
+            else:
+                # Will recreate ref at the end of this branch.
+                refs = set(ref)
+
+            # Determine which datasets are known to datastore directly.
+            id_to_ref = {ref.getCheckedId(): ref for ref in refs}
+            existing_ids = self._get_stored_records_associated_with_refs(refs)
+            existing_refs = {id_to_ref[ref_id] for ref_id in existing_ids}
+
+            missing = refs - existing_refs
+            if missing:
+                # Do an explicit existence check on these refs.
+                # We only care about the artifacts at this point and not
+                # the dataset existence.
+                artifact_existence: Dict[ButlerURI, bool] = {}
+                _ = self.mexists(missing, artifact_existence)
+                uris = [uri for uri, exists in artifact_existence.items() if exists]
+
+                # FUTURE UPGRADE: Implement a parallelized bulk remove.
+                log.debug("Removing %d artifacts from datastore that are unknown to datastore", len(uris))
+                for uri in uris:
+                    try:
+                        uri.remove()
+                    except Exception as e:
+                        if ignore_errors:
+                            log.debug("Artifact %s could not be removed: %s", uri, e)
+                            continue
+                        raise
+
+            # There is no point asking the code below to remove refs we
+            # know are missing so update it with the list of existing
+            # records. Try to retain one vs many logic.
+            if not existing_refs:
+                # Nothing more to do since none of the datasets were
+                # known to the datastore record table.
+                return
+            ref = list(existing_refs)
+            if len(ref) == 1:
+                ref = ref[0]
+
         # Get file metadata and internal metadata
         if not isinstance(ref, DatasetRef):
             log.debug("Doing multi-dataset trash in datastore %s", self.name)

--- a/python/lsst/daf/butler/tests/_dummyRegistry.py
+++ b/python/lsst/daf/butler/tests/_dummyRegistry.py
@@ -90,8 +90,8 @@ class DummyOpaqueTableStorage(OpaqueTableStorage):
             for where_row in rows:
                 if all(table_row[k] == v for k, v in where_row.items()):
                     break
-                else:
-                    kept_rows.append(table_row)
+            else:
+                kept_rows.append(table_row)
         self._rows = kept_rows
 
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -25,6 +25,7 @@ import shutil
 import yaml
 import tempfile
 import time
+from dataclasses import dataclass
 import lsst.utils.tests
 
 from lsst.utils import doImport
@@ -33,7 +34,7 @@ from lsst.daf.butler import StorageClassFactory, StorageClass, DimensionUniverse
 from lsst.daf.butler import DatastoreConfig, DatasetTypeNotSupportedError, DatastoreValidationError
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 from lsst.daf.butler import (DatastoreCacheManager, DatastoreDisabledCacheManager,
-                             DatastoreCacheManagerConfig, Config, ButlerURI)
+                             DatastoreCacheManagerConfig, Config, ButlerURI, NamedKeyDict)
 
 from lsst.daf.butler.tests import (DatasetTestHelper, DatastoreTestHelper, BadWriteFormatter,
                                    BadNoWriteFormatter, MetricsExample, DummyRegistry)
@@ -52,6 +53,25 @@ def makeExampleMetrics(use_none=False):
                            "b": {"blue": 5, "red": "green"}},
                           array,
                           )
+
+
+@dataclass(frozen=True)
+class Named:
+    name: str
+
+
+class FakeDataCoordinate(NamedKeyDict):
+    """A fake hashable frozen DataCoordinate built from a simple dict."""
+
+    @classmethod
+    def from_dict(cls, dataId):
+        new = cls()
+        for k, v in dataId.items():
+            new[Named(k)] = v
+        return new.freeze()
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self.items()))
 
 
 class TransactionTestError(Exception):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -679,13 +679,6 @@ class DatastoreTests(DatastoreTestsBase):
                                          transfer=mode)
                     self.assertFalse(datastore.exists(ref), f"Checking not in datastore using mode {mode}")
 
-                def failOutputExists(obj, path, ref):
-                    """Can't ingest files if transfer destination already
-                    exists."""
-                    with self.assertRaises(FileExistsError):
-                        datastore.ingest(FileDataset(path=os.path.abspath(path), refs=ref), transfer=mode)
-                    self.assertFalse(datastore.exists(ref), f"Checking not in datastore using mode {mode}")
-
                 def failNotImplemented(obj, path, ref):
                     with self.assertRaises(NotImplementedError):
                         datastore.ingest(FileDataset(path=os.path.abspath(path), refs=ref), transfer=mode)
@@ -693,7 +686,6 @@ class DatastoreTests(DatastoreTestsBase):
                 if mode in self.ingestTransferModes:
                     self.runIngestTest(failInputDoesNotExist)
                     self.runIngestTest(succeed, expectOutput=(mode != "move"))
-                    self.runIngestTest(failOutputExists)
                 else:
                     self.runIngestTest(failNotImplemented)
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -450,25 +450,28 @@ class DatastoreTests(DatastoreTestsBase):
             metricsOut = sc.delegate().assemble(compsRead)
             self.assertEqual(metrics, metricsOut)
 
-    def prepDeleteTest(self):
+    def prepDeleteTest(self, n_refs=1):
         metrics = makeExampleMetrics()
         datastore = self.makeDatastore()
         # Put
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = {"instrument": "dummy", "visit": 638, "physical_filter": "U"}
-
         sc = self.storageClassFactory.getStorageClass("StructuredData")
-        ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
-        datastore.put(metrics, ref)
+        refs = []
+        for i in range(n_refs):
+            dataId = FakeDataCoordinate.from_dict({"instrument": "dummy", "visit": 638 + i,
+                                                   "physical_filter": "U"})
+            ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+            datastore.put(metrics, ref)
 
-        # Does it exist?
-        self.assertTrue(datastore.exists(ref))
+            # Does it exist?
+            self.assertTrue(datastore.exists(ref))
 
-        # Get
-        metricsOut = datastore.get(ref)
-        self.assertEqual(metrics, metricsOut)
+            # Get
+            metricsOut = datastore.get(ref)
+            self.assertEqual(metrics, metricsOut)
+            refs.append(ref)
 
-        return datastore, ref
+        return datastore, *refs
 
     def testRemove(self):
         datastore, ref = self.prepDeleteTest()


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
