### PR TITLE
DM-31963: Update parquet writing to use default per-column compression.

### DIFF
--- a/doc/changes/DM-31963.misc.rst
+++ b/doc/changes/DM-31963.misc.rst
@@ -1,0 +1,1 @@
+Update parquet writing to use default per-column compression.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -167,7 +167,7 @@ def _writeParquet(path: str, inMemoryDataset: pd.DataFrame) -> None:
     """Write a `pandas.DataFrame` instance as a Parquet file.
     """
     table = pa.Table.from_pandas(inMemoryDataset)
-    pq.write_table(table, path, compression="none")
+    pq.write_table(table, path)
 
 
 class ParquetFormatter(Formatter):


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
