### PR TITLE
DM-31976: Be more careful with run collection creation and dataset type registration

### DIFF
--- a/doc/changes/DM-31976.feature.rst
+++ b/doc/changes/DM-31976.feature.rst
@@ -1,0 +1,2 @@
+* The ``Butler.transfer_from`` method no longer registers new dataset types by default.
+* Add the related option ``--register-dataset-types`` to the ``butler transfer-datasets`` subcommand.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -39,6 +39,7 @@ from ..opt import (
     glob_argument,
     options_file_option,
     query_datasets_options,
+    register_dataset_types_option,
     repo_argument,
     transfer_option,
     verbose_option,
@@ -494,6 +495,7 @@ def retrieve_artifacts(**kwargs):
 @click.argument("dest", required=True)
 @query_datasets_options(showUri=False, useArguments=False, repo=False)
 @transfer_option()
+@register_dataset_types_option()
 @options_file_option()
 def transfer_datasets(**kwargs):
     """Transfer datasets from a source butler to a destination butler.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -643,7 +643,7 @@ def register_dataset_type(**kwargs):
 
 
 @click.command(cls=ButlerCommand)
-@repo_argument(required=True, help=willCreateRepoHelp)
+@repo_argument(required=True)
 @directory_argument(required=True)
 @collections_argument(help="COLLECTIONS are the collection to export calibrations from.")
 def export_calibs(*args, **kwargs):

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -159,6 +159,11 @@ processes_option = MWOptionDecorator("-j", "--processes",
 regex_option = MWOptionDecorator("--regex")
 
 
+register_dataset_types_option = MWOptionDecorator("--register-dataset-types",
+                                                  help=unwrap("""Register DatasetTypes that do not already
+                                                              exist in the Registry."""),
+                                                  is_flag=True)
+
 run_option = MWOptionDecorator("--output-run",
                                help="The name of the run datasets should be output to.")
 

--- a/python/lsst/daf/butler/registries/remote.py
+++ b/python/lsst/daf/butler/registries/remote.py
@@ -203,7 +203,7 @@ class RemoteRegistry(Registry):
     #    use by Datastore. DatastoreBridgeManager also is not needed.
 
     def registerCollection(self, name: str, type: CollectionType = CollectionType.TAGGED,
-                           doc: Optional[str] = None) -> None:
+                           doc: Optional[str] = None) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError()
 
@@ -222,7 +222,7 @@ class RemoteRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError
 
-    def registerRun(self, name: str, doc: Optional[str] = None) -> None:
+    def registerRun(self, name: str, doc: Optional[str] = None) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -324,9 +324,10 @@ class SqlRegistry(Registry):
         self._managers.opaque[tableName].delete(where.keys(), where)
 
     def registerCollection(self, name: str, type: CollectionType = CollectionType.TAGGED,
-                           doc: Optional[str] = None) -> None:
+                           doc: Optional[str] = None) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
-        self._managers.collections.register(name, type, doc=doc)
+        _, registered = self._managers.collections.register(name, type, doc=doc)
+        return registered
 
     def getCollectionType(self, name: str) -> CollectionType:
         # Docstring inherited from lsst.daf.butler.registry.Registry
@@ -336,9 +337,10 @@ class SqlRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return self._managers.collections.find(name)
 
-    def registerRun(self, name: str, doc: Optional[str] = None) -> None:
+    def registerRun(self, name: str, doc: Optional[str] = None) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
-        self._managers.collections.register(name, CollectionType.RUN, doc=doc)
+        _, registered = self._managers.collections.register(name, CollectionType.RUN, doc=doc)
+        return registered
 
     @transactional
     def removeCollection(self, name: str) -> None:

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -311,7 +311,7 @@ class Registry(ABC):
 
     @abstractmethod
     def registerCollection(self, name: str, type: CollectionType = CollectionType.TAGGED,
-                           doc: Optional[str] = None) -> None:
+                           doc: Optional[str] = None) -> bool:
         """Add a new collection if one with the given name does not exist.
 
         Parameters
@@ -322,6 +322,12 @@ class Registry(ABC):
             Enum value indicating the type of collection to create.
         doc : `str`, optional
             Documentation string for the collection.
+
+        Returns
+        -------
+        registered : `bool`
+            Boolean indicating whether the collection was already registered
+            or was created by this call.
 
         Notes
         -----
@@ -369,7 +375,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def registerRun(self, name: str, doc: Optional[str] = None) -> None:
+    def registerRun(self, name: str, doc: Optional[str] = None) -> bool:
         """Add a new run if one with the given name does not exist.
 
         Parameters
@@ -378,6 +384,12 @@ class Registry(ABC):
             The name of the run to create.
         doc : `str`, optional
             Documentation string for the collection.
+
+        Returns
+        -------
+        registered : `bool`
+            Boolean indicating whether a new run was registered. `False`
+            if it already existed.
 
         Notes
         -----

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -32,6 +32,7 @@ from typing import (
     Any,
     Iterator,
     Optional,
+    Tuple,
     TYPE_CHECKING,
 )
 
@@ -404,7 +405,8 @@ class CollectionManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def register(self, name: str, type: CollectionType, doc: Optional[str] = None) -> CollectionRecord:
+    def register(self, name: str, type: CollectionType,
+                 doc: Optional[str] = None) -> Tuple[CollectionRecord, bool]:
         """Ensure that a collection of the given name and type are present
         in the layer this manager is associated with.
 
@@ -425,6 +427,9 @@ class CollectionManager(VersionedExtension):
             If ``type is CollectionType.RUN``, this will be a `RunRecord`
             instance.  If ``type is CollectionType.CHAIN``, this will be a
             `ChainedCollectionRecord` instance.
+        registered : `bool`
+            True if the collection was registered, `False` if it already
+            existed.
 
         Raises
         ------

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 def transferDatasets(source: str, dest: str, dataset_type: Tuple[str, ...], collections: Tuple[str, ...],
                      where: str, find_first: bool,
-                     transfer: str) -> int:
+                     transfer: str, register_dataset_types: bool) -> int:
     """Transfer datasets from run in source to dest.
 
     Parameters
@@ -52,6 +52,8 @@ def transferDatasets(source: str, dest: str, dataset_type: Tuple[str, ...], coll
         Whether only the first match should be used.
     transfer : `str`
         Transfer mode to use when placing artifacts in the destination.
+    register_dataset_types : `bool`
+        Indicate whether missing dataset types should be registered.
     """
     source_butler = Butler(source, writeable=False)
     dest_butler = Butler(dest, writeable=True)
@@ -72,5 +74,6 @@ def transferDatasets(source: str, dest: str, dataset_type: Tuple[str, ...], coll
     # Place results in a set to remove duplicates
     source_refs = set(source_refs)
 
-    transferred = dest_butler.transfer_from(source_butler, source_refs, transfer=transfer)
+    transferred = dest_butler.transfer_from(source_butler, source_refs, transfer=transfer,
+                                            register_dataset_types=register_dataset_types)
     return len(transferred)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1830,7 +1830,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
         for datasetTypeName in datasetTypeNames:
             datasetType = DatasetType(datasetTypeName, dimensions, badStorageClass)
             self.target_butler.registry.registerDatasetType(datasetType)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ConflictingDefinitionError):
             self.target_butler.transfer_from(self.source_butler, source_refs,
                                              id_gen_map=id_gen_map)
         # And remove the bad definitions.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -427,7 +427,9 @@ class ButlerPutGetTests:
         metric = makeExampleMetrics()
         # Register a new run and put dataset.
         run = "deferred"
-        butler.registry.registerRun(run)
+        self.assertTrue(butler.registry.registerRun(run))
+        # Second time it will be allowed but indicate no-op
+        self.assertFalse(butler.registry.registerRun(run))
         ref = butler.put(metric, datasetType, dataId, run=run)
         # Putting with no run should fail with TypeError.
         with self.assertRaises(TypeError):
@@ -669,7 +671,11 @@ class ButlerTests(ButlerPutGetTests):
             butler.pruneCollection(run2, purge=True)
         # Add a TAGGED collection and associate ref3 only into it.
         tag1 = "tag1"
-        butler.registry.registerCollection(tag1, type=CollectionType.TAGGED)
+        registered = butler.registry.registerCollection(tag1, type=CollectionType.TAGGED)
+        self.assertTrue(registered)
+        # Registering a second time should be allowed.
+        registered = butler.registry.registerCollection(tag1, type=CollectionType.TAGGED)
+        self.assertFalse(registered)
         butler.registry.associate(tag1, [ref3])
         # Add a CHAINED collection that searches run1 and then run2.  It
         # logically contains only ref1, because ref2 is shadowed due to them

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1894,7 +1894,10 @@ class PosixDatastoreTransfers(unittest.TestCase):
         self.target_butler.pruneCollection("run2", purge=True, unstore=True)
         self.target_butler.registry.registerCollection("run2", CollectionType.CHAINED)
         with self.assertRaises(TypeError):
-            self.target_butler.transfer_from(self.source_butler, source_refs,
+            # Re-importing the run1 datasets can be problematic if they
+            # use integer IDs so filter those out.
+            to_transfer = [ref for ref in source_refs if ref.run == "run2"]
+            self.target_butler.transfer_from(self.source_butler, to_transfer,
                                              id_gen_map=id_gen_map)
 
 


### PR DESCRIPTION
By default now configure Butler.transfer_from to not register
dataset types. As part of this reorganization consistency
is now ensured between source butler definitions and target
butler definitions.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
