### PR TITLE
DM-31769 Remove Placeholder from DatasetType

### DIFF
--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -100,10 +100,7 @@ class DatasetType:
     parentStorageClass : `StorageClass` or `str`, optional
         Instance of a `StorageClass` or name of `StorageClass` that defines
         how the composite parent is persisted.  Must be `None` if this
-        is not a component. Mandatory if it is a component but can be the
-        special temporary placeholder
-        (`DatasetType.PlaceholderParentStorageClass`) to allow
-        construction with an intent to finalize later.
+        is not a component.
     universe : `DimensionUniverse`, optional
         Set of all known dimensions, used to normalize ``dimensions`` if it
         is not already a `DimensionGraph`.
@@ -119,14 +116,6 @@ class DatasetType:
     _serializedType = SerializedDatasetType
 
     VALID_NAME_REGEX = re.compile("^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*$")
-
-    PlaceholderParentStorageClass = StorageClass("PlaceHolder")
-    """Placeholder StorageClass that can be used temporarily for a
-    component.
-
-    This can be useful in pipeline construction where we are creating
-    dataset types without a registry.
-    """
 
     @staticmethod
     def nameWithComponent(datasetTypeName: str, componentName: str) -> str:
@@ -301,38 +290,6 @@ class DatasetType:
             collections.
         """
         return self._isCalibration
-
-    def finalizeParentStorageClass(self, newParent: StorageClass) -> None:
-        """Finalize the parent storage class definition.
-
-        Replaces the current placeholder parent storage class with
-        the real parent.
-
-        Parameters
-        ----------
-        newParent : `StorageClass`
-            The new parent to be associated with this composite dataset
-            type.  This replaces the temporary placeholder parent that
-            was specified during construction.
-
-        Raises
-        ------
-        ValueError
-            Raised if this dataset type is not a component of a composite.
-            Raised if a StorageClass is not given.
-            Raised if the parent currently associated with the dataset
-            type is not a placeholder.
-        """
-        if not self.isComponent():
-            raise ValueError("Can not set a parent storage class if this is not a component"
-                             f" ({self.name})")
-        if self._parentStorageClass != self.PlaceholderParentStorageClass:
-            raise ValueError(f"This DatasetType has a parent of {self._parentStorageClassName} and"
-                             " is not a placeholder.")
-        if not isinstance(newParent, StorageClass):
-            raise ValueError(f"Supplied parent must be a StorageClass. Got {newParent!r}")
-        self._parentStorageClass = newParent
-        self._parentStorageClassName = newParent.name
 
     @staticmethod
     def splitDatasetTypeName(datasetTypeName: str) -> Tuple[str, Optional[str]]:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -168,33 +168,6 @@ class DatasetTypeTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             sort = sorted(["z", d_p, "c", d_f, d_a, "d"])
 
-    def testParentPlaceholder(self):
-        """Test that a parent placeholder can be replaced."""
-        storageComp = StorageClass("component")
-        storageParent = StorageClass("Parent")
-        dimensions = self.universe.extract(["instrument"])
-        component = DatasetType("a.b", dimensions, storageComp,
-                                parentStorageClass=DatasetType.PlaceholderParentStorageClass)
-        self.assertIsNotNone(component.parentStorageClass)
-
-        with self.assertRaises(ValueError):
-            component.finalizeParentStorageClass("parent")
-
-        component.finalizeParentStorageClass(storageParent)
-        self.assertEqual(component.parentStorageClass, storageParent)
-
-        component = DatasetType("a.b", dimensions, storageComp,
-                                parentStorageClass=storageParent)
-
-        with self.assertRaises(ValueError):
-            # Can not replace unless a placeholder
-            component.finalizeParentStorageClass(storageComp)
-
-        datasetType = DatasetType("a", dimensions, storageParent)
-        with self.assertRaises(ValueError):
-            # Can not add parent if not component
-            datasetType.finalizeParentStorageClass(storageComp)
-
     def testHashability(self):
         """Test `DatasetType.__hash__`.
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -30,6 +30,8 @@ from lsst.daf.butler import DatasetType, DatasetRef, FileTemplates, DimensionUni
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
+PlaceHolder = StorageClass("PlaceHolder")
+
 
 class TestFileTemplates(unittest.TestCase):
     """Test creation of paths from templates."""
@@ -42,7 +44,7 @@ class TestFileTemplates(unittest.TestCase):
 
         # Pretend we have a parent if this looks like a composite
         compositeName, componentName = DatasetType.splitDatasetTypeName(datasetTypeName)
-        parentStorageClass = DatasetType.PlaceholderParentStorageClass if componentName else None
+        parentStorageClass = PlaceHolder if componentName else None
 
         datasetType = DatasetType(datasetTypeName, DimensionGraph(self.universe, names=dataId.keys()),
                                   StorageClass(storageClassName),


### PR DESCRIPTION
Previously a placeholder was created to aid in graph creation
involving component dataset types. Graph creation code was modified
such that this no longer needs to be an attribute of DatasetType.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
