### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -6,6 +6,7 @@ default:
     # default is the default recipe regardless but this demonstrates
     # how to specify a default write parameter
     recipe: default
+int: lsst.daf.butler.formatters.json.JsonFormatter
 TablePersistable: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Wcs: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Psf: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -1,4 +1,6 @@
 storageClasses:
+  int:
+    pytype: int
   StructuredDataDict:
     pytype: dict
   StructuredDataList:
@@ -195,6 +197,7 @@ storageClasses:
       validPolygon: Polygon
       summaryStats: ExposureSummaryStats
     derivedComponents:
+      id: int
       bbox: Box2I
       dimensions: Extent2I
       xy0: Point2I


### PR DESCRIPTION
This PR adds an `id` component to `ExposureInfo`, in keeping with the changes made on lsst/afw#613 and lsst/obs_base#394.