### PR TITLE
DM-32407: Fix YAML serialization of empty Timespans

### DIFF
--- a/python/lsst/daf/butler/transfers/_yaml.py
+++ b/python/lsst/daf/butler/transfers/_yaml.py
@@ -183,8 +183,7 @@ class YamlRepoExportBackend(RepoExportBackend):
                 "collection_type": collectionType.name,
                 "validity_ranges": [
                     {
-                        "begin": timespan.begin,
-                        "end": timespan.end,
+                        "timespan": timespan,
                         "dataset_ids": dataset_ids,
                     }
                     for timespan, dataset_ids in idsByTimespan.items()
@@ -311,7 +310,12 @@ class YamlRepoImportBackend(RepoImportBackend):
                 elif collectionType is CollectionType.CALIBRATION:
                     assocsByTimespan = self.calibAssociations[data["collection"]]
                     for d in data["validity_ranges"]:
-                        assocsByTimespan[Timespan(begin=d["begin"], end=d["end"])] = d["dataset_ids"]
+                        if "timespan" in d:
+                            assocsByTimespan[d["timespan"]] = d["dataset_ids"]
+                        else:
+                            # TODO: this is for backward compatibility, should
+                            # be removed at some point.
+                            assocsByTimespan[Timespan(begin=d["begin"], end=d["end"])] = d["dataset_ids"]
                 else:
                     raise ValueError(f"Unexpected calibration type for association: {collectionType.name}.")
             else:

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -797,14 +797,9 @@ class PosixDatastoreNoChecksumsTestCase(PosixDatastoreTestCase):
         self.assertIsNotNone(infos[0].checksum)
 
 
-class TrashDatastoreTestCase(PosixDatastoreTestCase, unittest.TestCase):
+class TrashDatastoreTestCase(PosixDatastoreTestCase):
     """Restrict trash test to FileDatastore."""
     configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
-
-    def setUp(self):
-        # Override the working directory before calling the base class
-        self.root = tempfile.mkdtemp(dir=TESTDIR)
-        super().setUp()
 
     def testTrash(self):
         datastore, *refs = self.prepDeleteTest(n_refs=10)

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -282,6 +282,7 @@ class SimpleButlerTestCase(unittest.TestCase):
         t1 = astropy.time.Time('2020-01-01T01:00:00', format="isot", scale="tai")
         t2 = astropy.time.Time('2020-01-01T02:00:00', format="isot", scale="tai")
         t3 = astropy.time.Time('2020-01-01T03:00:00', format="isot", scale="tai")
+        bias1a = registry1.findDataset("bias", instrument="Cam1", detector=1, collections="imported_g")
         bias2a = registry1.findDataset("bias", instrument="Cam1", detector=2, collections="imported_g")
         bias3a = registry1.findDataset("bias", instrument="Cam1", detector=3, collections="imported_g")
         bias2b = registry1.findDataset("bias", instrument="Cam1", detector=2, collections="imported_r")
@@ -289,6 +290,7 @@ class SimpleButlerTestCase(unittest.TestCase):
         registry1.certify("calibration1", [bias2a, bias3a], Timespan(t1, t2))
         registry1.certify("calibration1", [bias2b], Timespan(t2, None))
         registry1.certify("calibration1", [bias3b], Timespan(t2, t3))
+        registry1.certify("calibration1", [bias1a], Timespan.makeEmpty())
 
         with tempfile.NamedTemporaryFile(mode='w', suffix=".yaml") as file:
             # Export all collections, and some datasets.
@@ -298,7 +300,7 @@ class SimpleButlerTestCase(unittest.TestCase):
                 for collection in sorted(registry1.queryCollections()):
                     exporter.saveCollection(collection)
                 exporter.saveDatasets(flats1)
-                exporter.saveDatasets([bias2a, bias2b, bias3a, bias3b])
+                exporter.saveDatasets([bias1a, bias2a, bias2b, bias3a, bias3b])
             # Import them into a new registry.
             butler2 = self.makeButler(writeable=True)
             butler2.import_(filename=file.name)


### PR DESCRIPTION
Add special YAML representer and constructor for  the _SpecialTimespanBound
class. Extend unit test with a trivial case for an empty Timespan.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
