### PR TITLE
DM-32058 Fail dataset type query early on non extant type

### DIFF
--- a/python/lsst/daf/butler/registries/remote.py
+++ b/python/lsst/daf/butler/registries/remote.py
@@ -354,9 +354,13 @@ class RemoteRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError()
 
-    def queryDatasetTypes(self, expression: Any = ..., *, components: Optional[bool] = None
+    def queryDatasetTypes(self, expression: Any = ..., *, components: Optional[bool] = None,
+                          missing: Optional[List[str]] = None,
                           ) -> Iterator[DatasetType]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
+        if missing is not None:
+            raise NotImplementedError("RemoteRegistry does not support the 'missing' parameter.")
+
         params: Dict[str, Any] = {}
 
         expression = ExpressionQueryParameter.from_expression(expression)

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1109,7 +1109,8 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def queryDatasetTypes(self, expression: Any = ..., *, components: Optional[bool] = None
+    def queryDatasetTypes(self, expression: Any = ..., *, components: Optional[bool] = None,
+                          missing: Optional[List[str]] = None,
                           ) -> Iterator[DatasetType]:
         """Iterate over the dataset types whose names match an expression.
 
@@ -1128,6 +1129,10 @@ class Registry(ABC):
             parent datasets were not matched by the expression.
             Fully-specified component datasets (`str` or `DatasetType`
             instances) are always included.
+        missing : `list` of `str`, optional
+            String dataset type names that were explicitly given (i.e. not
+            regular expression patterns) but not found will be appended to this
+            list, if it is provided.
 
         Yields
         ------

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -66,6 +66,8 @@ from .._exceptions import (
     MissingCollectionError,
     OrphanedRecordError,
 )
+
+
 from ..interfaces import ButlerAttributeExistsError
 
 if TYPE_CHECKING:
@@ -2379,6 +2381,11 @@ class RegistryTests(ABC):
             (
                 # Dataset type name doesn't match any existing dataset types.
                 registry.queryDatasets("nonexistent", collections=...),
+                ["nonexistent"],
+            ),
+            (
+                # Dataset type name doesn't match any existing dataset types.
+                registry.queryDataIds(["detector"], datasets=["nonexistent"], collections=...),
                 ["nonexistent"],
             ),
             (


### PR DESCRIPTION
If a dataset type is used in queryDatasetTypes call, and it is a
type that is not known to the registry, the method should raise
instead of silently continuing. This was causing down stream
consumers of this method to get confusing registry issues.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
