### PR TITLE
DM-32467: Allow a Path object to be used in Butler constructor

### DIFF
--- a/doc/changes/DM-32467.bugfix.rst
+++ b/doc/changes/DM-32467.bugfix.rst
@@ -1,0 +1,1 @@
+Butler constructor can now take a `os.PathLike` object when the ``butler.yaml`` is not included in the path.

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 __all__ = ("ButlerConfig",)
 
+import os
 import copy
 from typing import (
     Optional,
@@ -83,7 +84,7 @@ class ButlerConfig(Config):
             self.configDir = copy.copy(other.configDir)
             return
 
-        if isinstance(other, str):
+        if isinstance(other, (str, os.PathLike)):
             # This will only allow supported schemes
             uri = ButlerURI(other)
 

--- a/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
+++ b/python/lsst/daf/butler/core/_butlerUri/_butlerUri.py
@@ -30,6 +30,7 @@ import logging
 import re
 import shutil
 import tempfile
+import os
 
 from random import Random
 from pathlib import Path, PurePath, PurePosixPath
@@ -145,7 +146,7 @@ class ButlerURI:
         dirLike: bool = False
         subclass: Optional[Type[ButlerURI]] = None
 
-        if isinstance(uri, Path):
+        if isinstance(uri, os.PathLike):
             uri = str(uri)
 
         # Record if we need to post process the URI components

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -33,6 +33,7 @@ import string
 import random
 import time
 import socket
+import pathlib
 
 try:
     import boto3
@@ -1145,6 +1146,25 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
     datastoreStr = ["/tmp"]
     datastoreName = [f"FileDatastore@{BUTLER_ROOT_TAG}"]
     registryStr = "/gen3.sqlite3"
+
+    def testPathConstructor(self):
+        """Independent test of constructor using PathLike.
+        """
+        butler = Butler(self.tmpConfigFile, run="ingest")
+        self.assertIsInstance(butler, Butler)
+
+        # And again with a Path object with the butler yaml
+        path = pathlib.Path(self.tmpConfigFile)
+        butler = Butler(path, writeable=False)
+        self.assertIsInstance(butler, Butler)
+
+        # And again with a Path object without the butler yaml
+        # (making sure we skip it if the tmp config doesn't end
+        # in butler.yaml -- which is the case for a subclass)
+        if self.tmpConfigFile.endswith("butler.yaml"):
+            path = pathlib.Path(os.path.dirname(self.tmpConfigFile))
+            butler = Butler(path, writeable=False)
+            self.assertIsInstance(butler, Butler)
 
     def testExportTransferCopy(self):
         """Test local export using all transfer modes"""

--- a/tests/test_uri.py
+++ b/tests/test_uri.py
@@ -25,6 +25,7 @@ import shutil
 import unittest
 import urllib.parse
 import responses
+import pathlib
 
 try:
     import boto3
@@ -61,6 +62,10 @@ class FileURITestCase(unittest.TestCase):
         file = os.path.join(self.tmpdir, "test.txt")
         uri = ButlerURI(file)
         self.assertFalse(uri.exists(), f"{uri} should not exist")
+        self.assertEqual(uri.ospath, file)
+
+        path = pathlib.Path(file)
+        uri = ButlerURI(path)
         self.assertEqual(uri.ospath, file)
 
         content = "abcdefghijklmnopqrstuv\n"


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
