### PR TITLE
DM-31956: (v23) Don't lock tables in database sync

### DIFF
--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1241,7 +1241,7 @@ class Database(ABC):
                 row.update(compared)
             if extra is not None:
                 row.update(extra)
-            with self.transaction(lock=[table]):
+            with self.transaction():
                 inserted = bool(self.ensure(table, row))
                 inserted_or_updated: Union[bool, Dict[str, Any]]
                 # Need to perform check() for this branch inside the


### PR DESCRIPTION
Locking tables makes us susceptible to deadlocks when within an outer
transaction block, but not locking opens up the possibility that a
concurrent writer might modify a just-inserted row before the check()
query runs.  But we already have logic to raise RuntimeError if that
happens, which is not a bad outcome for conflicting concurrent writes.

We might want to switch the exception type to DatabaseConflictError if
we want a conflicting concurrent write to look the same as a
preexisting conflict, but I think knowing that somebody else (probably
the same user in a different process) is what's causing the problem is
more useful.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
