### PR TITLE
DM-32403: Add support for order_by/limit to query results

### DIFF
--- a/doc/changes/registry/DM-32403.feature.md
+++ b/doc/changes/registry/DM-32403.feature.md
@@ -1,0 +1,1 @@
+Iterables returned from registry methods `queryDataIds` and `queryDimensionRecords` have two new methods - `order_by` and `limit`.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -385,3 +385,28 @@ Few examples of valid expressions using some of the constructs:
     visit.datetime_end < T'mjd/58938.515/tai'
 
     ingest_date < T'2020-11-06 21:10:00'
+
+
+.. _daf_butler_query_ordering:
+
+Query result ordering
+---------------------
+
+Few query methods (`~Registry.queryDataIds` and `~Registry.queryDimensionRecords`) support special constructs for ordering and limiting the number of the returned records. These methods return iterable objects which have ``order_by()`` and ``limit()`` methods. Methods modify the iterable object and should be used before iterating over resulting records, for convenience the methods can be chained, see example below.
+
+The ``order_by()`` method accepts a variable number of positional arguments specifying columns/fields used for ordering, each argument can have one of the supported formats:
+
+- A dimension name, corresponding to the value of the dimension primary key, e.g. ``"visit"``
+- A dimension name and a field name separated bey a dot. Field name can refer to any of the dimension's metadata or key, e.g. ``"visit.name"``, ``"detector.raft"``. Special field names ``"timespan.begin"`` and ``"timespan.end"`` can be used for temporal dimensions (visit and exposure).
+- A field name without dimension name, in that case field is searched in all dimensions used by the query, and it has to be unique. E.g. ``"cell_x"`` means the same as ``"patch.cell_x"``.
+- To reverse ordering for the field it is prefixed with a minus sign, e.g. ``"-visit.timespan.begin"``.
+
+The ``limit()`` method accepts two positional integer arguments - limit for the number of returned records and offset (number of records to skip). The offset argument is optional, if not provided it is equivalent to offset 0.
+
+Example of use of these two methods:
+
+.. code-block:: Python
+
+    # Print ten latest visit records in reverse time order
+    for record in registry.queryDimensionRecords("visit").order_by("-timespan.begin").limit(10):
+        print(record)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -583,7 +583,7 @@ class Butler:
         -------
         dataId : `dict` or `DataCoordinate`
             The, possibly rewritten, dataId. If given a `DataCoordinate` and
-            no keyword arguments, the orginal dataId will be returned
+            no keyword arguments, the original dataId will be returned
             unchanged.
         **kwargs : `dict`
             Any unused keyword arguments.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -37,7 +37,10 @@ from ..opt import (
     directory_argument,
     element_argument,
     glob_argument,
+    limit_option,
+    offset_option,
     options_file_option,
+    order_by_option,
     query_datasets_options,
     register_dataset_types_option,
     repo_argument,
@@ -432,6 +435,9 @@ def certify_calibrations(*args, **kwargs):
                              "physical_filter" values to only those for which at least one "raw" dataset
                              exists in "collections".  Requires --collections."""))
 @where_option(help=where_help)
+@order_by_option()
+@limit_option()
+@offset_option()
 @options_file_option()
 def query_data_ids(**kwargs):
     """List the data IDs in a repository.
@@ -454,6 +460,9 @@ def query_data_ids(**kwargs):
                              --collections."""))
 @collections_option(help=collections_option.help + " May only be used with --datasets.")
 @where_option(help=where_help)
+@order_by_option()
+@limit_option()
+@offset_option()
 @click.option("--no-check", is_flag=True,
               help=unwrap("""Don't check the query before execution. By default the query is checked before it
                           executed, this may reject some valid queries that resemble common mistakes."""))

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -183,3 +183,29 @@ verbose_option = MWOptionDecorator("-v", "--verbose",
 
 where_option = MWOptionDecorator("--where",
                                  help="A string expression similar to a SQL WHERE clause.")
+
+
+order_by_option = MWOptionDecorator(
+    "--order-by",
+    help=unwrap("""One or more comma-separated names used to order records. Names can be dimension names,
+                metadata names optionally prefixed by a dimension name and dot, or
+                timestamp_begin/timestamp_end (with optional dimension name). To reverse ordering for a name
+                prefix it with a minus sign."""),
+    multiple=True,
+    callback=split_commas
+)
+
+
+limit_option = MWOptionDecorator(
+    "--limit",
+    help=unwrap("Limit the number of records, by default all records are shown."),
+    type=int,
+    default=0
+)
+
+offset_option = MWOptionDecorator(
+    "--offset",
+    help=unwrap("Skip initial number of records, only used when --limit is specified."),
+    type=int,
+    default=0
+)

--- a/python/lsst/daf/butler/core/_topology.py
+++ b/python/lsst/daf/butler/core/_topology.py
@@ -212,7 +212,7 @@ class TopologicalExtentDatabaseRepresentation(Generic[_R]):
     @abstractmethod
     def makeFieldSpecs(cls, nullable: bool, name: Optional[str] = None, **kwargs: Any
                        ) -> Tuple[ddl.FieldSpec, ...]:
-        """Make objects that relfect the fields that must be added to table.
+        """Make objects that reflect the fields that must be added to table.
 
         Makes one or more `ddl.FieldSpec` objects that reflect the fields
         that must be added to a table for this representation.

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -1070,7 +1070,7 @@ class ConfigSubset(Config):
         consistency.
     mergeDefaults : `bool`, optional
         If `True` defaults will be read and the supplied config will
-        be combined with the defaults, with the supplied valiues taking
+        be combined with the defaults, with the supplied values taking
         precedence.
     searchPaths : `list` or `tuple`, optional
         Explicit additional paths to search for defaults. They should
@@ -1128,7 +1128,7 @@ class ConfigSubset(Config):
             if searchPaths:
                 fullSearchPath.extend(searchPaths)
 
-            # Read default paths from enviroment
+            # Read default paths from environment
             fullSearchPath.extend(self.defaultSearchPaths())
 
             # There are two places to find defaults for this particular config

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -243,7 +243,7 @@ class DatasetType:
     def name(self) -> str:
         """Return a string name for the Dataset.
 
-        Mmust correspond to the same `DatasetType` across all Registries.
+        Must correspond to the same `DatasetType` across all Registries.
         """
         return self._name
 
@@ -514,7 +514,7 @@ class DatasetType:
                     registry: Optional[Registry] = None) -> DatasetType:
         """Construct a new object from the simplified form.
 
-        This is usally data returned from the `to_simple` method.
+        This is usually data returned from the `to_simple` method.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -102,7 +102,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
     An immutable data ID dictionary that guarantees that its key-value pairs
     identify at least all required dimensions in a `DimensionGraph`.
 
-    `DataCoordinateSet` itself is an ABC, but provides `staticmethod` factory
+    `DataCoordinate` itself is an ABC, but provides `staticmethod` factory
     functions for private concrete implementations that should be sufficient
     for most purposes.  `standardize` is the most flexible and safe of these;
     the others (`makeEmpty`, `fromRequiredValues`, and `fromFullValues`) are

--- a/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
+++ b/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
@@ -195,7 +195,7 @@ class DataCoordinateIterable(Iterable[DataCoordinate]):
             May be ``self`` if ``graph == self.graph``.  Elements are
             equivalent to those that would be created by calling
             `DataCoordinate.subset` on all elements in ``self``, possibly
-            with deduplication and/or reordeding (depending on the subclass,
+            with deduplication and/or reordering (depending on the subclass,
             which may make more specific guarantees).
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/core/dimensions/_database.py
+++ b/python/lsst/daf/butler/core/dimensions/_database.py
@@ -197,7 +197,7 @@ class DatabaseDimensionElement(DimensionElement):
 
     @property
     def name(self) -> str:
-        # Docstring inherited from TopoogicalRelationshipEndpoint.
+        # Docstring inherited from TopologicalRelationshipEndpoint.
         return self._name
 
     @property

--- a/python/lsst/daf/butler/core/dimensions/_elements.py
+++ b/python/lsst/daf/butler/core/dimensions/_elements.py
@@ -65,7 +65,7 @@ class DimensionElement(TopologicalRelationshipEndpoint):
 
     Notes
     -----
-    `DimensionElement` instances should always be constructed by and retreived
+    `DimensionElement` instances should always be constructed by and retrieved
     from a `DimensionUniverse`.  They are immutable after they are fully
     constructed, and should never be copied.
 

--- a/python/lsst/daf/butler/core/dimensions/_governor.py
+++ b/python/lsst/daf/butler/core/dimensions/_governor.py
@@ -120,7 +120,7 @@ class GovernorDimension(Dimension):
 
     @property
     def name(self) -> str:
-        # Docstring inherited from TopoogicalRelationshipEndpoint.
+        # Docstring inherited from TopologicalRelationshipEndpoint.
         return self._name
 
     @property

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -83,7 +83,7 @@ class DimensionGraph:
         be included.  At most one of ``dimensions`` and ``names`` must be
         provided.
     names : iterable of `str`, optional
-        An iterable of the names of dimensiosn that must be included in the
+        An iterable of the names of dimensions that must be included in the
         graph.  All (recursive) dependencies of these dimensions will also
         be included.  At most one of ``dimensions`` and ``names`` must be
         provided.
@@ -454,8 +454,8 @@ class DimensionGraph:
     """
 
     required: NamedValueAbstractSet[Dimension]
-    """The subset of `dimensions` whose elments must be directly identified via
-    their primary keys in a data ID in order to identify the rest of the
+    """The subset of `dimensions` whose elements must be directly identified
+    via their primary keys in a data ID in order to identify the rest of the
     elements in the graph (`NamedValueAbstractSet` of `Dimension`).
     """
 

--- a/python/lsst/daf/butler/core/dimensions/_universe.py
+++ b/python/lsst/daf/butler/core/dimensions/_universe.py
@@ -392,7 +392,7 @@ class DimensionUniverse:
             Name of the packer, matching a key in the "packers" section of the
             dimension configuration.
         dataId : `DataCoordinate`
-            Fully-expanded data ID that identfies the at least the "fixed"
+            Fully-expanded data ID that identifies the at least the "fixed"
             dimensions of the packer (i.e. those that are assumed/given,
             setting the space over which packed integer IDs are unique).
             ``dataId.hasRecords()`` must return `True`.

--- a/python/lsst/daf/butler/core/dimensions/construction.py
+++ b/python/lsst/daf/butler/core/dimensions/construction.py
@@ -106,7 +106,7 @@ class DimensionConstructionBuilder:
     `DimensionConstructionVisitor` objects can be added to a
     `DimensionConstructionBuilder` object in any order, and are invoked
     in a deterministic order consistent with their dependency relationships
-    by a single call (by the `DimensionUnvierse`) to the `finish` method.
+    by a single call (by the `DimensionUniverse`) to the `finish` method.
 
     Parameters
     ----------

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -391,7 +391,7 @@ class Formatter(metaclass=ABCMeta):
             raise NotImplementedError("No file extension registered with this formatter") from None
 
         # If extension is implemented as an instance property it won't return
-        # a string when called as a class propertt. Assume that
+        # a string when called as a class property. Assume that
         # the supported extensions class property is complete.
         if default is not None and isinstance(default, str):
             supported.add(default)

--- a/python/lsst/daf/butler/core/named.py
+++ b/python/lsst/daf/butler/core/named.py
@@ -254,7 +254,7 @@ class NamedKeyDict(NamedKeyMutableMapping[K, V]):
         -------
         self : `NamedKeyMapping`
             While ``self`` is modified in-place, it is also returned with a
-            type anotation that reflects its new, frozen state; assigning it
+            type annotation that reflects its new, frozen state; assigning it
             to a new variable (and considering any previous references
             invalidated) should allow for more accurate static type checking.
         """
@@ -558,7 +558,7 @@ class NamedValueSet(NameMappingSetView[K], NamedValueMutableSet[K]):
         -------
         self : `NamedValueAbstractSet`
             While ``self`` is modified in-place, it is also returned with a
-            type anotation that reflects its new, frozen state; assigning it
+            type annotation that reflects its new, frozen state; assigning it
             to a new variable (and considering any previous references
             invalidated) should allow for more accurate static type checking.
         """

--- a/python/lsst/daf/butler/core/storageClassDelegate.py
+++ b/python/lsst/daf/butler/core/storageClassDelegate.py
@@ -374,7 +374,7 @@ class StorageClassDelegate:
 
     @classmethod
     def selectResponsibleComponent(cls, derivedComponent: str, fromComponents: Set[Optional[str]]) -> str:
-        """Select the best component for calcluating a derived component.
+        """Select the best component for calculating a derived component.
 
         Given a possible set of components to choose from, return the
         component that should be used to calculate the requested derived

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -614,7 +614,7 @@ class TimespanDatabaseRepresentation(TopologicalExtentDatabaseRepresentation[Tim
 
     Compound: ClassVar[Type[TimespanDatabaseRepresentation]]
     """A concrete subclass of `TimespanDatabaseRepresentation` that simply
-    uses two separate fields for the begin (inclusive) and end (excusive)
+    uses two separate fields for the begin (inclusive) and end (exclusive)
     endpoints.
 
     This implementation should be compatible with any SQL database, and should

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -758,6 +758,15 @@ class TimespanDatabaseRepresentation(TopologicalExtentDatabaseRepresentation[Tim
         -------
         lower : `sqlalchemy.sql.ColumnElement`
             A SQLAlchemy expression for a lower bound.
+
+        Notes
+        -----
+        If database holds ``NULL`` for a timespan then the returned expression
+        should evaluate to 0. Main purpose of this and `upper` method is to use
+        them in generating SQL, in particular ORDER BY clause, to guarantee a
+        predictable ordering. It may potentially be used for transforming
+        boolean user expressions into SQL, but it will likely require extra
+        attention to ordering issues.
         """
         raise NotImplementedError()
 
@@ -770,6 +779,11 @@ class TimespanDatabaseRepresentation(TopologicalExtentDatabaseRepresentation[Tim
         -------
         upper : `sqlalchemy.sql.ColumnElement`
             A SQLAlchemy expression for an upper bound.
+
+        Notes
+        -----
+        If database holds ``NULL`` for a timespan then the returned expression
+        should evaluate to 0. Also see notes for `lower` method.
         """
         raise NotImplementedError()
 
@@ -945,11 +959,11 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
 
     def lower(self) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
-        return self._nsec[0]
+        return sqlalchemy.sql.functions.coalesce(self._nsec[0], sqlalchemy.sql.literal(0))
 
     def upper(self) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
-        return self._nsec[1]
+        return sqlalchemy.sql.functions.coalesce(self._nsec[1], sqlalchemy.sql.literal(0))
 
     def flatten(self, name: Optional[str] = None) -> Iterator[sqlalchemy.sql.ColumnElement]:
         # Docstring inherited.

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -749,6 +749,30 @@ class TimespanDatabaseRepresentation(TopologicalExtentDatabaseRepresentation[Tim
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def lower(self: _S) -> sqlalchemy.sql.ColumnElement:
+        """Return a SQLAlchemy expression representing a lower bound of a
+        timespan.
+
+        Returns
+        -------
+        lower : `sqlalchemy.sql.ColumnElement`
+            A SQLAlchemy expression for a lower bound.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def upper(self: _S) -> sqlalchemy.sql.ColumnElement:
+        """Return a SQLAlchemy expression representing an upper bound of a
+        timespan.
+
+        Returns
+        -------
+        upper : `sqlalchemy.sql.ColumnElement`
+            A SQLAlchemy expression for an upper bound.
+        """
+        raise NotImplementedError()
+
 
 class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
     """Representation of a time span as two separate fields.
@@ -918,6 +942,14 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
             return sqlalchemy.sql.and_(self._nsec[0] <= other, self._nsec[1] > other)
         else:
             return sqlalchemy.sql.and_(self._nsec[0] <= other._nsec[0], self._nsec[1] >= other._nsec[1])
+
+    def lower(self) -> sqlalchemy.sql.ColumnElement:
+        # Docstring inherited.
+        return self._nsec[0]
+
+    def upper(self) -> sqlalchemy.sql.ColumnElement:
+        # Docstring inherited.
+        return self._nsec[1]
 
     def flatten(self, name: Optional[str] = None) -> Iterator[sqlalchemy.sql.ColumnElement]:
         # Docstring inherited.

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -581,7 +581,7 @@ class ChainedDatastore(Datastore):
         primary, components = self.getURIs(ref, predict)
         if primary is None or components:
             raise RuntimeError(f"Dataset ({ref}) includes distinct URIs for components. "
-                               "Use Dataastore.getURIs() instead.")
+                               "Use Datastore.getURIs() instead.")
         return primary
 
     def retrieveArtifacts(self, refs: Iterable[DatasetRef],

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -843,7 +843,7 @@ class FileDatastore(GenericBaseDatastore):
         -------
         info : `StoredFileInfo`
             Internal datastore record for this file.  This will be inserted by
-            the caller; the `_extractIngestInfo` is only resposible for
+            the caller; the `_extractIngestInfo` is only responsible for
             creating and populating the struct.
 
         Raises
@@ -1016,7 +1016,7 @@ class FileDatastore(GenericBaseDatastore):
         Returns
         -------
         info : `StoredFileInfo`
-            Information describin the artifact written to the datastore.
+            Information describing the artifact written to the datastore.
         """
         location, formatter = self._prepare_for_put(inMemoryDataset, ref)
         uri = location.uri
@@ -1588,7 +1588,7 @@ class FileDatastore(GenericBaseDatastore):
         primary, components = self.getURIs(ref, predict)
         if primary is None or components:
             raise RuntimeError(f"Dataset ({ref}) includes distinct URIs for components. "
-                               "Use Dataastore.getURIs() instead.")
+                               "Use Datastore.getURIs() instead.")
         return primary
 
     def retrieveArtifacts(self, refs: Iterable[DatasetRef],

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -37,6 +37,7 @@ from typing import (
     Mapping,
     Optional,
     Set,
+    Tuple,
     TYPE_CHECKING,
     Union,
 )
@@ -84,6 +85,7 @@ from ..registry import queries
 from ..registry.wildcards import CategorizedWildcard, CollectionQuery, Ellipsis
 from ..registry.summaries import CollectionSummary
 from ..registry.managers import RegistryManagerTypes, RegistryManagerInstances
+from ..registry.queries import Query
 from ..registry.interfaces import ChainedCollectionRecord, DatasetIdGenEnum, RunRecord
 
 if TYPE_CHECKING:
@@ -972,23 +974,30 @@ class SqlRegistry(Registry):
         elif collections:
             raise TypeError(f"Cannot pass 'collections' (='{collections}') without 'datasets'.")
 
-        summary = queries.QuerySummary(
-            requested=requestedDimensions,
-            dataId=standardizedDataId,
-            expression=where,
-            bind=bind,
-            defaults=self.defaults.dataId,
-            check=check,
-            datasets=standardizedDatasetTypes,
-        )
-        builder = self._makeQueryBuilder(
-            summary,
-            doomed_by=[f"Dataset type {name} is not registered." for name in missing]
-        )
-        for datasetType in standardizedDatasetTypes:
-            builder.joinDataset(datasetType, collections, isResult=False)
-        query = builder.finish()
-        return queries.DataCoordinateQueryResults(self._db, query)
+        def query_factory(order_by: Optional[Iterable[str]] = None,
+                          limit: Optional[Tuple[int, Optional[int]]] = None) -> Query:
+            """Construct the Query object that generates query results.
+            """
+            summary = queries.QuerySummary(
+                requested=requestedDimensions,
+                dataId=standardizedDataId,
+                expression=where,
+                bind=bind,
+                defaults=self.defaults.dataId,
+                check=check,
+                datasets=standardizedDatasetTypes,
+                order_by=order_by,
+                limit=limit
+            )
+            builder = self._makeQueryBuilder(
+                summary,
+                doomed_by=[f"Dataset type {name} is not registered." for name in missing]
+            )
+            for datasetType in standardizedDatasetTypes:
+                builder.joinDataset(datasetType, collections, isResult=False,)
+            return builder.finish()
+
+        return queries.DataCoordinateQueryResults(self._db, query_factory, requestedDimensions)
 
     def queryDimensionRecords(self, element: Union[DimensionElement, str], *,
                               dataId: Optional[DataId] = None,
@@ -998,7 +1007,7 @@ class SqlRegistry(Registry):
                               components: Optional[bool] = None,
                               bind: Optional[Mapping[str, Any]] = None,
                               check: bool = True,
-                              **kwargs: Any) -> Iterator[DimensionRecord]:
+                              **kwargs: Any) -> queries.DimensionRecordQueryResults:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         if not isinstance(element, DimensionElement):
             try:
@@ -1008,7 +1017,7 @@ class SqlRegistry(Registry):
                                + str(self.dimensions.getStaticElements())) from e
         dataIds = self.queryDataIds(element.graph, dataId=dataId, datasets=datasets, collections=collections,
                                     where=where, components=components, bind=bind, check=check, **kwargs)
-        return iter(self._managers.dimensions[element].fetch(dataIds))
+        return queries.DatabaseDimensionRecordQueryResults(dataIds, self._managers.dimensions[element])
 
     def queryDatasetAssociations(
         self,

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -165,7 +165,7 @@ class SqlRegistry(Registry):
                    defaults: Optional[RegistryDefaults] = None) -> Registry:
         """Create `Registry` subclass instance from `config`.
 
-        Registry database must be inbitialized prior to calling this method.
+        Registry database must be initialized prior to calling this method.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1119,8 +1119,8 @@ class Registry(ABC):
         expression : `Any`, optional
             An expression that fully or partially identifies the dataset types
             to return, such as a `str`, `re.Pattern`, or iterable thereof.
-            `...` can be used to return all dataset types, and is the default.
-            See :ref:`daf_butler_dataset_type_expressions` for more
+            ``...`` can be used to return all dataset types, and is the
+            default. See :ref:`daf_butler_dataset_type_expressions` for more
             information.
         components : `bool`, optional
             If `True`, apply all expression patterns to component dataset type
@@ -1154,7 +1154,7 @@ class Registry(ABC):
         expression : `Any`, optional
             An expression that identifies the collections to return, such as
             a `str` (for full matches or partial matches via globs),
-            `re.Pattern` (for partial matches), or iterable thereof.  `...`
+            `re.Pattern` (for partial matches), or iterable thereof.  ``...``
             can be used to return all collections, and is the default.
             See :ref:`daf_butler_collection_expressions` for more information.
         datasetType : `DatasetType`, optional
@@ -1197,13 +1197,13 @@ class Registry(ABC):
         datasetType
             An expression that fully or partially identifies the dataset types
             to be queried.  Allowed types include `DatasetType`, `str`,
-            `re.Pattern`, and iterables thereof.  The special value `...` can
+            `re.Pattern`, and iterables thereof.  The special value ``...`` can
             be used to query all dataset types.  See
             :ref:`daf_butler_dataset_type_expressions` for more information.
         collections: optional
             An expression that identifies the collections to search, such as a
             `str` (for full matches or partial matches via globs), `re.Pattern`
-            (for partial matches), or iterable thereof.  `...` can be used to
+            (for partial matches), or iterable thereof.  ``...`` can be used to
             search all collections (actually just all `~CollectionType.RUN`
             collections, because this will still find all datasets).
             If not provided, ``self.default.collections`` is used.  See
@@ -1228,7 +1228,7 @@ class Registry(ABC):
             collection in which a dataset of that dataset type appears
             (according to the order of ``collections`` passed in).  If `True`,
             ``collections`` must not contain regular expressions and may not
-            be `...`.
+            be ``...``.
         components : `bool`, optional
             If `True`, apply all dataset expression patterns to component
             dataset type names as well.  If `False`, never apply patterns to
@@ -1319,7 +1319,7 @@ class Registry(ABC):
             An expression that identifies the collections to search for
             datasets, such as a `str` (for full matches or partial matches
             via globs), `re.Pattern` (for partial matches), or iterable
-            thereof.  `...` can be used to search all collections (actually
+            thereof.  ``...`` can be used to search all collections (actually
             just all `~CollectionType.RUN` collections, because this will
             still find all datasets).  If not provided,
             ``self.default.collections`` is used.  Ignored unless ``datasets``
@@ -1381,7 +1381,7 @@ class Registry(ABC):
                               components: Optional[bool] = None,
                               bind: Optional[Mapping[str, Any]] = None,
                               check: bool = True,
-                              **kwargs: Any) -> Iterator[DimensionRecord]:
+                              **kwargs: Any) -> Iterable[DimensionRecord]:
         """Query for dimension information matching user-provided criteria.
 
         Parameters
@@ -1395,11 +1395,11 @@ class Registry(ABC):
             An expression that fully or partially identifies dataset types
             that should constrain the yielded records.  See `queryDataIds` and
             :ref:`daf_butler_dataset_type_expressions` for more information.
-        collections: `Any`, optional
+        collections : `Any`, optional
             An expression that identifies the collections to search for
             datasets, such as a `str` (for full matches  or partial matches
             via globs), `re.Pattern` (for partial matches), or iterable
-            thereof.  `...` can be used to search all collections (actually
+            thereof.  ``...`` can be used to search all collections (actually
             just all `~CollectionType.RUN` collections, because this will
             still find all datasets).  If not provided,
             ``self.default.collections`` is used.  Ignored unless ``datasets``
@@ -1428,7 +1428,7 @@ class Registry(ABC):
 
         Returns
         -------
-        dataIds : `DataCoordinateQueryResults`
+        dataIds : `Iterator` [ `DimensionRecord` ]
             Data IDs matching the given query parameters.
         """
         raise NotImplementedError()
@@ -1458,7 +1458,7 @@ class Registry(ABC):
             An expression that identifies the collections to search for
             datasets, such as a `str` (for full matches  or partial matches
             via globs), `re.Pattern` (for partial matches), or iterable
-            thereof.  `...` can be used to search all collections (actually
+            thereof.  ``...`` can be used to search all collections (actually
             just all `~CollectionType.RUN` collections, because this will still
             find all datasets).  If not provided, ``self.default.collections``
             is used.  See :ref:`daf_butler_collection_expressions` for more

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1038,7 +1038,7 @@ class Registry(ABC):
         -------
         expanded : `DataCoordinate`
             A data ID that includes full metadata for all of the dimensions it
-            identifieds, i.e. guarantees that ``expanded.hasRecords()`` and
+            identifies, i.e. guarantees that ``expanded.hasRecords()`` and
             ``expanded.hasFull()`` both return `True`.
         """
         raise NotImplementedError()
@@ -1446,7 +1446,7 @@ class Registry(ABC):
         the collection.
 
         This method is a temporary placeholder for better support for
-        assocation results in `queryDatasets`.  It will probably be
+        association results in `queryDatasets`.  It will probably be
         removed in the future, and should be avoided in production code
         whenever possible.
 
@@ -1474,7 +1474,7 @@ class Registry(ABC):
         Yields
         ------
         association : `DatasetAssociation`
-            Object representing the relationship beween a single dataset and
+            Object representing the relationship between a single dataset and
             a single collection.
 
         Raises

--- a/python/lsst/daf/butler/registry/connectionString.py
+++ b/python/lsst/daf/butler/registry/connectionString.py
@@ -80,7 +80,7 @@ class ConnectionStringFactory:
         DbAuthPermissionsError
             If the credentials file has incorrect permissions.
         DbAuthError
-            A problem occured when retrieving DB authentication.
+            A problem occurred when retrieving DB authentication.
 
         Notes
         -----

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -409,6 +409,14 @@ class _RangeTimespanRepresentation(TimespanDatabaseRepresentation):
         else:
             return self.column.contains(other)
 
+    def lower(self) -> sqlalchemy.sql.ColumnElement:
+        # Docstring inherited.
+        return sqlalchemy.sql.func.lower(self.column)
+
+    def upper(self) -> sqlalchemy.sql.ColumnElement:
+        # Docstring inherited.
+        return sqlalchemy.sql.func.upper(self.column)
+
     def flatten(self, name: Optional[str] = None) -> Iterator[sqlalchemy.sql.ColumnElement]:
         # Docstring inherited.
         if name is None:

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -411,11 +411,13 @@ class _RangeTimespanRepresentation(TimespanDatabaseRepresentation):
 
     def lower(self) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
-        return sqlalchemy.sql.func.lower(self.column)
+        return sqlalchemy.sql.functions.coalesce(sqlalchemy.sql.func.lower(self.column),
+                                                 sqlalchemy.sql.literal(0))
 
     def upper(self) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
-        return sqlalchemy.sql.func.upper(self.column)
+        return sqlalchemy.sql.functions.coalesce(sqlalchemy.sql.func.upper(self.column),
+                                                 sqlalchemy.sql.literal(0))
 
     def flatten(self, name: Optional[str] = None) -> Iterator[sqlalchemy.sql.ColumnElement]:
         # Docstring inherited.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
@@ -247,7 +247,7 @@ class CollectionSummaryManager:
         # present.
         # That guarantee (and the possibility of rollbacks) means we can't get
         # away with checking the cache before we try the database inserts,
-        # however; if someone had attemped to insert datasets of some dataset
+        # however; if someone had attempted to insert datasets of some dataset
         # type previously, and that rolled back, and we're now trying to insert
         # some more datasets of that same type, it would not be okay to skip
         # the DB summary table insertions because we found entries in the
@@ -291,7 +291,7 @@ class CollectionSummaryManager:
             # Collection key should never be None/NULL; it's what we join on.
             # Extract that and then turn it into a collection name.
             collectionKey = row[self._collectionKeyName]
-            # dataset_type_id should also nver be None/NULL; it's in the first
+            # dataset_type_id should also never be None/NULL; it's in the first
             # table we joined.
             datasetType = get_dataset_type(row["dataset_type_id"])
             # See if we have a summary already for this collection; if not,

--- a/python/lsst/daf/butler/registry/dimensions/query.py
+++ b/python/lsst/daf/butler/registry/dimensions/query.py
@@ -50,8 +50,8 @@ from ..queries import QueryBuilder
 class QueryDimensionRecordStorage(DatabaseDimensionRecordStorage):
     """A read-only record storage implementation backed by SELECT query.
 
-    At present, the only query this class supports is a SELECT DISTNCT over the
-    table for some other dimension that has this dimension as an implied
+    At present, the only query this class supports is a SELECT DISTINCT over
+    the table for some other dimension that has this dimension as an implied
     dependency.  For example, we can use this class to provide access to the
     set of ``band`` names referenced by any ``physical_filter``.
 

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -356,7 +356,7 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
         -------
         bridge : `DatastoreRegistryBridge`
             Object that provides the interface this `Datastore` should use to
-            communicate with the `Regitry`.
+            communicate with the `Registry`.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -406,7 +406,7 @@ class Database(ABC):
 
         Parameters
         ----------
-        engine : `sqllachemy.engine.Engine`
+        engine : `sqlalchemy.engine.Engine`
             The engine for the database.  May be shared between `Database`
             instances.
         origin : `int`

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -341,7 +341,7 @@ class DatasetRecordStorage(ABC):
         run : `None` or `Select`
             If `Select` (default), include the dataset's run key value (as
             column labeled with the return value of
-            ``CollectionManager.getRunForiegnKeyName``).
+            ``CollectionManager.getRunForeignKeyName``).
             If `None`, do not include this column (to constrain the run,
             pass a `RunRecord` as the ``collection`` argument instead).
         timespan : `None`, `Select`, or `Timespan`

--- a/python/lsst/daf/butler/registry/queries/_query.py
+++ b/python/lsst/daf/butler/registry/queries/_query.py
@@ -568,7 +568,7 @@ class Query(ABC):
             argument is `None`.
         columns : `QueryColumns` or `None`
             A struct containing the SQLAlchemy column objects to use in the
-            new query, contructed by delegating to other (mostly abstract)
+            new query, constructed by delegating to other (mostly abstract)
             methods on ``self``.  If `None`, `subset` may return ``self``.
         """
         if graph is None:
@@ -891,7 +891,7 @@ class MaterializedQuery(Query):
     Parameters
     ----------
     table : `sqlalchemy.schema.Table`
-        SQLAlchemy object represnting the temporary table.
+        SQLAlchemy object representing the temporary table.
     spatial : `Iterable` [ `DimensionElement` ]
         Spatial dimension elements whose regions must overlap for each valid
         result row (which may reject some rows that are in the table).
@@ -900,7 +900,7 @@ class MaterializedQuery(Query):
         if there are no dataset results
     isUnique : `bool`
         If `True`, the table's rows are unique, and there is no need to
-        add ``SELECT DISTINCT`` to gaurantee this in results.
+        add ``SELECT DISTINCT`` to guarantee this in results.
     graph : `DimensionGraph`
         Dimensions included in the columns of this table.
     whereRegion : `Region` or `None`

--- a/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
@@ -351,12 +351,12 @@ class PrecedenceTier(enum.Enum):
     """
 
     COMPARISON = 3
-    """Precendence tier for binary comparison operators that accept non-boolean
+    """Precedence tier for binary comparison operators that accept non-boolean
     values and return boolean values.
     """
 
     AND = 4
-    """Precendence tier for logical AND.
+    """Precedence tier for logical AND.
     """
 
     OR = 5
@@ -393,9 +393,9 @@ class PrecedenceTier(enum.Enum):
         operators either; the `LogicalBinaryOperation.unwrap` method that calls
         it is never invoked by `NormalFormExpression` (the main public
         interface), because those operators are flattened out (see
-        `TransormationWrapper.flatten`) instead.  Parentheses are instead added
-        there by `TreeReconstructionVisitor`, which is simpler because the
-        structure of operators is restricted.
+        `TransformationWrapper.flatten`) instead.  Parentheses are instead
+        added there by `TreeReconstructionVisitor`, which is simpler because
+        the structure of operators is restricted.
         """
         if outer is cls.OR and inner is cls.AND:
             return True
@@ -766,7 +766,7 @@ class Opaque(TransformationWrapper):
     """A `TransformationWrapper` implementation for tree nodes that do not need
     to be modified in boolean expression transformations.
 
-    This includes all identifers, literals, and operators whose arguments are
+    This includes all identifiers, literals, and operators whose arguments are
     not boolean.
 
     Parameters
@@ -809,7 +809,7 @@ class LogicalNot(TransformationWrapper):
 
     Notes
     -----
-    Instances should aways be created by calling `not_` on an existing
+    Instances should always be created by calling `not_` on an existing
     `TransformationWrapper` instead of calling `LogicalNot` directly.
     `LogicalNot` should only be called directly by `Opaque.not_`.  This
     guarantees that double-negatives are simplified away and NOT operations

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -183,7 +183,7 @@ class DatabaseTests(ABC):
         newDatabase = self.makeEmptyDatabase()
         with newDatabase.declareStaticTables(create=True) as context:
             context.addTableTuple(STATIC_TABLE_SPECS)
-        # Try to ensure the dyamic table exists in a read-only version of that
+        # Try to ensure the dynamic table exists in a read-only version of that
         # database, which should fail because we can't create it.
         with self.asReadOnly(newDatabase) as existingReadOnlyDatabase:
             with existingReadOnlyDatabase.declareStaticTables(create=False) as context:

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -103,7 +103,7 @@ class RegistryTests(ABC):
 
         This method should be called by a subclass from `makeRegistry`.
         Returned instance will be pre-configured based on the values of class
-        members, and default-configured for all other parametrs. Subclasses
+        members, and default-configured for all other parameters. Subclasses
         that need default configuration should just instantiate
         `RegistryConfig` directly.
         """

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 __all__ = ["RegistryTests"]
 
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta
 import itertools
 import logging
@@ -2119,7 +2119,7 @@ class RegistryTests(ABC):
             registry.queryDatasets("bias", collections=coll_list, findFirst=True)
         with self.assertRaises(NotImplementedError):
             registry.queryDataIds(["instrument", "detector", "exposure"], datasets="bias",
-                                  collections=coll_list)
+                                  collections=coll_list).count()
 
         # chain will skip
         datasets = list(registry.queryDatasets("bias", collections=chain))
@@ -2498,6 +2498,156 @@ class RegistryTests(ABC):
                 for message in messages
             )
         )
+
+    def testQueryDataIdsOrderBy(self):
+        """Test order_by and limit on result returned by queryDataIds().
+        """
+        registry = self.makeRegistry()
+        self.loadData(registry, "base.yaml")
+        self.loadData(registry, "datasets.yaml")
+        self.loadData(registry, "spatial.yaml")
+
+        def do_query(dimensions=("visit", "tract"), datasets=None, collections=None):
+            return registry.queryDataIds(dimensions, datasets=datasets, collections=collections,
+                                         instrument="Cam1", skymap="SkyMap1")
+
+        # query = do_query()
+        # self.assertEqual(len(list(query)), 6)
+
+        Test = namedtuple(
+            "testQueryDataIdsOrderByTest",
+            ("order_by", "keys", "result", "limit", "datasets", "collections"),
+            defaults=(None, None, None),
+        )
+
+        # For each test four items are defined here:
+        #  - order_by column names, comma separated
+        #  - limit tuple or None
+        #  - DataId keys to extract
+        #  - tuple of the resulting values we expect
+        test_data = (
+            Test("tract,visit", "tract,visit", ((0, 1), (0, 1), (0, 2), (0, 2), (1, 2), (1, 2))),
+            Test("-tract,visit", "tract,visit", ((1, 2), (1, 2), (0, 1), (0, 1), (0, 2), (0, 2))),
+            Test("tract,-visit", "tract,visit", ((0, 2), (0, 2), (0, 1), (0, 1), (1, 2), (1, 2))),
+            Test("-tract,-visit", "tract,visit", ((1, 2), (1, 2), (0, 2), (0, 2), (0, 1), (0, 1))),
+            Test("tract.id,visit.id", "tract,visit", ((0, 1), (0, 1), (0, 2)), limit=(3, ),),
+            Test("-tract,-visit", "tract,visit", ((1, 2), (1, 2), (0, 2)), limit=(3, )),
+            Test("tract,visit", "tract,visit", ((0, 2), (1, 2), (1, 2)), limit=(3, 3)),
+            Test("-tract,-visit", "tract,visit", ((0, 1), ), limit=(3, 5)),
+            Test("tract,visit.exposure_time", "tract,visit",
+                 ((0, 2), (0, 2), (0, 1), (0, 1), (1, 2), (1, 2))),
+            Test("-tract,-visit.exposure_time", "tract,visit",
+                 ((1, 2), (1, 2), (0, 1), (0, 1), (0, 2), (0, 2))),
+            Test("tract,-exposure_time", "tract,visit", ((0, 1), (0, 1), (0, 2), (0, 2), (1, 2), (1, 2))),
+            Test("tract,visit.name", "tract,visit", ((0, 1), (0, 1), (0, 2), (0, 2), (1, 2), (1, 2))),
+            Test("tract,-timespan.begin,timespan.end", "tract,visit",
+                 ((0, 2), (0, 2), (0, 1), (0, 1), (1, 2), (1, 2))),
+            Test("visit.day_obs,exposure.day_obs", "visit,exposure", ()),
+            Test("visit.timespan.begin,-exposure.timespan.begin", "visit,exposure", ()),
+            Test("tract,detector", "tract,detector",
+                 ((0, 1), (0, 2), (0, 3), (0, 4), (1, 1), (1, 2), (1, 3), (1, 4)),
+                 datasets="flat", collections="imported_r"),
+            Test("tract,detector.full_name", "tract,detector",
+                 ((0, 1), (0, 2), (0, 3), (0, 4), (1, 1), (1, 2), (1, 3), (1, 4)),
+                 datasets="flat", collections="imported_r"),
+            Test("tract,detector.raft,detector.name_in_raft", "tract,detector",
+                 ((0, 1), (0, 2), (0, 3), (0, 4), (1, 1), (1, 2), (1, 3), (1, 4)),
+                 datasets="flat", collections="imported_r"),
+        )
+
+        for test in test_data:
+            order_by = test.order_by.split(",")
+            keys = test.keys.split(",")
+            query = do_query(keys, test.datasets, test.collections).order_by(*order_by)
+            if test.limit is not None:
+                query = query.limit(*test.limit)
+            dataIds = tuple(tuple(dataId[k] for k in keys) for dataId in query)
+            self.assertEqual(dataIds, test.result)
+
+            # and materialize
+            query = do_query(keys).order_by(*order_by)
+            if test.limit is not None:
+                query = query.limit(*test.limit)
+            with query.materialize() as materialized:
+                dataIds = tuple(tuple(dataId[k] for k in keys) for dataId in materialized)
+                self.assertEqual(dataIds, test.result)
+
+        # errors in a name
+        for order_by in ("", "-"):
+            with self.assertRaisesRegex(ValueError, "Empty dimension name in ORDER BY"):
+                list(do_query().order_by(order_by))
+
+        for order_by in ("undimension.name", "-undimension.name"):
+            with self.assertRaisesRegex(ValueError, "Unknown dimension element name 'undimension'"):
+                list(do_query().order_by(order_by))
+
+        for order_by in ("attract", "-attract"):
+            with self.assertRaisesRegex(ValueError, "Metadata 'attract' cannot be found in any dimension"):
+                list(do_query().order_by(order_by))
+
+        with self.assertRaisesRegex(ValueError, "Metadata 'exposure_time' exists in more than one dimension"):
+            list(do_query(("exposure", "visit")).order_by("exposure_time"))
+
+        with self.assertRaisesRegex(ValueError, "Timespan exists in more than one dimesion"):
+            list(do_query(("exposure", "visit")).order_by("timespan.begin"))
+
+        with self.assertRaisesRegex(ValueError,
+                                    "Cannot find any temporal dimension element for 'timespan.begin'"):
+            list(do_query(("tract")).order_by("timespan.begin"))
+
+        with self.assertRaisesRegex(ValueError, "Cannot use 'timespan.begin' with non-temporal element"):
+            list(do_query(("tract")).order_by("tract.timespan.begin"))
+
+        with self.assertRaisesRegex(ValueError, "Field 'name' does not exist in 'tract'."):
+            list(do_query(("tract")).order_by("tract.name"))
+
+    def testQueryDimensionRecordsOrderBy(self):
+        """Test order_by and limit on result returned by
+        queryDimensionRecords().
+        """
+        registry = self.makeRegistry()
+        self.loadData(registry, "base.yaml")
+        self.loadData(registry, "datasets.yaml")
+        self.loadData(registry, "spatial.yaml")
+
+        def do_query():
+            return registry.queryDimensionRecords("detector", instrument="Cam1")
+
+        query = do_query()
+        self.assertEqual(len(list(query)), 4)
+
+        # For each test three items are defined here:
+        #  - order_by column names, comma separated
+        #  - limit tuple or None
+        #  - tuple of the detector IDs
+        test_data = (
+            ("detector", None, (1, 2, 3, 4)),
+            ("-detector", None, (4, 3, 2, 1)),
+            ("raft,-name_in_raft", None, (2, 1, 4, 3)),
+            ("-detector.purpose", (1, ), (4, )),
+            ("-purpose,detector.raft,name_in_raft", (2, 2), (2, 3)),
+        )
+
+        for order_by, limit, expected in test_data:
+            order_by = order_by.split(",")
+            query = do_query().order_by(*order_by)
+            if limit is not None:
+                query = query.limit(*limit)
+            dataIds = tuple(rec.id for rec in query)
+            self.assertEqual(dataIds, expected)
+
+        # errors in a name
+        for order_by in ("", "-"):
+            with self.assertRaisesRegex(ValueError, "Empty dimension name in ORDER BY"):
+                list(do_query().order_by(order_by))
+
+        for order_by in ("undimension.name", "-undimension.name"):
+            with self.assertRaisesRegex(ValueError, "Unknown dimension element name 'undimension'"):
+                list(do_query().order_by(order_by))
+
+        for order_by in ("attract", "-attract"):
+            with self.assertRaisesRegex(ValueError, "Metadata 'attract' cannot be found in any dimension"):
+                list(do_query().order_by(order_by))
 
     def testDatasetConstrainedDimensionRecordQueries(self):
         """Test that queryDimensionRecords works even when given a dataset

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -119,7 +119,7 @@ class CliLogTestBase():
         self.assertEqual(pyButler.logger.level, pyButler.initialLevel)
         if lsstLog is not None:
             self.assertEqual(lsstRoot.logger.getLevel(), lsstLog.INFO)
-            # lsstLogLevel can either be the inital level, or uninitialized or
+            # lsstLogLevel can either be the initial level, or uninitialized or
             # the defined default value.
             expectedLsstLogLevel = ((lsstButler.initialLevel, ) if lsstButler.initialLevel != -1
                                     else(-1, CliLog.defaultLsstLogLevel))

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -189,7 +189,7 @@ class MetricsExampleFormatter(Formatter):
 class MetricsExampleDataFormatter(Formatter):
     """A specialist test formatter for the data component of a MetricsExample.
 
-    This is needed if the MetricsExample is dissassembled and we want to
+    This is needed if the MetricsExample is disassembled and we want to
     support the derived component.
     """
 

--- a/python/lsst/daf/butler/transfers/_context.py
+++ b/python/lsst/daf/butler/transfers/_context.py
@@ -71,7 +71,7 @@ class RepoExportContext:
     directory : `str`, optional
         Directory to pass to `Datastore.export`.
     transfer : `str`, optional
-        Transfer mdoe to pass to `Datastore.export`.
+        Transfer mode to pass to `Datastore.export`.
     """
 
     def __init__(self, registry: Registry, datastore: Datastore, backend: RepoExportBackend, *,

--- a/tests/test_cliCmdQueryDataIds.py
+++ b/tests/test_cliCmdQueryDataIds.py
@@ -47,7 +47,10 @@ class QueryDataIdsTest(unittest.TestCase, ButlerTestHelper):
                                    dimensions=dimensions,
                                    collections=collections,
                                    datasets=datasets,
-                                   where=where)
+                                   where=where,
+                                   order_by=None,
+                                   limit=0,
+                                   offset=0)
 
     def setUp(self):
         self.root = makeTestTempDir(TESTDIR)

--- a/tests/test_cliUtilSplitKv.py
+++ b/tests/test_cliUtilSplitKv.py
@@ -95,7 +95,7 @@ class SplitKvTestCase(unittest.TestCase):
                          {...: "foo"})
 
     def test_dashSeparator(self):
-        """Test that specifying a spearator is accepted and converts to a dict.
+        """Test that specifying a separator is accepted and converts to a dict.
         """
         self.assertEqual(split_kv("context", "param", "first-1,second-2", separator="-"),
                          {"first": "1", "second": "2"})
@@ -162,7 +162,7 @@ class SplitKvCmdTestCase(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, msg=clickResultMsg(result))
         mock.assert_called_with({"lsst.daf.butler": "BAR"})
 
-        # check that invalid choices with and wihtout kv separators fail &
+        # check that invalid choices with and without kv separators fail &
         # return a non-zero exit code.
         for val in ("BOZ", "lsst.daf.butler=BOZ"):
             result = self.runner.invoke(cli, ["--metasyntactic-var", val])

--- a/tests/test_cliUtils.py
+++ b/tests/test_cliUtils.py
@@ -70,7 +70,7 @@ class ArgumentHelpGeneratorTestCase(unittest.TestCase):
     def runTest(self, cli):
         """Tests `utils.addArgumentHelp` and its use in repo_argument and
         directory_argument; verifies that the argument help gets added to the
-        command fucntion help, and that it's added in the correct order. See
+        command function help, and that it's added in the correct order. See
         addArgumentHelp for more details."""
         expected = """Usage: cli [OPTIONS] REPO DIRECTORY
 
@@ -150,9 +150,9 @@ class MWOptionTest(unittest.TestCase):
             pass
         result = self.runner.invoke(cmd, ["--help"])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
-        expectedOutut = """Options:
+        expectedOutput = """Options:
   --things TEXT ..."""
-        self.assertIn(expectedOutut, result.output)
+        self.assertIn(expectedOutput, result.output)
 
     def test_addElipsisToNargs(self):
         """Verify that MWOption adds " ..." after the option metavar when
@@ -169,9 +169,9 @@ class MWOptionTest(unittest.TestCase):
                 pass
             result = self.runner.invoke(cmd, ["--help"])
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
-            expectedOutut = f"""Options:
+            expectedOutput = f"""Options:
   --things TEXT{' ...' if numberOfArgs != 1 else ''}"""
-            self.assertIn(expectedOutut, result.output)
+            self.assertIn(expectedOutput, result.output)
 
 
 class MWArgumentDecoratorTest(unittest.TestCase):
@@ -209,7 +209,7 @@ class MWArgumentDecoratorTest(unittest.TestCase):
                     pass
                 result = self.runner.invoke(cmd, ["--help"])
                 self.assertEqual(result.exit_code, 0, clickResultMsg(result))
-                expectedOutut = (f"""Usage: cmd [OPTIONS] {'THINGS' if required else '[THINGS]'} {'... ' if numberOfArgs != 1 else ''}OTHER
+                expectedOutput = (f"""Usage: cmd [OPTIONS] {'THINGS' if required else '[THINGS]'} {'... ' if numberOfArgs != 1 else ''}OTHER
 
   Cmd help text.
 
@@ -217,7 +217,7 @@ class MWArgumentDecoratorTest(unittest.TestCase):
 
   {self.otherHelpText}
 """)
-                self.assertIn(expectedOutut, result.output)
+                self.assertIn(expectedOutput, result.output)
 
     def testUse(self):
         """Test using the MWArgumentDecorator with a command."""
@@ -293,7 +293,7 @@ class SectionOptionTest(unittest.TestCase):
         """Verify that the section break is printed in the help output in the
         expected location and with expected formatting."""
         result = self.runner.invoke(self.cli, ["--help"])
-        # \x20 is a space, added explicity below to prevent the
+        # \x20 is a space, added explicitly below to prevent the
         # normally-helpful editor setting "remove trailing whitespace" from
         # stripping it out in this case. (The blank line with 2 spaces is an
         # artifact of how click and our code generate help text.)

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1206,7 +1206,7 @@ cached:
         self.assertIsNone(cache_manager.move_to_cache(self.files[1], self.refs[1]))
 
         # Cached file should no longer exist but uncached file should be
-        # unaffectted.
+        # unaffected.
         self.assertFalse(self.files[0].exists())
         self.assertTrue(self.files[1].exists())
 

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -354,7 +354,7 @@ class DataCoordinateTestCase(unittest.TestCase):
              Number of dimensions to select, before automatic expansion by
              `DimensionGraph`.
         dataIds : `DimensionGraph`, optional
-            Dimensions to select ffrom.  Defaults to ``self.allDataIds.graph``.
+            Dimensions to select from.  Defaults to ``self.allDataIds.graph``.
 
         Returns
         -------

--- a/tests/test_normalFormExpression.py
+++ b/tests/test_normalFormExpression.py
@@ -137,7 +137,7 @@ class NormalFormExpressionTestCase(unittest.TestCase):
             originalTree = parser.parse(expression)
             wrapper = originalTree.visit(TransformationVisitor())
             trees = {form: NormalFormExpression.fromTree(originalTree, form).toTree() for form in NormalForm}
-            if conjunctive is True:  # expected to be conjuctive already
+            if conjunctive is True:  # expected to be conjunctive already
                 self.assertTrue(wrapper.satisfies(NormalForm.CONJUNCTIVE), msg=str(wrapper))
             elif conjunctive:  # str to expect after normalization to conjunctive
                 self.assertEqual(str(trees[NormalForm.CONJUNCTIVE]), conjunctive)


### PR DESCRIPTION
SQL registry method `queryDimensionRecords` now returns special iterable
object instead of plain iterator. Iterables returned from `queryDataIds`
and `queryDimensionRecords` have new methods `order_by()` and `limit()`. Same
two methods were added to `Query` classes. Extended unit tests for query
methods to check this new functionality.

Note that remote registry does not support this functionality (yet)

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
