### PR TITLE
DM-32750: Complain if unrecognized dataId/kwarg dimension keys are given in Butler APIs

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -731,6 +731,7 @@ class Butler:
 
             # Go through the missing dimensions and associate the
             # given names with records within those dimensions
+            matched_dims = set()
             for dimensionName in candidateDimensions:
                 dimension = self.registry.dimensions.getStaticDimensions()[dimensionName]
                 fields = dimension.metadata.names | dimension.uniqueKeys.names
@@ -739,6 +740,13 @@ class Butler:
                         guessedAssociation[dimensionName][field] = not_dimensions[field]
                         counter[dimensionName] += 1
                         assigned[field].add(dimensionName)
+                        matched_dims.add(field)
+
+            # Calculate the fields that matched nothing.
+            never_found = set(not_dimensions) - matched_dims
+
+            if never_found:
+                raise ValueError(f"Unrecognized keyword args given: {never_found}")
 
             # There is a chance we have allocated a single dataId item
             # to multiple dimensions. Need to decide which should be retained.

--- a/python/lsst/daf/butler/tests/utils.py
+++ b/python/lsst/daf/butler/tests/utils.py
@@ -270,5 +270,4 @@ class MetricTestRepo:
         self.butler.put(metric,
                         self.datasetType if datasetType is None else datasetType,
                         dataId,
-                        run=run,
-                        tags=())
+                        run=run)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -995,7 +995,7 @@ class ButlerTests(ButlerPutGetTests):
                       "list": [2*x for x in range(i)]}
 
             # Use the seq_num for the put to test rewriting.
-            dataId = {"seq_num": i, "day_obs": dayobs, "detector": 1, "instrument": "DummyCamComp",
+            dataId = {"seq_num": i, "day_obs": dayobs, "instrument": "DummyCamComp",
                       "physical_filter": "d-r"}
             ref = butler.put(metric, datasetTypeName, dataId=dataId)
 
@@ -1829,7 +1829,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
         run = "distraction"
         butler = Butler(butler=self.source_butler, run=run)
         butler.put(makeExampleMetrics(), datasetTypeName,
-                   exposure=1, detector=1, instrument="DummyCamComp", physical_filter="d-r")
+                   exposure=1, instrument="DummyCamComp", physical_filter="d-r")
 
         # Write some example metrics to the source
         butler = Butler(butler=self.source_butler)
@@ -1851,7 +1851,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
                            "output": {"text": "metric"},
                            "data": [2*x for x in range(i)]}
             metric = MetricsExample(**metric_data)
-            dataId = {"exposure": i, "detector": 1, "instrument": "DummyCamComp", "physical_filter": "d-r"}
+            dataId = {"exposure": i, "instrument": "DummyCamComp", "physical_filter": "d-r"}
             ref = butler.put(metric, datasetTypeName, dataId=dataId, run=run)
 
             # Remove the datastore record using low-level API

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -468,6 +468,17 @@ class SimpleButlerTestCase(unittest.TestCase):
                                   collections="calibs", instrument="Cam1")
         self.assertEqual(bias3b_id, bias3b.id)
 
+        # Ensure that spurious kwargs cause an exception.
+        with self.assertRaises(ValueError):
+            butler.get("bias", {"exposure.obs_id": "four", "immediate": True,
+                       "detector.full_name": "Ba"},
+                       collections="calibs", instrument="Cam1")
+
+        with self.assertRaises(ValueError):
+            butler.get("bias", day_obs=20211114, seq_num=42,
+                       raft="B", name_in_raft="a",
+                       collections="calibs", instrument="Cam1", immediate=True)
+
     def testRegistryDefaults(self):
         """Test that we can default the collections and some data ID keys when
         constructing a butler.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
