### PR TITLE
DM-32820: Skip ButlerURI in table of contents

### DIFF
--- a/doc/changes/DM-31723.api.rst
+++ b/doc/changes/DM-31723.api.rst
@@ -1,0 +1,3 @@
+The ``ButlerURI`` class has now been removed from this package.
+It now exists as `lsst.resources.ResourcePath`.
+All code should be modified to use the new class name.

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -100,6 +100,12 @@ Python API reference
 
 .. automodapi:: lsst.daf.butler
    :no-main-docstr:
+   :skip: ButlerURI
+
+.. py:class:: lsst.daf.butler.ButlerURI(uri)
+
+   ``ButlerURI`` implementation. Exists for backwards compatibility.
+   New code should use `lsst.resources.ResourcePath`.
 
 .. automodapi:: lsst.daf.butler.registry
    :no-main-docstr:


### PR DESCRIPTION
Aliasing `ButlerURI` to `ResourcePath` works fine for code but breaks sphinx documentation building. Workaround this by removing the table of content entry.


## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
