### PR TITLE
DM-32883: Support StorageClass conversion on get.

### DIFF
--- a/doc/changes/DM-32883.feature.rst
+++ b/doc/changes/DM-32883.feature.rst
@@ -1,0 +1,12 @@
+It is now possible to register type conversion functions with storage classes.
+This can allow a dataset type definition to change storage class in the registry whilst allowing datasets that have already been serialized using one python type to be returned using the new python type.
+The ``storageClasses.yaml`` definitions can now look like:
+
+.. code-block:: yaml
+
+   TaskMetadata:
+     pytype: lsst.pipe.base.TaskMetadata
+     converters:
+       lsst.daf.base.PropertySet: lsst.pipe.base.TaskMetadata.from_metadata
+
+Declares that if a ``TaskMetadata`` is expected then a ``PropertySet`` can be converted to the correct python type.

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -271,3 +271,6 @@ storageClasses:
     pytype: lsst.daf.butler.ButlerLogRecords
   TaskMetadata:
     pytype: lsst.pipe.base.TaskMetadata
+    converters:
+      # Compatible python types.
+      lsst.daf.base.PropertySet: lsst.pipe.base.TaskMetadata.from_metadata

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -189,12 +189,15 @@ class StorageClass:
             self._converters_by_type = {}
 
             for candidate_type_str, converter_str in self.converters.items():
-                try:
-                    candidate_type = doImportType(candidate_type_str)
-                except ImportError as e:
-                    log.info("Unable to import type %s associated with storage class %s (%s)",
-                             candidate_type_str, self.name, e)
-                    continue
+                if hasattr(builtins, candidate_type_str):
+                    candidate_type = getattr(builtins, candidate_type_str)
+                else:
+                    try:
+                        candidate_type = doImportType(candidate_type_str)
+                    except ImportError as e:
+                        log.info("Unable to import type %s associated with storage class %s (%s)",
+                                 candidate_type_str, self.name, e)
+                        continue
 
                 try:
                     converter = doImportType(converter_str)

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -210,7 +210,12 @@ class StorageClass:
                     del self.converters[candidate_type_str]
                     continue
                 if not callable(converter):
-                    log.warning("Conversion function %s associated with storage class %s to "
+                    # doImportType is annotated to return a Type but in actual
+                    # fact it can return Any except ModuleType because package
+                    # variables can be accessed. This make mypy believe it
+                    # is impossible for the return value to not be a callable
+                    # so we must ignore the warning.
+                    log.warning("Conversion function %s associated with storage class %s to "  # type: ignore
                                 "convert type %s is not a callable.", converter_str, self.name,
                                 candidate_type_str)
                     del self.converters[candidate_type_str]

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -196,17 +196,17 @@ class StorageClass:
                     try:
                         candidate_type = doImportType(candidate_type_str)
                     except ImportError as e:
-                        log.info("Unable to import type %s associated with storage class %s (%s)",
-                                 candidate_type_str, self.name, e)
+                        log.warning("Unable to import type %s associated with storage class %s (%s)",
+                                    candidate_type_str, self.name, e)
                         del self.converters[candidate_type_str]
                         continue
 
                 try:
                     converter = doImportType(converter_str)
                 except ImportError as e:
-                    log.info("Unable to import conversion function %s associated with storage class %s "
-                             "required to convert type %s (%s)",
-                             candidate_type_str, self.name, candidate_type_str, e)
+                    log.warning("Unable to import conversion function %s associated with storage class %s "
+                                "required to convert type %s (%s)",
+                                candidate_type_str, self.name, candidate_type_str, e)
                     del self.converters[candidate_type_str]
                     continue
                 self._converters_by_type[candidate_type] = converter

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -188,7 +188,8 @@ class StorageClass:
         if self._converters_by_type is None:
             self._converters_by_type = {}
 
-            for candidate_type_str, converter_str in self.converters.items():
+            # Loop over list because the dict can be edited in loop.
+            for candidate_type_str, converter_str in list(self.converters.items()):
                 if hasattr(builtins, candidate_type_str):
                     candidate_type = getattr(builtins, candidate_type_str)
                 else:
@@ -197,6 +198,7 @@ class StorageClass:
                     except ImportError as e:
                         log.info("Unable to import type %s associated with storage class %s (%s)",
                                  candidate_type_str, self.name, e)
+                        del self.converters[candidate_type_str]
                         continue
 
                 try:
@@ -205,6 +207,7 @@ class StorageClass:
                     log.info("Unable to import conversion function %s associated with storage class %s "
                              "required to convert type %s (%s)",
                              candidate_type_str, self.name, candidate_type_str, e)
+                    del self.converters[candidate_type_str]
                     continue
                 self._converters_by_type[candidate_type] = converter
         return self._converters_by_type

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -167,8 +167,7 @@ class GenericBaseDatastore(Datastore):
             allowedTypes.append(type(None))
 
         if allowedTypes and not isinstance(inMemoryDataset, tuple(allowedTypes)):
-            raise TypeError("Got Python type {} from datastore but expected {}".format(type(inMemoryDataset),
-                                                                                       pytype))
+            inMemoryDataset = readStorageClass.coerce_type(inMemoryDataset)
 
         return inMemoryDataset
 

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -25,10 +25,14 @@ large external dependencies on python classes such as afw or serialization
 formats such as FITS or HDF5.
 """
 
-__all__ = ("ListDelegate", "MetricsDelegate", "MetricsExample", "registerMetricsExample")
+__all__ = ("ListDelegate", "MetricsDelegate", "MetricsExample", "registerMetricsExample",
+           "MetricsExampleModel")
 
 
 import copy
+from typing import Optional, Any, Dict, List
+
+from pydantic import BaseModel
 from lsst.daf.butler import StorageClassDelegate, StorageClass
 
 
@@ -232,6 +236,19 @@ class MetricsExample:
         if "data" in exportDict:
             data = exportDict["data"]
         return cls(exportDict["summary"], exportDict["output"], data)
+
+
+class MetricsExampleModel(BaseModel):
+    """A variant of `MetricsExample` based on model."""
+
+    summary: Optional[Dict[str, Any]]
+    output: Optional[Dict[str, Any]]
+    data: Optional[List[Any]]
+
+    @classmethod
+    def from_metrics(cls, metrics: MetricsExample) -> "MetricsExampleModel":
+        """Create a model based on an example."""
+        return cls.parse_obj(metrics.exportAsDict())
 
 
 class ListDelegate(StorageClassDelegate):

--- a/tests/config/basic/formatters.yaml
+++ b/tests/config/basic/formatters.yaml
@@ -36,3 +36,4 @@ instrument<DummyHSC>:
 StructuredCompositeReadComp: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
 StructuredCompositeReadCompNoDisassembly: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
 StructuredDataDataTest: lsst.daf.butler.tests.testFormatters.MetricsExampleDataFormatter
+StructuredDataNoComponentsModel: lsst.daf.butler.formatters.json.JsonFormatter

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -79,3 +79,11 @@ storageClasses:
       counter: Integer
   StructuredCompositeReadCompNoDisassembly:
     inheritsFrom: StructuredCompositeReadComp
+  StructuredDataNoComponentsModel:
+    # Reading and writing a blob and no components known
+    pytype: lsst.daf.butler.tests.MetricsExampleModel
+    converters:
+      lsst.daf.butler.tests.MetricsExample: lsst.daf.butler.tests.MetricsExampleModel.from_metrics
+      # Add some entries that will fail to import.
+      lsst.daf.butler.bad.type: lsst.daf.butler.tests.MetricsExampleModel.from_metrics
+      lsst.daf.butler.tests.MetricsExampleModel: lsst.daf.butler.bad.function

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -87,3 +87,4 @@ storageClasses:
       # Add some entries that will fail to import.
       lsst.daf.butler.bad.type: lsst.daf.butler.tests.MetricsExampleModel.from_metrics
       lsst.daf.butler.tests.MetricsExampleModel: lsst.daf.butler.bad.function
+      lsst.daf.butler.Butler: lsst.daf.butler.core.location.__all__

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -247,9 +247,18 @@ class StorageClassFactoryTestCase(unittest.TestCase):
         sc2 = StorageClass("Test2", pytype=set)
         sc3 = StorageClass("Test3", pytype="lsst.daf.butler.tests.MetricsExample")
 
+        self.assertIn("lsst.daf.butler.tests.MetricsExample", repr(sc))
+        # Initially the converter list is not filtered.
+        self.assertIn("lsst.daf.butler.bad.type", repr(sc))
+        self.assertNotIn("converters", repr(sc2))
+
         self.assertTrue(sc.can_convert(sc))
         self.assertFalse(sc.can_convert(sc2))
         self.assertTrue(sc.can_convert(sc3))
+
+        # After we've processed the converters the bad ones will no longer
+        # be reported.
+        self.assertNotIn("lsst.daf.butler.bad.type", repr(sc))
 
         self.assertIsNone(sc.coerce_type(None))
 

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -230,7 +230,9 @@ class StorageClassFactoryTestCase(unittest.TestCase):
 
     @classmethod
     def _convert_type(cls, data):
-        # Test helper function.
+        # Test helper function. Fail if the list is empty.
+        if not len(data):
+            raise RuntimeError("Deliberate failure.")
         return {"key": data}
 
     def testConverters(self):
@@ -269,10 +271,15 @@ class StorageClassFactoryTestCase(unittest.TestCase):
         converted = sc.coerce_type([1, 2, 3])
         self.assertEqual(converted, {"key": [1, 2, 3]})
 
+        # Try to coerce a type that is not supported.
         with self.assertRaises(TypeError):
-            with self.assertLogs(level=logging.ERROR) as cm:
-                sc.coerce_type(set([1, 2, 3]))
-            self.assertIn("Converter list failed to convert", cm.output[0])
+            sc.coerce_type(set([1, 2, 3]))
+
+        # Coerce something that will fail to convert.
+        with self.assertLogs(level=logging.ERROR) as cm:
+            with self.assertRaises(RuntimeError):
+                sc.coerce_type([])
+        self.assertIn("failed to convert type list", cm.output[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows a converter to be registered with a storage class that will be run if the dataset read from the datastore has an incorrect type that can be converted to the expected one.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
