### PR TITLE
DM-32986: fix option handling in butler CLI presets files

### DIFF
--- a/doc/changes/DM-32986.bugfix.rst
+++ b/doc/changes/DM-32986.bugfix.rst
@@ -1,0 +1,2 @@
+In the butler presets file, use option names that match the butler CLI command option names (without leading dashes).
+Fail if option names used in the presets file do not match options for the current butler command.


### PR DESCRIPTION
accept option names in the preset file,
map them to argument names before applying
them to the click.context.default_map.

also fail if an option is named in the
preset file that does not have a matching
parameter in the current command's options
or arguments.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
