### PR TITLE
DM-33049: Allow duplicate values in dataId

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -870,7 +870,14 @@ class Butler:
                         str(values),
                     )
                     # Get the actual record and compare with these values.
-                    recs = list(self.registry.queryDimensionRecords(dimensionName, dataId=newDataId))
+                    try:
+                        recs = list(self.registry.queryDimensionRecords(dimensionName, dataId=newDataId))
+                    except LookupError:
+                        raise ValueError(
+                            f"Could not find dimension '{dimensionName}'"
+                            f" with dataId {newDataId} as part of comparing with"
+                            f" record values {byRecord[dimensionName]}"
+                        ) from None
                     if len(recs) == 1:
                         errmsg: List[str] = []
                         for k, v in values.items():
@@ -883,8 +890,7 @@ class Butler:
                             )
                     else:
                         # Multiple matches for an explicit dimension
-                        # should never happen, and if there are no matches
-                        # let downstream complain.
+                        # should never happen but let downstream complain.
                         pass
                     continue
 

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -901,12 +901,12 @@ class Butler:
                         log.debug("Received %d records from constraints of %s", len(records), str(values))
                         for r in records:
                             log.debug("- %s", str(r))
-                        raise RuntimeError(
+                        raise ValueError(
                             f"DataId specification for dimension {dimensionName} is not"
                             f" uniquely constrained to a single dataset by {values}."
                             f" Got {len(records)} results."
                         )
-                    raise RuntimeError(
+                    raise ValueError(
                         f"DataId specification for dimension {dimensionName} matched no"
                         f" records when constrained by {values}"
                     )

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -866,6 +866,23 @@ class Butler:
                         newDataId[dimensionName],
                         str(values),
                     )
+                    # Get the actual record and compare with these values.
+                    recs = list(self.registry.queryDimensionRecords(dimensionName, dataId=newDataId))
+                    if len(recs) == 1:
+                        errmsg: List[str] = []
+                        for k, v in values.items():
+                            if (recval := getattr(recs[0], k)) != v:
+                                errmsg.append(f"{k}({recval} != {v})")
+                        if errmsg:
+                            raise ValueError(
+                                f"Dimension {dimensionName} in dataId has explicit value"
+                                " inconsistent with records: " + ", ".join(errmsg)
+                            )
+                    else:
+                        # Multiple matches for an explicit dimension
+                        # should never happen, and if there are no matches
+                        # let downstream complain.
+                        pass
                     continue
 
                 # Build up a WHERE expression

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -387,6 +387,7 @@ class SimpleButlerTestCase(unittest.TestCase):
             # Inconsistent detector information.
             (None, {"instrument": "Cam1", "detector": 2, "raft": "B", "physical_filter": "Cam1-G"}),
             ({"detector": 2}, {"instrument": "Cam1", "raft": "B", "physical_filter": "Cam1-G"}),
+            ({"detector": 12}, {"instrument": "Cam1", "raft": "B", "physical_filter": "Cam1-G"}),
             ({"raft": "B"}, {"instrument": "Cam1", "detector": 2, "physical_filter": "Cam1-G"}),
             ({"raft": "B"}, {"instrument": "Cam1", "detector": "Ab", "physical_filter": "Cam1-G"}),
             # Under-specified.

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -368,6 +368,11 @@ class SimpleButlerTestCase(unittest.TestCase):
                 },
                 {},
             ),
+            # Duplicate (but valid) information.
+            (None, {"instrument": "Cam1", "detector": 2, "raft": "A", "physical_filter": "Cam1-G"}),
+            ({"detector": 2}, {"instrument": "Cam1", "raft": "A", "physical_filter": "Cam1-G"}),
+            ({"raft": "A"}, {"instrument": "Cam1", "detector": 2, "physical_filter": "Cam1-G"}),
+            ({"raft": "A"}, {"instrument": "Cam1", "detector": "Ab", "physical_filter": "Cam1-G"}),
         )
 
         for dataId, kwds in variants:
@@ -376,6 +381,23 @@ class SimpleButlerTestCase(unittest.TestCase):
             except Exception as e:
                 raise type(e)(f"{str(e)}: dataId={dataId}, kwds={kwds}") from e
             self.assertEqual(flat_id, flat2g.id, msg=f"DataId: {dataId}, kwds: {kwds}")
+
+        # Check that bad combinations raise.
+        variants = (
+            # Inconsistent detector information.
+            (None, {"instrument": "Cam1", "detector": 2, "raft": "B", "physical_filter": "Cam1-G"}),
+            ({"detector": 2}, {"instrument": "Cam1", "raft": "B", "physical_filter": "Cam1-G"}),
+            ({"raft": "B"}, {"instrument": "Cam1", "detector": 2, "physical_filter": "Cam1-G"}),
+            ({"raft": "B"}, {"instrument": "Cam1", "detector": "Ab", "physical_filter": "Cam1-G"}),
+            # Under-specified.
+            ({"raft": "B"}, {"instrument": "Cam1", "physical_filter": "Cam1-G"}),
+            # Spurious kwargs.
+            (None, {"instrument": "Cam1", "detector": 2, "physical_filter": "Cam1-G", "x": "y"}),
+            ({"x": "y"}, {"instrument": "Cam1", "detector": 2, "physical_filter": "Cam1-G"}),
+        )
+        for dataId, kwds in variants:
+            with self.assertRaises(ValueError):
+                butler.get("flat", dataId=dataId, collections=coll, **kwds)
 
     def testGetCalibration(self):
         """Test that `Butler.get` can be used to fetch from
@@ -475,6 +497,33 @@ class SimpleButlerTestCase(unittest.TestCase):
             instrument="Cam1",
         )
         self.assertEqual(bias3b_id, bias3b.id)
+
+        # Allow a fully-specified dataId and unnecessary extra information
+        # that comes from the record.
+        bias3b_id, _ = butler.get(
+            "bias",
+            dataId=dict(
+                exposure=4,
+                day_obs=20211114,
+                seq_num=42,
+                detector=3,
+                instrument="Cam1",
+            ),
+            collections="calibs",
+        )
+        self.assertEqual(bias3b_id, bias3b.id)
+
+        # Extra but inconsistent record values are a problem.
+        with self.assertRaises(ValueError):
+            bias3b_id, _ = butler.get(
+                "bias",
+                exposure=3,
+                day_obs=20211114,
+                seq_num=42,
+                detector=3,
+                collections="calibs",
+                instrument="Cam1",
+            )
 
         # Ensure that spurious kwargs cause an exception.
         with self.assertRaises(ValueError):


### PR DESCRIPTION
`detector` and `raft` and `day_obs` and `exposure` should be allowed so long as they are consistent.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
