### PR TITLE
DM-33085: Specify explicit caching option for SQLAlchemy classes

### DIFF
--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -155,6 +155,8 @@ class Base64Region(Base64Bytes):
     Maps Python `sphgeom.Region` to a base64-encoded `sqlalchemy.String`.
     """
 
+    cache_ok = True  # have to be set explicitly in each class
+
     def process_bind_param(
         self, value: Optional[Region], dialect: sqlalchemy.engine.Dialect
     ) -> Optional[str]:

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -64,7 +64,7 @@ class _Replace(sqlalchemy.sql.Insert):
     on the primary key constraint for the table.
     """
 
-    pass
+    inherit_cache = True  # make it cacheable
 
 
 # SQLite and PostgreSQL use similar syntax for their ON CONFLICT extension,
@@ -95,7 +95,7 @@ class _Ensure(sqlalchemy.sql.Insert):
     ``INSERT ... ON CONFLICT DO NOTHING``.
     """
 
-    pass
+    inherit_cache = True  # make it cacheable
 
 
 @sqlalchemy.ext.compiler.compiles(_Ensure, "sqlite")


### PR DESCRIPTION
Suppresses warnings about missing caching attribute for some classes.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
