### PR TITLE
DM-33155: Also allow storage class conversion on butler.put

### DIFF
--- a/doc/changes/DM-33155.feature.rst
+++ b/doc/changes/DM-33155.feature.rst
@@ -1,0 +1,1 @@
+Storage class converters can now also be used on `~lsst.daf.butler.Butler.put`.

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -110,6 +110,8 @@ storageClasses:
     pytype: lsst.skymap.BaseSkyMap
   PropertySet:
     pytype: lsst.daf.base.PropertySet
+    converters:
+      lsst.pipe.base.TaskMetadata: lsst.daf.base.PropertySet.from_mapping
   PropertyList:
     pytype: lsst.daf.base.PropertyList
   IsrCalib:

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1081,6 +1081,10 @@ class FileDatastore(GenericBaseDatastore):
         info : `StoredFileInfo`
             Information describing the artifact written to the datastore.
         """
+        # May need to coerce the in memory dataset to the correct
+        # python type.
+        inMemoryDataset = ref.datasetType.storageClass.coerce_type(inMemoryDataset)
+
         location, formatter = self._prepare_for_put(inMemoryDataset, ref)
         uri = location.uri
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,3 @@ matplotlib >= 3.0.3
 pyarrow >= 0.16
 responses >= 0.12.0
 urllib3 >= 1.25.10
-
-# These are required by lsst.utils
-psutil >= 5.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,12 +21,13 @@ setup_requires =
 install_requires =
   astropy >=4.0
   pyyaml >=5.1
-  sqlalchemy >= 1.03
+  sqlalchemy >= 1.3
   click >= 7.0
   lsst_sphgeom @ git+https://github.com/lsst/sphgeom@main
   lsst_utils @ git+https://github.com/lsst/utils@main
   lsst_resources @ git+https://github.com/lsst/resources@main
   deprecated >= 1.2
+  pydantic
 tests_require =
   pytest >= 3.2
   flake8 >= 3.7.5

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -21,6 +21,8 @@ storageClasses:
     delegate: lsst.daf.butler.tests.MetricsDelegate
     parameters:
       - slice
+    converters:
+      dict: lsst.daf.butler.tests.MetricsExample.makeFromDict
   StructuredData:
     # Data from a simple Python class
     pytype: lsst.daf.butler.tests.MetricsExample

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -154,10 +154,7 @@ class ButlerPutGetTests:
     def tearDown(self):
         removeTestTempDir(self.root)
 
-    def runPutGetTest(self, storageClass, datasetTypeName):
-        # New datasets will be added to run and tag, but we will only look in
-        # tag when looking up datasets.
-        run = "ingest"
+    def create_butler(self, run, storageClass, datasetTypeName):
         butler = Butler(self.tmpConfigFile, run=run)
 
         collections = set(butler.registry.queryCollections())
@@ -202,6 +199,13 @@ class ButlerPutGetTests:
                 "visit_system": 1,
             },
         )
+        return butler, datasetType
+
+    def runPutGetTest(self, storageClass, datasetTypeName):
+        # New datasets will be added to run and tag, but we will only look in
+        # tag when looking up datasets.
+        run = "ingest"
+        butler, datasetType = self.create_butler(run, storageClass, datasetTypeName)
 
         # Create and store a dataset
         metric = makeExampleMetrics()
@@ -378,7 +382,7 @@ class ButlerPutGetTests:
 
         # Create a Dataset type that has the same name but is inconsistent.
         inconsistentDatasetType = DatasetType(
-            datasetTypeName, dimensions, self.storageClassFactory.getStorageClass("Config")
+            datasetTypeName, datasetType.dimensions, self.storageClassFactory.getStorageClass("Config")
         )
 
         # Getting with a dataset type that does not match registry fails
@@ -1371,7 +1375,7 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         # Store some data with the normal example storage class.
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
         datasetTypeName = "test_metric"
-        butler = self.runPutGetTest(storageClass, datasetTypeName)
+        butler, _ = self.create_butler("ingest", storageClass, datasetTypeName)
 
         dataId = {"instrument": "DummyCamComp", "visit": 423}
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1365,6 +1365,24 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         # Clear out the datasets from registry.
         butler.pruneDatasets([ref1, ref2, ref3], purge=True, unstore=True)
 
+    def testPytypePutCoercion(self):
+        """Test python type coercion on Butler.get and put."""
+
+        # Store some data with the normal example storage class.
+        storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
+        datasetTypeName = "test_metric"
+        butler = self.runPutGetTest(storageClass, datasetTypeName)
+
+        dataId = {"instrument": "DummyCamComp", "visit": 423}
+
+        # Put a dict and this should coerce to a MetricsExample
+        test_dict = {"summary": {"a": 1}, "output": {"b": 2}}
+        metric_ref = butler.put(test_dict, datasetTypeName, dataId=dataId, visit=424)
+        test_metric = butler.getDirect(metric_ref)
+        self.assertEqual(get_full_type_name(test_metric), "lsst.daf.butler.tests.MetricsExample")
+        self.assertEqual(test_metric.summary, test_dict["summary"])
+        self.assertEqual(test_metric.output, test_dict["output"])
+
     def testPytypeCoercion(self):
         """Test python type coercion on Butler.get and put."""
 
@@ -1379,15 +1397,6 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
 
         datasetType_ori = butler.registry.getDatasetType(datasetTypeName)
         self.assertEqual(datasetType_ori.storageClass.name, "StructuredDataNoComponents")
-
-        # Put a dict and this should coerce to a MetricsExample
-        test_dict = {"summary": {"a": 1}, "output": {"b": 2}}
-        metric_ref = butler.put(test_dict, datasetTypeName, dataId=dataId, visit=424)
-        test_metric = butler.getDirect(metric_ref)
-        self.assertEqual(test_metric.summary, test_dict["summary"])
-        self.assertEqual(test_metric.output, test_dict["output"])
-        # Remove the dataset because another will be stored later in the test.
-        butler.pruneDatasets([metric_ref], unstore=True, purge=True)
 
         # Now need to hack the registry dataset type definition.
         # There is no API for this.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1366,7 +1366,7 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         butler.pruneDatasets([ref1, ref2, ref3], purge=True, unstore=True)
 
     def testPytypeCoercion(self):
-        """Test python type coercion on Butler.get"""
+        """Test python type coercion on Butler.get and put."""
 
         # Store some data with the normal example storage class.
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
@@ -1379,6 +1379,15 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
 
         datasetType_ori = butler.registry.getDatasetType(datasetTypeName)
         self.assertEqual(datasetType_ori.storageClass.name, "StructuredDataNoComponents")
+
+        # Put a dict and this should coerce to a MetricsExample
+        test_dict = {"summary": {"a": 1}, "output": {"b": 2}}
+        metric_ref = butler.put(test_dict, datasetTypeName, dataId=dataId, visit=424)
+        test_metric = butler.getDirect(metric_ref)
+        self.assertEqual(test_metric.summary, test_dict["summary"])
+        self.assertEqual(test_metric.output, test_dict["output"])
+        # Remove the dataset because another will be stored later in the test.
+        butler.pruneDatasets([metric_ref], unstore=True, purge=True)
 
         # Now need to hack the registry dataset type definition.
         # There is no API for this.


### PR DESCRIPTION
The infrastructure already existed to support it and there
is no particular reason why get should convert but put
should not. Doing this provides a way for newer classes
to be used in code but whilst still supporting old
dataset type definitions.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
