### PR TITLE
DM-33174: Allow "@" in run collection names

### DIFF
--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -103,7 +103,7 @@ def globToRegex(
     if not expressions or "*" in expressions:
         return Ellipsis
 
-    nomagic = re.compile(r"^[\w/\.\-]+$", re.ASCII)
+    nomagic = re.compile(r"^[\w/\.\-@]+$", re.ASCII)
 
     # Try not to convert simple string to a regex.
     results: List[Union[str, Pattern]] = []

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -511,6 +511,12 @@ class ButlerTests(ButlerPutGetTests):
         collections = set(butler.registry.queryCollections())
         self.assertEqual(collections, {"ingest"})
 
+        # Check that some special characters can be included in run name.
+        special_run = "u@b.c-A"
+        butler_special = Butler(butler=butler, run=special_run)
+        collections = set(butler_special.registry.queryCollections("*@*"))
+        self.assertEqual(collections, {special_run})
+
         butler2 = Butler(butler=butler, collections=["other"])
         self.assertEqual(butler2.collections, CollectionSearch.fromExpression(["other"]))
         self.assertIsNone(butler2.run)


### PR DESCRIPTION
They were not included in the none-magic list of characters.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
