### PR TITLE
DM-33086: Add new parameter to butler.ingest to disable tracking of file size

### DIFF
--- a/doc/changes/DM-33086.api.rst
+++ b/doc/changes/DM-33086.api.rst
@@ -1,0 +1,2 @@
+A new optional parameter, ``record_validation_info`` has been added to `~lsst.daf.butler.Butler.ingest` (and related datastore APIs) to allow the caller to declare that file attributes such as the file size or checksum should not be recorded.
+This can be useful if the file is being monitored by an external system or it is known that the file might be compressed in-place after ingestion.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1716,6 +1716,7 @@ class Butler:
         transfer: Optional[str] = "auto",
         run: Optional[str] = None,
         idGenerationMode: DatasetIdGenEnum = DatasetIdGenEnum.UNIQUE,
+        record_validation_info: bool = True,
     ) -> None:
         """Store and register one or more datasets that already exist on disk.
 
@@ -1743,6 +1744,13 @@ class Butler:
         idGenerationMode : `DatasetIdGenEnum`, optional
             Specifies option for generating dataset IDs. By default unique IDs
             are generated for each inserted dataset.
+        record_validation_info : `bool`, optional
+            If `True`, the default, the datastore can record validation
+            information associated with the file. If `False` the datastore
+            will not attempt to track any information such as checksums
+            or file sizes. This can be useful if such information is tracked
+            in an external system or if the file is to be compressed in place.
+            It is up to the datastore whether this parameter is relevant.
 
         Raises
         ------
@@ -1860,7 +1868,7 @@ class Butler:
                 dataset.refs = resolvedRefs
 
         # Bulk-insert everything into Datastore.
-        self.datastore.ingest(*datasets, transfer=transfer)
+        self.datastore.ingest(*datasets, transfer=transfer, record_validation_info=record_validation_info)
 
     @contextlib.contextmanager
     def export(

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -527,7 +527,9 @@ class Datastore(metaclass=ABCMeta):
         """
         raise NotImplementedError(f"Datastore {self} does not support direct file-based ingest.")
 
-    def _finishIngest(self, prepData: IngestPrepData, *, transfer: Optional[str] = None) -> None:
+    def _finishIngest(
+        self, prepData: IngestPrepData, *, transfer: Optional[str] = None, record_validation_info: bool = True
+    ) -> None:
         """Complete an ingest operation.
 
         Parameters
@@ -538,6 +540,13 @@ class Datastore(metaclass=ABCMeta):
         transfer : `str`, optional
             How (and whether) the dataset should be added to the datastore.
             See `ingest` for details of transfer modes.
+        record_validation_info : `bool`, optional
+            If `True`, the default, the datastore can record validation
+            information associated with the file. If `False` the datastore
+            will not attempt to track any information such as checksums
+            or file sizes. This can be useful if such information is tracked
+            in an external system or if the file is to be compressed in place.
+            It is up to the datastore whether this parameter is relevant.
 
         Raises
         ------
@@ -555,7 +564,9 @@ class Datastore(metaclass=ABCMeta):
         """
         raise NotImplementedError(f"Datastore {self} does not support direct file-based ingest.")
 
-    def ingest(self, *datasets: FileDataset, transfer: Optional[str] = None) -> None:
+    def ingest(
+        self, *datasets: FileDataset, transfer: Optional[str] = None, record_validation_info: bool = True
+    ) -> None:
         """Ingest one or more files into the datastore.
 
         Parameters
@@ -580,6 +591,13 @@ class Datastore(metaclass=ABCMeta):
             Most datastores do not support all transfer modes.
             "auto" is a special option that will let the
             data store choose the most natural option for itself.
+        record_validation_info : `bool`, optional
+            If `True`, the default, the datastore can record validation
+            information associated with the file. If `False` the datastore
+            will not attempt to track any information such as checksums
+            or file sizes. This can be useful if such information is tracked
+            in an external system or if the file is to be compressed in place.
+            It is up to the datastore whether this parameter is relevant.
 
         Raises
         ------
@@ -635,7 +653,7 @@ class Datastore(metaclass=ABCMeta):
                 "DatasetType(s) not supported in ingest: "
                 + ", ".join(f"{k.name} ({len(v)} dataset(s))" for k, v in byDatasetType.items())
             )
-        self._finishIngest(prepData, transfer=transfer)
+        self._finishIngest(prepData, transfer=transfer, record_validation_info=record_validation_info)
 
     def transfer_from(
         self,

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -487,10 +487,18 @@ class ChainedDatastore(Datastore):
             raise NotImplementedError(f"No child datastore supports transfer mode {transfer}.")
         return _IngestPrepData(children=children)
 
-    def _finishIngest(self, prepData: _IngestPrepData, *, transfer: Optional[str] = None) -> None:
+    def _finishIngest(
+        self,
+        prepData: _IngestPrepData,
+        *,
+        transfer: Optional[str] = None,
+        record_validation_info: bool = True,
+    ) -> None:
         # Docstring inherited from Datastore._finishIngest.
         for datastore, prepDataForChild in prepData.children:
-            datastore._finishIngest(prepDataForChild, transfer=transfer)
+            datastore._finishIngest(
+                prepDataForChild, transfer=transfer, record_validation_info=record_validation_info
+            )
 
     def getURIs(
         self, ref: DatasetRef, predict: bool = False

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -685,7 +685,15 @@ class ButlerTests(ButlerPutGetTests):
         datasets = []
         datasets.append(FileDataset(path=metricFile, refs=refs, formatter=MultiDetectorFormatter))
 
-        butler.ingest(*datasets, transfer="copy")
+        butler.ingest(*datasets, transfer="copy", record_validation_info=False)
+
+        # Check that the datastore recorded no file size.
+        # Not all datastores can support this.
+        try:
+            infos = butler.datastore.getStoredItemsInfo(datasets[0].refs[0])
+            self.assertEqual(infos[0].file_size, -1)
+        except AttributeError:
+            pass
 
         dataId1 = {"instrument": "DummyCamComp", "detector": 1, "visit": 424}
         dataId2 = {"instrument": "DummyCamComp", "detector": 2, "visit": 424}


### PR DESCRIPTION
Needed when people know they are going to compress the file after they ingest it.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
