### PR TITLE
DM-33164: Reimplement `order_by` method for query results

### DIFF
--- a/python/lsst/daf/butler/core/simpleQuery.py
+++ b/python/lsst/daf/butler/core/simpleQuery.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 __all__ = ("SimpleQuery",)
 
-from typing import Any, ClassVar, List, Optional, Type, TypeVar, Union
+from typing import Any, ClassVar, List, Optional, Tuple, Type, TypeVar, Union
 
 import sqlalchemy
 
@@ -39,6 +39,8 @@ class SimpleQuery:
     def __init__(self) -> None:
         self.columns = []
         self.where = []
+        self.order_by = []
+        self.limit = None
         self._from: Optional[sqlalchemy.sql.FromClause] = None
 
     class Select:
@@ -126,6 +128,12 @@ class SimpleQuery:
             result = result.select_from(self._from)
         if self.where:
             result = result.where(sqlalchemy.sql.and_(*self.where))
+        if self.order_by:
+            result = result.order_by(*self.order_by)
+        if self.limit:
+            result = result.limit(self.limit[0])
+            if self.limit[1] is not None:
+                result = result.offset(self.limit[1])
         return result
 
     @property
@@ -152,6 +160,8 @@ class SimpleQuery:
         result = SimpleQuery()
         result.columns = list(self.columns)
         result.where = list(self.where)
+        result.order_by = list(self.order_by)
+        result.limit = self.limit
         result._from = self._from
         return result
 
@@ -164,3 +174,11 @@ class SimpleQuery:
     """Boolean expressions that will be combined with AND to form the WHERE
     clause (`list` [ `sqlalchemy.sql.ColumnElement` ]).
     """
+
+    order_by: List[sqlalchemy.sql.ColumnElement]
+    """Columns to appear in ORDER BY clause (`list`
+    [`sqlalchemy.sql.ColumnElement` ])
+    """
+
+    limit: Optional[Tuple[int, Optional[int]]]
+    """Limit on the number of returned rows and optional offset (`tuple`)"""

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -50,7 +50,7 @@ from ..summaries import GovernorDimensionRestriction
 # We're not trying to add typing to the lex/yacc parser code, so MyPy
 # doesn't know about some of these imports.
 from .expressions import Node, NormalForm, NormalFormExpression, ParserYacc  # type: ignore
-from .expressions.categorize import categorizeOrderByName
+from .expressions.categorize import categorizeElementOrderByName, categorizeOrderByName
 
 
 @immutable
@@ -292,6 +292,39 @@ class OrderByClause:
     elements: NamedValueSet[DimensionElement]
     """Dimension elements whose non-key columns were referenced by order_by
     (`NamedValueSet` [ `DimensionElement` ]).
+    """
+
+
+@immutable
+class ElementOrderByClause:
+    """Class for information about columns in ORDER BY clause for one element.
+
+    Parameters
+    ----------
+    order_by : `Iterable` [ `str` ]
+        Sequence of names to use for ordering with optional "-" prefix.
+    element : `DimensionElement`
+        Dimensions used by a query.
+    """
+
+    def __init__(self, order_by: Iterable[str], element: DimensionElement):
+
+        self.order_by_columns = []
+        for name in order_by:
+            if not name or name == "-":
+                raise ValueError("Empty dimension name in ORDER BY")
+            ascending = True
+            if name[0] == "-":
+                ascending = False
+                name = name[1:]
+            column = categorizeElementOrderByName(element, name)
+            self.order_by_columns.append(
+                OrderByClauseColumn(element=element, column=column, ordering=ascending)
+            )
+
+    order_by_columns: Iterable[OrderByClauseColumn]
+    """Columns that appear in the ORDER BY
+    (`Iterable` [ `OrderByClauseColumn` ]).
     """
 
 


### PR DESCRIPTION
`DataCoordinateQueryResults` is now using window function `row_number()` ordering rank for DataIds query, this simplifies handling of the ordering columns and generation of the materialized query. `queryDimensionRecords()` is doing ordering in-memory by using an ordering function that compares attributes of `DimensionRecord` instances.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
