### PR TITLE
DM-33303: Allow DatasetType to differ to registry on get/put

### DIFF
--- a/doc/changes/DM-33303.misc.rst
+++ b/doc/changes/DM-33303.misc.rst
@@ -1,0 +1,1 @@
+If a `DatasetType` has been constructed that differs from the registry definition, but in a way that is compatible through `StorageClass` conversion, then using that in a `Butler.get()` call will return a python type that matches the user-specified `StorageClass` instead of the internal python type.

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -3,6 +3,8 @@ storageClasses:
     pytype: int
   StructuredDataDict:
     pytype: dict
+    converters:
+      lsst.pipe.base.TaskMetadata: lsst.pipe.base.TaskMetadata.to_dict
   StructuredDataList:
     pytype: list
   TablePersistable:

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -443,12 +443,26 @@ class StorageClass:
             # Identical storage classes are compatible.
             return True
 
-        if issubclass(other.pytype, self.pytype):
+        # It may be that the storage class being compared is not
+        # available because the python type can't be imported. In that
+        # case conversion must be impossible.
+        try:
+            other_pytype = other.pytype
+        except Exception:
+            return False
+
+        # Or even this storage class itself can not have the type imported.
+        try:
+            self_pytype = self.pytype
+        except Exception:
+            return False
+
+        if issubclass(other_pytype, self_pytype):
             # Storage classes have different names but the same python type.
             return True
 
         for candidate_type in self.converters_by_type:
-            if issubclass(other.pytype, candidate_type):
+            if issubclass(other_pytype, candidate_type):
                 return True
         return False
 

--- a/python/lsst/daf/butler/formatters/file.py
+++ b/python/lsst/daf/butler/formatters/file.py
@@ -112,9 +112,10 @@ class FileFormatter(Formatter):
                 # for this pytype.
                 if not readStorageClass.can_convert(fileDescriptor.storageClass):
                     raise ValueError(
-                        f"Storage class inconsistency ({readStorageClass.name,} vs"
+                        f"Storage class inconsistency ({readStorageClass.name} vs"
                         f" {fileDescriptor.storageClass.name}) but no"
-                        " component requested or converter registered"
+                        " component requested or converter registered for"
+                        f" python type {type(data)}"
                     )
             else:
                 # Concrete composite written as a single file (we hope)

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -9,6 +9,8 @@ storageClasses:
       - slice
   StructuredDataDictJson:
     pytype: dict
+    converters:
+      lsst.daf.butler.tests.MetricsExample: lsst.daf.butler.tests.MetricsExample.exportAsDict
   StructuredDataListJson:
     pytype: list
   StructuredDataDictPickle:


### PR DESCRIPTION
If the DatasetTypes are compatible with each other.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
