### PR TITLE
DM-31253: Allow leading underscores in dataset type names

### DIFF
--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -147,7 +147,7 @@ class DatasetType:
 
     _serializedType = SerializedDatasetType
 
-    VALID_NAME_REGEX = re.compile("^[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*$")
+    VALID_NAME_REGEX = re.compile("^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
 
     @staticmethod
     def nameWithComponent(datasetTypeName: str, componentName: str) -> str:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -77,8 +77,8 @@ class DatasetTypeTestCase(unittest.TestCase):
         in certain positions.
         """
         dimensions = self.universe.extract(("instrument", "visit"))
-        goodNames = ("a", "A", "z1", "Z1", "a_1B", "A_1b")
-        badNames = ("1", "_", "a%b", "B+Z", "T[0]")
+        goodNames = ("a", "A", "z1", "Z1", "a_1B", "A_1b", "_a")
+        badNames = ("1", "a%b", "B+Z", "T[0]")
 
         # Construct storage class with all the good names included as
         # components so that we can test internal consistency


### PR DESCRIPTION
Simple update for regular expression to allow leading underscore in dataset type name.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
