### PR TITLE
DM-33417: manual back port of DM-33360 — Improve performance of https as_local() method

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -19,7 +19,8 @@ jobs:
           python-version: 3.8
 
       - name: Install
-        run: pip install mypy pydantic
+        # pin mypy to fix a compatibility issue between mypy 0.92 and pedantic
+        run: pip install "mypy==0.910" pydantic
 
       - name: Install third party stubs
         run: pip install types-requests types-PyYAML types-click types-pkg_resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ httpx
 backoff >= 1.10
 boto3 >= 1.13
 botocore >= 1.15
-moto >= 1.3
+moto >= 1.3,<3
 pandas >= 1.0
 numpy >= 1.17
 matplotlib >= 3.0.3


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins: done on macOS, ongoing on centOS
- [ ] added a release note for user-visible changes to `doc/changes` (n/a)
