### PR TITLE
DM-33414: Allow id to be used in file template

### DIFF
--- a/doc/changes/DM-33414.feature.rst
+++ b/doc/changes/DM-33414.feature.rst
@@ -1,0 +1,1 @@
+The dataset ID can now be used in a file template for datastore (using ``{id}``).

--- a/tests/config/basic/templates.yaml
+++ b/tests/config/basic/templates.yaml
@@ -7,6 +7,7 @@ test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d
 metric2: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
 metric3: "{run:/}/{datasetType}/{instrument}"
 metric4: "{run:/}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+Integer: "{id}"
 physical_filter+: "{run:/}/{instrument}_{physical_filter}"
 instrument<DummyCamComp>:
   metric33: "{run:/}/{instrument}/{datasetType}.{component:?}/{datasetType}_v{visit:08d}_f{physical_filter}_{component:?}"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -98,6 +98,23 @@ class TestFileTemplates(unittest.TestCase):
             self.makeDatasetRef("calexp", run="run/2", conform=False),
         )
 
+        # Check that the id is sufficient without any other information.
+        self.assertTemplate("{id}", "1", self.makeDatasetRef("calexp", run="run2", conform=False))
+
+        self.assertTemplate("{run}/{id}", "run2/1", self.makeDatasetRef("calexp", run="run2", conform=False))
+
+        self.assertTemplate(
+            "fixed/{id}",
+            "fixed/1",
+            self.makeDatasetRef("calexp", run="run2", conform=False),
+        )
+
+        self.assertTemplate(
+            "fixed/{id}_{physical_filter}",
+            "fixed/1_Most_Amazing_U_Filter_Ever",
+            self.makeDatasetRef("calexp", run="run2", conform=False),
+        )
+
         # Retain any "/" in run
         tmplstr = "{run:/}/{datasetType}/{visit:05d}/{physical_filter}-trail-{run}"
         self.assertTemplate(
@@ -122,6 +139,9 @@ class TestFileTemplates(unittest.TestCase):
 
         with self.assertRaises(FileTemplateValidationError):
             FileTemplate("{run}_{datasetType}")
+
+        with self.assertRaises(FileTemplateValidationError):
+            FileTemplate("{id}/fixed")
 
     def testRunOrCollectionNeeded(self):
         tmplstr = "{datasetType}/{visit:05d}/{physical_filter}"
@@ -343,6 +363,12 @@ class TestFileTemplates(unittest.TestCase):
         entities["hsc+instrument+physical_filter"] = self.makeDatasetRef(
             "filter_inst",
             storageClassName="StorageClassX",
+            dataId={"physical_filter": "i", "instrument": "HSC"},
+        )
+
+        entities["metric6"] = self.makeDatasetRef(
+            "filter_inst",
+            storageClassName="Integer",
             dataId={"physical_filter": "i", "instrument": "HSC"},
         )
 


### PR DESCRIPTION
@gpdf / @TallJimbo this does the job -- I also restrict the id to having to be in the filename itself if it is specified anywhere.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
