### PR TITLE
DM-33638: Check datastore cache for existence before checking remote datastore

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/posixDatastore.yaml
+++ b/python/lsst/daf/butler/configs/datastores/posixDatastore.yaml
@@ -1,1 +1,0 @@
-fileDatastore.yaml

--- a/python/lsst/daf/butler/configs/datastores/s3Datastore.yaml
+++ b/python/lsst/daf/butler/configs/datastores/s3Datastore.yaml
@@ -1,1 +1,0 @@
-fileDatastore.yaml

--- a/python/lsst/daf/butler/configs/datastores/webdavDatastore.yaml
+++ b/python/lsst/daf/butler/configs/datastores/webdavDatastore.yaml
@@ -1,1 +1,0 @@
-fileDatastore.yaml

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -457,7 +457,7 @@ class DatasetType:
         """
         if component in self.storageClass.allComponents():
             return self.nameWithComponent(self.name, component)
-        raise KeyError("Requested component ({}) not understood by this DatasetType".format(component))
+        raise KeyError(f"Requested component ({component}) not understood by this DatasetType ({self})")
 
     def makeCompositeDatasetType(self) -> DatasetType:
         """Return a composite dataset type from the component.

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -714,7 +714,7 @@ class DatastoreCacheManager(AbstractDatastoreCacheManager):
         """
         if self._cache_directory is None:
             return False
-        if self.cache_size == 0:
+        if self.file_count == 0:
             return False
 
         if extension is None:

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -714,6 +714,8 @@ class DatastoreCacheManager(AbstractDatastoreCacheManager):
         """
         if self._cache_directory is None:
             return False
+        if self.cache_size == 0:
+            return False
 
         if extension is None:
             # Look solely for matching dataset ref ID and not specific

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1405,7 +1405,7 @@ class FileDatastore(GenericBaseDatastore):
 
             # Check the local cache directly for a dataset corresponding
             # to the remote URI.
-            if self.cacheManager.cache_size > 0:
+            if self.cacheManager.file_count > 0:
                 ref = id_to_ref[ref_id]
                 for uri, storedFileInfo in zip(uris, infos):
                     check_ref = ref

--- a/tests/test_cliCmdPruneCollection.py
+++ b/tests/test_cliCmdPruneCollection.py
@@ -120,54 +120,60 @@ class PruneCollectionExecutionTest(unittest.TestCase, ButlerTestHelper):
         confirm_initial_tables()
 
         # Try pruning RUN without purge or unstore, should fail.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest/run"],
-            input="yes",
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest/run"],
+                input="yes",
+            )
         self.assertEqual(result.exit_code, 1, clickResultMsg(result))
 
         # Try pruning RUN without unstore, should fail.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest/run", "--purge"],
-            input="yes",
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest/run", "--purge"],
+                input="yes",
+            )
         self.assertEqual(result.exit_code, 1, clickResultMsg(result))
 
         # Try pruning RUN without purge, should fail.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest/run", "--unstore"],
-            input="yes",
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest/run", "--unstore"],
+                input="yes",
+            )
         self.assertEqual(result.exit_code, 1, clickResultMsg(result))
 
         # Try pruning RUN with purge and unstore but say "no" for confirmation,
         # should succeed but not change datasets.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest/run", "--purge", "--unstore"],
-            input="no",
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest/run", "--purge", "--unstore"],
+                input="no",
+            )
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
         confirm_initial_tables()
 
         # Try pruning RUN with purge and unstore, should succeed.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest/run", "--purge", "--unstore"],
-            input="no",
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest/run", "--purge", "--unstore"],
+                input="no",
+            )
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
         # Try pruning RUN with purge and unstore, and use --no-confirm instead
         # of confirm dialog, should succeed.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest/run", "--purge", "--unstore", "--no-confirm"],
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest/run", "--purge", "--unstore", "--no-confirm"],
+            )
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
         result = self.runner.invoke(
@@ -185,11 +191,12 @@ class PruneCollectionExecutionTest(unittest.TestCase, ButlerTestHelper):
         self.assertAstropyTablesEqual(readTable(result.output), expected)
 
         # Try pruning TAGGED, should succeed.
-        result = self.runner.invoke(
-            butlerCli,
-            ["prune-collection", self.root, "ingest", "--unstore"],
-            input="yes",
-        )
+        with self.assertWarns(FutureWarning):  # Capture the deprecation warning
+            result = self.runner.invoke(
+                butlerCli,
+                ["prune-collection", self.root, "ingest", "--unstore"],
+                input="yes",
+            )
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
         result = self.runner.invoke(butlerCli, ["query-collections", self.root])

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -476,6 +476,9 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertEqual(datasetTypeComponentB.parentStorageClass, storageClass)
         self.assertIsNone(datasetTypeComposite.parentStorageClass)
 
+        with self.assertRaises(KeyError):
+            datasetTypeComposite.makeComponentDatasetType("compF")
+
 
 class DatasetRefTestCase(unittest.TestCase):
     """Test for DatasetRef."""


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
