### PR TITLE
DM-33799: Remove unneeded try/except block

### DIFF
--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -261,12 +261,8 @@ class SqliteDatabase(Database):
 
         sqlalchemy.event.listen(engine, "connect", _onSqlite3Connect)
         sqlalchemy.event.listen(engine, "begin", _onSqlite3Begin)
-        try:
-            return engine
-        except sqlalchemy.exc.OperationalError as err:
-            raise RuntimeError(
-                f"Error creating connection with uri='{uri}', filename='{filename}', target={target}."
-            ) from err
+
+        return engine
 
     @classmethod
     def fromEngine(


### PR DESCRIPTION
That was a leftover from previous migration, the statement in try block
cannot ever raise an exception.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
