### PR TITLE
DM-33870: Support repo aliases in Butler constructor

### DIFF
--- a/doc/changes/DM-33870.feature.rst
+++ b/doc/changes/DM-33870.feature.rst
@@ -1,0 +1,1 @@
+If repository aliases have been defined for the site they can now be used in place of the Butler repository URI in both the `~lsst.daf.butler.Butler` constructor and command-line tools.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -259,6 +259,17 @@ class Butler(LimitedButler):
             self._config: ButlerConfig = butler._config
             self._allow_put_of_predefined_dataset = butler._allow_put_of_predefined_dataset
         else:
+            # Can only look for strings in the known repos list.
+            if isinstance(config, str) and config in self.get_known_repos():
+                config = str(self.get_repo_uri(config))
+            try:
+                self._config = ButlerConfig(config, searchPaths=searchPaths)
+            except FileNotFoundError as e:
+                if known := self.get_known_repos():
+                    aliases = f"(known aliases: {', '.join(known)})"
+                else:
+                    aliases = "(no known aliases)"
+                raise FileNotFoundError(f"{e} {aliases}") from e
             self._config = ButlerConfig(config, searchPaths=searchPaths)
             try:
                 if "root" in self._config:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -551,6 +551,10 @@ class ButlerTests(ButlerPutGetTests):
                     uri = Butler.get_repo_uri("label")
                     butler = Butler(uri, writeable=False)
                     self.assertIsInstance(butler, Butler)
+                    butler = Butler("label", writeable=False)
+                    self.assertIsInstance(butler, Butler)
+                    with self.assertRaisesRegex(FileNotFoundError, "aliases:.*bad_label"):
+                        Butler("not_there", writeable=False)
                     with self.assertRaises(KeyError) as cm:
                         Butler.get_repo_uri("missing")
                     self.assertIn("not known to", str(cm.exception))
@@ -562,6 +566,9 @@ class ButlerTests(ButlerPutGetTests):
             # No environment variable set.
             Butler.get_repo_uri("label")
         self.assertIn("No repository index defined", str(cm.exception))
+        with self.assertRaisesRegex(FileNotFoundError, "no known aliases"):
+            # No aliases registered.
+            Butler("not_there")
         self.assertEqual(Butler.get_known_repos(), set())
 
     def testBasicPutGet(self):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
