### PR TITLE
DM-33890: Fix certifyCalibrations crash due to exception type change

### DIFF
--- a/python/lsst/daf/butler/script/certifyCalibrations.py
+++ b/python/lsst/daf/butler/script/certifyCalibrations.py
@@ -62,11 +62,8 @@ def certifyCalibrations(
         end=astropy.time.Time(end_date, scale="tai") if end_date is not None else None,
     )
     if not search_all_inputs:
-        try:
+        if registry.getCollectionType(input_collection) is CollectionType.CHAINED:
             input_collection = next(iter(registry.getCollectionChain(input_collection)))
-        except TypeError:
-            # Not a CHAINED collection; do nothing.
-            pass
 
     refs = set(registry.queryDatasets(dataset_type_name, collections=[input_collection]))
     if not refs:


### PR DESCRIPTION
Replaced exception catching with a collection type cheeck.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
