### PR TITLE
DM-33809: Change how --log-level works

### DIFF
--- a/doc/changes/DM-33809.feature.rst
+++ b/doc/changes/DM-33809.feature.rst
@@ -1,4 +1,4 @@
 The command-line tooling has changed how it sets the default logger when using ``--log-level``.
-Now only the default logger (``lsst`` or the value stored in the ``$DAF_BUTLER_ROOT_LOGGER``) will be affected by using ``--log-level`` without a specific logger name.
+Now only the default logger(s) (``lsst`` and the colon-separated values stored in the ``$DAF_BUTLER_ROOT_LOGGER``) will be affected by using ``--log-level`` without a specific logger name.
 By default only this default logger will be set to ``INFO`` log level and all other loggers will remain as ``WARNING``.
-Use ``--log-level __root__=INFO`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).
+Use ``--log-level __root__=level`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).

--- a/doc/changes/DM-33809.feature.rst
+++ b/doc/changes/DM-33809.feature.rst
@@ -1,4 +1,4 @@
 The command-line tooling has changed how it sets the default logger when using ``--log-level``.
 Now only the default logger(s) (``lsst`` and the colon-separated values stored in the ``$DAF_BUTLER_ROOT_LOGGER``) will be affected by using ``--log-level`` without a specific logger name.
 By default only this default logger will be set to ``INFO`` log level and all other loggers will remain as ``WARNING``.
-Use ``--log-level __root__=level`` or ``--log-level '=level'`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).
+Use ``--log-level '.=level'`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).

--- a/doc/changes/DM-33809.feature.rst
+++ b/doc/changes/DM-33809.feature.rst
@@ -1,4 +1,4 @@
 The command-line tooling has changed how it sets the default logger when using ``--log-level``.
 Now only the default logger(s) (``lsst`` and the colon-separated values stored in the ``$DAF_BUTLER_ROOT_LOGGER``) will be affected by using ``--log-level`` without a specific logger name.
 By default only this default logger will be set to ``INFO`` log level and all other loggers will remain as ``WARNING``.
-Use ``--log-level __root__=level`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).
+Use ``--log-level __root__=level`` or ``--log-level '=level'`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).

--- a/doc/changes/DM-33809.feature.rst
+++ b/doc/changes/DM-33809.feature.rst
@@ -1,0 +1,4 @@
+The command-line tooling has changed how it sets the default logger when using ``--log-level``.
+Now only the default logger (``lsst`` or the value stored in the ``$DAF_BUTLER_ROOT_LOGGER``) will be affected by using ``--log-level`` without a specific logger name.
+By default only this default logger will be set to ``INFO`` log level and all other loggers will remain as ``WARNING``.
+Use ``--log-level __root__=INFO`` to change the root logger (this will not change the default logger level and so an additional call to ``--log-level DEBUG`` may be needed to turn on debugging for all loggers).

--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -70,6 +70,7 @@ Butler Command-Line Reference
    :maxdepth: 1
 
    scripts/options-file.rst
+   scripts/logging.rst
    scripts/butler
 
 .. _lsst.daf.butler-dev:

--- a/doc/lsst.daf.butler/scripts/logging.rst
+++ b/doc/lsst.daf.butler/scripts/logging.rst
@@ -1,0 +1,35 @@
+.. _cli_logging_options:
+
+Controlling Log Output from Command-Line Tooling
+================================================
+
+Every command-line program has a standard set of options that control how logs are reported.
+These can be listed using ``butler --help`` and are available to all command-line programs that :ref:`use the Butler command-line infrastructure <daf_butler_cli-other_commands>`.
+The logging options must be given before any subcommand is specified.
+
+By default the ``lsst`` log hierarchy is set to ``INFO`` logging level and the python root logger is left at its default level of ``WARNING``.
+Additional root loggers can be treated as the default loggers by setting the ``$DAF_BUTLER_ROOT_LOGGER`` environment variable to a colon-separated list of logger names.
+
+The logging level can be changed by using the ``--log-level`` command line option.
+To change all the default loggers to ``DEBUG`` use ``--log-level DEBUG``.
+The help text will list all the supported level names.
+To change the logging level of the root python logger use either ``--log-level "=LEVEL"`` or ``--log-level __root__=LEVEL`` (where ``LEVEL`` is the required level from the supported list).
+Since the default logger is always set to ``INFO``, in order to set all loggers to, say, ``DEBUG`` then both the default and root logger must be set explicitly: ``--log-level "=DEBUG" --log-level DEBUG``.
+
+This syntax demonstrates how to specify finer control of specific loggers.
+For example to turn on debug logging solely in Butler datastores use ``--log-level lsst.daf.butler.datastores=DEBUG``.
+The ``-log-level`` option can be given multiple times.
+
+As an example of how the log options can be combined:
+
+.. code-block:: bash
+
+    butler --log-level lsst.daf.butler=DEBUG --long-log --log-label MY_ID --log-file log.json
+
+These options will:
+
+* set the ``lsst`` logger to ``INFO`` and the butler logger to ``DEBUG``;
+* generate formatted log messages that will use the long format that includes time stamps with every log message containing the special text ``MY_ID``;
+* Will create a log file containing a JSON representation of the log messages.
+
+The JSON output always includes every piece of information from the log record; the ``--long-log`` option has no effect on the content of the JSON file.

--- a/doc/lsst.daf.butler/scripts/logging.rst
+++ b/doc/lsst.daf.butler/scripts/logging.rst
@@ -13,7 +13,7 @@ Additional loggers (and their descendants) can be treated the same as the defaul
 The logging level can be changed by using the ``--log-level`` command line option.
 To change all the default loggers to ``DEBUG`` use ``--log-level DEBUG``.
 The help text will list all the supported level names.
-To change the logging level of the root python logger use either ``--log-level "=LEVEL"`` or ``--log-level __root__=LEVEL`` (where ``LEVEL`` is the required level from the supported list).
+To change the logging level of the root python logger use either ``--log-level .=LEVEL`` (where ``LEVEL`` is the required level from the supported list).
 Since the default logger is always set to ``INFO``, in order to set all loggers to, say, ``DEBUG`` then both the default and root logger must be set explicitly: ``--log-level "=DEBUG" --log-level DEBUG``.
 
 This syntax demonstrates how to specify finer control of specific loggers.

--- a/doc/lsst.daf.butler/scripts/logging.rst
+++ b/doc/lsst.daf.butler/scripts/logging.rst
@@ -8,7 +8,7 @@ These can be listed using ``butler --help`` and are available to all command-lin
 The logging options must be given before any subcommand is specified.
 
 By default the ``lsst`` log hierarchy is set to ``INFO`` logging level and the python root logger is left at its default level of ``WARNING``.
-Additional root loggers can be treated as the default loggers by setting the ``$DAF_BUTLER_ROOT_LOGGER`` environment variable to a colon-separated list of logger names.
+Additional loggers (and their descendants) can be treated the same as the default ``lsst`` logger by setting the ``$DAF_BUTLER_DEFAULT_LOGGER`` environment variable to a colon-separated list of logger names.
 
 The logging level can be changed by using the ``--log-level`` command line option.
 To change all the default loggers to ``DEBUG`` use ``--log-level DEBUG``.
@@ -30,6 +30,6 @@ These options will:
 
 * set the ``lsst`` logger to ``INFO`` and the butler logger to ``DEBUG``;
 * generate formatted log messages that will use the long format that includes time stamps with every log message containing the special text ``MY_ID``;
-* Will create a log file containing a JSON representation of the log messages.
+* create a log file containing a JSON representation of the log messages.
 
 The JSON output always includes every piece of information from the log record; the ``--long-log`` option has no effect on the content of the JSON file.

--- a/doc/lsst.daf.butler/scripts/logging.rst
+++ b/doc/lsst.daf.butler/scripts/logging.rst
@@ -28,7 +28,7 @@ As an example of how the log options can be combined:
 
 These options will:
 
-* set the ``lsst`` logger to ``INFO`` and the butler logger to ``DEBUG``;
+* set the ``lsst`` logger to ``INFO`` and the butler logger to ``DEBUG``, leaving all non-lsst loggers at ``WARNING``;
 * generate formatted log messages that will use the long format that includes time stamps with every log message containing the special text ``MY_ID``;
 * create a log file containing a JSON representation of the log messages.
 

--- a/doc/lsst.daf.butler/writing-subcommands.rst
+++ b/doc/lsst.daf.butler/writing-subcommands.rst
@@ -413,6 +413,8 @@ The settings for ``obs_base`` are like this:
 
     envPrepend(DAF_BUTLER_PLUGINS, $OBS_BASE_DIR/python/lsst/obs/base/cli/resources.yaml)
 
+.. _daf_butler_cli-other_commands:
+
 Writing Other Commands
 ======================
 

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -29,7 +29,7 @@ try:
 except ModuleNotFoundError:
     lsstLog = None
 
-from lsst.utils.logging import VERBOSE
+from lsst.utils.logging import TRACE, VERBOSE
 
 from ..core.logging import ButlerMDC, JsonLogFormatter
 
@@ -322,6 +322,8 @@ class CliLog:
         """
         if level == "VERBOSE":
             return VERBOSE
+        elif level == "TRACE":
+            return TRACE
         return getattr(logging, level, None)
 
     @staticmethod
@@ -345,13 +347,16 @@ class CliLog:
 
         Notes
         -----
-        ``VERBOSE`` logging is not supported by the LSST logger and so will
-        always be converted to ``INFO``.
+        ``VERBOSE`` and ``TRACE`` logging are not supported by the LSST logger.
+        ``VERBOSE`` will be converted to ``INFO`` and ``TRACE`` will be
+        converted to ``DEBUG``.
         """
         if lsstLog is None:
             return None
         if level == "VERBOSE":
             level = "INFO"
+        elif level == "TRACE":
+            level = "DEBUG"
         pylog_level = CliLog._getPyLogLevel(level)
         return lsstLog.LevelTranslator.logging2lsstLog(pylog_level)
 

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -150,13 +150,13 @@ class CliLog:
             defaultHandler.setFormatter(formatter)
 
             logging.basicConfig(
-                level=logging.INFO,
+                level=logging.WARNING,
                 force=True,
                 handlers=[defaultHandler],
             )
 
         else:
-            logging.basicConfig(level=logging.INFO, format=cls.pylog_normalFmt, style="{")
+            logging.basicConfig(level=logging.WARNING, format=cls.pylog_normalFmt, style="{")
 
         # Initialize root logger level.
         cls._setLogLevel(None, "INFO")

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -286,14 +286,16 @@ class CliLog:
         Parameters
         ----------
         component : `str` or None
-            The name of the log component or None for the root logger.
+            The name of the log component or None for the default logger.
+            The root logger can be specified either by an empty string or
+            with the special name ``__root__``.
         level : `str`
             A valid python logging level.
         """
         components: Set[Optional[str]]
-        if not component:
+        if component is None:
             components = cls.root_loggers()
-        elif component == "__root__":
+        elif not component or component == "__root__":
             components = {None}
         else:
             components = {component}

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -265,7 +265,7 @@ class CliLog:
 
         Notes
         -----
-        The special name ``__root__`` can be used to set the Python root
+        The special name ``.`` can be used to set the Python root
         logger.
         """
         if isinstance(logLevels, dict):
@@ -288,14 +288,14 @@ class CliLog:
         component : `str` or None
             The name of the log component or None for the default logger.
             The root logger can be specified either by an empty string or
-            with the special name ``__root__``.
+            with the special name ``.``.
         level : `str`
             A valid python logging level.
         """
         components: Set[Optional[str]]
         if component is None:
             components = cls.root_loggers()
-        elif not component or component == "__root__":
+        elif not component or component == ".":
             components = {None}
         else:
             components = {component}

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -25,6 +25,7 @@ from functools import partial
 import click
 from lsst.daf.butler.registry import CollectionType
 
+from ..cliLog import CliLog
 from ..utils import MWOptionDecorator, MWPath, split_commas, split_kv, unwrap, yaml_presets
 
 
@@ -127,8 +128,12 @@ log_level_option = MWOptionDecorator(
         normalize=True,
         unseparated_okay=True,
         add_to_default=True,
+        default_key=None,  # No separator
     ),
-    help=f"The logging level. Supported levels are [{'|'.join(logLevelChoices)}]",
+    help=f"The logging level. Without an explicit logger name, will only affect the default root loggers "
+    f"({', '.join(CliLog.root_loggers())}). "
+    f"To modify the root logger set '__root__=LEVEL' or '=LEVEL'. "
+    f"Supported levels are [{'|'.join(logLevelChoices)}]",
     is_eager=True,
     metavar="LEVEL|COMPONENT=LEVEL",
     multiple=True,

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -119,7 +119,7 @@ dataset_type_option = MWOptionDecorator(
 datasets_option = MWOptionDecorator("--datasets")
 
 
-logLevelChoices = ["CRITICAL", "ERROR", "WARNING", "INFO", "VERBOSE", "DEBUG"]
+logLevelChoices = ["CRITICAL", "ERROR", "WARNING", "INFO", "VERBOSE", "DEBUG", "TRACE"]
 log_level_option = MWOptionDecorator(
     "--log-level",
     callback=partial(

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -131,8 +131,7 @@ log_level_option = MWOptionDecorator(
         default_key=None,  # No separator
     ),
     help=f"The logging level. Without an explicit logger name, will only affect the default root loggers "
-    f"({', '.join(CliLog.root_loggers())}). "
-    f"To modify the root logger set '__root__=LEVEL' or '=LEVEL'. "
+    f"({', '.join(CliLog.root_loggers())}). To modify the root logger use '.=LEVEL'. "
     f"Supported levels are [{'|'.join(logLevelChoices)}]",
     is_eager=True,
     metavar="LEVEL|COMPONENT=LEVEL",

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -50,11 +50,6 @@ log = logging.getLogger(__name__)
 typeStrAcceptsMultiple = "TEXT ..."
 typeStrAcceptsSingle = "TEXT"
 
-# For parameters that support key-value inputs, this defines the separator
-# for those inputs.
-split_kv_separator = "="
-
-
 # The standard help string for the --where option when it takes a WHERE clause.
 where_help = (
     "A string expression similar to a SQL WHERE clause. May involve any column of a "

--- a/python/lsst/daf/butler/script/configDump.py
+++ b/python/lsst/daf/butler/script/configDump.py
@@ -50,5 +50,8 @@ def configDump(repo, subset, searchpath, outfile):
         try:
             config = config[subset]
         except KeyError:
-            raise KeyError(f"{subset} not found in config at {repo}")
-    config.dump(outfile)
+            raise KeyError(f"{subset} not found in config at {repo} (has {config.names()})")
+    if hasattr(config, "dump"):
+        config.dump(outfile)
+    else:
+        print(f"{subset}: {config}", file=outfile)

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -25,6 +25,7 @@ it can't be tested there because daf_butler does not directly depend on
 lsst.log, and only uses it if it has been setup by another package."""
 
 import logging
+import os
 import re
 import subprocess
 import tempfile
@@ -32,40 +33,62 @@ import unittest
 from collections import namedtuple
 from functools import partial
 from io import StringIO
+from logging import DEBUG, INFO, WARNING
 
 import click
 from lsst.daf.butler.cli.butler import cli as butlerCli
 from lsst.daf.butler.cli.cliLog import CliLog
 from lsst.daf.butler.cli.utils import LogCliRunner, clickResultMsg, command_test_env
 from lsst.daf.butler.core.logging import ButlerLogRecords
+from lsst.utils.logging import TRACE
 
 try:
     import lsst.log as lsstLog
+
+    lsstLog_INFO = lsstLog.INFO
+    lsstLog_DEBUG = lsstLog.DEBUG
+    lsstLog_WARN = lsstLog.WARN
 except ModuleNotFoundError:
     lsstLog = None
+    lsstLog_INFO = 0
+    lsstLog_DEBUG = 0
+    lsstLog_WARN = 0
 
 
 @click.command()
 @click.option("--expected-pyroot-level", type=int)
+@click.option("--expected-pylsst-level", type=int)
 @click.option("--expected-pybutler-level", type=int)
 @click.option("--expected-lsstroot-level", type=int)
 @click.option("--expected-lsstbutler-level", type=int)
+@click.option("--expected-lsstx-level", type=int)
 def command_log_settings_test(
-    expected_pyroot_level, expected_pybutler_level, expected_lsstroot_level, expected_lsstbutler_level
+    expected_pyroot_level,
+    expected_pylsst_level,
+    expected_pybutler_level,
+    expected_lsstroot_level,
+    expected_lsstbutler_level,
+    expected_lsstx_level,
 ):
 
     LogLevel = namedtuple("LogLevel", ("expected", "actual", "name"))
 
     logLevels = [
-        LogLevel(expected_pyroot_level, logging.getLogger("lsst").level, "pyRoot"),
-        LogLevel(expected_pybutler_level, logging.getLogger("lsst.daf.butler").level, "pyButler"),
+        LogLevel(expected_pyroot_level, logging.getLogger().level, "pyRoot"),
+        LogLevel(expected_pylsst_level, logging.getLogger("lsst").getEffectiveLevel(), "pyLsst"),
+        LogLevel(
+            expected_pybutler_level, logging.getLogger("lsst.daf.butler").getEffectiveLevel(), "pyButler"
+        ),
+        LogLevel(expected_lsstx_level, logging.getLogger("lsstx").getEffectiveLevel(), "pyLsstx"),
     ]
     if lsstLog is not None:
         logLevels.extend(
             [
-                LogLevel(expected_lsstroot_level, lsstLog.getLogger("lsst").getLevel(), "lsstRoot"),
+                LogLevel(expected_lsstroot_level, lsstLog.getLogger("lsst").getEffectiveLevel(), "lsstRoot"),
                 LogLevel(
-                    expected_lsstbutler_level, lsstLog.getLogger("lsst.daf.butler").getLevel(), "lsstButler"
+                    expected_lsstbutler_level,
+                    lsstLog.getLogger("lsst.daf.butler").getEffectiveLevel(),
+                    "lsstButler",
                 ),
             ]
         )
@@ -138,27 +161,79 @@ class CliLogTestBase:
         of the command execution and resets the logging system to its previous
         state or expected state when command execution finishes."""
 
-        self.runTest(
-            partial(
-                self.runner.invoke,
-                butlerCli,
-                [
-                    "--log-level",
-                    "WARNING",
-                    "--log-level",
-                    "lsst.daf.butler=DEBUG",
-                    "command-log-settings-test",
-                    "--expected-pyroot-level",
-                    logging.WARNING,
-                    "--expected-pybutler-level",
-                    logging.DEBUG,
-                    "--expected-lsstroot-level",
-                    lsstLog.WARN if lsstLog else 0,
-                    "--expected-lsstbutler-level",
-                    lsstLog.DEBUG if lsstLog else 0,
-                ],
-            )
+        # Run with two different log level settings.
+        log_levels = (
+            # --log-level / --log-level / expected pyroot, pylsst, pybutler,
+            # lsstroot, lsstbutler, lsstx
+            (
+                "WARNING",
+                "lsst.daf.butler=DEBUG",
+                WARNING,
+                WARNING,
+                DEBUG,
+                lsstLog_WARN,
+                lsstLog_DEBUG,
+                WARNING,
+            ),
+            ("DEBUG", "lsst.daf.butler=TRACE", WARNING, DEBUG, TRACE, lsstLog_DEBUG, lsstLog_DEBUG, WARNING),
+            (".=DEBUG", "lsst.daf.butler=WARNING", DEBUG, INFO, WARNING, lsstLog_INFO, lsstLog_WARN, DEBUG),
+            (".=DEBUG", "DEBUG", DEBUG, DEBUG, DEBUG, lsstLog_DEBUG, lsstLog_DEBUG, DEBUG),
+            (".=DEBUG", "conda=DEBUG", DEBUG, INFO, INFO, lsstLog_INFO, lsstLog_INFO, DEBUG),
         )
+
+        self._test_levels(log_levels)
+
+        # Check that the environment variable can set additional roots.
+        log_levels = (
+            # --log-level / --log-level / expected pyroot, pylsst, pybutler,
+            # lsstroot, lsstbutler, lsstx
+            (
+                "WARNING",
+                "lsst.daf.butler=DEBUG",
+                WARNING,
+                WARNING,
+                DEBUG,
+                lsstLog_WARN,
+                lsstLog_DEBUG,
+                WARNING,
+            ),
+            ("DEBUG", "lsst.daf.butler=TRACE", WARNING, DEBUG, TRACE, lsstLog_DEBUG, lsstLog_DEBUG, DEBUG),
+            (".=DEBUG", "lsst.daf.butler=WARNING", DEBUG, INFO, WARNING, lsstLog_INFO, lsstLog_WARN, INFO),
+            (".=DEBUG", "DEBUG", DEBUG, DEBUG, DEBUG, lsstLog_DEBUG, lsstLog_DEBUG, DEBUG),
+            (".=DEBUG", "conda=DEBUG", DEBUG, INFO, INFO, lsstLog_INFO, lsstLog_INFO, INFO),
+        )
+
+        with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_ROOT_LOGGER": "lsstx"}):
+            self._test_levels(log_levels)
+
+    def _test_levels(self, log_levels):
+        for level1, level2, x_pyroot, x_pylsst, x_pybutler, x_lsstroot, x_lsstbutler, x_lsstx in log_levels:
+            with self.subTest("Test different log levels", level1=level1, level2=level2):
+                self.runTest(
+                    partial(
+                        self.runner.invoke,
+                        butlerCli,
+                        [
+                            "--log-level",
+                            level1,
+                            "--log-level",
+                            level2,
+                            "command-log-settings-test",
+                            "--expected-pyroot-level",
+                            x_pyroot,
+                            "--expected-pylsst-level",
+                            x_pylsst,
+                            "--expected-pybutler-level",
+                            x_pybutler,
+                            "--expected-lsstroot-level",
+                            x_lsstroot,
+                            "--expected-lsstbutler-level",
+                            x_lsstbutler,
+                            "--expected-lsstx-level",
+                            x_lsstx,
+                        ],
+                    )
+                )
 
     def test_helpLogReset(self):
         """Verify that when a command does not execute, like when the help menu

--- a/tests/test_cliCmdConfigDump.py
+++ b/tests/test_cliCmdConfigDump.py
@@ -102,6 +102,11 @@ class ConfigDumpUseTest(unittest.TestCase):
             self.assertIn("root", cfg)
             self.assertIn("templates", cfg)
 
+            # Test that a subset that returns a scalar quantity does work.
+            result = self.runner.invoke(butler.cli, ["config-dump", "here", "--subset", ".datastore.root"])
+            self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+            self.assertEqual(result.stdout.strip(), ".datastore.root: <butlerRoot>")
+
     def test_invalidSubset(self):
         """Test selecting a subset key that does not exist in the config."""
         with self.runner.isolated_filesystem():


### PR DESCRIPTION
Now by default only applies to the lsst root logger.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
