### PR TITLE
DM-34007: Fix printing of raw bytes in butler query-dimension-records.

### DIFF
--- a/doc/changes/DM-34007.bugfix.md
+++ b/doc/changes/DM-34007.bugfix.md
@@ -1,0 +1,1 @@
+Fix garbled printing of raw-byte hashes in query-dimension-records.

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -58,7 +58,7 @@ def queryDimensionRecords(repo, element, datasets, collections, where, no_check,
         if isinstance(v, Timespan):
             v = (v.begin, v.end)
         elif isinstance(v, bytes):
-            v = v.hex()
+            v = "0x" + v.hex()
         return v
 
     return Table([[conform(getattr(record, key, None)) for record in records] for key in keys], names=keys)

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -57,6 +57,8 @@ def queryDimensionRecords(repo, element, datasets, collections, where, no_check,
     def conform(v):
         if isinstance(v, Timespan):
             v = (v.begin, v.end)
+        elif isinstance(v, bytes):
+            v = v.hex()
         return v
 
     return Table([[conform(getattr(record, key, None)) for record in records] for key in keys], names=keys)

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -254,6 +254,21 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
         expected = AstropyTable(rows, names=self.expectedColumnNames)
         self.assertAstropyTablesEqual(readTable(result.output), expected)
 
+    def testSkymap(self):
+        butler = Butler(self.root, run="foo")
+        # try replacing the testRepo's butler with the one with the "foo" run.
+        self.testRepo.butler = butler
+
+        skymapRecord = {"name": "example_skymap", "hash": (50).to_bytes(8, byteorder="little")}
+        self.testRepo.butler.registry.insertDimensionData("skymap", skymapRecord)
+
+        result = self.runner.invoke(butlerCli, ["query-dimension-records", self.root, "skymap"])
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+        rows = array((("example_skymap", "3200000000000000", "None", "None", "None")))
+        expected = AstropyTable(rows, names=["name", "hash", "tract_max", "patch_nx_max", "patch_ny_max"])
+        self.assertAstropyTablesEqual(readTable(result.output), expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -265,7 +265,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
         result = self.runner.invoke(butlerCli, ["query-dimension-records", self.root, "skymap"])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
-        rows = array((("example_skymap", "3200000000000000", "None", "None", "None")))
+        rows = array((("example_skymap", "0x3200000000000000", "None", "None", "None")))
         expected = AstropyTable(rows, names=["name", "hash", "tract_max", "patch_nx_max", "patch_ny_max"])
         self.assertAstropyTablesEqual(readTable(result.output), expected)
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
