### PR TITLE
DM-34120: Restore exception types raised by Butler

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -91,10 +91,7 @@ from .registry import (
     CollectionType,
     ConflictingDefinitionError,
     DataIdError,
-    DataIdValueError,
     DatasetIdGenEnum,
-    DimensionNameError,
-    InconsistentDataIdError,
     Registry,
     RegistryConfig,
     RegistryDefaults,
@@ -843,7 +840,7 @@ class Butler(LimitedButler):
             never_found = set(not_dimensions) - matched_dims
 
             if never_found:
-                raise DimensionNameError(f"Unrecognized keyword args given: {never_found}")
+                raise ValueError(f"Unrecognized keyword args given: {never_found}")
 
             # There is a chance we have allocated a single dataId item
             # to multiple dimensions. Need to decide which should be retained.
@@ -906,7 +903,7 @@ class Butler(LimitedButler):
                     try:
                         recs = list(self.registry.queryDimensionRecords(dimensionName, dataId=newDataId))
                     except DataIdError:
-                        raise DataIdValueError(
+                        raise ValueError(
                             f"Could not find dimension '{dimensionName}'"
                             f" with dataId {newDataId} as part of comparing with"
                             f" record values {byRecord[dimensionName]}"
@@ -917,7 +914,7 @@ class Butler(LimitedButler):
                             if (recval := getattr(recs[0], k)) != v:
                                 errmsg.append(f"{k}({recval} != {v})")
                         if errmsg:
-                            raise InconsistentDataIdError(
+                            raise ValueError(
                                 f"Dimension {dimensionName} in dataId has explicit value"
                                 " inconsistent with records: " + ", ".join(errmsg)
                             )
@@ -943,12 +940,12 @@ class Butler(LimitedButler):
                         log.debug("Received %d records from constraints of %s", len(records), str(values))
                         for r in records:
                             log.debug("- %s", str(r))
-                        raise InconsistentDataIdError(
+                        raise ValueError(
                             f"DataId specification for dimension {dimensionName} is not"
                             f" uniquely constrained to a single dataset by {values}."
                             f" Got {len(records)} results."
                         )
-                    raise InconsistentDataIdError(
+                    raise ValueError(
                         f"DataId specification for dimension {dimensionName} matched no"
                         f" records when constrained by {values}"
                     )

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -36,7 +36,7 @@ except ImportError:
 
 import astropy.time
 from lsst.daf.butler import Butler, ButlerConfig, CollectionType, DatasetRef, DatasetType, Registry, Timespan
-from lsst.daf.butler.registry import ConflictingDefinitionError, DataIdError, RegistryConfig, RegistryDefaults
+from lsst.daf.butler.registry import ConflictingDefinitionError, RegistryConfig, RegistryDefaults
 from lsst.daf.butler.tests import DatastoreMock
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
 
@@ -397,7 +397,7 @@ class SimpleButlerTestCase(unittest.TestCase):
             ({"x": "y"}, {"instrument": "Cam1", "detector": 2, "physical_filter": "Cam1-G"}),
         )
         for dataId, kwds in variants:
-            with self.assertRaises(DataIdError):
+            with self.assertRaises(ValueError):
                 butler.get("flat", dataId=dataId, collections=coll, **kwds)
 
     def testGetCalibration(self):
@@ -515,7 +515,7 @@ class SimpleButlerTestCase(unittest.TestCase):
         self.assertEqual(bias3b_id, bias3b.id)
 
         # Extra but inconsistent record values are a problem.
-        with self.assertRaises(DataIdError):
+        with self.assertRaises(ValueError):
             bias3b_id, _ = butler.get(
                 "bias",
                 exposure=3,
@@ -527,7 +527,7 @@ class SimpleButlerTestCase(unittest.TestCase):
             )
 
         # Ensure that spurious kwargs cause an exception.
-        with self.assertRaises(DataIdError):
+        with self.assertRaises(ValueError):
             butler.get(
                 "bias",
                 {"exposure.obs_id": "four", "immediate": True, "detector.full_name": "Ba"},
@@ -535,7 +535,7 @@ class SimpleButlerTestCase(unittest.TestCase):
                 instrument="Cam1",
             )
 
-        with self.assertRaises(DataIdError):
+        with self.assertRaises(ValueError):
             butler.get(
                 "bias",
                 day_obs=20211114,


### PR DESCRIPTION
Undo some changes made on DM-33600 ticket, butler will raise ValueError
instead of DataIdError, just as it did before DM-33600.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
