### PR TITLE
DM-34105: Move Packages formatter from obs_base

### DIFF
--- a/doc/changes/DM-34105.feature.rst
+++ b/doc/changes/DM-34105.feature.rst
@@ -1,0 +1,1 @@
+Added a formatter for `lsst.utils.packages.Packages` Python types in `lsst.daf.butler.formatters.packages.PackagesFormatter`.

--- a/python/lsst/daf/butler/cli/cmd/__init__.py
+++ b/python/lsst/daf/butler/cli/cmd/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of obs_base.
+# This file is part of daf_butler.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/lsst/daf/butler/cli/opt/__init__.py
+++ b/python/lsst/daf/butler/cli/opt/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of obs_base.
+# This file is part of daf_butler.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -47,7 +47,7 @@ ExposureI: lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter
 SkyMap: lsst.daf.butler.formatters.pickle.PickleFormatter
 Background: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 FocalPlaneBackground: lsst.daf.butler.formatters.pickle.PickleFormatter
-Config: lsst.obs.base.formatters.pexConfig.PexConfigFormatter
+Config: lsst.pipe.base.formatters.pexConfig.PexConfigFormatter
 Packages:
   formatter: lsst.daf.butler.formatters.packages.PackagesFormatter
   parameters:

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -49,7 +49,7 @@ Background: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 FocalPlaneBackground: lsst.daf.butler.formatters.pickle.PickleFormatter
 Config: lsst.obs.base.formatters.pexConfig.PexConfigFormatter
 Packages:
-  formatter: lsst.obs.base.formatters.packages.PackagesFormatter
+  formatter: lsst.daf.butler.formatters.packages.PackagesFormatter
   parameters:
     format: yaml
 PropertyList:

--- a/python/lsst/daf/butler/formatters/packages.py
+++ b/python/lsst/daf/butler/formatters/packages.py
@@ -1,0 +1,141 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ("PackagesFormatter",)
+
+import os.path
+from typing import Any, Optional, Type
+
+from lsst.daf.butler.formatters.file import FileFormatter
+from lsst.utils.packages import Packages
+
+
+class PackagesFormatter(FileFormatter):
+    """Interface for reading and writing `~lsst.utils.packages.Packages`.
+
+    This formatter supports write parameters:
+
+    * ``format``: The file format to use to write the package data. Allowed
+      options are ``yaml``, ``json``, and ``pickle``.
+    """
+
+    supportedWriteParameters = frozenset({"format"})
+    supportedExtensions = frozenset({".yaml", ".pickle", ".pkl", ".json"})
+
+    # MyPy does't like the fact that the base declares this an instance
+    # attribute while this derived class uses a property.
+    @property
+    def extension(self) -> str:  # type: ignore
+        # Default to YAML but allow configuration via write parameter
+        format = self.writeParameters.get("format", "yaml")
+        ext = "." + format
+        if ext not in self.supportedExtensions:
+            raise RuntimeError(f"Requested file format '{format}' is not supported for Packages")
+        return ext
+
+    def _readFile(self, path: str, pytype: Optional[Type] = None) -> Any:
+        """Read a file from the path.
+
+        Parameters
+        ----------
+        path : `str`
+            Path to use to open the file.
+        pytype : `type`
+            Class to use to read the serialized file.
+
+        Returns
+        -------
+        data : `object`
+            Instance of class ``pytype`` read from serialized file. None
+            if the file could not be opened.
+        """
+        if not os.path.exists(path):
+            return None
+
+        assert pytype is not None
+        assert issubclass(pytype, Packages)
+        return pytype.read(path)
+
+    def _fromBytes(self, serializedDataset: Any, pytype: Optional[Type] = None) -> Any:
+        """Read the bytes object as a python object.
+
+        Parameters
+        ----------
+        serializedDataset : `bytes`
+            Bytes object to unserialize.
+        pytype : `type`
+            The Python type to be instantiated. Required.
+
+        Returns
+        -------
+        inMemoryDataset : `object`
+            The requested data as an object, or None if the string could
+            not be read.
+        """
+        # The format can not come from the formatter configuration
+        # because the current configuration has no connection to how
+        # the data were stored.
+        if serializedDataset.startswith(b"!<lsst."):
+            format = "yaml"
+        elif serializedDataset.startswith(b'{"'):
+            format = "json"
+        else:
+            format = "pickle"
+
+        assert pytype is not None
+        assert issubclass(pytype, Packages)
+        return pytype.fromBytes(serializedDataset, format)
+
+    def _writeFile(self, inMemoryDataset: Any) -> None:
+        """Write the in memory dataset to file on disk.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to serialize.
+
+        Raises
+        ------
+        Exception
+            The file could not be written.
+        """
+        inMemoryDataset.write(self.fileDescriptor.location.path)
+
+    def _toBytes(self, inMemoryDataset: Any) -> bytes:
+        """Write the in memory dataset to a bytestring.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to serialize
+
+        Returns
+        -------
+        serializedDataset : `bytes`
+            YAML string encoded to bytes.
+
+        Raises
+        ------
+        Exception
+            The object could not be serialized.
+        """
+        format = self.extension.lstrip(".")
+        return inMemoryDataset.toBytes(format)

--- a/python/lsst/daf/butler/script/__init__.py
+++ b/python/lsst/daf/butler/script/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of obs_base.
+# This file is part of daf_butler.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,14 +51,14 @@ console_scripts =
 [flake8]
 max-line-length = 110
 max-doc-length = 79
-ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503, E203
+ignore = W503, E203, N802, N803, N806, N812, N815, N816
 exclude = __init__.py
     lex.py
     yacc.py
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W503 E203
+flake8-ignore = W503 E203 N802 N803 N806 N812 N815 N816 W503 E203
 # The matplotlib test may not release font files.
 # Some unit tests open registry database in setUpClass.
 open_files_ignore = "*.ttf" "gen3.sqlite3"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,0 +1,62 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for PackagesFormatter.
+"""
+
+import os
+import unittest
+
+from lsst.daf.butler import Butler, DatasetType
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+from lsst.utils.packages import Packages
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class PackagesFormatterTestCase(unittest.TestCase):
+    """Tests for PackagesFormatter, using local file datastore."""
+
+    def setUp(self):
+        """Create a new butler root for each test."""
+        self.root = makeTestTempDir(TESTDIR)
+        Butler.makeRepo(self.root)
+        self.butler = Butler(self.root, run="test_run")
+        # No dimensions in dataset type so we don't have to worry about
+        # inserting dimension data or defining data IDs.
+        self.datasetType = DatasetType(
+            "data", dimensions=(), storageClass="Packages", universe=self.butler.registry.dimensions
+        )
+        self.butler.registry.registerDatasetType(self.datasetType)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def testPackages(self):
+        packages = Packages.fromSystem()
+        self.butler.put(packages, self.datasetType, dataId={})
+
+        stored = self.butler.get(self.datasetType, dataId={})
+        self.assertEqual(stored, packages)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Pex Config formatter has been relocated to pipe_base (requires lsst/pipe_base#239)

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
