### PR TITLE
DM-33490: Implement export_records/import_records methods

### DIFF
--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -209,7 +209,7 @@ class Quantum:
         initInputs: Optional[Union[Mapping[DatasetType, DatasetRef], Iterable[DatasetRef]]] = None,
         inputs: Optional[Mapping[DatasetType, List[DatasetRef]]] = None,
         outputs: Optional[Mapping[DatasetType, List[DatasetRef]]] = None,
-        datastore_records: Optional[DatastoreRecordData] = None,
+        datastore_records: Optional[Mapping[str, DatastoreRecordData]] = None,
     ):
         if taskClass is not None:
             taskName = f"{taskClass.__module__}.{taskClass.__name__}"
@@ -228,7 +228,7 @@ class Quantum:
         self._inputs = NamedKeyDict[DatasetType, List[DatasetRef]](inputs).freeze()
         self._outputs = NamedKeyDict[DatasetType, List[DatasetRef]](outputs).freeze()
         if datastore_records is None:
-            datastore_records = DatastoreRecordData()
+            datastore_records = {}
         self._datastore_records = datastore_records
 
     def to_simple(self, accumulator: Optional[DimensionRecordsAccumulator] = None) -> SerializedQuantum:
@@ -505,7 +505,7 @@ class Quantum:
         return self._outputs
 
     @property
-    def datastore_records(self) -> DatastoreRecordData:
+    def datastore_records(self) -> Mapping[str, DatastoreRecordData]:
         """Tabular data stored with this quantum (`dict`).
 
         This attribute may be modified in place, but not assigned to.
@@ -547,7 +547,7 @@ class Quantum:
         initInputs: Optional[Union[Mapping[DatasetType, DatasetRef], Iterable[DatasetRef]]],
         inputs: Optional[Mapping[DatasetType, List[DatasetRef]]],
         outputs: Optional[Mapping[DatasetType, List[DatasetRef]]],
-        datastore_records: Optional[DatastoreRecordData] = None,
+        datastore_records: Optional[Mapping[str, DatastoreRecordData]] = None,
     ) -> Quantum:
         return Quantum(
             taskName=taskName,

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 from urllib.parse import urlencode
 
-from lsst.daf.butler import DatasetId, DatasetRef, StorageClass, StoredDatastoreItemInfo
+from lsst.daf.butler import DatasetId, DatasetRef, DatastoreRecordData, StorageClass, StoredDatastoreItemInfo
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
 from lsst.resources import ResourcePath
 
@@ -50,7 +50,7 @@ class StoredMemoryItemInfo(StoredDatastoreItemInfo):
     DatasetRef.
     """
 
-    __slots__ = {"timestamp", "storageClass", "parentID"}
+    __slots__ = {"timestamp", "storageClass", "parentID", "dataset_id"}
 
     timestamp: float
     """Unix timestamp indicating the time the dataset was stored."""
@@ -63,6 +63,9 @@ class StoredMemoryItemInfo(StoredDatastoreItemInfo):
     composite. Not used if the dataset being stored is not a
     virtual component of a composite
     """
+
+    dataset_id: DatasetId
+    """DatasetId associated with this record."""
 
 
 class InMemoryDatastore(GenericBaseDatastore):
@@ -385,7 +388,9 @@ class InMemoryDatastore(GenericBaseDatastore):
         # Store time we received this content, to allow us to optionally
         # expire it. Instead of storing a filename here, we include the
         # ID of this datasetRef so we can find it from components.
-        itemInfo = StoredMemoryItemInfo(time.time(), ref.datasetType.storageClass, parentID=ref.id)
+        itemInfo = StoredMemoryItemInfo(
+            time.time(), ref.datasetType.storageClass, parentID=ref.id, dataset_id=ref.getCheckedId()
+        )
 
         # We have to register this content with registry.
         # Currently this assumes we have a file so we need to use stub entries
@@ -642,3 +647,13 @@ class InMemoryDatastore(GenericBaseDatastore):
     ) -> bool:
         # Docstring inherited.
         return False
+
+    def import_records(self, data: Mapping[str, DatastoreRecordData]) -> None:
+        # Docstring inherited from the base class.
+        return
+
+    def export_records(self, refs: Iterable[DatasetIdRef]) -> Mapping[str, DatastoreRecordData]:
+        # Docstring inherited from the base class.
+
+        # In-memory Datastore records cannot be exported or imported
+        return {}

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -28,7 +28,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Type, cast
 
 import sqlalchemy
-from lsst.daf.butler import DatasetRef, NamedValueSet, StoredDatastoreItemInfo, ddl
+from lsst.daf.butler import NamedValueSet, StoredDatastoreItemInfo, ddl
 from lsst.daf.butler.registry.bridge.ephemeral import EphemeralDatastoreRegistryBridge
 from lsst.daf.butler.registry.interfaces import (
     DatasetIdRef,
@@ -352,7 +352,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
             return self._ephemeral.setdefault(name, EphemeralDatastoreRegistryBridge(name))
         return MonolithicDatastoreRegistryBridge(name, db=self._db, tables=self._tables)
 
-    def findDatastores(self, ref: DatasetRef) -> Iterable[str]:
+    def findDatastores(self, ref: DatasetIdRef) -> Iterable[str]:
         # Docstring inherited from DatastoreRegistryBridge
         sql = (
             sqlalchemy.sql.select(self._tables.dataset_location.columns.datastore_name)

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -362,12 +362,12 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def findDatastores(self, ref: DatasetRef) -> Iterable[str]:
+    def findDatastores(self, ref: DatasetIdRef) -> Iterable[str]:
         """Retrieve datastore locations for a given dataset.
 
         Parameters
         ----------
-        ref : `DatasetRef`
+        ref : `DatasetIdRef`
             A reference to the dataset for which to retrieve storage
             information.
 


### PR DESCRIPTION
These methods are not useful for the in-memory datastore and their
implementation does nothing. FileDatastore has a working implementation
of both methods. ChainedDatastore methods will work if it is backed by
FileDatastores.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
