### PR TITLE
DM-34203: Ensure that lsstLog loggers are defaulted to WARNING

### DIFF
--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -182,7 +182,12 @@ class CliLog:
         else:
             logging.basicConfig(level=logging.WARNING, format=cls.pylog_normalFmt, style="{")
 
-        # Initialize root logger level.
+        # Initialize the root logger. Calling this ensures that both
+        # python loggers and lsst loggers are consistent in their default
+        # logging level.
+        cls._setLogLevel(".", "WARNING")
+
+        # Initialize default root logger level.
         cls._setLogLevel(None, "INFO")
 
         # also capture warnings and send them to logging


### PR DESCRIPTION
Without this python root logger was WARNING but lsst.log root logger was DEBUG.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
