### PR TITLE
DM-34172: Allow Butler to be created using directory ResourcePath

### DIFF
--- a/doc/changes/DM-34172.bugfix.rst
+++ b/doc/changes/DM-34172.bugfix.rst
@@ -1,0 +1,1 @@
+The automatic addition of ``butler.yaml`` to the Butler configuration URI now also happens when a ``ResourcePath`` instance is given.

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -79,7 +79,9 @@ class ButlerConfig(Config):
             self.configDir = copy.copy(other.configDir)
             return
 
-        if isinstance(other, (str, os.PathLike)):
+        # Include ResourcePath here in case it refers to a directory.
+        # Creating a ResourcePath from a ResourcePath is a no-op.
+        if isinstance(other, (str, os.PathLike, ResourcePath)):
             # This will only allow supported schemes
             uri = ResourcePath(other)
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -520,6 +520,10 @@ class ButlerTests(ButlerPutGetTests):
             butler = Butler(config_dir, run=self.default_run)
             self.assertIsInstance(butler, Butler)
 
+            # Even with a ResourcePath.
+            butler = Butler(ResourcePath(config_dir, forceDirectory=True), run=self.default_run)
+            self.assertIsInstance(butler, Butler)
+
         collections = set(butler.registry.queryCollections())
         self.assertEqual(collections, {self.default_run})
 


### PR DESCRIPTION
Previously the "append butler.yaml" logic only worked for strings.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
