### PR TITLE
DM-34328: fix collection sorting in query results and scripts

### DIFF
--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -883,17 +883,13 @@ class SqlRegistry(Registry):
         except TypeError as exc:
             raise CollectionExpressionError(f"Invalid collection expression '{expression}'") from exc
         collectionTypes = ensure_iterable(collectionTypes)
-        recordNames = [
-            record.name
-            for record in query.iter(
-                self._managers.collections,
-                collectionTypes=frozenset(collectionTypes),
-                flattenChains=flattenChains,
-                includeChains=includeChains,
-            )
-        ]
-        for name in sorted(recordNames):
-            yield name
+        for record in query.iter(
+            self._managers.collections,
+            collectionTypes=frozenset(collectionTypes),
+            flattenChains=flattenChains,
+            includeChains=includeChains,
+        ):
+            yield record.name
 
     def _makeQueryBuilder(
         self, summary: queries.QuerySummary, doomed_by: Iterable[str] = ()

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1234,8 +1234,6 @@ class Registry(ABC):
     ) -> Iterator[str]:
         """Iterate over the collections whose names match an expression.
 
-        Collection names are sorted alphabetically.
-
         Parameters
         ----------
         expression : `Any`, optional
@@ -1268,6 +1266,15 @@ class Registry(ABC):
         ------
         CollectionExpressionError
             Raised when ``expression`` is invalid.
+
+        Notes
+        -----
+        The order in which collections are returned is unspecified, except that
+        the children of a `~CollectionType.CHAINED` collection are guaranteed
+        to be in the order in which they are searched.  When multiple parent
+        `~CollectionType.CHAINED` collections match the same criteria, the
+        order in which the two lists appear is unspecified, and the lists of
+        children may be incomplete if a child has multiple parents.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/script/pruneCollection.py
+++ b/python/lsst/daf/butler/script/pruneCollection.py
@@ -116,6 +116,8 @@ def pruneCollection(
         for name in collectionNames:
             addCollection(name)
 
+        collections = {k: collections[k] for k in sorted(collections.keys())}
+
         queryDatasets = QueryDatasets(
             repo=repo,
             glob=None,
@@ -127,7 +129,7 @@ def pruneCollection(
         for datasetRef in queryDatasets.getDatasets():
             collectionInfo = collections[datasetRef.run]
             if collectionInfo.count is None:
-                raise RuntimeError(f"Unexpected datasaset in collection of type {collectionInfo.type}")
+                raise RuntimeError(f"Unexpected dataset in collection of type {collectionInfo.type}")
             collectionInfo.count += 1
 
         result.removeTable = Table(

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -63,7 +63,7 @@ def _getTable(
         dtype=(str, str, str),
     )
     butler = Butler(repo)
-    names = list(
+    names = sorted(
         butler.registry.queryCollections(collectionTypes=frozenset(collection_type), expression=glob or ...)
     )
     if inverse:
@@ -146,13 +146,13 @@ def _getTree(
         else:
             if collectionType == CollectionType.CHAINED:
                 childNames = butler.registry.getCollectionChain(name)
-                for name in sorted(childNames):
+                for name in childNames:
                     addCollection(name, level + 1)
 
     collections = butler.registry.queryCollections(
         collectionTypes=frozenset(collection_type), expression=glob or ...
     )
-    for collection in collections:
+    for collection in sorted(collections):
         addCollection(collection)
     return table
 

--- a/python/lsst/daf/butler/script/removeCollections.py
+++ b/python/lsst/daf/butler/script/removeCollections.py
@@ -77,7 +77,7 @@ def _getCollectionInfo(
     """
     butler = Butler(repo)
     try:
-        names = list(
+        names = sorted(
             butler.registry.queryCollections(
                 collectionTypes=frozenset(
                     (

--- a/python/lsst/daf/butler/tests/utils.py
+++ b/python/lsst/daf/butler/tests/utils.py
@@ -103,7 +103,7 @@ def safeTestTempDir(default_base: str) -> str:
 class ButlerTestHelper:
     """Mixin with helpers for unit tests."""
 
-    def assertAstropyTablesEqual(self, tables, expectedTables, filterColumns=False):
+    def assertAstropyTablesEqual(self, tables, expectedTables, filterColumns=False, unorderedRows=False):
         """Verify that a list of astropy tables matches a list of expected
         astropy tables.
 
@@ -118,6 +118,9 @@ class ButlerTestHelper:
         filterColumns : `bool`
             If `True` then only compare columns that exist in
             ``expectedTables``.
+        unorderedRows : `bool`, optional
+            If `True` (`False` is default), don't require tables to have their
+            rows in the same order.
         """
         # If a single table is passed in for tables or expectedTables, put it
         # in a list.
@@ -134,6 +137,11 @@ class ButlerTestHelper:
             if filterColumns:
                 table = table.copy()
                 table.keep_columns(expected.colnames)
+            if unorderedRows:
+                table = table.copy()
+                table.sort(table.colnames)
+                expected = expected.copy()
+                expected.sort(expected.colnames)
             # Assert that they match:
             self.assertTrue(report_diff_values(table, expected, fileobj=diff), msg="\n" + diff.getvalue())
 

--- a/tests/test_cliCmdPruneCollection.py
+++ b/tests/test_cliCmdPruneCollection.py
@@ -117,7 +117,7 @@ class PruneCollectionExecutionTest(unittest.TestCase, ButlerTestHelper):
             result = self.runner.invoke(butlerCli, ["query-collections", self.root])
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
             expected = Table(array((("ingest", "TAGGED"), ("ingest/run", "RUN"))), names=("Name", "Type"))
-            self.assertAstropyTablesEqual(readTable(result.output), expected)
+            self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
 
         confirm_initial_tables()
 
@@ -190,7 +190,7 @@ class PruneCollectionExecutionTest(unittest.TestCase, ButlerTestHelper):
         result = self.runner.invoke(butlerCli, ["query-collections", self.root])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
         expected = Table(array((("ingest", "TAGGED"), ("ingest/run", "RUN"))), names=("Name", "Type"))
-        self.assertAstropyTablesEqual(readTable(result.output), expected)
+        self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
 
         # Try pruning TAGGED, should succeed.
         with self.assertWarns(FutureWarning):  # Capture the deprecation warning

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -162,11 +162,11 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
                     (
                         ("calibration1", "CALIBRATION"),
                         ("chain1", "CHAINED"),
+                        ("  tag1", "TAGGED"),
+                        ("  run1", "RUN"),
                         ("  chain2", "CHAINED"),
                         ("    calibration1", "CALIBRATION"),
                         ("    run1", "RUN"),
-                        ("  run1", "RUN"),
-                        ("  tag1", "TAGGED"),
                         ("chain2", "CHAINED"),
                         ("  calibration1", "CALIBRATION"),
                         ("  run1", "RUN"),
@@ -271,7 +271,7 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
                 ),
                 names=("Name", "Type"),
             )
-            self.assertAstropyTablesEqual(readTable(result.output), expected)
+            self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
 
             # Add a couple more run collections for chain testing
             registry1.registerRun("run2")

--- a/tests/test_cliCmdRemoveCollections.py
+++ b/tests/test_cliCmdRemoveCollections.py
@@ -109,7 +109,7 @@ class RemoveCollectionTest(unittest.TestCase, ButlerTestHelper):
         result = self.runner.invoke(butlerCli, ["query-collections", self.root, "--chains", "TABLE"])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
         expected = Table(array(before_rows), names=_query_collection_column_names(before_rows))
-        self.assertAstropyTablesEqual(readTable(result.output), expected)
+        self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
 
         removal = removeCollections(
             repo=self.root,
@@ -123,7 +123,7 @@ class RemoveCollectionTest(unittest.TestCase, ButlerTestHelper):
         result = self.runner.invoke(butlerCli, ["query-collections", self.root])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
         expected = Table(array(after_rows), names=_query_collection_column_names(after_rows))
-        self.assertAstropyTablesEqual(readTable(result.output), expected)
+        self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
 
     def testRemoveScript(self):
         """Test removing collections.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
