### PR TITLE
DM-34375: Fix for a NULL component bug

### DIFF
--- a/doc/changes/DM-34375.bugfix.md
+++ b/doc/changes/DM-34375.bugfix.md
@@ -1,0 +1,1 @@
+Fixes the bug introduced in DM-33489 (appeared in w_2022_15) which causes not-NULL constraint violation for datastore component column.

--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -182,12 +182,17 @@ class StoredFileInfo(StoredDatastoreItemInfo):
 
     def to_record(self) -> Dict[str, Any]:
         """Convert the supplied ref to a database record."""
+        component = self.component
+        if component is None:
+            # Use empty string since we want this to be part of the
+            # primary key.
+            component = NULLSTR
         return dict(
             dataset_id=self.dataset_id,
             formatter=self.formatter,
             path=self.path,
             storage_class=self.storageClass.name,
-            component=self.component,
+            component=component,
             checksum=self.checksum,
             file_size=self.file_size,
         )


### PR DESCRIPTION
The bug was introduced in a previous merge (#672 )

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
