### PR TITLE
DM-33493: Add serialization support for datastore records

### DIFF
--- a/python/lsst/daf/butler/core/__init__.py
+++ b/python/lsst/daf/butler/core/__init__.py
@@ -13,6 +13,7 @@ from .constraints import *
 from .datasets import *
 from .datastore import *
 from .datastoreCacheManager import *
+from .datastoreRecordData import *
 from .dimensions import *
 from .exceptions import *
 from .fileDataset import *

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -23,7 +23,7 @@
 
 from __future__ import annotations
 
-__all__ = ("DatastoreConfig", "Datastore", "DatastoreValidationError", "DatastoreRecordData")
+__all__ = ("DatastoreConfig", "Datastore", "DatastoreValidationError")
 
 import contextlib
 import dataclasses
@@ -61,8 +61,8 @@ if TYPE_CHECKING:
     from ..registry.interfaces import DatasetIdRef, DatastoreRegistryBridgeManager
     from .configSupport import LookupKey
     from .datasets import DatasetRef, DatasetType
+    from .datastoreRecordData import DatastoreRecordData
     from .storageClass import StorageClass
-    from .storedFileInfo import StoredDatastoreItemInfo
 
 
 class DatastoreConfig(ConfigSubset):
@@ -77,23 +77,6 @@ class DatastoreValidationError(ValidationError):
     """There is a problem with the Datastore configuration."""
 
     pass
-
-
-@dataclasses.dataclass
-class DatastoreRecordData:
-    """A struct that represents a tabular data export from a single
-    datastore.
-    """
-
-    refs: List[DatasetIdRef] = dataclasses.field(default_factory=list)
-    """List of DatasetRefs known to this datastore.
-    """
-
-    records: Dict[str, List[StoredDatastoreItemInfo]] = dataclasses.field(
-        default_factory=lambda: defaultdict(list)
-    )
-    """Opaque table data, grouped by opaque table name.
-    """
 
 
 @dataclasses.dataclass(frozen=True)
@@ -135,7 +118,7 @@ class DatastoreTransaction:
 
     Event: ClassVar[Type] = Event
 
-    parent: Optional["DatastoreTransaction"]
+    parent: Optional[DatastoreTransaction]
     """The parent transaction. (`DatastoreTransaction`, optional)"""
 
     def __init__(self, parent: Optional[DatastoreTransaction] = None):

--- a/python/lsst/daf/butler/core/datastoreRecordData.py
+++ b/python/lsst/daf/butler/core/datastoreRecordData.py
@@ -1,0 +1,174 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for generic data stores."""
+
+from __future__ import annotations
+
+__all__ = ("DatastoreRecordData", "SerializedDatastoreRecordData")
+
+import dataclasses
+import uuid
+from collections import defaultdict
+from typing import TYPE_CHECKING, AbstractSet, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from .datasets import DatasetId
+from .dimensions import DimensionUniverse
+from .storedFileInfo import SerializedStoredDatastoreItemInfo, StoredDatastoreItemInfo
+
+if TYPE_CHECKING:
+
+    from ..registry import Registry
+    from ..registry.interfaces import DatasetIdRef
+
+
+class SerializedDatastoreRecordData(BaseModel):
+    """Representation of a `DatastoreRecordData` suitable for serialization."""
+
+    ref_ids: List[uuid.UUID]
+    records: Dict[str, List[SerializedStoredDatastoreItemInfo]]
+
+    @classmethod
+    def direct(
+        cls,
+        *,
+        ref_ids: List[uuid.UUID],
+        records: Dict[str, List[Dict]],
+    ) -> SerializedDatastoreRecordData:
+        """Construct a `SerializedDatastoreRecordData` directly without
+        validators.
+
+        This differs from the pydantic "construct" method in that the
+        arguments are explicitly what the model requires, and it will recurse
+        through members, constructing them from their corresponding `direct`
+        methods.
+
+        This method should only be called when the inputs are trusted.
+        """
+        data = SerializedDatastoreRecordData.__new__(cls)
+        setter = object.__setattr__
+        setter(data, "ref_ids", ref_ids)
+        setter(
+            data,
+            "records",
+            {k: [SerializedStoredDatastoreItemInfo.direct(**item) for item in v] for k, v in records.items()},
+        )
+        return data
+
+
+@dataclasses.dataclass
+class DatastoreRecordData:
+    """A struct that represents a tabular data export from a single
+    datastore.
+    """
+
+    refs: List["DatasetIdRef"] = dataclasses.field(default_factory=list)
+    """List of DatasetRefs known to this datastore.
+    """
+
+    records: Dict[str, List[StoredDatastoreItemInfo]] = dataclasses.field(
+        default_factory=lambda: defaultdict(list)
+    )
+    """Opaque table data, grouped by opaque table name.
+    """
+
+    def subset(self, dataset_ids: AbstractSet[DatasetId]) -> Optional[DatastoreRecordData]:
+        """Extract a subset of the records that match given dataset IDs.
+
+        Parameters
+        ----------
+        dataset_ids : `set` [ `DatasetId` ]
+            Dataset IDs to match.
+
+        Returns
+        -------
+        record_data : `DatastoreRecordData` or `None`
+            `None` is returned if there are no matching refs.
+        """
+        matching_refs = [ref for ref in self.refs if ref.id in dataset_ids]
+        records: Dict[str, List[StoredDatastoreItemInfo]] = {}
+        for table_name, record_data in self.records.items():
+            matching_records = [record for record in record_data if record.dataset_id in dataset_ids]
+            if matching_records:
+                records[table_name] = matching_records
+        if matching_refs or matching_records:
+            return DatastoreRecordData(refs=matching_refs, records=records)
+        else:
+            return None
+
+    def to_simple(self, minimal: bool = False) -> SerializedDatastoreRecordData:
+        """Make representation of the object for serialization.
+
+        Implements `~lsst.daf.butler.core.json.SupportsSimple` protocol.
+
+        Parameters
+        ----------
+        minimal : `bool`, optional
+            If True produce minimal representation, not used by this method.
+
+        Returns
+        -------
+        simple : `dict`
+            Representation of this instance as a simple dictionary.
+        """
+        ref_ids = [ref.id for ref in self.refs]
+        record_data = {
+            table_name: [record.to_simple() for record in records]
+            for table_name, records in self.records.items()
+        }
+        return SerializedDatastoreRecordData(ref_ids=ref_ids, records=record_data)
+
+    @classmethod
+    def from_simple(
+        cls,
+        simple: SerializedDatastoreRecordData,
+        universe: Optional[DimensionUniverse] = None,
+        registry: Optional[Registry] = None,
+    ) -> DatastoreRecordData:
+        """Make an instance of this class from serialized data.
+
+        Implements `~lsst.daf.butler.core.json.SupportsSimple` protocol.
+
+        Parameters
+        ----------
+        data : `dict`
+            Serialized representation returned from `to_simple` method.
+        universe : `DimensionUniverse`, optional
+            Dimension universe, not used by this method.
+        registry : `Registry`, optional
+            Registry instance, not used by this method.
+
+        Returns
+        -------
+        item_info : `StoredDatastoreItemInfo`
+            De-serialized instance of `StoredDatastoreItemInfo`.
+        """
+        # this causes dependency cycle if imported at top level
+        from ..registry.interfaces import FakeDatasetRef
+
+        refs: List[DatasetIdRef] = [FakeDatasetRef(id) for id in simple.ref_ids]
+        record_data = {
+            table_name: [StoredDatastoreItemInfo.from_simple(record) for record in records]
+            for table_name, records in simple.records.items()
+        }
+        return cls(refs=refs, records=record_data)

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -29,7 +29,7 @@ from lsst.utils import doImportType
 from pydantic import BaseModel
 
 from .datasets import DatasetRef, DatasetType, SerializedDatasetRef, SerializedDatasetType
-from .datastore import DatastoreRecordData
+from .datastoreRecordData import DatastoreRecordData, SerializedDatastoreRecordData
 from .dimensions import (
     DataCoordinate,
     DimensionRecord,
@@ -84,6 +84,7 @@ class SerializedQuantum(BaseModel):
     inputs: Mapping[str, List[Tuple[SerializedDatasetRef, List[int]]]]
     outputs: Mapping[str, List[Tuple[SerializedDatasetRef, List[int]]]]
     dimensionRecords: Optional[Dict[int, SerializedDimensionRecord]] = None
+    datastore_records: Optional[Dict[str, SerializedDatastoreRecordData]] = None
 
     @classmethod
     def direct(
@@ -96,6 +97,7 @@ class SerializedQuantum(BaseModel):
         inputs: Mapping[str, List[Tuple[Dict, List[int]]]],
         outputs: Mapping[str, List[Tuple[Dict, List[int]]]],
         dimensionRecords: Optional[Dict[int, Dict]],
+        datastore_records: Optional[Dict[str, Dict]],
     ) -> SerializedQuantum:
         """Construct a `SerializedQuantum` directly without validators.
 
@@ -138,6 +140,13 @@ class SerializedQuantum(BaseModel):
         )
         setter(
             node,
+            "datastore_records",
+            datastore_records
+            if datastore_records is None
+            else {k: SerializedDatastoreRecordData.direct(**v) for k, v in datastore_records.items()},
+        )
+        setter(
+            node,
             "__fields_set__",
             {
                 "taskName",
@@ -147,6 +156,7 @@ class SerializedQuantum(BaseModel):
                 "inputs",
                 "outputs",
                 "dimensionRecords",
+                "datastore_records",
             },
         )
         return node
@@ -359,6 +369,13 @@ class Quantum:
         else:
             dimensionRecords = None
 
+        datastore_records: Optional[Dict[str, SerializedDatastoreRecordData]] = None
+        if self.datastore_records is not None:
+            datastore_records = {
+                datastore_name: record_data.to_simple()
+                for datastore_name, record_data in self.datastore_records.items()
+            }
+
         return SerializedQuantum(
             taskName=self._taskName,
             dataId=self.dataId.to_simple() if self.dataId is not None else None,
@@ -367,6 +384,7 @@ class Quantum:
             inputs=inputs,
             outputs=outputs,
             dimensionRecords=dimensionRecords,
+            datastore_records=datastore_records,
         )
 
     @classmethod
@@ -439,8 +457,21 @@ class Quantum:
             if simple.dataId is not None
             else None
         )
+
+        datastore_records: Optional[Dict[str, DatastoreRecordData]] = None
+        if simple.datastore_records is not None:
+            datastore_records = {
+                datastore_name: DatastoreRecordData.from_simple(record_data)
+                for datastore_name, record_data in simple.datastore_records.items()
+            }
+
         return Quantum(
-            taskName=simple.taskName, dataId=dataId, initInputs=initInputs, inputs=inputs, outputs=outputs
+            taskName=simple.taskName,
+            dataId=dataId,
+            initInputs=initInputs,
+            inputs=inputs,
+            outputs=outputs,
+            datastore_records=datastore_records,
         )
 
     @property

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -84,7 +84,7 @@ class SerializedQuantum(BaseModel):
     inputs: Mapping[str, List[Tuple[SerializedDatasetRef, List[int]]]]
     outputs: Mapping[str, List[Tuple[SerializedDatasetRef, List[int]]]]
     dimensionRecords: Optional[Dict[int, SerializedDimensionRecord]] = None
-    datastore_records: Optional[Dict[str, SerializedDatastoreRecordData]] = None
+    datastoreRecords: Optional[Dict[str, SerializedDatastoreRecordData]] = None
 
     @classmethod
     def direct(
@@ -97,7 +97,7 @@ class SerializedQuantum(BaseModel):
         inputs: Mapping[str, List[Tuple[Dict, List[int]]]],
         outputs: Mapping[str, List[Tuple[Dict, List[int]]]],
         dimensionRecords: Optional[Dict[int, Dict]],
-        datastore_records: Optional[Dict[str, Dict]],
+        datastoreRecords: Optional[Dict[str, Dict]],
     ) -> SerializedQuantum:
         """Construct a `SerializedQuantum` directly without validators.
 
@@ -140,10 +140,10 @@ class SerializedQuantum(BaseModel):
         )
         setter(
             node,
-            "datastore_records",
-            datastore_records
-            if datastore_records is None
-            else {k: SerializedDatastoreRecordData.direct(**v) for k, v in datastore_records.items()},
+            "datastoreRecords",
+            datastoreRecords
+            if datastoreRecords is None
+            else {k: SerializedDatastoreRecordData.direct(**v) for k, v in datastoreRecords.items()},
         )
         setter(
             node,
@@ -384,7 +384,7 @@ class Quantum:
             inputs=inputs,
             outputs=outputs,
             dimensionRecords=dimensionRecords,
-            datastore_records=datastore_records,
+            datastoreRecords=datastore_records,
         )
 
     @classmethod
@@ -459,10 +459,10 @@ class Quantum:
         )
 
         datastore_records: Optional[Dict[str, DatastoreRecordData]] = None
-        if simple.datastore_records is not None:
+        if simple.datastoreRecords is not None:
             datastore_records = {
                 datastore_name: DatastoreRecordData.from_simple(record_data)
-                for datastore_name, record_data in simple.datastore_records.items()
+                for datastore_name, record_data in simple.datastoreRecords.items()
             }
 
         return Quantum(

--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -21,68 +21,23 @@
 
 from __future__ import annotations
 
-__all__ = ("SerializedStoredDatastoreItemInfo", "StoredFileInfo", "StoredDatastoreItemInfo")
+__all__ = ("StoredDatastoreItemInfo", "StoredFileInfo")
 
-import functools
 import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type
 
 from lsst.resources import ResourcePath
-from lsst.utils import doImportType
-from lsst.utils.introspection import get_full_type_name
-from pydantic import BaseModel
 
 from .formatter import Formatter, FormatterParameter
 from .location import Location, LocationFactory
 from .storageClass import StorageClass, StorageClassFactory
 
 if TYPE_CHECKING:
-    from ..registry import Registry
     from .datasets import DatasetId, DatasetRef
-    from .dimensions import DimensionUniverse
 
 # String to use when a Python None is encountered
 NULLSTR = "__NULL_STRING__"
-
-
-class SerializedStoredDatastoreItemInfo(BaseModel):
-    """Representation of `StoredDatastoreItemInfo` used for serialization.
-
-    Note that this class supports polymorphism by storing actual class name of
-    the items together with all other data members. It depends on a correct
-    implementation of ``to_record`` and ``from_record`` methods in each
-    sub-class.
-    """
-
-    class_name: str
-    """Actual fully-qualified name of the item class."""
-
-    record: Dict[str, Any]
-    """Values of all record attributes."""
-
-    @classmethod
-    def direct(
-        cls,
-        *,
-        class_name: str,
-        record: Dict[str, Any],
-    ) -> SerializedStoredDatastoreItemInfo:
-        """Construct a `SerializedStoredDatastoreItemInfo` directly without
-        validators.
-
-        This differs from the pydantic "construct" method in that the
-        arguments are explicitly what the model requires, and it will recurse
-        through members, constructing them from their corresponding `direct`
-        methods.
-
-        This method should only be called when the inputs are trusted.
-        """
-        data = SerializedStoredDatastoreItemInfo.__new__(cls)
-        setter = object.__setattr__
-        setter(data, "class_name", class_name)
-        setter(data, "record", record)
-        return data
 
 
 class StoredDatastoreItemInfo:
@@ -133,59 +88,6 @@ class StoredDatastoreItemInfo:
     def dataset_id(self) -> DatasetId:
         """Dataset ID associated with this record (`DatasetId`)"""
         raise NotImplementedError()
-
-    def to_simple(self, minimal: bool = False) -> SerializedStoredDatastoreItemInfo:
-        """Make representation of the object for serialization.
-
-        Implements `~lsst.daf.butler.core.json.SupportsSimple` protocol.
-
-        Parameters
-        ----------
-        minimal : `bool`, optional
-            If True produce minimal representation, not used by this method.
-
-        Returns
-        -------
-        simple : `dict`
-            Representation of this instance as a simple dictionary.
-        """
-        class_name = get_full_type_name(self)
-        record = self.to_record()
-        return SerializedStoredDatastoreItemInfo(class_name=class_name, record=record)
-
-    @classmethod
-    def from_simple(
-        cls,
-        simple: SerializedStoredDatastoreItemInfo,
-        universe: Optional[DimensionUniverse] = None,
-        registry: Optional[Registry] = None,
-    ) -> StoredDatastoreItemInfo:
-        """Make an instance of this class from serialized data.
-
-        Implements `~lsst.daf.butler.core.json.SupportsSimple` protocol.
-
-        Parameters
-        ----------
-        data : `dict`
-            Serialized representation returned from `to_simple` method.
-        universe : `DimensionUniverse`, optional
-            Dimension universe, not used by this method.
-        registry : `Registry`, optional
-            Registry instance, not used by this method.
-
-        Returns
-        -------
-        item_info : `StoredDatastoreItemInfo`
-            De-serialized instance of `StoredDatastoreItemInfo`.
-        """
-
-        @functools.lru_cache(maxsize=None)
-        def _get_class(class_name: str) -> Type:
-            """Get class type for a given class name"""
-            return doImportType(class_name)
-
-        subclass = _get_class(simple.class_name)
-        return subclass.from_record(simple.record)
 
 
 @dataclass(frozen=True)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -82,6 +82,7 @@ from lsst.utils.logging import VERBOSE, getLogger
 from lsst.utils.timer import time_this
 from sqlalchemy import BigInteger, String
 
+from ..registry.interfaces import FakeDatasetRef
 from .genericDatastore import GenericBaseDatastore
 
 if TYPE_CHECKING:
@@ -2702,25 +2703,30 @@ class FileDatastore(GenericBaseDatastore):
         if not record_data:
             return
 
-        if record_data.refs:
-            self._bridge.insert(record_data.refs)
+        if record_data.dataset_ids:
+            self._bridge.insert(FakeDatasetRef(dataset_id) for dataset_id in record_data.dataset_ids)
 
         # TODO: Verify that there are no unexpected table names in the dict?
-        records = record_data.records.get(self._table.name)
-        if records:
-            unpacked_records = []
-            for info in records:
-                assert isinstance(info, StoredFileInfo), "Expecting StoredFileInfo records"
-                unpacked_records.append(info.to_record())
+        unpacked_records = []
+        for dataset_id, dataset_data in record_data.records.items():
+            records = dataset_data.get(self._table.name)
+            if records:
+                for info in records:
+                    assert isinstance(info, StoredFileInfo), "Expecting StoredFileInfo records"
+                    unpacked_records.append(info.to_record())
+        if unpacked_records:
             self._table.insert(*unpacked_records)
 
     def export_records(self, refs: Iterable[DatasetIdRef]) -> Mapping[str, DatastoreRecordData]:
         # Docstring inherited from the base class.
         exported_refs = list(self._bridge.check(refs))
+        ids = {ref.getCheckedId() for ref in exported_refs}
+        records: Dict[DatasetId, Dict[str, List[StoredDatastoreItemInfo]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        for row in self._table.fetch(dataset_id=ids):
+            info: StoredDatastoreItemInfo = StoredFileInfo.from_record(row)
+            records[info.dataset_id][self._table.name].append(info)
 
-        id2ref = {ref.id: ref for ref in exported_refs}
-        rows = self._table.fetch(dataset_id=list(id2ref.keys()))
-        records: List[StoredDatastoreItemInfo] = [StoredFileInfo.from_record(row) for row in rows]
-
-        record_data = DatastoreRecordData(refs=exported_refs, records={self._table.name: records})
+        record_data = DatastoreRecordData(dataset_ids=ids, records=records)
         return {self.name: record_data}

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -807,7 +807,6 @@ class DatastoreTests(DatastoreTestsBase):
             # In a ChainedDatastore each FileDatastore will have a complete set
             for datastore_name in records:
                 record_data = records[datastore_name]
-                self.assertEqual(len(record_data.dataset_ids), n_refs)
                 self.assertEqual(len(record_data.records), n_refs)
 
         # Use the same datastore name to import relative path.

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -25,7 +25,6 @@ import tempfile
 import time
 import unittest
 from dataclasses import dataclass
-from itertools import chain
 
 import lsst.utils.tests
 import yaml
@@ -808,8 +807,8 @@ class DatastoreTests(DatastoreTestsBase):
             # In a ChainedDatastore each FileDatastore will have a complete set
             for datastore_name in records:
                 record_data = records[datastore_name]
-                self.assertEqual(len(record_data.refs), n_refs)
-                self.assertEqual(len(list(chain(*record_data.records.values()))), n_refs)
+                self.assertEqual(len(record_data.dataset_ids), n_refs)
+                self.assertEqual(len(record_data.records), n_refs)
 
         # Use the same datastore name to import relative path.
         datastore2 = self.makeDatastore("test_datastore")

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import os
 import unittest
 import uuid
@@ -247,14 +248,10 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         for ref in self.output_refs:
             qbb.putDirect({"data": ref.dataId["detector"] ** 2}, ref)
 
-        provenance = qbb.extract_provenance_data()
-        for i in range(2):
-            if i == 1:
-                # round trip to JSON format
-                provenance = qbb.extract_provenance_data()
-                prov_json = provenance.json()
-                provenance = QuantumProvenanceData.parse_raw(prov_json)
-
+        provenance1 = qbb.extract_provenance_data()
+        prov_json = provenance1.json()
+        provenance2 = QuantumProvenanceData.direct(**json.loads(prov_json))
+        for provenance in (provenance1, provenance2):
             input_ids = set(ref.id for ref in self.input_refs)
             self.assertEqual(provenance.predicted_inputs, input_ids)
             self.assertEqual(provenance.available_inputs, input_ids)


### PR DESCRIPTION
Adds a bunch of pydantic classes for datastore records and implements
serialization of the records in `Quantum` class. I switched back
`QuantumProvenanceData` to be a pydantic model to use the same pydantic
classes for datastore records. Moved `DatastoreRecordData` class (and its
pydantic friend) to a separate module, for some reason pydantic was not
happy when I added `SerializedDatastoreRecordData` class to the
`datastore` module.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
