### PR TITLE
DM-34526: Change default to not use threading on parquet read.

### DIFF
--- a/doc/changes/DM-34526.feature.rst
+++ b/doc/changes/DM-34526.feature.rst
@@ -1,0 +1,1 @@
+Parquet table reading now turns off implicit threading.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -153,7 +153,7 @@ class _ParquetLoader:
             A Pandas DataFrame.
         """
         if columns is None:
-            return self.file.read(use_pandas_metadata=True).to_pandas()
+            return self.file.read(use_pandas_metadata=True, use_threads=False).to_pandas()
         elif isinstance(self.columns, pd.MultiIndex):
             assert isinstance(columns, dict) or isinstance(columns, list)
             columns = list(self._standardizeColumnParameter(columns))
@@ -161,7 +161,7 @@ class _ParquetLoader:
             for column in columns:
                 if column not in self.columns:
                     raise ValueError(f"Unrecognized column name {column!r}.")
-        return self.file.read(columns=columns, use_pandas_metadata=True).to_pandas()
+        return self.file.read(columns=columns, use_pandas_metadata=True, use_threads=False).to_pandas()
 
 
 def _writeParquet(path: str, inMemoryDataset: pd.DataFrame) -> None:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
