### PR TITLE
DM-34483: Fix DataCoordinate.timespan method

### DIFF
--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -623,7 +623,12 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
                 return None
             else:
                 timespans.append(record.timespan)
-        return Timespan.intersection(*timespans)
+        if not timespans:
+            return None
+        elif len(timespans) == 1:
+            return timespans[0]
+        else:
+            return Timespan.intersection(*timespans)
 
     def pack(self, name: str, *, returnMaxBits: bool = False) -> Union[Tuple[int, int], int]:
         """Pack this data ID into an integer.

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -658,6 +658,11 @@ class DataCoordinateTestCase(unittest.TestCase):
             self.assertIsNotNone(dataId.timespan)
             self.assertEqual(dataId.graph.temporal.names, {"observation_timespans"})
             self.assertEqual(dataId.timespan, dataId.records["visit"].timespan)
+        # Also test the case for non-temporal DataIds.
+        for dataId in self.randomDataIds(n=4).subset(
+            DimensionGraph(self.allDataIds.universe, names=["patch"])
+        ):
+            self.assertIsNone(dataId.timespan)
 
     def testIterableStatusFlags(self):
         """Test that DataCoordinateSet and DataCoordinateSequence compute


### PR DESCRIPTION
Add protection for a case when there are no timespans found.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
