### PR TITLE
DM-34589: Add a way to mark which dimensions populate others.

### DIFF
--- a/doc/changes/DM-34589.misc.md
+++ b/doc/changes/DM-34589.misc.md
@@ -1,0 +1,3 @@
+Add dimensions config entries that declare that the `visit` dimension "populates" various dimension elements that define many-to-many relationships.
+
+In the future, this will be used to ensure the correct records are included in exports of dimension records.

--- a/python/lsst/daf/butler/configs/dimensions.yaml
+++ b/python/lsst/daf/butler/configs/dimensions.yaml
@@ -1,4 +1,4 @@
-version: 3
+version: 4
 namespace: daf_butler
 skypix:
   # 'common' is the skypix system and level used to relate all other spatial
@@ -427,6 +427,7 @@ elements:
       A many-to-many join table that provides region information for
       visit-detector combinations.
     requires: [visit, detector]
+    populated_by: visit
     storage:
       cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
 
@@ -459,6 +460,7 @@ elements:
       A many-to-many join table that relates exposures to the visits they
       belong to.
     requires: [exposure, visit]
+    populated_by: visit
     always_join: true
     storage:
       cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
@@ -468,6 +470,7 @@ elements:
       A many-to-many join table that relates visits to the visit_systems they
       belong to.
     requires: [visit, visit_system]
+    populated_by: visit
     always_join: true
     storage:
       cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage

--- a/python/lsst/daf/butler/core/dimensions/_config.py
+++ b/python/lsst/daf/butler/core/dimensions/_config.py
@@ -214,6 +214,7 @@ class DimensionConfig(ConfigSubset):
                     metadata=metadata,
                     alwaysJoin=subconfig.get("always_join", False),
                     uniqueKeys=uniqueKeys,
+                    populated_by=subconfig.get("populated_by", None),
                 )
 
     def _extractTopologyVisitors(self) -> Iterator[DimensionConstructionVisitor]:

--- a/python/lsst/daf/butler/core/dimensions/_elements.py
+++ b/python/lsst/daf/butler/core/dimensions/_elements.py
@@ -330,6 +330,22 @@ class DimensionElement(TopologicalRelationshipEndpoint):
         """
         return False
 
+    @property
+    @abstractmethod
+    def populated_by(self) -> Dimension | None:
+        """The dimension that this element's records are always inserted,
+        exported, and imported alongside.
+
+        Notes
+        -----
+        When this is `None` (as it will be, at least at first, for any data
+        repositories created before this attribute was added), records for
+        this element will often need to be exported manually when datasets
+        associated with some other related dimension are exported, in order for
+        the post-import data repository to function as expected.
+        """
+        raise NotImplementedError()
+
 
 class Dimension(DimensionElement):
     """A dimension.
@@ -375,6 +391,11 @@ class Dimension(DimensionElement):
         """
         _, *alternateKeys = self.uniqueKeys
         return NamedValueSet(alternateKeys).freeze()
+
+    @property
+    def populated_by(self) -> Dimension:
+        # Docstring inherited.
+        return self
 
 
 class DimensionCombination(DimensionElement):

--- a/python/lsst/daf/butler/core/dimensions/_universe.py
+++ b/python/lsst/daf/butler/core/dimensions/_universe.py
@@ -26,6 +26,7 @@ __all__ = ["DimensionUniverse"]
 import logging
 import math
 import pickle
+from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
@@ -169,6 +170,11 @@ class DimensionUniverse:
         # Same for dimension to index, sorted topologically across required
         # and implied.  This is used for encode/decode.
         self._dimensionIndices = {name: i for i, name in enumerate(self._dimensions.names)}
+
+        self._populates = defaultdict(NamedValueSet)
+        for element in self._elements:
+            if element.populated_by is not None:
+                self._populates[element.populated_by.name].add(element)
 
         return self
 
@@ -483,6 +489,12 @@ class DimensionUniverse:
         """
         return math.ceil(len(self._dimensions) / 8)
 
+    def get_elements_populated_by(self, dimension: Dimension) -> NamedValueAbstractSet[DimensionElement]:
+        """Return the set of `DimensionElement` objects whose
+        `~DimensionElement.populated_by` atttribute is the given dimension.
+        """
+        return self._populates[dimension.name]
+
     @classmethod
     def _unpickle(cls, version: int, namespace: str | None = None) -> DimensionUniverse:
         """Return an unpickled dimension universe.
@@ -541,6 +553,8 @@ class DimensionUniverse:
     _elementIndices: dict[str, int]
 
     _packers: dict[str, DimensionPackerFactory]
+
+    _populates: defaultdict[str, NamedValueSet[DimensionElement]]
 
     _version: int
 

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -285,6 +285,20 @@ class DimensionTestCase(unittest.TestCase):
         self.assertEqual(graph.temporal.names, {"observation_timespans"})
         self.assertEqual(next(iter(graph.spatial)).governor, self.universe["instrument"])
         self.assertEqual(next(iter(graph.temporal)).governor, self.universe["instrument"])
+        self.assertEqual(self.universe["visit_definition"].populated_by, self.universe["visit"])
+        self.assertEqual(self.universe["visit_system_membership"].populated_by, self.universe["visit"])
+        self.assertEqual(self.universe["visit_detector_region"].populated_by, self.universe["visit"])
+        self.assertEqual(
+            self.universe.get_elements_populated_by(self.universe["visit"]),
+            NamedValueSet(
+                {
+                    self.universe["visit"],
+                    self.universe["visit_definition"],
+                    self.universe["visit_system_membership"],
+                    self.universe["visit_detector_region"],
+                }
+            ),
+        )
 
     def testSkyMapDimensions(self):
         graph = DimensionGraph(self.universe, names=("patch",))


### PR DESCRIPTION
In the future, this will be used to make it easier to export dimension data without knowing the details of the dimension combinations that represent many-to-main joins (DM-34838).

There's no real gain to updating the dimensions configuration before that happens, but merging these changes early is useful because it will make software versions with just this change much better able to handle future data repositories that use them in their dimensions configuration, even if the associated functionality isn't available as a result.

## Checklist

- [x] ran ~Jenkins~ local lsstsw
- [x] added a release note for user-visible changes to `doc/changes`
