### PR TITLE
DM-34884: Disable checks of schema checksums

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -44,7 +44,7 @@ from .interfaces import (
     OpaqueTableStorageManager,
     StaticTablesContext,
 )
-from .versions import ButlerVersionsManager, DigestMismatchError
+from .versions import ButlerVersionsManager
 
 _Attributes = TypeVar("_Attributes")
 _Dimensions = TypeVar("_Dimensions")
@@ -202,13 +202,6 @@ class RegistryManagerTypes(
         # verify that configured versions are compatible with schema
         versions.checkManagersConfig()
         versions.checkManagersVersions(database.isWriteable())
-        try:
-            versions.checkManagersDigests()
-        except DigestMismatchError as exc:
-            # potentially digest mismatch is a serious error but during
-            # development it could be benign, treat this as warning for
-            # now.
-            _LOG.warning(f"Registry schema digest mismatch: {exc}")
         # Load content from database that we try to keep in-memory.
         instances.refresh()
         return instances

--- a/python/lsst/daf/butler/registry/versions.py
+++ b/python/lsst/daf/butler/registry/versions.py
@@ -33,6 +33,8 @@ __all__ = [
 import logging
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional
 
+from deprecated.sphinx import deprecated
+
 from .interfaces import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
@@ -316,6 +318,7 @@ class ButlerVersionsManager:
                         f"{storedVersion} for extension {extension.extensionName()}"
                     )
 
+    @deprecated(reason="Schema checksums are ignored", category=FutureWarning, version="v24.0")
     def checkManagersDigests(self) -> None:
         """Compare current schema digests with digests stored in database.
 
@@ -323,6 +326,11 @@ class ButlerVersionsManager:
         ------
         DigestMismatchError
             Raised if digests are not equal.
+
+        Notes
+        -----
+        This method is not used currently and will probably disappear in the
+        future as we remove schema checksums.
         """
         if self._attributesEmpty:
             return


### PR DESCRIPTION
The code that calculates checksums is still there, will be removed when
we are sure that we never need it.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
