### PR TITLE
DM-34919: Ensure that a component dataset type inherits the calibration flag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
+          python-version: '3.10'
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -71,4 +71,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/docstyle.yaml
+++ b/.github/workflows/docstyle.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           cache: "pip"
 
       - name: Install

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           cache: "pip"
 
       - name: Install isort and black

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           cache: "pip"
 
       - name: Install

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: '3.10'
           cache: "pip"
 
       - name: Install

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -479,7 +479,12 @@ class DatasetType:
             raise ValueError(
                 f"Parent storage class is not set. Unable to create composite type from {self.name}"
             )
-        return DatasetType(composite_name, dimensions=self.dimensions, storageClass=self.parentStorageClass)
+        return DatasetType(
+            composite_name,
+            dimensions=self.dimensions,
+            storageClass=self.parentStorageClass,
+            isCalibration=self.isCalibration(),
+        )
 
     def makeComponentDatasetType(self, component: str) -> DatasetType:
         """Return a component dataset type from a composite.
@@ -502,6 +507,7 @@ class DatasetType:
             dimensions=self.dimensions,
             storageClass=self.storageClass.allComponents()[component],
             parentStorageClass=self.storageClass,
+            isCalibration=self.isCalibration(),
         )
 
     def makeAllComponentDatasetTypes(self) -> List[DatasetType]:

--- a/python/lsst/daf/butler/registry/queries/expressions/categorize.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/categorize.py
@@ -105,10 +105,11 @@ def categorizeElementId(universe: DimensionUniverse, name: str) -> Tuple[Dimensi
             # possibly not actually a column name, though we can guess
             # what they were trying to do.
             # Encourage them to clean that up and try again.
+            name = universe[column].primaryKey.name  # type: ignore
             raise RuntimeError(
-                f"Invalid reference to '{table}.{column}' "  # type: ignore
+                f"Invalid reference to '{table}.{column}' "
                 f"in expression; please use '{column}' or "
-                f"'{column}.{universe[column].primaryKey.name}' instead."
+                f"'{column}.{name}' instead."
             )
         else:
             return element, column

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -25,7 +25,9 @@
 import os
 import unittest
 
+import astropy
 from astropy.table import Table as AstropyTable
+from astropy.utils.introspection import minversion
 from lsst.daf.butler import Butler, StorageClassFactory
 from lsst.daf.butler.cli.butler import cli as butlerCli
 from lsst.daf.butler.cli.utils import LogCliRunner, clickResultMsg
@@ -39,6 +41,10 @@ from lsst.daf.butler.tests.utils import (
 from numpy import array
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+# Astropy changed the handling of numpy columns in v5.1 so anything
+# greater than 5.0 (two digit version) does not need the annotated column.
+timespan_columns = "" if minversion(astropy, "5.1") else " [2]"
 
 
 class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
@@ -61,7 +67,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
         "science_program",
         "zenith_angle",
         "region",
-        "timespan [2]",
+        f"timespan{timespan_columns}",
     )
 
     def setUp(self):


### PR DESCRIPTION
And that a composite dataset type also inherits the calibration flag from a component.

Other changes triggered by action failures:

* Switch to Python 3.10 to match rubin-env 4.0.0
* Fix a problem in a test with astropy 5.1
* Fix mypy problem where py3.8 picked the wrong line to ignore.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
