### PR TITLE
DM-34955: deprecate repo creation with integer dataset IDs and trim tests

### DIFF
--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -28,8 +28,10 @@ __all__ = (
 
 import dataclasses
 import logging
+import warnings
 from typing import Any, Dict, Generic, Type, TypeVar
 
+import sqlalchemy
 from lsst.utils import doImportType
 
 from ..core import Config, DimensionConfig, DimensionUniverse
@@ -151,6 +153,12 @@ class RegistryManagerTypes(
         """
         universe = DimensionUniverse(dimensionConfig)
         with database.declareStaticTables(create=True) as context:
+            if self.datasets.getIdColumnType() == sqlalchemy.BigInteger:
+                warnings.warn(
+                    "New data repositories should be created with UUID dataset IDs instead of autoincrement "
+                    "integer dataset IDs; support for integers will be removed after v25.",
+                    FutureWarning,
+                )
             instances = RegistryManagerInstances.initialize(database, context, types=self, universe=universe)
             versions = instances.getVersions()
         # store managers and their versions in attributes table

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1997,18 +1997,20 @@ class PosixDatastoreTransfers(unittest.TestCase):
         self.assertButlerTransfers(id_gen_map={"random_data_2": DatasetIdGenEnum.DATAID_TYPE})
 
     def testTransferIntToInt(self):
-        self.create_butlers(
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
-        )
+        with self.assertWarns(FutureWarning):
+            self.create_butlers(
+                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
+                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
+            )
         # int dataset ID only allows UNIQUE
         self.assertButlerTransfers()
 
     def testTransferIntToUuid(self):
-        self.create_butlers(
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-        )
+        with self.assertWarns(FutureWarning):
+            self.create_butlers(
+                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
+                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
+            )
         self.assertButlerTransfers(id_gen_map={"random_data_2": DatasetIdGenEnum.DATAID_TYPE})
 
     def testTransferMissing(self):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -266,17 +266,6 @@ class PostgresqlRegistryNameKeyCollMgrTestCase(PostgresqlRegistryTests, unittest
     datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
 
 
-class PostgresqlRegistrySynthIntKeyCollMgrTestCase(PostgresqlRegistryTests, unittest.TestCase):
-    """Tests for `Registry` backed by a PostgreSQL database.
-
-    This test case uses SynthIntKeyCollectionManager and
-    ByDimensionsDatasetRecordStorageManager.
-    """
-
-    collectionsManager = "lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager"
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
-
-
 class PostgresqlRegistryNameKeyCollMgrUUIDTestCase(PostgresqlRegistryTests, unittest.TestCase):
     """Tests for `Registry` backed by a PostgreSQL database.
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -255,6 +255,13 @@ class PostgresqlRegistryNameKeyCollMgrTestCase(PostgresqlRegistryTests, unittest
     ByDimensionsDatasetRecordStorageManager.
     """
 
+    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Registry:
+        if share_repo_with is None:
+            with self.assertWarns(FutureWarning):
+                return super().makeRegistry()
+        else:
+            return super().makeRegistry(share_repo_with)
+
     collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
     datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
 

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -71,7 +71,11 @@ class SimpleButlerTestCase(unittest.TestCase):
 
         # have to make a registry first
         registryConfig = RegistryConfig(config.get("registry"))
-        Registry.createFromConfig(registryConfig)
+        if self.datasetsIdType is int:
+            with self.assertWarns(FutureWarning):
+                Registry.createFromConfig(registryConfig)
+        else:
+            Registry.createFromConfig(registryConfig)
 
         butler = Butler(config, **kwargs)
         DatastoreMock.apply(butler)

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -227,17 +227,6 @@ class SqliteFileRegistryNameKeyCollMgrTestCase(SqliteFileRegistryTests, unittest
     datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
 
 
-class SqliteFileRegistrySynthIntKeyCollMgrTestCase(SqliteFileRegistryTests, unittest.TestCase):
-    """Tests for `Registry` backed by a SQLite file-based database.
-
-    This test case uses SynthIntKeyCollectionManager and
-    ByDimensionsDatasetRecordStorageManager.
-    """
-
-    collectionsManager = "lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager"
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
-
-
 class SqliteFileRegistryNameKeyCollMgrUUIDTestCase(SqliteFileRegistryTests, unittest.TestCase):
     """Tests for `Registry` backed by a SQLite file-based database.
 
@@ -288,28 +277,6 @@ class SqliteMemoryRegistryTests(RegistryTests):
         config["db"] = "sqlite://"
         with self.assertRaises(sqlalchemy.exc.OperationalError):
             Registry.fromConfig(config)
-
-
-class SqliteMemoryRegistryNameKeyCollMgrTestCase(unittest.TestCase, SqliteMemoryRegistryTests):
-    """Tests for `Registry` backed by a SQLite in-memory database.
-
-    This test case uses NameKeyCollectionManager and
-    ByDimensionsDatasetRecordStorageManager.
-    """
-
-    collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
-
-
-class SqliteMemoryRegistrySynthIntKeyCollMgrTestCase(unittest.TestCase, SqliteMemoryRegistryTests):
-    """Tests for `Registry` backed by a SQLite in-memory database.
-
-    This test case uses SynthIntKeyCollectionManager and
-    ByDimensionsDatasetRecordStorageManager.
-    """
-
-    collectionsManager = "lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager"
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
 
 
 class SqliteMemoryRegistryNameKeyCollMgrUUIDTestCase(unittest.TestCase, SqliteMemoryRegistryTests):

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -216,6 +216,13 @@ class SqliteFileRegistryNameKeyCollMgrTestCase(SqliteFileRegistryTests, unittest
     ByDimensionsDatasetRecordStorageManager.
     """
 
+    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Registry:
+        if share_repo_with is None:
+            with self.assertWarns(FutureWarning):
+                return super().makeRegistry()
+        else:
+            return super().makeRegistry(share_repo_with)
+
     collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
     datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
