### PR TITLE
DM-27177: Remove lsst.afw.image.Filter

### DIFF
--- a/doc/changes/DM-27177.removal.rst
+++ b/doc/changes/DM-27177.removal.rst
@@ -1,0 +1,1 @@
+The ``filter`` exposure component and all support for reading and writing `~lsst.afw.image.Filter` objects has been removed.

--- a/doc/changes/DM-27177.removal.rst
+++ b/doc/changes/DM-27177.removal.rst
@@ -1,1 +1,2 @@
-The ``filter`` exposure component and all support for reading and writing `~lsst.afw.image.Filter` objects has been removed.
+All support for reading and writing `~lsst.afw.image.Filter` objects has been removed.
+The old ``filter`` component for exposures has been removed, and replaced with a new ``filter`` component backed by `~lsst.afw.image.FilterLabel`.

--- a/doc/changes/DM-27177.removal.rst
+++ b/doc/changes/DM-27177.removal.rst
@@ -1,2 +1,3 @@
 All support for reading and writing `~lsst.afw.image.Filter` objects has been removed.
 The old ``filter`` component for exposures has been removed, and replaced with a new ``filter`` component backed by `~lsst.afw.image.FilterLabel`.
+It functions identically to the ``filterLabel`` component, which has been deprecated.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -67,8 +67,6 @@ MetricValue:
   parameters:
     unsafe_dump: true
 StructuredDataDict: lsst.daf.butler.formatters.yaml.YamlFormatter
-# TODO: remove Filter in DM-27177
-Filter: lsst.obs.base.formatters.filter.FilterFormatter
 StampsBase: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Stamps: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 BrightStarStamps: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -190,6 +190,7 @@ storageClasses:
       coaddInputs: CoaddInputs
       transmissionCurve: TransmissionCurve
       metadata: PropertyList
+      filter: FilterLabel
       # TODO: for consistency with Exposure.getFilterLabel(). Deprecate in DM-27177, remove in DM-27811.
       filterLabel: FilterLabel
       detector: Detector

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -191,8 +191,6 @@ storageClasses:
       transmissionCurve: TransmissionCurve
       metadata: PropertyList
       filter: FilterLabel
-      # TODO: for consistency with Exposure.getFilterLabel(). Deprecate in DM-27177, remove in DM-27811.
-      filterLabel: FilterLabel
       detector: Detector
       validPolygon: Polygon
       summaryStats: ExposureSummaryStats
@@ -201,6 +199,8 @@ storageClasses:
       bbox: Box2I
       dimensions: Extent2I
       xy0: Point2I
+      # TODO: deprecated; remove in DM-27811.
+      filterLabel: FilterLabel
   ExposureF:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -132,13 +132,8 @@ storageClasses:
     pytype: lsst.ip.isr.StrayLightData
   BrighterFatterKernel:
     pytype: lsst.ip.isr.BrighterFatterKernel
-  # TODO: remove Filter in DM-27177
-  Filter:
-    pytype: lsst.afw.image.Filter
   FilterLabel:
     pytype: lsst.afw.image.FilterLabel
-    # To support exposure.filter; remove in DM-27177
-    delegate: lsst.obs.base.formatters.filter.FilterTranslator
   Exposure:
     pytype: lsst.afw.image.Exposure
     delegate: lsst.obs.base.exposureAssembler.ExposureAssembler
@@ -205,8 +200,6 @@ storageClasses:
       bbox: Box2I
       dimensions: Extent2I
       xy0: Point2I
-      # TODO: change filter to FilterLabel and make non-derived in DM-27177. This is a breaking change.
-      filter: Filter
   ExposureF:
     inheritsFrom: Exposure
     pytype: lsst.afw.image.ExposureF


### PR DESCRIPTION
This PR replaces the old `filter` component (backed by the obsolete `afw.image.Filter`) with a new component (backed by `afw.image.FilterLabel`), and deprecates the transitional `filterLabel` component.