### PR TITLE
DM-34919-v23: backport single commit: workaround change in column handling in astropy 5.1

### DIFF
--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -170,7 +170,7 @@ class YamlFormatter(FileFormatter):
             serialized = yaml.dump(inMemoryDataset)
         else:
             serialized = yaml.safe_dump(inMemoryDataset)
-        return serialized.encode()
+        return serialized.encode()  # type: ignore
 
     def _coerceType(self, inMemoryDataset: Any, storageClass: StorageClass,
                     pytype: Optional[Type[Any]] = None) -> Any:

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -22,7 +22,9 @@
 """Unit tests for daf_butler CLI query-collections command.
 """
 
+import astropy
 from astropy.table import Table as AstropyTable
+from astropy.utils.introspection import minversion
 from numpy import array
 import os
 import unittest
@@ -42,6 +44,10 @@ from lsst.daf.butler.tests.utils import (
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
+# Astropy changed the handling of numpy columns in v5.1 so anything
+# greater than 5.0 (two digit version) does not need the annotated column.
+timespan_columns = "" if minversion(astropy, "5.1") else " [2]"
+
 
 class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
 
@@ -52,7 +58,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
 
     expectedColumnNames = ("instrument", "id", "physical_filter", "visit_system", "name", "day_obs",
                            "exposure_time", "target_name", "observation_reason", "science_program",
-                           "zenith_angle", "region", "timespan [2]")
+                           "zenith_angle", "region", f"timespan{timespan_columns}")
 
     def setUp(self):
         self.root = makeTestTempDir(TESTDIR)


### PR DESCRIPTION
Astropy 5.1 has full support for multi-dimensional columns
and so has changed the way that a timespan column is named.
Support old and new approaches by checking astropy version.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
