### PR TITLE
DM-33488: Add pruneDataset method to QuntumBackedButler (DM-33488

### DIFF
--- a/doc/changes/DM-33488.api.rst
+++ b/doc/changes/DM-33488.api.rst
@@ -1,0 +1,2 @@
+The `run` parameter has been removed from Butler method `lsst.daf.butler.Butler.pruneDatasets`.
+It was never used in Butler implementation, client code should simply remove it.

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -318,10 +318,7 @@ class QuantumBackedButler(LimitedButler):
         if purge:
             for ref in refs:
                 # We only care about removing them from actual output refs,
-                try:
-                    self._actual_output_refs.remove(ref)
-                except KeyError:
-                    pass
+                self._actual_output_refs.discard(ref)
 
         if unstore:
             # Point of no return for removing artifacts

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 _LOG = logging.getLogger(__name__)
 
 
-class _DatasetRecordStorageManagerDatastoreContructionMimic:
+class _DatasetRecordStorageManagerDatastoreConstructionMimic:
     """A partial implementation of `DatasetRecordStorageManager` that exists
     only to allow a `DatastoreRegistryBridgeManager` (and hence a `Datastore`)
     to be constructed without a full `Registry`.
@@ -217,7 +217,7 @@ class QuantumBackedButler(LimitedButler):
                 context,
                 opaque=opaque_manager,
                 # MyPy can tell it's a fake, but we know it shouldn't care.
-                datasets=_DatasetRecordStorageManagerDatastoreContructionMimic,  # type: ignore
+                datasets=_DatasetRecordStorageManagerDatastoreConstructionMimic,  # type: ignore
                 universe=dimensions,
             )
         # TODO: We need to inform `Datastore` here that it needs to support
@@ -285,6 +285,47 @@ class QuantumBackedButler(LimitedButler):
         self.datastore.put(obj, ref)
         self._actual_output_refs.add(ref)
         return ref
+
+    def pruneDatasets(
+        self,
+        refs: Iterable[DatasetRef],
+        *,
+        disassociate: bool = True,
+        unstore: bool = False,
+        tags: Iterable[str] = (),
+        purge: bool = False,
+    ) -> None:
+        # docstring inherited from LimitedButler
+
+        if purge:
+            if not disassociate:
+                raise TypeError("Cannot pass purge=True without disassociate=True.")
+            if not unstore:
+                raise TypeError("Cannot pass purge=True without unstore=True.")
+        elif disassociate:
+            # No tagged collections for this butler.
+            raise TypeError("Cannot pass disassociate=True without purge=True.")
+
+        refs = list(refs)
+
+        # Pruning a component of a DatasetRef makes no sense.
+        for ref in refs:
+            if ref.datasetType.component():
+                raise ValueError(f"Can not prune a component of a dataset (ref={ref})")
+
+        if unstore:
+            self.datastore.trash(refs)
+        if purge:
+            for ref in refs:
+                # We only care about removing them from actual output refs,
+                try:
+                    self._actual_output_refs.remove(ref)
+                except KeyError:
+                    pass
+
+        if unstore:
+            # Point of no return for removing artifacts
+            self.datastore.emptyTrash()
 
     def extract_provenance_data(self) -> QuantumProvenanceData:
         """Extract provenance information and datastore records from this

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -296,7 +296,8 @@ purge_option = MWOptionDecorator(
     help=unwrap(
         """Completely remove the dataset from the given RUN in the Registry. May not be used with
                 --disassociate. Note, this may remove provenance information from datasets other than those
-                provided, and should be used with extreme care."""
+                provided, and should be used with extreme care. RUN has to provided for backward
+                compatibility, but datasets will be removed from any RUN-type collections."""
     ),
     metavar="RUN",
 )

--- a/python/lsst/daf/butler/script/_pruneDatasets.py
+++ b/python/lsst/daf/butler/script/_pruneDatasets.py
@@ -135,7 +135,9 @@ def pruneDatasets(
     unstore : `bool`
         Same as the unstore argument to ``Butler.pruneDatasets``.
     purge_run : `str`
-        Completely remove the dataset from this run in the ``Registry``.
+        Completely remove datasets from the ``Registry``. Note that current
+        implementation accepts any RUN-type collection, but will remove
+        datasets from all collections.
     dry_run : `bool`
         Get results for what would be removed but do not remove.
     confirm : `bool`
@@ -184,8 +186,7 @@ def pruneDatasets(
 
     butler = Butler(repo)
 
-    # If purging, verify that all the collections to purge are RUN type
-    # collections:
+    # If purging, verify that the collection to purge is RUN type collection.
     if purge_run:
         collectionType = butler.registry.getCollectionType(purge_run)
         if collectionType is not CollectionType.RUN:
@@ -224,7 +225,6 @@ def pruneDatasets(
             disassociate=disassociate,
             tags=disassociate_tags or (),
             purge=purge,
-            run=purge_run or None,
             unstore=unstore,
         )
         result.state = PruneDatasetsResult.State.FINISHED

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -337,7 +337,7 @@ class ButlerPutGetTests:
                             self.assertEqual(set(transferred_again), set(transferred))
 
                 # Now remove the dataset completely.
-                butler.pruneDatasets([ref], purge=True, unstore=True, run=this_run)
+                butler.pruneDatasets([ref], purge=True, unstore=True)
                 # Lookup with original args should still fail.
                 with self.assertRaises(LookupError):
                     butler.datasetExists(*args, collections=this_run)

--- a/tests/test_cliCmdPruneDatasets.py
+++ b/tests/test_cliCmdPruneDatasets.py
@@ -90,7 +90,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
 
     @staticmethod
     def makePruneDatasetsArgs(**kwargs):
-        expectedArgs = dict(refs=tuple(), disassociate=False, tags=(), purge=False, run=None, unstore=False)
+        expectedArgs = dict(refs=tuple(), disassociate=False, tags=(), purge=False, unstore=False)
         expectedArgs.update(kwargs)
         return expectedArgs
 
@@ -390,7 +390,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         """Verify the arguments implied by --purge.
 
         --purge <run> implies the following arguments to butler.pruneDatasets:
-        purge=True, run=<run>, disassociate=True, unstore=True
+        purge=True, disassociate=True, unstore=True
         And for QueryDatasets, if COLLECTIONS is not passed then <run> gets
         used as the value of COLLECTIONS (and when there is a COLLECTIONS
         value then find_first gets set to True)
@@ -399,7 +399,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
             cliArgs=["--purge", "run"],
             invokeInput="yes",
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(
-                purge=True, run="run", refs=getDatasets(), disassociate=True, unstore=True
+                purge=True, refs=getDatasets(), disassociate=True, unstore=True
             ),
             exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
                 repo=self.repo, collections=("run",), find_first=True
@@ -424,7 +424,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
             cliArgs=["myCollection", "--purge", "run"],
             invokeInput="yes",
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(
-                purge=True, run="run", disassociate=True, unstore=True, refs=getDatasets()
+                purge=True, disassociate=True, unstore=True, refs=getDatasets()
             ),
             exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
                 repo=self.repo, collections=("myCollection",), find_first=True


### PR DESCRIPTION
There are few changes to the `pruneDatasets` method:

- `run` parameter has been removed completely, it was not used in the
  standard Butler implementation.
- Handling of the execution butler-specific logic is now performed in
  `Butler.pruneDataset` method, clients are not supposed to know the
  exact type of butler (and can use LimitedButler where possible).
- `QuantumBackedButler.pruneDataset` does not support removal of datasets
  from tagged collections (which do not exist in QBB).

## Checklist

- [X] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
