### PR TITLE
fix requirement for sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyyaml >= 5.1
 astropy >= 4.0
 click >7.0
-sqlalchemy >= 1.3
+sqlalchemy >= 1.4
 pydantic
 httpx
 deprecated >=1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
 install_requires =
   astropy >=4.0
   pyyaml >=5.1
-  sqlalchemy >= 1.3
+  sqlalchemy >= 1.4
   click >= 7.0
   lsst-sphgeom
   lsst-utils


### PR DESCRIPTION
We use sqlalchemy.sql.visitors.InternalTraversal, which requires
sqlalchemy 1.4.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
