### PR TITLE
DM-32061: Fix some issues with export-calibs command

### DIFF
--- a/doc/changes/DM-32061.bugfix.rst
+++ b/doc/changes/DM-32061.bugfix.rst
@@ -1,0 +1,2 @@
+``butler export-calibs`` can now copy files that require the use of a file template (for example if a direct URI was stored in datastore) with metadata records.
+File templates that use metadata records now complain if the record is not attached to the ``DatasetRef``.

--- a/doc/changes/DM-32061.feature.rst
+++ b/doc/changes/DM-32061.feature.rst
@@ -1,0 +1,2 @@
+``butler export-calibs`` now takes a ``--transfer`` option to control how data are exported (use ``direct`` to do in-place export) and a ``--datasets`` option to limit the dataset types to be exported.
+It also now takes a default collections parameter (all calibration collections).

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -825,7 +825,7 @@ def register_dataset_type(**kwargs):
 
 @click.command(cls=ButlerCommand)
 @repo_argument(required=True)
-@directory_argument(required=True)
+@directory_argument(required=True, help="DIRECTORY is the folder to receive the exported calibrations.")
 @collections_argument(help="COLLECTIONS are the collection to export calibrations from.")
 def export_calibs(*args, **kwargs):
     """Export calibrations from the butler for import elsewhere."""

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -828,6 +828,7 @@ def register_dataset_type(**kwargs):
 @directory_argument(required=True, help="DIRECTORY is the folder to receive the exported calibrations.")
 @collections_argument(help="COLLECTIONS are the collection to export calibrations from.")
 @dataset_type_option(help="Specific DatasetType(s) to export.", multiple=True)
+@transfer_option()
 def export_calibs(*args, **kwargs):
     """Export calibrations from the butler for import elsewhere."""
     table = script.exportCalibs(*args, **kwargs)

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -827,6 +827,7 @@ def register_dataset_type(**kwargs):
 @repo_argument(required=True)
 @directory_argument(required=True, help="DIRECTORY is the folder to receive the exported calibrations.")
 @collections_argument(help="COLLECTIONS are the collection to export calibrations from.")
+@dataset_type_option(help="Specific DatasetType(s) to export.", multiple=True)
 def export_calibs(*args, **kwargs):
     """Export calibrations from the butler for import elsewhere."""
     table = script.exportCalibs(*args, **kwargs)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2680,6 +2680,15 @@ class FileDatastore(GenericBaseDatastore):
         if transfer is not None and directory is None:
             raise RuntimeError(f"Cannot export using transfer mode {transfer} with no export directory given")
 
+        if transfer == "move":
+            raise RuntimeError("Can not export by moving files out of datastore.")
+        elif transfer == "direct":
+            # For an export, treat this as equivalent to None. We do not
+            # want an import to risk using absolute URIs to datasets owned
+            # by another datastore.
+            log.info("Treating 'direct' transfer mode as in-place export.")
+            transfer = None
+
         # Force the directory to be a URI object
         directoryUri: Optional[ResourcePath] = None
         if directory is not None:

--- a/python/lsst/daf/butler/script/exportCalibs.py
+++ b/python/lsst/daf/butler/script/exportCalibs.py
@@ -107,6 +107,8 @@ def exportCalibs(repo, directory, collections, dataset_type):
 
     if not dataset_type:
         dataset_type = ...
+    if not collections:
+        collections = ...
 
     calibTypes = [
         datasetType

--- a/python/lsst/daf/butler/script/exportCalibs.py
+++ b/python/lsst/daf/butler/script/exportCalibs.py
@@ -65,8 +65,12 @@ def parseCalibrationCollection(registry, collection, datasetTypes):
             calibType, collections=collection, collectionTypes=[CollectionType.CALIBRATION]
         )
         for result in associations:
-            exportDatasets.append(result.ref)
-            exportCollections.append(result.ref.run)
+            # Need an expanded dataId in case file templates will be used
+            # in the transfer.
+            dataId = registry.expandDataId(result.ref.dataId)
+            ref = result.ref.expanded(dataId)
+            exportDatasets.append(ref)
+            exportCollections.append(ref.run)
     return exportCollections, exportDatasets
 
 

--- a/python/lsst/daf/butler/script/exportCalibs.py
+++ b/python/lsst/daf/butler/script/exportCalibs.py
@@ -74,7 +74,7 @@ def parseCalibrationCollection(registry, collection, datasetTypes):
     return exportCollections, exportDatasets
 
 
-def exportCalibs(repo, directory, collections):
+def exportCalibs(repo, directory, collections, dataset_type):
     """Certify a set of calibrations with a validity range.
 
     Parameters
@@ -89,6 +89,8 @@ def exportCalibs(repo, directory, collections):
        Data collections to pull calibrations from.  Must be an
        existing `~CollectionType.CHAINED` or
        `~CollectionType.CALIBRATION` collection.
+    dataset_type : `tuple` [`str`]
+       The dataset types to export. Default is to export all.
 
     Returns
     -------
@@ -103,8 +105,13 @@ def exportCalibs(repo, directory, collections):
     """
     butler = Butler(repo, writeable=False)
 
+    if not dataset_type:
+        dataset_type = ...
+
     calibTypes = [
-        datasetType for datasetType in butler.registry.queryDatasetTypes(...) if datasetType.isCalibration()
+        datasetType
+        for datasetType in butler.registry.queryDatasetTypes(dataset_type)
+        if datasetType.isCalibration()
     ]
 
     collectionsToExport = []

--- a/python/lsst/daf/butler/script/exportCalibs.py
+++ b/python/lsst/daf/butler/script/exportCalibs.py
@@ -74,7 +74,7 @@ def parseCalibrationCollection(registry, collection, datasetTypes):
     return exportCollections, exportDatasets
 
 
-def exportCalibs(repo, directory, collections, dataset_type):
+def exportCalibs(repo, directory, collections, dataset_type, transfer):
     """Certify a set of calibrations with a validity range.
 
     Parameters
@@ -91,6 +91,8 @@ def exportCalibs(repo, directory, collections, dataset_type):
        `~CollectionType.CALIBRATION` collection.
     dataset_type : `tuple` [`str`]
        The dataset types to export. Default is to export all.
+    transfer : `str`
+        The transfer mode to use for exporting.
 
     Returns
     -------
@@ -140,7 +142,7 @@ def exportCalibs(repo, directory, collections, dataset_type):
     if os.path.exists(directory):
         raise RuntimeError(f"Export directory exists: {directory}")
     os.makedirs(directory)
-    with butler.export(directory=directory, format="yaml", transfer="auto") as export:
+    with butler.export(directory=directory, format="yaml", transfer=transfer) as export:
         collectionsToExport = list(set(collectionsToExport))
         datasetsToExport = list(set(datasetsToExport))
 

--- a/tests/config/basic/templates.yaml
+++ b/tests/config/basic/templates.yaml
@@ -7,6 +7,7 @@ test_metric_comp: "{run:/}/{datasetType}.{component:?}/{datasetType}_v{visit:08d
 metric2: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit.name:?}"
 metric3: "{run:/}/{datasetType}/{instrument}"
 metric4: "{run:/}/{component:?}_{instrument}_{physical_filter}_{visit:08d}"
+metric5: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{physical_filter:?}/{instrument:?}_{visit:?}"
 Integer: "{id}"
 physical_filter+: "{run:/}/{instrument}_{physical_filter}"
 instrument<DummyCamComp>:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -78,6 +78,7 @@ from lsst.daf.butler import (
     DatasetRef,
     DatasetType,
     FileDataset,
+    FileTemplate,
     FileTemplateValidationError,
     StorageClassFactory,
     ValidationError,
@@ -1178,6 +1179,18 @@ class FileDatastoreButlerTests(ButlerTests):
 
         # Check the template based on dimensions
         butler.datastore.templates.validateTemplates([ref])
+
+        # Use a template that has a typo in dimension record metadata.
+        # Easier to test with a butler that has a ref with records attached.
+        template = FileTemplate("a/{visit.name}/{id}_{visit.namex:?}.fits")
+        with self.assertLogs("lsst.daf.butler.core.fileTemplates", "INFO"):
+            path = template.format(ref)
+        self.assertEqual(path, f"a/v423/{ref.id}_fits")
+
+        template = FileTemplate("a/{visit.name}/{id}_{visit.namex}.fits")
+        with self.assertRaises(KeyError):
+            with self.assertLogs("lsst.daf.butler.core.fileTemplates", "INFO"):
+                template.format(ref)
 
         # Now use a file template that will not result in unique filenames
         with self.assertRaises(FileTemplateValidationError):

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -921,6 +921,7 @@ class ButlerTests(ButlerPutGetTests):
             ignore=[
                 "test_metric_comp",
                 "metric3",
+                "metric5",
                 "calexp",
                 "DummySC",
                 "datasetType.component",
@@ -943,6 +944,7 @@ class ButlerTests(ButlerPutGetTests):
             ignore=[
                 "test_metric_comp",
                 "metric3",
+                "metric5",
                 "calexp",
                 "DummySC",
                 "datasetType.component",

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -336,7 +336,7 @@ class DatastoreTests(DatastoreTestsBase):
         i = 0
         for sc_name in ("StructuredData", "StructuredComposite"):
             i += 1
-            datasetTypeName = f"metric{i}"
+            datasetTypeName = f"test_metric{i}"  # Different dataset type name each time.
 
             if sc_name == "StructuredComposite":
                 disassembled = True
@@ -1135,9 +1135,9 @@ class DatastoreConstraintsTests(DatastoreTestsBase):
         testfile_j = tempfile.NamedTemporaryFile(suffix=".json")
         for datasetTypeName, sc, accepted in (
             ("metric", sc1, True),
-            ("metric2", sc1, False),
+            ("metric5", sc1, False),
             ("metric33", sc1, True),
-            ("metric2", sc2, True),
+            ("metric5", sc2, True),
         ):
             # Choose different temp file depending on StorageClass
             testfile = testfile_j if sc.name.endswith("Json") else testfile_y
@@ -1233,10 +1233,10 @@ class ChainedDatastorePerStoreConstraintsTests(DatastoreTestsBase, unittest.Test
 
         for typeName, dataId, sc, accept, ingest in (
             ("metric", dataId1, sc1, (False, True, False), True),
-            ("metric2", dataId1, sc1, (False, False, False), False),
-            ("metric2", dataId2, sc1, (True, False, False), False),
+            ("metric5", dataId1, sc1, (False, False, False), False),
+            ("metric5", dataId2, sc1, (True, False, False), False),
             ("metric33", dataId2, sc2, (True, True, False), True),
-            ("metric2", dataId1, sc2, (False, True, False), True),
+            ("metric5", dataId1, sc2, (False, True, False), True),
         ):
 
             # Choose different temp file depending on StorageClass

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -148,6 +148,15 @@ class TestFileTemplates(unittest.TestCase):
         with self.assertRaises(FileTemplateValidationError):
             self.assertTemplate(tmplstr, "run2/calexp/00052/U", self.makeDatasetRef("calexp"))
 
+    def testNoRecord(self):
+        # Attaching records is not possible in this test code but we can check
+        # that a missing record when a metadata entry has been requested
+        # does fail.
+        tmplstr = "{run}/{datasetType}/{visit.name}/{physical_filter}"
+        with self.assertRaises(RuntimeError) as cm:
+            self.assertTemplate(tmplstr, "", self.makeDatasetRef("calexp"))
+        self.assertIn("No metadata", str(cm.exception))
+
     def testOptional(self):
         """Optional units in templates."""
         ref = self.makeDatasetRef("calexp", conform=False)


### PR DESCRIPTION
* Complain if a template uses record metadata but no record metadata available.
* Add `--transfer` and `--datasets` to `butler export-calibs`
* Add collection defaulting.
* Expand dataset refs in `export-calibs`

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
