### PR TITLE
DM-34887: Transfer dimension records with butler.transfer_from()

### DIFF
--- a/doc/changes/DM-34887.feature.rst
+++ b/doc/changes/DM-34887.feature.rst
@@ -1,0 +1,3 @@
+Now ``Butler.transfer_from()`` can copy dimension records as well as datasets.
+This significantly enhances the usability of this method when transferring between disconnected Butlers.
+The ``butler transfer-datasets`` command will transfer dimension records by default but this can be disabled with the ``--no-transfer-dimensions`` option (which can be more efficient if you know that the destination Butler contains all the records).

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -78,6 +78,8 @@ from .core import (
     Datastore,
     Dimension,
     DimensionConfig,
+    DimensionElement,
+    DimensionRecord,
     DimensionUniverse,
     FileDataset,
     Progress,
@@ -2115,6 +2117,7 @@ class Butler(LimitedButler):
         id_gen_map: Dict[str, DatasetIdGenEnum] = None,
         skip_missing: bool = True,
         register_dataset_types: bool = False,
+        transfer_dimension_data: bool = False,
     ) -> List[DatasetRef]:
         """Transfer datasets to this Butler from a run in another Butler.
 
@@ -2140,6 +2143,9 @@ class Butler(LimitedButler):
         register_dataset_types : `bool`
             If `True` any missing dataset types are registered. Otherwise
             an exception is raised.
+        transfer_dimension_data : `bool`, optional
+            If `True`, dimension record data associated with the new datasets
+            will be transferred.
 
         Returns
         -------
@@ -2235,6 +2241,27 @@ class Butler(LimitedButler):
         else:
             log.log(VERBOSE, "All required dataset types are known to the target Butler")
 
+        dimension_records: Dict[DimensionElement, Dict[DataCoordinate, DimensionRecord]] = defaultdict(dict)
+        if transfer_dimension_data:
+            # Collect all the dimension records for these refs.
+            # All dimensions are to be copied but the list of valid dimensions
+            # come from this butler's universe.
+            elements = frozenset(
+                element
+                for element in self.registry.dimensions.getStaticElements()
+                if element.hasTable() and element.viewOf is None
+            )
+            dataIds = set(ref.dataId for ref in source_refs)
+            # This logic comes from saveDataIds.
+            for dataId in dataIds:
+                # Should be a no-op if the ref has already been expanded.
+                dataId = source_butler.registry.expandDataId(dataId)
+                # If this butler doesn't know about a dimension in the source
+                # butler things will break later.
+                for record in dataId.records.values():
+                    if record is not None and record.definition in elements:
+                        dimension_records[record.definition].setdefault(record.dataId, record)
+
         # The returned refs should be identical for UUIDs.
         # For now must also support integers and so need to retain the
         # newly-created refs from this registry.
@@ -2246,6 +2273,15 @@ class Butler(LimitedButler):
 
         # Do all the importing in a single transaction.
         with self.transaction():
+            if dimension_records:
+                log.verbose("Ensuring that dimension records exist for transferred datasets.")
+                for element, r in dimension_records.items():
+                    records = [r[dataId] for dataId in r]
+                    # Assume that if the record is already present that we can
+                    # use it without having to check that the record metadata
+                    # is consistent.
+                    self.registry.insertDimensionData(element, *records, skip_existing=True)
+
             for (datasetType, run), refs_to_import in progress.iter_item_chunks(
                 grouped_refs.items(), desc="Importing to registry by run and dataset type"
             ):

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -2117,7 +2117,7 @@ class Butler(LimitedButler):
         id_gen_map: Dict[str, DatasetIdGenEnum] = None,
         skip_missing: bool = True,
         register_dataset_types: bool = False,
-        transfer_dimension_data: bool = False,
+        transfer_dimensions: bool = False,
     ) -> List[DatasetRef]:
         """Transfer datasets to this Butler from a run in another Butler.
 
@@ -2143,7 +2143,7 @@ class Butler(LimitedButler):
         register_dataset_types : `bool`
             If `True` any missing dataset types are registered. Otherwise
             an exception is raised.
-        transfer_dimension_data : `bool`, optional
+        transfer_dimensions : `bool`, optional
             If `True`, dimension record data associated with the new datasets
             will be transferred.
 
@@ -2242,7 +2242,7 @@ class Butler(LimitedButler):
             log.log(VERBOSE, "All required dataset types are known to the target Butler")
 
         dimension_records: Dict[DimensionElement, Dict[DataCoordinate, DimensionRecord]] = defaultdict(dict)
-        if transfer_dimension_data:
+        if transfer_dimensions:
             # Collect all the dimension records for these refs.
             # All dimensions are to be copied but the list of valid dimensions
             # come from this butler's universe.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -653,6 +653,17 @@ def retrieve_artifacts(**kwargs):
 @query_datasets_options(showUri=False, useArguments=False, repo=False)
 @transfer_option()
 @register_dataset_types_option()
+@click.option(
+    "--transfer-dimensions/--no-transfer-dimensions",
+    is_flag=True,
+    default=True,
+    help=unwrap(
+        """If true, also copy dimension records along with datasets.
+        If the dmensions are already present in the destination butler it
+        can be more efficient to disable this. The default is to transfer
+        dimensions."""
+    ),
+)
 @options_file_option()
 def transfer_datasets(**kwargs):
     """Transfer datasets from a source butler to a destination butler.

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -85,6 +85,6 @@ def transferDatasets(
         source_refs_set,
         transfer=transfer,
         register_dataset_types=register_dataset_types,
-        transfer_dimension_data=True,
+        transfer_dimensions=True,
     )
     return len(transferred)

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -81,6 +81,10 @@ def transferDatasets(
     source_refs_set = set(source_refs)
 
     transferred = dest_butler.transfer_from(
-        source_butler, source_refs_set, transfer=transfer, register_dataset_types=register_dataset_types
+        source_butler,
+        source_refs_set,
+        transfer=transfer,
+        register_dataset_types=register_dataset_types,
+        transfer_dimension_data=True,
     )
     return len(transferred)

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -39,6 +39,7 @@ def transferDatasets(
     find_first: bool,
     transfer: str,
     register_dataset_types: bool,
+    transfer_dimensions: bool = True,
 ) -> int:
     """Transfer datasets from run in source to dest.
 
@@ -61,6 +62,10 @@ def transferDatasets(
         Transfer mode to use when placing artifacts in the destination.
     register_dataset_types : `bool`
         Indicate whether missing dataset types should be registered.
+    transfer_dimensions : `bool`
+        Indicate whether dimensions should be transferred along with
+        datasets. It can be more efficient to disable this if it is known
+        that all dimensions exist.
     """
     source_butler = Butler(source, writeable=False)
     dest_butler = Butler(dest, writeable=True)
@@ -85,6 +90,6 @@ def transferDatasets(
         source_refs_set,
         transfer=transfer,
         register_dataset_types=register_dataset_types,
-        transfer_dimensions=True,
+        transfer_dimensions=transfer_dimensions,
     )
     return len(transferred)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2201,7 +2201,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
                 source_refs,
                 id_gen_map=id_gen_map,
                 register_dataset_types=True,
-                transfer_dimension_data=True,
+                transfer_dimensions=True,
             )
         self.assertEqual(len(transferred), n_expected)
         log_output = ";".join(cm.output)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2077,25 +2077,24 @@ class PosixDatastoreTransfers(unittest.TestCase):
         for run in runs:
             self.source_butler.registry.registerCollection(run, CollectionType.RUN)
 
-        # Create dimensions in both butlers (transfer will not create them).
+        # Create dimensions in source butler.
         n_exposures = 30
-        for butler in (self.source_butler, self.target_butler):
-            butler.registry.insertDimensionData("instrument", {"name": "DummyCamComp"})
-            butler.registry.insertDimensionData(
-                "physical_filter", {"instrument": "DummyCamComp", "name": "d-r", "band": "R"}
-            )
-            butler.registry.insertDimensionData(
-                "detector", {"instrument": "DummyCamComp", "id": 1, "full_name": "det1"}
-            )
+        self.source_butler.registry.insertDimensionData("instrument", {"name": "DummyCamComp"})
+        self.source_butler.registry.insertDimensionData(
+            "physical_filter", {"instrument": "DummyCamComp", "name": "d-r", "band": "R"}
+        )
+        self.source_butler.registry.insertDimensionData(
+            "detector", {"instrument": "DummyCamComp", "id": 1, "full_name": "det1"}
+        )
 
-            for i in range(n_exposures):
-                butler.registry.insertDimensionData(
-                    "exposure",
-                    {"instrument": "DummyCamComp", "id": i, "obs_id": f"exp{i}", "physical_filter": "d-r"},
-                )
+        for i in range(n_exposures):
+            self.source_butler.registry.insertDimensionData(
+                "exposure",
+                {"instrument": "DummyCamComp", "id": i, "obs_id": f"exp{i}", "physical_filter": "d-r"},
+            )
 
         # Create dataset types in the source butler.
-        dimensions = butler.registry.dimensions.extract(["instrument", "exposure"])
+        dimensions = self.source_butler.registry.dimensions.extract(["instrument", "exposure"])
         for datasetTypeName in datasetTypeNames:
             datasetType = DatasetType(datasetTypeName, dimensions, storageClass)
             self.source_butler.registry.registerDatasetType(datasetType)
@@ -2170,8 +2169,10 @@ class PosixDatastoreTransfers(unittest.TestCase):
         for datasetTypeName in datasetTypeNames:
             datasetType = DatasetType(datasetTypeName, dimensions, badStorageClass)
             self.target_butler.registry.registerDatasetType(datasetType)
-        with self.assertRaises(ConflictingDefinitionError):
+        with self.assertRaises(ConflictingDefinitionError) as cm:
             self.target_butler.transfer_from(self.source_butler, source_refs, id_gen_map=id_gen_map)
+        self.assertIn("dataset type differs", str(cm.exception))
+
         # And remove the bad definitions.
         for datasetTypeName in datasetTypeNames:
             self.target_butler.registry.removeDatasetType(datasetTypeName)
@@ -2180,10 +2181,27 @@ class PosixDatastoreTransfers(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.target_butler.transfer_from(self.source_butler, source_refs, id_gen_map=id_gen_map)
 
-        # Now transfer them to the second butler
+        # Transfer without creating dimensions should fail.
+        with self.assertRaises(ConflictingDefinitionError) as cm:
+            self.target_butler.transfer_from(
+                self.source_butler, source_refs, id_gen_map=id_gen_map, register_dataset_types=True
+            )
+        self.assertIn("dimension", str(cm.exception))
+
+        # The failed transfer above leaves registry in an inconsistent
+        # state because the run is created but then rolled back without
+        # the collection cache being cleared. For now force a refresh.
+        # Can remove with DM-35498.
+        self.target_butler.registry.refresh()
+
+        # Now transfer them to the second butler, including dimensions.
         with self.assertLogs(level=logging.DEBUG) as cm:
             transferred = self.target_butler.transfer_from(
-                self.source_butler, source_refs, id_gen_map=id_gen_map, register_dataset_types=True
+                self.source_butler,
+                source_refs,
+                id_gen_map=id_gen_map,
+                register_dataset_types=True,
+                transfer_dimension_data=True,
             )
         self.assertEqual(len(transferred), n_expected)
         log_output = ";".join(cm.output)


### PR DESCRIPTION
This allows completely unrelated datasets to be copied into
a new butler.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
