### PR TITLE
Dm-35082: Add Universe compatibility check

### DIFF
--- a/doc/changes/DM-35082.api.rst
+++ b/doc/changes/DM-35082.api.rst
@@ -1,0 +1,2 @@
+``DimensionUniverse`` now has a ``isCompatibleWith()`` method to check if two universes are compatible with each other.
+The initial test is very basic but can be improved later.

--- a/python/lsst/daf/butler/core/dimensions/_universe.py
+++ b/python/lsst/daf/butler/core/dimensions/_universe.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 __all__ = ["DimensionUniverse"]
 
+import logging
 import math
 import pickle
 from typing import (
@@ -60,6 +61,7 @@ if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
 
 
 E = TypeVar("E", bound=DimensionElement)
+_LOG = logging.getLogger(__name__)
 
 
 @immutable
@@ -220,7 +222,20 @@ class DimensionUniverse:
             If the other `DimensionUniverse` is compatible with this one return
             `True`, else `False`
         """
-        return self.namespace == other.namespace
+        # Different namespaces mean that these universes cannot be compatible.
+        if self.namespace != other.namespace:
+            return False
+        if self.version != other.version:
+            _LOG.info(
+                "Universes share a namespace %r but have differing versions (%d != %d). "
+                " This could be okay but may be responsible for dimension errors later.",
+                self.namespace,
+                self.version,
+                other.version,
+            )
+
+        # For now assume compatibility if versions differ.
+        return True
 
     def __repr__(self) -> str:
         return f"DimensionUniverse({self._version}, {self._namespace})"

--- a/python/lsst/daf/butler/core/dimensions/_universe.py
+++ b/python/lsst/daf/butler/core/dimensions/_universe.py
@@ -208,7 +208,7 @@ class DimensionUniverse:
         """
         return self._namespace
 
-    def checkCompatibility(self, other: DimensionUniverse) -> bool:
+    def isCompatibleWith(self, other: DimensionUniverse) -> bool:
         """Check compatibility between this `DimensionUniverse` and another
 
         Parameters

--- a/python/lsst/daf/butler/core/dimensions/_universe.py
+++ b/python/lsst/daf/butler/core/dimensions/_universe.py
@@ -206,6 +206,22 @@ class DimensionUniverse:
         """
         return self._namespace
 
+    def checkCompatibility(self, other: DimensionUniverse) -> bool:
+        """Check compatibility between this `DimensionUniverse` and another
+
+        Parameters
+        ----------
+        other : `DimensionUniverse`
+            The other `DimensionUniverse` to check for compatibility
+
+        Returns
+        -------
+        results : `bool`
+            If the other `DimensionUniverse` is compatible with this one return
+            `True`, else `False`
+        """
+        return self.namespace == other.namespace
+
     def __repr__(self) -> str:
         return f"DimensionUniverse({self._version}, {self._namespace})"
 

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -133,6 +133,16 @@ class DimensionTestCase(unittest.TestCase):
         # Simple check that should always be true.
         self.assertTrue(self.universe.checkCompatibility(self.universe))
 
+        # Create a universe like the default universe but with a different
+        # version number.
+        clone = self.universe.dimensionConfig.copy()
+        clone["version"] = clone["version"] + 1_000_000  # High version number
+        universe_clone = DimensionUniverse(config=clone)
+        with self.assertLogs("lsst.daf.butler.core.dimensions", "INFO") as cm:
+            self.assertTrue(self.universe.checkCompatibility(universe_clone))
+        self.assertIn("differing versions", "\n".join(cm.output))
+
+        # Create completely incompatible universe.
         config = Config(
             {
                 "version": 1,

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -131,7 +131,7 @@ class DimensionTestCase(unittest.TestCase):
 
     def testCompatibility(self):
         # Simple check that should always be true.
-        self.assertTrue(self.universe.checkCompatibility(self.universe))
+        self.assertTrue(self.universe.isCompatibleWith(self.universe))
 
         # Create a universe like the default universe but with a different
         # version number.
@@ -139,7 +139,7 @@ class DimensionTestCase(unittest.TestCase):
         clone["version"] = clone["version"] + 1_000_000  # High version number
         universe_clone = DimensionUniverse(config=clone)
         with self.assertLogs("lsst.daf.butler.core.dimensions", "INFO") as cm:
-            self.assertTrue(self.universe.checkCompatibility(universe_clone))
+            self.assertTrue(self.universe.isCompatibleWith(universe_clone))
         self.assertIn("differing versions", "\n".join(cm.output))
 
         # Create completely incompatible universe.
@@ -182,7 +182,7 @@ class DimensionTestCase(unittest.TestCase):
             }
         )
         universe2 = DimensionUniverse(config=config)
-        self.assertFalse(universe2.checkCompatibility(self.universe))
+        self.assertFalse(universe2.isCompatibleWith(self.universe))
 
     def testVersion(self):
         self.assertEqual(self.universe.namespace, "daf_butler")

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -29,6 +29,7 @@ from random import Random
 from typing import Iterator, Optional
 
 from lsst.daf.butler import (
+    Config,
     DataCoordinate,
     DataCoordinateSequence,
     DataCoordinateSet,
@@ -127,6 +128,51 @@ class DimensionTestCase(unittest.TestCase):
     def testConfigPresent(self):
         config = self.universe.dimensionConfig
         self.assertIsInstance(config, DimensionConfig)
+
+    def testCompatibility(self):
+        # Simple check that should always be true.
+        self.assertTrue(self.universe.checkCompatibility(self.universe))
+
+        config = Config(
+            {
+                "version": 1,
+                "namespace": "compat_test",
+                "skypix": {
+                    "common": "htm7",
+                    "htm": {
+                        "class": "lsst.sphgeom.HtmPixelization",
+                        "max_level": 24,
+                    },
+                },
+                "elements": {
+                    "A": {
+                        "keys": [
+                            {
+                                "name": "id",
+                                "type": "int",
+                            }
+                        ],
+                        "storage": {
+                            "cls": "lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage",
+                        },
+                    },
+                    "B": {
+                        "keys": [
+                            {
+                                "name": "id",
+                                "type": "int",
+                            }
+                        ],
+                        "storage": {
+                            "cls": "lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage",
+                        },
+                    },
+                },
+                "packers": {},
+            }
+        )
+        universe2 = DimensionUniverse(config=config)
+        self.assertFalse(universe2.checkCompatibility(self.universe))
 
     def testVersion(self):
         self.assertEqual(self.universe.namespace, "daf_butler")


### PR DESCRIPTION
Add a method on DimensionUniverse that checks if another universe
is compatible with itself.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
