### PR TITLE
DM-35886: Expose optional dependencies of lsst-resources

### DIFF
--- a/doc/changes/DM-35886.feature.rst
+++ b/doc/changes/DM-35886.feature.rst
@@ -1,0 +1,2 @@
+The optional dependencies of ``lsst-resources`` can be requested as optional dependencies of ``lsst-daf-butler`` and will be passed down to the underlying package.
+This allows callers of ``lsst.daf.butler`` to specify the type of resources they want to be able to access without being aware of the role of ``lsst.resources`` as an implementation detail.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,15 @@ test = [
     "pyarrow >= 0.16",
     "pandas >= 1.0",
 ]
+# Also expose the optional dependencies of lsst-resources as optional
+# dependencies of lsst-daf-butler.  lsst-daf-butler itself doesn't care what
+# resource methods are available, but the client of lsst-daf-butler may view
+# it as a black box and lsst-resources as an internal implementation detail,
+# and therefore may find it more logical to specify optional dependencies
+# here.
+s3 = ["lsst-resources[s3]"]
+https = ["lsst-resources[https]"]
+gs = ["lsst-resources[gs]"]
 
 [tool.setuptools.packages.find]
 where = ["python"]


### PR DESCRIPTION
For each optional (non-test) dependency group of lsst-resources,
expose a group of the same name that depends on that optional
dependency.  This allows callers of lsst-daf-butler to treat it as
a black box and not know that lsst-resources implements the access
methods.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
