### PR TITLE
DM-35937: Get the composite dataset type from the component dataset type

### DIFF
--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -426,10 +426,8 @@ class DataCoordinateQueryResults(DataCoordinateIterable):
             )
         if datasetType.isComponent():
             # We were given a true DatasetType instance, but it's a component.
-            parentName, componentName = datasetType.nameAndComponent()
-            storage = self._query.managers.datasets[parentName]
-            datasetType = storage.datasetType
-            components = [componentName]
+            components = [datasetType.component()]
+            datasetType = datasetType.makeCompositeDatasetType()
         else:
             components = [None]
         summary = QuerySummary(self.graph, whereRegion=self._query.whereRegion, datasets=[datasetType])

--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -411,8 +411,8 @@ class DataCoordinateQueryResults(DataCoordinateIterable):
                 return ChainedDatasetQueryResults(
                     [],
                     doomed_by=[
-                        f"No registered dataset type {datasetType!r} found, so no instances can "
-                        "exist in any collection."
+                        f"Dataset type {datasetType!r} is not registered, so no instances of it can exist in "
+                        "any collection."
                     ],
                 )
             else:


### PR DESCRIPTION
There is no need to ask registry for this (assuming the component
dataset type has been properly configured with a parent storage
class). This also prevents look ups into registry for non-existent
dataset types which do not occur in the else branch (which always
uses the given dataset type).

@kfindeisen can you see if this works for you?

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
