### PR TITLE
DM-29835: Support move of FocalPlaneBackground to pipe_tasks (v24 backport)

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -225,7 +225,7 @@ storageClasses:
   Background:
     pytype: lsst.afw.math.BackgroundList
   FocalPlaneBackground:
-    pytype: lsst.pipe.drivers.background.FocalPlaneBackground
+    pytype: lsst.pipe.tasks.background.FocalPlaneBackground
   Config:
     pytype: lsst.pex.config.Config
   Packages:

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -226,6 +226,8 @@ storageClasses:
     pytype: lsst.afw.math.BackgroundList
   FocalPlaneBackground:
     pytype: lsst.pipe.tasks.background.FocalPlaneBackground
+    converters:
+      lsst.pipe.drivers.background.FocalPlaneBackground: lsst.pipe.tasks.background.FocalPlaneBackground.fromSimilar
   Config:
     pytype: lsst.pex.config.Config
   Packages:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
