### PR TITLE
DM-36108: move Ellipsis typing workaround to utils

### DIFF
--- a/doc/changes/DM-36108.misc.md
+++ b/doc/changes/DM-36108.misc.md
@@ -1,0 +1,1 @@
+Moved the typing workaround for the built-in `Ellipsis` (`...`) singleton to `utils`.

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -26,7 +26,7 @@ import logging
 import traceback
 from contextlib import contextmanager
 from logging import Formatter, LogRecord, StreamHandler
-from typing import IO, Any, ClassVar, Dict, Generator, Iterable, Iterator, List, Optional, Union
+from typing import IO, Any, Callable, ClassVar, Dict, Generator, Iterable, Iterator, List, Optional, Union
 
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import isplit
@@ -71,7 +71,7 @@ class ButlerMDC:
 
     _MDC = MDCDict()
 
-    _old_factory = None
+    _old_factory: Optional[Callable[..., logging.LogRecord]] = None
     """Old log record factory."""
 
     @classmethod

--- a/python/lsst/daf/butler/core/progress.py
+++ b/python/lsst/daf/butler/core/progress.py
@@ -44,7 +44,7 @@ _K = TypeVar("_K")
 _V = TypeVar("_V", bound=Collection)
 
 
-class ProgressBar(Protocol, Iterable[_T]):
+class ProgressBar(Iterable[_T], Protocol):
     """A structural interface for progress bars that wrap iterables.
 
     An object conforming to this interface can be obtained from the

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Pattern, TypeVa
 from lsst.utils.iteration import ensure_iterable
 
 if TYPE_CHECKING:
-    from ..registry.wildcards import Ellipsis, EllipsisType
+    from lsst.utils.ellipsis import Ellipsis, EllipsisType
 
 
 _LOG = logging.getLogger(__name__)

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -29,6 +29,7 @@ from collections import defaultdict
 from typing import AbstractSet, Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Set, Union
 
 import sqlalchemy
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
 
 from ...core import (
     DatabaseDimensionElement,
@@ -56,7 +57,6 @@ from ..interfaces import (
     StaticTablesContext,
 )
 from ..queries import QueryBuilder
-from ..wildcards import Ellipsis, EllipsisType
 
 _LOG = logging.getLogger(__name__)
 

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -43,6 +43,7 @@ from typing import (
 )
 
 import sqlalchemy
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
 from lsst.utils.iteration import ensure_iterable
 from pydantic import BaseModel
 
@@ -51,28 +52,7 @@ from ..core.utils import globToRegex
 from ._collectionType import CollectionType
 
 if TYPE_CHECKING:
-    # Workaround for `...` not having an exposed type in Python, borrowed from
-    # https://github.com/python/typing/issues/684#issuecomment-548203158
-    # Along with that, we need to either use `Ellipsis` instead of `...` for
-    # the actual sentinal value internally, and tell MyPy to ignore conversions
-    # from `...` to `Ellipsis` at the public-interface boundary.
-    #
-    # `Ellipsis` and `EllipsisType` should be directly imported from this
-    # module by related code that needs them; hopefully that will stay confined
-    # to `lsst.daf.butler.registry`.  Putting these in __all__ is bad for
-    # Sphinx, and probably more confusing than helpful overall.
-    from enum import Enum
-
     from .interfaces import CollectionManager, CollectionRecord
-
-    class EllipsisType(Enum):
-        Ellipsis = "..."
-
-    Ellipsis = EllipsisType.Ellipsis
-
-else:
-    EllipsisType = type(Ellipsis)
-    Ellipsis = Ellipsis
 
 
 @dataclass


### PR DESCRIPTION
Requires https://github.com/lsst/utils/pull/137; checks here should only pass after that has been merged long enough to it to be picked up as a dependency in the checks here.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
