### PR TITLE
DM-36172: Add explicit transaction around moveToTrash calls

### DIFF
--- a/doc/changes/DM-36172.misc.rst
+++ b/doc/changes/DM-36172.misc.rst
@@ -1,0 +1,2 @@
+Add support for in-memory datastore to roll back a call to ``datastore.trash()``.
+This required that the ``bridge.moveToTrash()`` method now takes an additional ``transaction`` parameter (that can be `None`).

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2246,7 +2246,7 @@ class FileDatastore(GenericBaseDatastore):
             log.debug("Doing multi-dataset trash in datastore %s", self.name)
             # Assumed to be an iterable of refs so bulk mode enabled.
             try:
-                self.bridge.moveToTrash(ref)
+                self.bridge.moveToTrash(ref, transaction=self._transaction)
             except Exception as e:
                 if ignore_errors:
                     log.warning("Unexpected issue moving multiple datasets to trash: %s", e)
@@ -2280,7 +2280,7 @@ class FileDatastore(GenericBaseDatastore):
 
         # Mark dataset as trashed
         try:
-            self.bridge.moveToTrash([ref])
+            self.bridge.moveToTrash([ref], transaction=self._transaction)
         except Exception as e:
             if ignore_errors:
                 log.warning(

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -43,6 +43,7 @@ from .ephemeral import EphemeralDatastoreRegistryBridge
 
 if TYPE_CHECKING:
     from ...core import DimensionUniverse
+    from ...core.datastore import DatastoreTransaction
     from ..interfaces import (
         Database,
         DatasetRecordStorageManager,
@@ -157,7 +158,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         rows = self._refsToRows(self.check(refs))
         self._db.delete(self._tables.dataset_location, ["datastore_name", "dataset_id"], *rows)
 
-    def moveToTrash(self, refs: Iterable[DatasetIdRef]) -> None:
+    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: Optional[DatastoreTransaction]) -> None:
         # Docstring inherited from DatastoreRegistryBridge
         # TODO: avoid self.check() call via queries like
         #     INSERT INTO dataset_location_trash

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -32,6 +32,7 @@ from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
     from ...core import DatasetType, DimensionUniverse, StoredDatastoreItemInfo
+    from ...core.datastore import DatastoreTransaction
     from ._database import Database, StaticTablesContext
     from ._datasets import DatasetRecordStorageManager
     from ._opaque import OpaqueTableStorage, OpaqueTableStorageManager
@@ -150,13 +151,16 @@ class DatastoreRegistryBridge(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def moveToTrash(self, refs: Iterable[DatasetIdRef]) -> None:
+    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: Optional[DatastoreTransaction]) -> None:
         """Move dataset location information to trash.
 
         Parameters
         ----------
         refs : `Iterable` of `DatasetIdRef`
             References to the datasets.
+        transaction : `DatastoreTransaction` or `None`
+            Transaction object. Can be `None` in some bridges or if no rollback
+            is required.
 
         Raises
         ------

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -799,10 +799,10 @@ class ButlerTests(ButlerPutGetTests):
         # Try to delete RUN collections, which should fail with complete
         # rollback because they're still referenced by the CHAINED
         # collection.
-        with self.assertRaises(Exception):
-            butler.pruneCollection(run1, pruge=True, unstore=True)
-        with self.assertRaises(Exception):
-            butler.pruneCollection(run2, pruge=True, unstore=True)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            butler.pruneCollection(run1, purge=True, unstore=True)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            butler.pruneCollection(run2, purge=True, unstore=True)
         self.assertCountEqual(set(butler.registry.queryDatasets(..., collections=...)), [ref1, ref2, ref3])
         existence = butler.datastore.mexists([ref1, ref2, ref3])
         self.assertTrue(existence[ref1])

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1388,7 +1388,7 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         # Check that in normal mode, deleting the record will lead to
         # trash not touching the file.
         uri1 = butler.datastore.getURI(ref1)
-        butler.datastore.bridge.moveToTrash([ref1])  # Update the dataset_location table
+        butler.datastore.bridge.moveToTrash([ref1], transaction=None)  # Update the dataset_location table
         butler.datastore._table.delete(["dataset_id"], {"dataset_id": ref1.id})
         butler.datastore.trash(ref1)
         butler.datastore.emptyTrash()
@@ -1404,7 +1404,7 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         self.assertTrue(uri3.exists())
 
         # Remove the datastore record.
-        butler.datastore.bridge.moveToTrash([ref2])  # Update the dataset_location table
+        butler.datastore.bridge.moveToTrash([ref2], transaction=None)  # Update the dataset_location table
         butler.datastore._table.delete(["dataset_id"], {"dataset_id": ref2.id})
         self.assertTrue(uri2.exists())
         butler.datastore.trash([ref2, ref3])

--- a/ups/daf_butler.table
+++ b/ups/daf_butler.table
@@ -5,4 +5,3 @@ setupRequired(resources)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
-envPrepend(MYPYPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Without this the in-memory datastore can not rollback a `datastore.trash()` call.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
