### PR TITLE
DM-36312: Deprecate support for component datasets in Registry

### DIFF
--- a/doc/changes/DM-36312.api.md
+++ b/doc/changes/DM-36312.api.md
@@ -1,0 +1,1 @@
+Deprecate support for components in `Registry.query*` methods, per RFC-879.

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -929,6 +929,10 @@ class SqlRegistry(Registry):
             parent datasets were not matched by the expression.
             Fully-specified component datasets (`str` or `DatasetType`
             instances) are always included.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         mode : `str`, optional
             The way in which datasets are being used in this query; one of:
 

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -418,7 +418,12 @@ class SqlRegistry(Registry):
 
     def getDatasetType(self, name: str) -> DatasetType:
         # Docstring inherited from lsst.daf.butler.registry.Registry
-        return self._managers.datasets[name].datasetType
+        parent_name, component = DatasetType.splitDatasetTypeName(name)
+        storage = self._managers.datasets[parent_name]
+        if component is None:
+            return storage.datasetType
+        else:
+            return storage.datasetType.makeComponentDatasetType(component)
 
     def supportsIdGenerationMode(self, mode: DatasetIdGenEnum) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
@@ -435,9 +440,10 @@ class SqlRegistry(Registry):
     ) -> Optional[DatasetRef]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         if isinstance(datasetType, DatasetType):
-            storage = self._managers.datasets[datasetType.name]
+            parent_name, component = datasetType.nameAndComponent()
         else:
-            storage = self._managers.datasets[datasetType]
+            parent_name, component = DatasetType.splitDatasetTypeName(datasetType)
+        storage = self._managers.datasets[parent_name]
         dataId = DataCoordinate.standardize(
             dataId,
             graph=storage.datasetType.dimensions,
@@ -460,6 +466,8 @@ class SqlRegistry(Registry):
                 continue
             result = storage.find(collectionRecord, dataId, timespan=timespan)
             if result is not None:
+                if component is not None:
+                    return result.makeComponentRef(component)
                 return result
 
         return None

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -1038,7 +1038,7 @@ class SqlRegistry(Registry):
                 check=check,
                 datasets=[parent_dataset_type],
             )
-            builder = self._makeQueryBuilder(summary, doomed_by=doomed_by)
+            builder = self._makeQueryBuilder(summary)
             # Add the dataset subquery to the query, telling the QueryBuilder
             # to include the rank of the selected collection in the results
             # only if we need to findFirst.  Note that if any of the

--- a/python/lsst/daf/butler/registry/_exceptions.py
+++ b/python/lsst/daf/butler/registry/_exceptions.py
@@ -67,7 +67,7 @@ class DatasetTypeError(RegistryError):
     """Exception raised for problems with dataset types."""
 
 
-class MissingDatasetTypeError(DatasetTypeError):
+class MissingDatasetTypeError(DatasetTypeError, KeyError):
     """Exception raised when a dataset type does not exist."""
 
 

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1213,6 +1213,10 @@ class Registry(ABC):
             parent datasets were not matched by the expression.
             Fully-specified component datasets (`str` or `DatasetType`
             instances) are always included.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         missing : `list` of `str`, optional
             String dataset type names that were explicitly given (i.e. not
             regular expression patterns) but not found will be appended to this
@@ -1348,6 +1352,10 @@ class Registry(ABC):
             if their parent datasets were not matched by the expression.
             Fully-specified component datasets (`str` or `DatasetType`
             instances) are always included.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         bind : `Mapping`, optional
             Mapping containing literal values that should be injected into the
             ``where`` expression, keyed by the identifiers they replace.
@@ -1459,6 +1467,10 @@ class Registry(ABC):
             if their parent datasets were not matched by the expression.
             Fully-specified component datasets (`str` or `DatasetType`
             instances) are always included.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         bind : `Mapping`, optional
             Mapping containing literal values that should be injected into the
             ``where`` expression, keyed by the identifiers they replace.
@@ -1547,6 +1559,10 @@ class Registry(ABC):
         components : `bool`, optional
             Whether to apply dataset expressions to components as well.
             See `queryDataIds` for more information.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         bind : `Mapping`, optional
             Mapping containing literal values that should be injected into the
             ``where`` expression, keyed by the identifiers they replace.

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -639,8 +639,13 @@ class Registry(ABC):
 
         Raises
         ------
-        KeyError
-            Requested named DatasetType could not be found in registry.
+        MissingDatasetTypeError
+            Raised if the requested dataset type has not been registered.
+
+        Notes
+        -----
+        This method handles component dataset types automatically, though most
+        other registry operations do not.
         """
         raise NotImplementedError()
 
@@ -712,7 +717,7 @@ class Registry(ABC):
             ``self.defaults.collections`` is `None`.
         LookupError
             Raised if one or more data ID keys are missing.
-        KeyError
+        MissingDatasetTypeError
             Raised if the dataset type does not exist.
         MissingCollectionError
             Raised if any of ``collections`` does not exist in the registry.
@@ -728,6 +733,9 @@ class Registry(ABC):
         reported consistently, regardless of the reason, and that adding
         additional collections that do not contain a match to the search path
         never changes the behavior.
+
+        This method handles component dataset types automatically, though most
+        other registry operations do not.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -5,7 +5,6 @@ __all__ = (
     "ByDimensionsDatasetRecordStorageManagerUUID",
 )
 
-import copy
 import logging
 import warnings
 from collections import defaultdict
@@ -254,14 +253,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
 
     def find(self, name: str) -> DatasetRecordStorage | None:
         # Docstring inherited from DatasetRecordStorageManager.
-        compositeName, componentName = DatasetType.splitDatasetTypeName(name)
-        storage = self._byName.get(compositeName)
-        if storage is not None and componentName is not None:
-            componentStorage = copy.copy(storage)
-            componentStorage.datasetType = storage.datasetType.makeComponentDatasetType(componentName)
-            return componentStorage
-        else:
-            return storage
+        return self._byName.get(name)
 
     def register(self, datasetType: DatasetType) -> tuple[DatasetRecordStorage, bool]:
         # Docstring inherited from DatasetRecordStorageManager.

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -680,6 +680,10 @@ class DatasetRecordStorageManager(VersionedExtension):
             datasets were not matched by the expression.  Fully-specified
             component datasets (`str` or `DatasetType` instances) are always
             included.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         missing : `list` of `str`, optional
             String dataset type names that were explicitly given (i.e. not
             regular expression patterns) but not found will be appended to this

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 import sqlalchemy.sql
 
 from ...core import DataCoordinate, DatasetId, DatasetRef, DatasetType, SimpleQuery, Timespan, ddl
+from .._exceptions import MissingDatasetTypeError
 from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
@@ -596,7 +597,7 @@ class DatasetRecordStorageManager(VersionedExtension):
         """
         result = self.find(name)
         if result is None:
-            raise KeyError(f"Dataset type with name '{name}' not found.")
+            raise MissingDatasetTypeError(f"Dataset type with name '{name}' not found.")
         return result
 
     @abstractmethod

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -161,6 +161,10 @@ class QueryBackend(ABC):
             datasets were not matched by the expression.  Fully-specified
             component datasets (`str` or `DatasetType` instances) are always
             included.
+
+            Values other than `False` are deprecated, and only `False` will be
+            supported after v26.  After v27 this argument will be removed
+            entirely.
         explicit_only : `bool`, optional
             If `True`, require explicit `DatasetType` instances or `str` names,
             with `re.Pattern` instances deprecated and ``...`` prohibited.

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -67,6 +67,7 @@ from .._exceptions import (
     DatasetTypeError,
     InconsistentDataIdError,
     MissingCollectionError,
+    MissingDatasetTypeError,
     OrphanedRecordError,
 )
 from ..interfaces import ButlerAttributeExistsError, DatasetIdGenEnum
@@ -433,7 +434,7 @@ class RegistryTests(ABC):
         registry = self.makeRegistry()
         self.loadData(registry, "base.yaml")
         registry.removeDatasetType("flat")
-        with self.assertRaises(KeyError):
+        with self.assertRaises(MissingDatasetTypeError):
             registry.getDatasetType("flat")
 
     def testRemoveDatasetTypeFailure(self):

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -2666,6 +2666,16 @@ class RegistryTests(ABC):
         self.assertEqual(query5.count(exact=True), 0)
         messages = list(query5.explain_no_results())
         self.assertFalse(messages)
+        # This query should yield results from one dataset type but not the
+        # other, which is not registered.
+        query5 = registry.queryDatasets(["bias", "nonexistent"], collections=["biases"])
+        self.assertTrue(set(query5))
+        self.assertTrue(query5.any(execute=False, exact=False))
+        self.assertTrue(query5.any(execute=True, exact=False))
+        self.assertTrue(query5.any(execute=True, exact=True))
+        self.assertGreaterEqual(query5.count(exact=False), 1)
+        self.assertGreaterEqual(query5.count(exact=True), 1)
+        self.assertFalse(messages, list(query5.explain_no_results()))
 
     def testQueryDataIdsOrderBy(self):
         """Test order_by and limit on result returned by queryDataIds()."""

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1016,7 +1016,10 @@ class ButlerTests(ButlerPutGetTests):
             for componentName in storageClass.components:
                 components.add(DatasetType.nameWithComponent(datasetTypeName, componentName))
 
-        fromRegistry = set(butler.registry.queryDatasetTypes(components=True))
+        fromRegistry: set[DatasetType] = set()
+        for parent_dataset_type in butler.registry.queryDatasetTypes():
+            fromRegistry.add(parent_dataset_type)
+            fromRegistry.update(parent_dataset_type.makeAllComponentDatasetTypes())
         self.assertEqual({d.name for d in fromRegistry}, datasetTypeNames | components)
 
         # Now that we have some dataset types registered, validate them

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -163,41 +163,6 @@ class SimpleButlerTestCase(unittest.TestCase):
             [self.comparableRef(ref) for ref in datasets2],
         )
 
-    def testComponentExport(self):
-        """Test exporting component datasets and then importing them.
-
-        This test exports component datasets and then checks via the parent
-        dataset type, since this is the only valid way to handle component
-        exports (since Registry cannot record just a component without a
-        parent, even if Datastore can).
-        """
-        # Import data to play with.
-        butler1 = self.makeButler(writeable=True)
-        butler1.import_(filename=os.path.join(TESTDIR, "data", "registry", "base.yaml"))
-        butler1.import_(filename=os.path.join(TESTDIR, "data", "registry", self.datasetsImportFile))
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as file:
-            # Export all datasets.
-            with butler1.export(filename=file.name) as exporter:
-                exporter.saveDatasets(
-                    ref.makeComponentRef("psf")
-                    for ref in butler1.registry.queryDatasets("flat", collections=...)
-                )
-            # Import it all again.
-            butler2 = self.makeButler(writeable=True)
-            butler2.import_(filename=file.name)
-        datasets1 = [
-            ref.makeComponentRef("psf") for ref in butler1.registry.queryDatasets("flat", collections=...)
-        ]
-        datasets2 = [
-            ref.makeComponentRef("psf") for ref in butler2.registry.queryDatasets("flat", collections=...)
-        ]
-        self.assertTrue(all(isinstance(ref.id, self.datasetsIdType) for ref in datasets1))
-        self.assertTrue(all(isinstance(ref.id, self.datasetsIdType) for ref in datasets2))
-        self.assertCountEqual(
-            [self.comparableRef(ref) for ref in datasets1],
-            [self.comparableRef(ref) for ref in datasets2],
-        )
-
     def testImportTwice(self):
         """Test exporting dimension records and datasets from a repo and then
         importing them all back in again twice.

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -138,8 +138,9 @@ class ButlerUtilsTestSuite(unittest.TestCase):
             addDataIdValue(self.butler, "tract", 43, skymap="map")
 
     def testAddDatasetType(self):
-        # 1 for StructuredDataNoComponents, 4 for StructuredData
-        self.assertEqual(len(list(self.butler.registry.queryDatasetTypes(components=True))), 5)
+        # 1 for StructuredDataNoComponents, 1 for StructuredData (components
+        # not included).
+        self.assertEqual(len(list(self.butler.registry.queryDatasetTypes(components=False))), 2)
 
         # Testing the DatasetType objects is not practical, because all tests
         # need a DimensionUniverse. So just check that we have the dataset


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`

