### PR TITLE
DM-4551: Allow override of storage class on butler.get()

### DIFF
--- a/doc/changes/DM-4551.api.rst
+++ b/doc/changes/DM-4551.api.rst
@@ -1,0 +1,1 @@
+A method has been added to ``DatasetRef`` and ``DatasetType``, named ``overrideStorageClass``, to allow a new object to be created that has a different storage class associated with it.

--- a/doc/changes/DM-4551.feature.rst
+++ b/doc/changes/DM-4551.feature.rst
@@ -1,0 +1,9 @@
+It is now possible to override the python type returned by ``butler.get()`` (if the types are compatible with each other) by using the new ``readStorageClass`` parameter.
+
+For example, to return an `astropy.table.Table` from something that usually returns an ``lsst.afw.table.Catalog`` you would do:
+
+.. code-block:: python
+
+    table = butler.getDirect(ref, readStorageClass="AstropyTable")
+
+Any parameters given to the ``get()`` must still refer to the native storage class.

--- a/doc/changes/DM-4551.feature.rst
+++ b/doc/changes/DM-4551.feature.rst
@@ -1,4 +1,5 @@
 It is now possible to override the python type returned by ``butler.get()`` (if the types are compatible with each other) by using the new ``readStorageClass`` parameter.
+Deferred dataset handles can also be overridden.
 
 For example, to return an `astropy.table.Table` from something that usually returns an ``lsst.afw.table.Catalog`` you would do:
 

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1235,7 +1235,7 @@ class Butler(LimitedButler):
         ref: DatasetRef,
         *,
         parameters: Optional[Dict[str, Any]] = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Any:
         """Retrieve a stored dataset.
 
@@ -1250,13 +1250,19 @@ class Butler(LimitedButler):
         parameters : `dict`
             Additional StorageClass-defined options to control reading,
             typically used to efficiently read only a subset of the dataset.
+        storageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
 
         Returns
         -------
         obj : `object`
             The dataset.
         """
-        return self.datastore.get(ref, parameters=parameters, readStorageClass=readStorageClass)
+        return self.datastore.get(ref, parameters=parameters, storageClass=storageClass)
 
     def getDirectDeferred(
         self, ref: DatasetRef, *, parameters: Union[dict, None] = None
@@ -1346,7 +1352,7 @@ class Butler(LimitedButler):
         *,
         parameters: Optional[Dict[str, Any]] = None,
         collections: Any = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
         **kwargs: Any,
     ) -> Any:
         """Retrieve a stored dataset.
@@ -1367,7 +1373,7 @@ class Butler(LimitedButler):
             Collections to be searched, overriding ``self.collections``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
-        readStorageClass : `StorageClass` or `str`, optional
+        storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a
@@ -1405,7 +1411,7 @@ class Butler(LimitedButler):
         """
         log.debug("Butler get: %s, dataId=%s, parameters=%s", datasetRefOrType, dataId, parameters)
         ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
-        return self.getDirect(ref, parameters=parameters, readStorageClass=readStorageClass)
+        return self.getDirect(ref, parameters=parameters, storageClass=storageClass)
 
     def getURIs(
         self,

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1265,7 +1265,11 @@ class Butler(LimitedButler):
         return self.datastore.get(ref, parameters=parameters, storageClass=storageClass)
 
     def getDirectDeferred(
-        self, ref: DatasetRef, *, parameters: Union[dict, None] = None
+        self,
+        ref: DatasetRef,
+        *,
+        parameters: Union[dict, None] = None,
+        storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
         from a resolved `DatasetRef`.
@@ -1277,6 +1281,12 @@ class Butler(LimitedButler):
         parameters : `dict`
             Additional StorageClass-defined options to control reading,
             typically used to efficiently read only a subset of the dataset.
+        storageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
 
         Returns
         -------
@@ -1292,7 +1302,7 @@ class Butler(LimitedButler):
             raise AmbiguousDatasetError(
                 f"Dataset of type {ref.datasetType.name} with data ID {ref.dataId} is not resolved."
             )
-        return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters)
+        return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters, storageClass=storageClass)
 
     def getDeferred(
         self,
@@ -1301,6 +1311,7 @@ class Butler(LimitedButler):
         *,
         parameters: Union[dict, None] = None,
         collections: Any = None,
+        storageClass: str | StorageClass | None = None,
         **kwargs: Any,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
@@ -1322,6 +1333,12 @@ class Butler(LimitedButler):
             Collections to be searched, overriding ``self.collections``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
+        storageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
         **kwargs
             Additional keyword arguments used to augment or construct a
             `DataId`.  See `DataId` parameters.
@@ -1343,7 +1360,7 @@ class Butler(LimitedButler):
             Raised if no collections were provided.
         """
         ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
-        return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters)
+        return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters, storageClass=storageClass)
 
     def get(
         self,

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -84,6 +84,7 @@ from .core import (
     DimensionUniverse,
     FileDataset,
     Progress,
+    StorageClass,
     StorageClassFactory,
     Timespan,
     ValidationError,
@@ -1229,7 +1230,13 @@ class Butler(LimitedButler):
 
         return ref
 
-    def getDirect(self, ref: DatasetRef, *, parameters: Optional[Dict[str, Any]] = None) -> Any:
+    def getDirect(
+        self,
+        ref: DatasetRef,
+        *,
+        parameters: Optional[Dict[str, Any]] = None,
+        readStorageClass: Optional[Union[StorageClass, str]] = None,
+    ) -> Any:
         """Retrieve a stored dataset.
 
         Unlike `Butler.get`, this method allows datasets outside the Butler's
@@ -1249,7 +1256,7 @@ class Butler(LimitedButler):
         obj : `object`
             The dataset.
         """
-        return self.datastore.get(ref, parameters=parameters)
+        return self.datastore.get(ref, parameters=parameters, readStorageClass=readStorageClass)
 
     def getDirectDeferred(
         self, ref: DatasetRef, *, parameters: Union[dict, None] = None
@@ -1339,6 +1346,7 @@ class Butler(LimitedButler):
         *,
         parameters: Optional[Dict[str, Any]] = None,
         collections: Any = None,
+        readStorageClass: Optional[Union[StorageClass, str]] = None,
         **kwargs: Any,
     ) -> Any:
         """Retrieve a stored dataset.
@@ -1359,6 +1367,12 @@ class Butler(LimitedButler):
             Collections to be searched, overriding ``self.collections``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
+        readStorageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
         **kwargs
             Additional keyword arguments used to augment or construct a
             `DataCoordinate`.  See `DataCoordinate.standardize`
@@ -1391,7 +1405,7 @@ class Butler(LimitedButler):
         """
         log.debug("Butler get: %s, dataId=%s, parameters=%s", datasetRefOrType, dataId, parameters)
         ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
-        return self.getDirect(ref, parameters=parameters)
+        return self.getDirect(ref, parameters=parameters, readStorageClass=readStorageClass)
 
     def getURIs(
         self,

--- a/python/lsst/daf/butler/_deferredDatasetHandle.py
+++ b/python/lsst/daf/butler/_deferredDatasetHandle.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 __all__ = ("DeferredDatasetHandle",)
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     from ._limited_butler import LimitedButler
@@ -114,5 +114,5 @@ class DeferredDatasetHandle:
     to be loaded (`dict` or `None`).
     """
 
-    storageClass: None | str | StorageClass
+    storageClass: Optional[Union[str, StorageClass]] = None
     """Optional storage class override that can be applied on ``get()``."""

--- a/python/lsst/daf/butler/_deferredDatasetHandle.py
+++ b/python/lsst/daf/butler/_deferredDatasetHandle.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from ._limited_butler import LimitedButler
-    from .core import DataCoordinate, DatasetRef
+    from .core import DataCoordinate, DatasetRef, StorageClass
 
 
 @dataclasses.dataclass(frozen=True)
@@ -39,7 +39,12 @@ class DeferredDatasetHandle:
     """Proxy class that provides deferred loading of datasets from a butler."""
 
     def get(
-        self, *, component: Optional[str] = None, parameters: Optional[dict] = None, **kwargs: dict
+        self,
+        *,
+        component: Optional[str] = None,
+        parameters: Optional[dict] = None,
+        storageClass: str | StorageClass | None = None,
+        **kwargs: dict,
     ) -> Any:
         """Retrieves the dataset pointed to by this handle
 
@@ -56,6 +61,13 @@ class DeferredDatasetHandle:
             It defaults to None. If the value is not None,  this dict will
             be merged with the parameters dict used to construct the
             `DeferredDatasetHandle` class.
+        storageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset or the storage
+            class specified when this object was created. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
         **kwargs
             This argument is deprecated and only exists to support legacy
             gen2 butler code during migration. It is completely ignored
@@ -74,9 +86,11 @@ class DeferredDatasetHandle:
             mergedParameters = parameters
         else:
             mergedParameters = {}
+        if storageClass is None:
+            storageClass = self.storageClass
 
         ref = self.ref.makeComponentRef(component) if component is not None else self.ref
-        return self.butler.getDirect(ref, parameters=mergedParameters)
+        return self.butler.getDirect(ref, parameters=mergedParameters, storageClass=storageClass)
 
     @property
     def dataId(self) -> DataCoordinate:
@@ -99,3 +113,6 @@ class DeferredDatasetHandle:
     """Optional parameters that may be used to specify a subset of the dataset
     to be loaded (`dict` or `None`).
     """
+
+    storageClass: None | str | StorageClass
+    """Optional storage class override that can be applied on ``get()``."""

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -43,6 +43,7 @@ from .core import (
     DimensionUniverse,
     Quantum,
     SerializedDatastoreRecordData,
+    StorageClass,
     StorageClassFactory,
     ddl,
 )
@@ -235,10 +236,16 @@ class QuantumBackedButler(LimitedButler):
         # Docstring inherited.
         return True
 
-    def getDirect(self, ref: DatasetRef, *, parameters: Optional[Dict[str, Any]] = None) -> Any:
+    def getDirect(
+        self,
+        ref: DatasetRef,
+        *,
+        parameters: Optional[Dict[str, Any]] = None,
+        storageClass: str | StorageClass | None = None,
+    ) -> Any:
         # Docstring inherited.
         try:
-            obj = super().getDirect(ref, parameters=parameters)
+            obj = super().getDirect(ref, parameters=parameters, storageClass=storageClass)
         except (LookupError, FileNotFoundError, IOError):
             self._unavailable_inputs.add(ref.getCheckedId())
             raise
@@ -249,7 +256,11 @@ class QuantumBackedButler(LimitedButler):
         return obj
 
     def getDirectDeferred(
-        self, ref: DatasetRef, *, parameters: Union[dict, None] = None
+        self,
+        ref: DatasetRef,
+        *,
+        parameters: Union[dict, None] = None,
+        storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         # Docstring inherited.
         if ref.id in self._predicted_inputs:
@@ -257,7 +268,7 @@ class QuantumBackedButler(LimitedButler):
             # loading, so it's conceivable here that we're marking an input
             # as "actual" even when it's not even available.
             self._actual_inputs.add(ref.id)
-        return super().getDirectDeferred(ref, parameters=parameters)
+        return super().getDirectDeferred(ref, parameters=parameters, storageClass=storageClass)
 
     def datasetExistsDirect(self, ref: DatasetRef) -> bool:
         # Docstring inherited.

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -257,6 +257,8 @@ storageClasses:
       - bbox
   AstropyTable:
     pytype: astropy.table.Table
+    converters:
+      lsst.afw.table.Catalog: lsst.afw.table.Catalog.asAstropy
   AstropyQTable:
     pytype: astropy.table.QTable
   ExtendedPsf:

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -36,6 +36,7 @@ from .type import DatasetType, SerializedDatasetType
 
 if TYPE_CHECKING:
     from ...registry import Registry
+    from ..storageClass import StorageClass
 
 
 class AmbiguousDatasetError(Exception):
@@ -562,6 +563,29 @@ class DatasetRef:
         return DatasetRef(
             self.datasetType.makeComponentDatasetType(name),
             self.dataId,
+            id=self.id,
+            run=self.run,
+            conform=False,
+        )
+
+    def overrideStorageClass(self, storageClass: str | StorageClass) -> DatasetRef:
+        """Create a new `DatasetRef` from this one, but with a modified
+        `DatasetType` that has a different `StorageClass`.
+
+        Parameters
+        ----------
+        storageClass : `str` or `StorageClass`
+            The new storage class.
+
+        Returns
+        -------
+        modified : `DatasetRef`
+            A new dataset reference that is the same as the current one but
+            with a different storage class in the `DatasetType`.
+        """
+        return DatasetRef(
+            datasetType=self.datasetType.overrideStorageClass(storageClass),
+            dataId=self.dataId,
             id=self.id,
             run=self.run,
             conform=False,

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -532,6 +532,35 @@ class DatasetType:
             for componentName in self.storageClass.allComponents()
         ]
 
+    def overrideStorageClass(self, storageClass: str | StorageClass) -> DatasetType:
+        """Create a new `DatasetType` from this one but with an updated
+        `StorageClass`.
+
+        Parameters
+        ----------
+        storageClass : `str` or `StorageClass`
+            The new storage class.
+
+        Returns
+        -------
+        modified : `DatasetType`
+            A new dataset type that is the same as the current one but with
+            a different storage class.
+
+        Notes
+        -----
+        If this is a component dataset type, the parent storage class
+        will be retained.
+        """
+        parent = self._parentStorageClass if self._parentStorageClass else self._parentStorageClassName
+        return DatasetType(
+            self.name,
+            dimensions=self.dimensions,
+            storageClass=storageClass,
+            parentStorageClass=parent,
+            isCalibration=self.isCalibration(),
+        )
+
     def isComponent(self) -> bool:
         """Return whether this `DatasetType` refers to a component.
 

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -553,12 +553,19 @@ class DatasetType:
         will be retained.
         """
         parent = self._parentStorageClass if self._parentStorageClass else self._parentStorageClassName
-        return DatasetType(
+        new = DatasetType(
             self.name,
             dimensions=self.dimensions,
             storageClass=storageClass,
             parentStorageClass=parent,
             isCalibration=self.isCalibration(),
+        )
+        # Check validity.
+        if new.is_compatible_with(self) or self.is_compatible_with(new):
+            return new
+        raise ValueError(
+            f"The new storage class ({new.storageClass}) is not compatible with the "
+            f"existing storage class ({self.storageClass})."
         )
 
     def isComponent(self) -> bool:

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -466,7 +466,7 @@ class Datastore(metaclass=ABCMeta):
         self,
         datasetRef: DatasetRef,
         parameters: Mapping[str, Any] = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Any:
         """Load an `InMemoryDataset` from the store.
 
@@ -477,7 +477,7 @@ class Datastore(metaclass=ABCMeta):
         parameters : `dict`
             `StorageClass`-specific parameters that specify a slice of the
             Dataset to be loaded.
-        readStorageClass : `StorageClass` or `str`, optional
+        storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -462,7 +462,12 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def get(self, datasetRef: DatasetRef, parameters: Mapping[str, Any] = None) -> Any:
+    def get(
+        self,
+        datasetRef: DatasetRef,
+        parameters: Mapping[str, Any] = None,
+        readStorageClass: Optional[Union[StorageClass, str]] = None,
+    ) -> Any:
         """Load an `InMemoryDataset` from the store.
 
         Parameters
@@ -472,6 +477,12 @@ class Datastore(metaclass=ABCMeta):
         parameters : `dict`
             `StorageClass`-specific parameters that specify a slice of the
             Dataset to be loaded.
+        readStorageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
 
         Returns
         -------

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -565,7 +565,7 @@ class StorageClass:
                     raise
         raise TypeError(
             "Type does not match and no valid converter found to convert"
-            f" '{type(incorrect)}' to '{self.pytype}'"
+            f" '{get_full_type_name(incorrect)}' to '{get_full_type_name(self.pytype)}'"
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -315,7 +315,7 @@ class ChainedDatastore(Datastore):
         self,
         ref: DatasetRef,
         parameters: Optional[Mapping[str, Any]] = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Any:
         """Load an InMemoryDataset from the store.
 
@@ -329,7 +329,7 @@ class ChainedDatastore(Datastore):
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
             a slice of the dataset to be loaded.
-        readStorageClass : `StorageClass` or `str`, optional
+        storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a
@@ -353,7 +353,7 @@ class ChainedDatastore(Datastore):
 
         for datastore in self.datastores:
             try:
-                inMemoryObject = datastore.get(ref, parameters, readStorageClass=readStorageClass)
+                inMemoryObject = datastore.get(ref, parameters, storageClass=storageClass)
                 log.debug("Found dataset %s in datastore %s", ref, datastore.name)
                 return inMemoryObject
             except FileNotFoundError:

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -311,7 +311,12 @@ class ChainedDatastore(Datastore):
                 return True
         return False
 
-    def get(self, ref: DatasetRef, parameters: Optional[Mapping[str, Any]] = None) -> Any:
+    def get(
+        self,
+        ref: DatasetRef,
+        parameters: Optional[Mapping[str, Any]] = None,
+        readStorageClass: Optional[Union[StorageClass, str]] = None,
+    ) -> Any:
         """Load an InMemoryDataset from the store.
 
         The dataset is returned from the first datastore that has
@@ -324,6 +329,12 @@ class ChainedDatastore(Datastore):
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
             a slice of the dataset to be loaded.
+        readStorageClass : `StorageClass` or `str`, optional
+            The storage class to be used to override the Python type
+            returned by this method. By default the returned type matches
+            the dataset type definition for this dataset. Specifying a
+            read `StorageClass` can force a different type to be returned.
+            This type must be compatible with the original type.
 
         Returns
         -------
@@ -342,7 +353,7 @@ class ChainedDatastore(Datastore):
 
         for datastore in self.datastores:
             try:
-                inMemoryObject = datastore.get(ref, parameters)
+                inMemoryObject = datastore.get(ref, parameters, readStorageClass=readStorageClass)
                 log.debug("Found dataset %s in datastore %s", ref, datastore.name)
                 return inMemoryObject
             except FileNotFoundError:

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1925,7 +1925,7 @@ class FileDatastore(GenericBaseDatastore):
         self,
         ref: DatasetRef,
         parameters: Optional[Mapping[str, Any]] = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Any:
         """Load an InMemoryDataset from the store.
 
@@ -1936,7 +1936,7 @@ class FileDatastore(GenericBaseDatastore):
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
             a slice of the dataset to be loaded.
-        readStorageClass : `StorageClass` or `str`, optional
+        storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a
@@ -1960,8 +1960,8 @@ class FileDatastore(GenericBaseDatastore):
         # Supplied storage class for the component being read is either
         # from the ref itself or some an override if we want to force
         # type conversion.
-        if readStorageClass is not None:
-            ref = ref.overrideStorageClass(readStorageClass)
+        if storageClass is not None:
+            ref = ref.overrideStorageClass(storageClass)
         refStorageClass = ref.datasetType.storageClass
 
         allGetInfo = self._prepare_for_get(ref, parameters)

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -337,16 +337,11 @@ class InMemoryDatastore(GenericBaseDatastore):
             # Then disable parameters for later
             parameters = {}
 
-        # Different storage classes implies a component request
-        if readStorageClass != writeStorageClass:
-
-            if component is None:
-                raise ValueError(
-                    "Storage class inconsistency ({} vs {}) but no"
-                    " component requested".format(readStorageClass.name, writeStorageClass.name)
-                )
-
-            # Concrete composite written as a single object (we hope)
+        # Check if we have a component.
+        if component:
+            # In-memory datastore must have stored the dataset as a single
+            # object in the write storage class. We therefore use that
+            # storage class delegate to obtain the component.
             inMemoryDataset = writeStorageClass.delegate().getComponent(inMemoryDataset, component)
 
         # Since there is no formatter to process parameters, they all must be

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -284,7 +284,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         self,
         ref: DatasetRef,
         parameters: Optional[Mapping[str, Any]] = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Any:
         """Load an InMemoryDataset from the store.
 
@@ -295,7 +295,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         parameters : `dict`
             `StorageClass`-specific parameters that specify, for example,
             a slice of the dataset to be loaded.
-        readStorageClass : `StorageClass` or `str`, optional
+        storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a
@@ -323,8 +323,8 @@ class InMemoryDatastore(GenericBaseDatastore):
 
         # We have a write storage class and a read storage class and they
         # can be different for concrete composites or if overridden.
-        if readStorageClass is not None:
-            ref = ref.overrideStorageClass(readStorageClass)
+        if storageClass is not None:
+            ref = ref.overrideStorageClass(storageClass)
         refStorageClass = ref.datasetType.storageClass
         writeStorageClass = storedItemInfo.storageClass
 

--- a/python/lsst/daf/butler/formatters/file.py
+++ b/python/lsst/daf/butler/formatters/file.py
@@ -29,6 +29,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Optional, Type
 
 from lsst.daf.butler import Formatter
+from lsst.utils.introspection import get_full_type_name
 
 if TYPE_CHECKING:
     from lsst.daf.butler import StorageClass
@@ -115,7 +116,8 @@ class FileFormatter(Formatter):
                         f"Storage class inconsistency ({readStorageClass.name} vs"
                         f" {fileDescriptor.storageClass.name}) but no"
                         " component requested or converter registered for"
-                        f" python type {type(data)}"
+                        f" converting type {get_full_type_name(fileDescriptor.storageClass.pytype)}"
+                        f" to {get_full_type_name(readStorageClass.pytype)}."
                     )
             else:
                 # Concrete composite written as a single file (we hope)

--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -187,11 +187,12 @@ class YamlFormatter(FileFormatter):
             Object of expected type ``readStorageClass.pytype``.
         """
         if inMemoryDataset is not None and not hasattr(builtins, readStorageClass.pytype.__name__):
-            if readStorageClass.isComposite():
-                inMemoryDataset = readStorageClass.delegate().assemble(
-                    inMemoryDataset, pytype=readStorageClass.pytype
+            if writeStorageClass.isComposite():
+                # We know that the write storage class should work,
+                # then we convert to read storage class.
+                inMemoryDataset = writeStorageClass.delegate().assemble(
+                    inMemoryDataset, pytype=writeStorageClass.pytype
                 )
-                return readStorageClass.coerce_type(inMemoryDataset)
             elif not isinstance(inMemoryDataset, readStorageClass.pytype):
                 if not isinstance(inMemoryDataset, writeStorageClass.pytype):
                     # This does not look like the written type or the required
@@ -203,6 +204,5 @@ class YamlFormatter(FileFormatter):
                     else:
                         # Hope that we can pass the arguments in directly.
                         inMemoryDataset = writeStorageClass.pytype(inMemoryDataset)
-                # Coerce to the read storage class if necessary.
-                inMemoryDataset = readStorageClass.coerce_type(inMemoryDataset)
-        return inMemoryDataset
+        # Coerce to the read storage class if necessary.
+        return readStorageClass.coerce_type(inMemoryDataset)

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -44,6 +44,7 @@ from lsst.daf.butler import (
     Dimension,
     DimensionUniverse,
     FileDataset,
+    StorageClass,
 )
 
 
@@ -556,7 +557,9 @@ class DatastoreMock:
 
     @staticmethod
     def _mock_get(
-        ref: DatasetRef, parameters: Optional[Mapping[str, Any]] = None
+        ref: DatasetRef,
+        parameters: Optional[Mapping[str, Any]] = None,
+        readStorageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Tuple[int, Optional[Mapping[str, Any]]]:
         """A mock of `Datastore.get` that just returns the integer dataset ID
         value and parameters it was given.

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -559,7 +559,7 @@ class DatastoreMock:
     def _mock_get(
         ref: DatasetRef,
         parameters: Optional[Mapping[str, Any]] = None,
-        readStorageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: Optional[Union[StorageClass, str]] = None,
     ) -> Tuple[int, Optional[Mapping[str, Any]]]:
         """A mock of `Datastore.get` that just returns the integer dataset ID
         value and parameters it was given.

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -71,6 +71,15 @@ storageClasses:
       counter: Integer
     parameters:
       - slice
+  StructuredDataDataTestTuple:
+    pytype: tuple
+    delegate: lsst.daf.butler.tests.ListDelegate
+    derivedComponents:
+      counter: Integer
+    parameters:
+      - slice
+    converters:
+      builtins.list: builtins.tuple
   Integer:
     pytype: int
   StructuredCompositeReadComp:
@@ -92,3 +101,15 @@ storageClasses:
       lsst.daf.butler.bad.type: lsst.daf.butler.tests.MetricsExampleModel.from_metrics
       lsst.daf.butler.tests.MetricsExampleModel: lsst.daf.butler.bad.function
       lsst.daf.butler.Butler: lsst.daf.butler.core.location.__all__
+  MetricsConversion:
+    # Special storage class to test conversions with components and params.
+    pytype: lsst.daf.butler.tests.MetricsExampleModel
+    delegate: lsst.daf.butler.tests.MetricsDelegate
+    parameters:
+      - xslice
+    components:
+      summary: StructuredDataDictYaml
+      output: StructuredDataDictYaml
+      data: StructuredDataDataTestTuple
+    converters:
+      lsst.daf.butler.tests.MetricsExample: lsst.daf.butler.tests.MetricsExampleModel.from_metrics

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -679,6 +679,18 @@ class ButlerTests(ButlerPutGetTests):
         self.assertIs(type(model), new_sc.pytype)
         self.assertEqual(retrieved, model)
 
+        # Defer but override later.
+        deferred = butler.getDirectDeferred(ref)
+        model = deferred.get(storageClass=new_sc)
+        self.assertIs(type(model), new_sc.pytype)
+        self.assertEqual(retrieved, model)
+
+        # Defer but override up front.
+        deferred = butler.getDirectDeferred(ref, storageClass=new_sc)
+        model = deferred.get()
+        self.assertIs(type(model), new_sc.pytype)
+        self.assertEqual(retrieved, model)
+
         # Retrieve a component. Should be a tuple.
         data = butler.get("anything.data", dataId, storageClass="StructuredDataDataTestTuple")
         self.assertIs(type(data), tuple)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -674,13 +674,13 @@ class ButlerTests(ButlerPutGetTests):
 
         # Specify an override.
         new_sc = self.storageClassFactory.getStorageClass("MetricsConversion")
-        model = butler.getDirect(ref, readStorageClass=new_sc)
+        model = butler.getDirect(ref, storageClass=new_sc)
         self.assertNotEqual(type(model), type(retrieved))
         self.assertIs(type(model), new_sc.pytype)
         self.assertEqual(retrieved, model)
 
         # Retrieve a component. Should be a tuple.
-        data = butler.get("anything.data", dataId, readStorageClass="StructuredDataDataTestTuple")
+        data = butler.get("anything.data", dataId, storageClass="StructuredDataDataTestTuple")
         self.assertIs(type(data), tuple)
         self.assertEqual(data, tuple(retrieved.data))
 
@@ -689,7 +689,7 @@ class ButlerTests(ButlerPutGetTests):
         data = butler.get(
             "anything.data",
             dataId,
-            readStorageClass="StructuredDataDataTestTuple",
+            storageClass="StructuredDataDataTestTuple",
             parameters={"slice": slice(2, 4)},
         )
         self.assertEqual(len(data), 2)
@@ -700,7 +700,7 @@ class ButlerTests(ButlerPutGetTests):
             butler.get(
                 "anything.data",
                 dataId,
-                readStorageClass="StructuredDataDataTestTuple",
+                storageClass="StructuredDataDataTestTuple",
                 parameters={"xslice": slice(2, 4)},
             )
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -654,6 +654,47 @@ class ButlerTests(ButlerPutGetTests):
                 self.assertIn("424", str(compuri), f"Checking visit is in URI {compuri}")
                 self.assertEqual(compuri.fragment, "predicted", f"Checking for fragment in {compuri}")
 
+    def testPytypePutCoercion(self):
+        """Test python type coercion on Butler.get and put."""
+
+        # Store some data with the normal example storage class.
+        storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
+        datasetTypeName = "test_metric"
+        butler, _ = self.create_butler(self.default_run, storageClass, datasetTypeName)
+
+        dataId = {"instrument": "DummyCamComp", "visit": 423}
+
+        # Put a dict and this should coerce to a MetricsExample
+        test_dict = {"summary": {"a": 1}, "output": {"b": 2}}
+        metric_ref = butler.put(test_dict, datasetTypeName, dataId=dataId, visit=424)
+        test_metric = butler.getDirect(metric_ref)
+        self.assertEqual(get_full_type_name(test_metric), "lsst.daf.butler.tests.MetricsExample")
+        self.assertEqual(test_metric.summary, test_dict["summary"])
+        self.assertEqual(test_metric.output, test_dict["output"])
+
+        # Check that the put still works if a DatasetType is given with
+        # a definition matching this python type.
+        registry_type = butler.registry.getDatasetType(datasetTypeName)
+        this_type = DatasetType(datasetTypeName, registry_type.dimensions, "StructuredDataDictJson")
+        metric2_ref = butler.put(test_dict, this_type, dataId=dataId, visit=425)
+        self.assertEqual(metric2_ref.datasetType, registry_type)
+
+        # The get will return the type expected by registry.
+        test_metric2 = butler.getDirect(metric2_ref)
+        self.assertEqual(get_full_type_name(test_metric2), "lsst.daf.butler.tests.MetricsExample")
+
+        # Make a new DatasetRef with the compatible but different DatasetType.
+        # This should now return a dict.
+        new_ref = DatasetRef(this_type, metric2_ref.dataId, id=metric2_ref.id, run=metric2_ref.run)
+        test_dict2 = butler.getDirect(new_ref)
+        self.assertEqual(get_full_type_name(test_dict2), "dict")
+
+        # Get it again with the wrong dataset type definition using get()
+        # rather than getDirect(). This should be consistent with getDirect()
+        # behavior and return the type of the DatasetType.
+        test_dict3 = butler.get(this_type, dataId=dataId, visit=425)
+        self.assertEqual(get_full_type_name(test_dict3), "dict")
+
     def testIngest(self):
         butler = Butler(self.tmpConfigFile, run=self.default_run)
 
@@ -1416,47 +1457,6 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
 
         # Clear out the datasets from registry.
         butler.pruneDatasets([ref1, ref2, ref3], purge=True, unstore=True)
-
-    def testPytypePutCoercion(self):
-        """Test python type coercion on Butler.get and put."""
-
-        # Store some data with the normal example storage class.
-        storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
-        datasetTypeName = "test_metric"
-        butler, _ = self.create_butler(self.default_run, storageClass, datasetTypeName)
-
-        dataId = {"instrument": "DummyCamComp", "visit": 423}
-
-        # Put a dict and this should coerce to a MetricsExample
-        test_dict = {"summary": {"a": 1}, "output": {"b": 2}}
-        metric_ref = butler.put(test_dict, datasetTypeName, dataId=dataId, visit=424)
-        test_metric = butler.getDirect(metric_ref)
-        self.assertEqual(get_full_type_name(test_metric), "lsst.daf.butler.tests.MetricsExample")
-        self.assertEqual(test_metric.summary, test_dict["summary"])
-        self.assertEqual(test_metric.output, test_dict["output"])
-
-        # Check that the put still works if a DatasetType is given with
-        # a definition matching this python type.
-        registry_type = butler.registry.getDatasetType(datasetTypeName)
-        this_type = DatasetType(datasetTypeName, registry_type.dimensions, "StructuredDataDictJson")
-        metric2_ref = butler.put(test_dict, this_type, dataId=dataId, visit=425)
-        self.assertEqual(metric2_ref.datasetType, registry_type)
-
-        # The get will return the type expected by registry.
-        test_metric2 = butler.getDirect(metric2_ref)
-        self.assertEqual(get_full_type_name(test_metric2), "lsst.daf.butler.tests.MetricsExample")
-
-        # Make a new DatasetRef with the compatible but different DatasetType.
-        # This should now return a dict.
-        new_ref = DatasetRef(this_type, metric2_ref.dataId, id=metric2_ref.id, run=metric2_ref.run)
-        test_dict2 = butler.getDirect(new_ref)
-        self.assertEqual(get_full_type_name(test_dict2), "dict")
-
-        # Get it again with the wrong dataset type definition using get()
-        # rather than getDirect(). This should be consistent with getDirect()
-        # behavior and return the type of the DatasetType.
-        test_dict3 = butler.get(this_type, dataId=dataId, visit=425)
-        self.assertEqual(get_full_type_name(test_dict3), "dict")
 
     def testPytypeCoercion(self):
         """Test python type coercion on Butler.get and put."""

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -598,6 +598,12 @@ class DatasetRefTestCase(unittest.TestCase):
         self.assertEqual(ref_new.datasetType.storageClass, storageA)
         self.assertEqual(ref_new.overrideStorageClass(ref.datasetType.storageClass), ref)
 
+        incompatible_sc = StorageClass("my_int", pytype=int)
+        with self.assertRaises(ValueError):
+            # Do not test against "ref" because it has a default storage class
+            # of "object" which is compatible with everything.
+            ref_new.overrideStorageClass(incompatible_sc)
+
     def testPickle(self):
         ref = DatasetRef(self.datasetType, self.dataId, id=1, run="somerun")
         s = pickle.dumps(ref)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -269,7 +269,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertFalse(dA.is_compatible_with(dA3))
 
     def testOverrideStorageClass(self):
-        storageA = StorageClass("test_a", pytype=list)
+        storageA = StorageClass("test_a", pytype=list, converters={"dict": "builtins.list"})
         storageB = StorageClass("test_b", pytype=dict)
         dimensions = self.universe.extract(["instrument"])
 


### PR DESCRIPTION
Support `data = butler.getDirect(ref, readStorageClass="AstropyTable")` style overrides.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
