### PR TITLE
DM-36326: Simplify materialized skypix overlaps.

### DIFF
--- a/doc/changes/DM-36326.misc.md
+++ b/doc/changes/DM-36326.misc.md
@@ -1,0 +1,3 @@
+Remove unnecessary table-locking in dimension record insertion.
+
+Prior to this change, we used explicit full-table locks to guard against a race condition that wasn't actually possible, which could lead to deadlocks in rare cases involving insertion of governor dimension records.


### PR DESCRIPTION
We were maintaining a lot of unused, probably too-clever code for dealing with spatial overlaps between regular database dimension elements and arbitrary skypix dimensions, while only overlaps with the common skypix dimension are actually supported everywhere else.

This commit drops that extra complexity, and with it an undesirable dependency on GovernorDimensionRecordStorage.values (which I'd like to remove) and some unnecessary table locking.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
