### PR TITLE
DM-34874: Refactor parquet formatter to use Arrow Tables natively, and add converters.

### DIFF
--- a/doc/changes/DM-34874.feature.md
+++ b/doc/changes/DM-34874.feature.md
@@ -1,0 +1,1 @@
+Updated parquet backend to use Arrow Tables natively, and add converters to and from pandas DataFrames, Astropy Tables, and Numpy structured arrays.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -72,6 +72,9 @@ Stamps: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 BrightStarStamps: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 AstropyTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter
 AstropyQTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter
+ArrowAstropy: lsst.daf.butler.formatters.parquet.ParquetFormatter
+ArrowNumpy: lsst.daf.butler.formatters.parquet.ParquetFormatter
+ArrowTable: lsst.daf.butler.formatters.parquet.ParquetFormatter
 ExtendedPsf: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 HealSparseMap: lsst.pipe.tasks.healSparseMapping.HealSparseMapFormatter
 ButlerLogRecords: lsst.daf.butler.formatters.logs.ButlerLogRecordsFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -102,13 +102,94 @@ storageClasses:
     pytype: lsst.afw.table.ExposureCatalog
   DataFrame:
     pytype: pandas.core.frame.DataFrame
+    converters:
+      pyarrow.Table: lsst.daf.butler.formatters.parquet.arrow_to_pandas
+      astropy.table.Table: astropy.table.Table.to_pandas
+      numpy.ndarray: pandas.DataFrame.from_records
     delegate: lsst.daf.butler.delegates.dataframe.DataFrameDelegate
     derivedComponents:
       columns: DataFrameIndex
+      rowcount: int
+      schema: DataFrameSchema
     parameters:
       - columns
+      - filters
   DataFrameIndex:
     pytype: pandas.Index
+    converters:
+      pyarrow.Schema: lsst.daf.butler.formatters.parquet.arrow_schema_to_pandas_index
+      list: pandas.Index
+  DataFrameSchema:
+    pytype: lsst.daf.butler.formatters.parquet.DataFrameSchema
+    converters:
+      pyarrow.Schema: lsst.daf.butler.formatters.parquet.DataFrameSchema.from_arrow
+      lsst.daf.butler.formatters.parquet.ArrowAstropySchema: lsst.daf.butler.formatters.parquet.ArrowAstropySchema.to_dataframe_schema
+      lsst.daf.butler.formatters.parquet.ArrowNumpySchema: lsst.daf.butler.formatters.parquet.ArrowNumpySchema.to_dataframe_schema
+  ArrowTable:
+    pytype: pyarrow.lib.Table
+    converters:
+      pandas.core.frame.DataFrame: lsst.daf.butler.formatters.parquet.pandas_to_arrow
+      astropy.table.Table: lsst.daf.butler.formatters.parquet.astropy_to_arrow
+      numpy.ndarray: lsst.daf.butler.formatters.parquet.numpy_to_arrow
+    delegate: lsst.daf.butler.delegates.arrowtable.ArrowTableDelegate
+    derivedComponents:
+      columns: ArrowColumnList
+      rowcount: int
+      schema: ArrowSchema
+    parameters:
+      - columns
+      - filters
+  ArrowColumnList:
+    pytype: list
+    converters:
+      pyarrow.Schema: lsst.daf.butler.formatters.parquet.arrow_schema_to_column_list
+      pandas.Index: pandas.Index.to_list
+  ArrowSchema:
+    pytype: pyarrow.Schema
+    converters:
+      lsst.daf.butler.formatters.parquet.DataFrameSchema: lsst.daf.butler.formatters.parquet.DataFrameSchema.to_arrow_schema
+      lsst.daf.butler.formatters.parquet.ArrowAstropySchema: lsst.daf.butler.formatters.parquet.ArrowAstropySchema.to_arrow_schema
+      lsst.daf.butler.formatters.parquet.ArrowNumpySchema: lsst.daf.butler.formatters.parquet.ArrowNumpySchema.to_arrow_schema
+  ArrowAstropy:
+    pytype: astropy.table.Table
+    converters:
+      pyarrow.Table: lsst.daf.butler.formatters.parquet.arrow_to_astropy
+      pandas.core.frame.DataFrame: lsst.daf.butler.formatters.parquet.pandas_to_astropy
+      numpy.ndarray: lsst.daf.butler.formatters.parquet.numpy_to_astropy
+    delegate: lsst.daf.butler.delegates.arrowastropy.ArrowAstropyDelegate
+    derivedComponents:
+      columns: ArrowColumnList
+      rowcount: int
+      schema: ArrowAstropySchema
+    parameters:
+      - columns
+      - filters
+  ArrowAstropySchema:
+    pytype: lsst.daf.butler.formatters.parquet.ArrowAstropySchema
+    converters:
+      pyarrow.Schema: lsst.daf.butler.formatters.parquet.ArrowAstropySchema.from_arrow
+      lsst.daf.butler.formatters.parquet.DataFrameSchema: lsst.daf.butler.formatters.parquet.DataFrameSchema.to_arrow_astropy_schema
+      lsst.daf.butler.formatters.parquet.ArrowNumpySchema: lsst.daf.butler.formatters.parquet.ArrowNumpySchema.to_arrow_astropy_schema
+  ArrowNumpy:
+    pytype: numpy.ndarray
+    converters:
+      pyarrow.Table: lsst.daf.butler.formatters.parquet.arrow_to_numpy
+      pandas.core.frame.DataFrame: pandas.DataFrame.to_records
+      astropy.table.Table: astropy.table.Table.as_array
+    delegate: lsst.daf.butler.delegates.arrownumpy.ArrowNumpyDelegate
+    derivedComponents:
+      columns: ArrowColumnList
+      rowcount: int
+      schema: ArrowNumpySchema
+    parameters:
+      - columns
+      - filters
+  ArrowNumpySchema:
+    pytype: lsst.daf.butler.formatters.parquet.ArrowNumpySchema
+    converters:
+      pyarrow.Schema: lsst.daf.butler.formatters.parquet.ArrowNumpySchema.from_arrow
+      lsst.daf.butler.formatters.parquet.DataFrameSchema: lsst.daf.butler.formatters.parquet.DataFrameSchema.to_arrow_numpy_schema
+      lsst.daf.butler.formatters.parquet.ArrowAstropySchema: lsst.daf.butler.formatters.parquet.ArrowAstropySchema.to_arrow_numpy_schema
   SkyMap:
     pytype: lsst.skymap.BaseSkyMap
   PropertySet:

--- a/python/lsst/daf/butler/delegates/arrowastropy.py
+++ b/python/lsst/daf/butler/delegates/arrowastropy.py
@@ -1,0 +1,75 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for reading Astropy tables with the Arrow formatter."""
+from __future__ import annotations
+
+from typing import Any
+
+import astropy.table as atable
+from lsst.daf.butler.formatters.parquet import ArrowAstropySchema
+from lsst.utils.introspection import get_full_type_name
+
+from .arrowtable import ArrowTableDelegate
+
+__all__ = ["ArrowAstropyDelegate"]
+
+
+class ArrowAstropyDelegate(ArrowTableDelegate):
+    _datasetType = atable.Table
+
+    def getComponent(self, composite: atable.Table, componentName: str) -> Any:
+        """Get a component from an astropy table stored via ArrowAstropy.
+
+        Parameters
+        ----------
+        composite : `~astropy.table.Table`
+            Astropy table to access component.
+        componentName : `str`
+            Name of component to retrieve.
+
+        Returns
+        -------
+        component : `object`
+            The component.
+
+        Raises
+        ------
+        AttributeError
+            The component can not be found.
+        """
+        match componentName:
+            case "columns":
+                return list(composite.columns.keys())
+            case "schema":
+                return ArrowAstropySchema(composite)
+            case "rowcount":
+                return len(composite)
+
+        raise AttributeError(
+            f"Do not know how to retrieve component {componentName} from {get_full_type_name(composite)}"
+        )
+
+    def _getColumns(self, inMemoryDataset: atable.Table) -> list[str]:
+        return inMemoryDataset.columns.keys()
+
+    def _selectColumns(self, inMemoryDataset: atable.Table, columns: list[str]) -> atable.Table:
+        return inMemoryDataset[columns]

--- a/python/lsst/daf/butler/delegates/arrownumpy.py
+++ b/python/lsst/daf/butler/delegates/arrownumpy.py
@@ -1,0 +1,77 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for reading numpy tables (structured arrays) with the Arrow
+formatter.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from lsst.daf.butler.formatters.parquet import ArrowNumpySchema
+from lsst.utils.introspection import get_full_type_name
+
+from .arrowtable import ArrowTableDelegate
+
+__all__ = ["ArrowNumpyDelegate"]
+
+
+class ArrowNumpyDelegate(ArrowTableDelegate):
+    _datasetType = np.ndarray
+
+    def getComponent(self, composite: np.ndarray, componentName: str) -> Any:
+        """Get a component from a numpy table stored via ArrowNumpy.
+
+        Parameters
+        ----------
+        composite : `~numpy.ndarray`
+            Numpy table to access component.
+        componentName : `str`
+            Name of component to retrieve.
+
+        Returns
+        -------
+        component : `object`
+            The component.
+
+        Raises
+        ------
+        AttributeError
+            The component can not be found.
+        """
+        match componentName:
+            case "columns":
+                return list(composite.dtype.names)
+            case "schema":
+                return ArrowNumpySchema(composite.dtype)
+            case "rowcount":
+                return len(composite)
+
+        raise AttributeError(
+            f"Do not know how to retrieve component {componentName} from {get_full_type_name(composite)}"
+        )
+
+    def _getColumns(self, inMemoryDataset: np.ndarray) -> list[str]:
+        return inMemoryDataset.dtype.names
+
+    def _selectColumns(self, inMemoryDataset: np.ndarray, columns: list[str]) -> np.ndarray:
+        return inMemoryDataset[columns]

--- a/python/lsst/daf/butler/delegates/arrowtable.py
+++ b/python/lsst/daf/butler/delegates/arrowtable.py
@@ -1,0 +1,126 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Support for reading Arrow tables."""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+import pyarrow as pa
+from lsst.daf.butler import StorageClassDelegate
+from lsst.utils.introspection import get_full_type_name
+from lsst.utils.iteration import ensure_iterable
+
+__all__ = ["ArrowTableDelegate"]
+
+
+class ArrowTableDelegate(StorageClassDelegate):
+    _datasetType = pa.Table
+
+    def getComponent(self, composite: pa.Table, componentName: str) -> Any:
+        """Get a component from an Arrow table.
+
+        Parameters
+        ----------
+        composite : `~pyarrow.Table`
+            Arrow table to access component.
+        componentName : `str`
+            Name of component to retrieve.
+
+        Returns
+        -------
+        component : `object`
+            The component.
+
+        Raises
+        ------
+        AttributeError
+            The component can not be found.
+        """
+        if componentName in ("columns", "schema"):
+            # The schema will be translated to column format
+            # depending on the input type.
+            return composite.schema
+        elif componentName == "rowcount":
+            return len(composite[composite.schema.names[0]])
+
+        raise AttributeError(
+            f"Do not know how to retrieve component {componentName} from {get_full_type_name(composite)}"
+        )
+
+    def handleParameters(self, inMemoryDataset: Any, parameters: Optional[Mapping[str, Any]] = None) -> Any:
+        if not isinstance(inMemoryDataset, self._datasetType):
+            raise ValueError(
+                f"inMemoryDataset must be a {get_full_type_name(self._datasetType)} and "
+                f"not {get_full_type_name(inMemoryDataset)}."
+            )
+
+        if parameters is None:
+            return inMemoryDataset
+
+        if "columns" in parameters:
+            read_columns = list(ensure_iterable(parameters["columns"]))
+            for column in read_columns:
+                if not isinstance(column, str):
+                    raise NotImplementedError(
+                        "InMemoryDataset of an Arrow Table only supports string column names."
+                    )
+                if column not in self._getColumns(inMemoryDataset):
+                    raise ValueError(f"Unrecognized column name {column!r}.")
+
+            # Ensure uniqueness, keeping order.
+            read_columns = list(dict.fromkeys(read_columns))
+
+            return self._selectColumns(inMemoryDataset, read_columns)
+        else:
+            return inMemoryDataset
+
+    def _getColumns(self, inMemoryDataset: pa.Table) -> list[str]:
+        """Get the column names from the inMemoryDataset.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Dataset to extract columns.
+
+        Returns
+        -------
+        columns : `list` [`str`]
+            List of columns.
+        """
+        return inMemoryDataset.schema.names
+
+    def _selectColumns(self, inMemoryDataset: pa.Table, columns: list[str]) -> pa.Table:
+        """Select a subset of columns from the inMemoryDataset.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Dataset to extract columns.
+        columns : `list` [`str`]
+            List of columns to extract.
+
+        Returns
+        -------
+        subDataset : `object`
+            Subselection of inMemoryDataset.
+        """
+        return inMemoryDataset.select(columns)

--- a/python/lsst/daf/butler/delegates/dataframe.py
+++ b/python/lsst/daf/butler/delegates/dataframe.py
@@ -27,6 +27,7 @@ from typing import Any, Mapping, Optional
 
 import pandas
 from lsst.daf.butler import StorageClassDelegate
+from lsst.daf.butler.formatters.parquet import DataFrameSchema
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import ensure_iterable
 
@@ -56,6 +57,10 @@ class DataFrameDelegate(StorageClassDelegate):
         """
         if componentName == "columns":
             return pandas.Index(self._getAllColumns(composite))
+        elif componentName == "rowcount":
+            return len(composite)
+        elif componentName == "schema":
+            return DataFrameSchema(composite.iloc[:0])
         else:
             raise AttributeError(
                 f"Do not know how to retrieve component {componentName} from {get_full_type_name(composite)}"
@@ -113,6 +118,8 @@ class DataFrameDelegate(StorageClassDelegate):
                 for name in ensure_iterable(parameters["columns"])
                 if name not in inMemoryDataset.index.names
             ]
+            # Ensure uniqueness, keeping order.
+            readColumns = list(dict.fromkeys(readColumns))
 
             return inMemoryDataset[readColumns]
         else:

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -21,177 +21,866 @@
 
 from __future__ import annotations
 
-__all__ = ("ParquetFormatter",)
+__all__ = (
+    "ParquetFormatter",
+    "arrow_to_pandas",
+    "arrow_to_astropy",
+    "arrow_to_numpy",
+    "arrow_to_numpy_dict",
+    "pandas_to_arrow",
+    "pandas_to_astropy",
+    "astropy_to_arrow",
+    "numpy_to_arrow",
+    "numpy_to_astropy",
+    "numpy_dict_to_arrow",
+    "arrow_schema_to_pandas_index",
+    "DataFrameSchema",
+    "ArrowAstropySchema",
+    "ArrowNumpySchema",
+)
 
 import collections.abc
 import itertools
 import json
 import re
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence, Union
 
-import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 from lsst.daf.butler import Formatter
+from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import ensure_iterable
 
-
-class _ParquetLoader:
-    """Helper class for loading Parquet files into `pandas.DataFrame`
-    instances.
-
-    Parameters
-    ----------
-    path : `str`
-        Full path to the file to be loaded.
-    """
-
-    def __init__(self, path: str):
-        self.file = pq.ParquetFile(path)
-        self.md = json.loads(self.file.metadata.metadata[b"pandas"])
-        indexes = self.md["column_indexes"]
-        if len(indexes) <= 1:
-            self.columns = pd.Index(
-                name for name in self.file.metadata.schema.names if not name.startswith("__")
-            )
-        else:
-            raw_columns = list(self._splitColumnnNames(len(indexes), self.file.metadata.schema.names))
-            self.columns = pd.MultiIndex.from_tuples(raw_columns, names=[f["name"] for f in indexes])
-        self.indexLevelNames = tuple(self.columns.names)
-
-    @staticmethod
-    def _splitColumnnNames(n: int, names: Iterable[str]) -> Iterator[Sequence[str]]:
-        """Split a string that represents a multi-index column.
-
-        PyArrow maps Pandas' multi-index column names (which are tuples in
-        Pythons) to flat strings on disk.  This routine exists to
-        reconstruct the original tuple.
-
-        Parameters
-        ----------
-        n : `int`
-            Number of levels in the `pd.MultiIndex` that is being
-            reconstructed.
-        names : `~collections.abc.Iterable` of `str`
-            Strings to be split.
-
-        Yields
-        ------
-        tuple : `tuple` of `str`
-            A multi-index column name tuple.
-        """
-        pattern = re.compile(r"\({}\)".format(", ".join(["'(.*)'"] * n)))
-        for name in names:
-            m = re.search(pattern, name)
-            if m is not None:
-                yield m.groups()
-
-    def _standardizeColumnParameter(
-        self, columns: Union[List[str], List[tuple], Dict[str, Union[str, List[str]]]]
-    ) -> Iterator[str]:
-        """Transform a dictionary index into a multi-index column into a
-        string directly understandable by PyArrow.
-
-        Parameters
-        ----------
-        columns : `dict`
-            Dictionary whose elements are string multi-index level names
-            and whose values are the value or values (as a list) for that
-            level.
-
-        Yields
-        ------
-        name : `str`
-            Stringified tuple representing a multi-index column name.
-        """
-        if isinstance(columns, list):
-            for requested in columns:
-                if not isinstance(requested, tuple):
-                    raise ValueError(
-                        "columns parameter for multi-index data frame"
-                        "must be either a dictionary or list of tuples."
-                    )
-                yield str(requested)
-        else:
-            if not isinstance(columns, collections.abc.Mapping):
-                raise ValueError(
-                    "columns parameter for multi-index data frame"
-                    "must be either a dictionary or list of tuples."
-                )
-            if not set(self.indexLevelNames).issuperset(columns.keys()):
-                raise ValueError(
-                    f"Cannot use dict with keys {set(columns.keys())} "
-                    f"to select columns from {self.indexLevelNames}."
-                )
-            factors = [
-                ensure_iterable(columns.get(level, self.columns.levels[i]))
-                for i, level in enumerate(self.indexLevelNames)
-            ]
-            for requested in itertools.product(*factors):
-                for i, value in enumerate(requested):
-                    if value not in self.columns.levels[i]:
-                        raise ValueError(
-                            f"Unrecognized value {value!r} for index {self.indexLevelNames[i]!r}."
-                        )
-                yield str(requested)
-
-    def read(
-        self, columns: Union[str, List[str], List[tuple], Dict[str, Union[str, List[str]]]] = None
-    ) -> pd.DataFrame:
-        """Read some or all of the Parquet file into a `pandas.DataFrame`
-        instance.
-
-        Parameters
-        ----------
-        columns:  : `dict`, `list`, or `str`, optional
-            A description of the columns to be loaded.  See
-            :ref:`lsst.daf.butler-concrete_storage_classes_dataframe`.
-
-        Returns
-        -------
-        df : `pandas.DataFrame`
-            A Pandas DataFrame.
-        """
-        if columns is None:
-            return self.file.read(use_pandas_metadata=True).to_pandas()
-        elif isinstance(self.columns, pd.MultiIndex):
-            assert isinstance(columns, dict) or isinstance(columns, list)
-            columns = list(self._standardizeColumnParameter(columns))
-        else:
-            for column in ensure_iterable(columns):
-                if column not in self.columns:
-                    raise ValueError(f"Unrecognized column name {column!r}.")
-        return self.file.read(columns=ensure_iterable(columns), use_pandas_metadata=True).to_pandas()
-
-
-def _writeParquet(path: str, inMemoryDataset: pd.DataFrame) -> None:
-    """Write a `pandas.DataFrame` instance as a Parquet file."""
-    table = pa.Table.from_pandas(inMemoryDataset)
-    pq.write_table(table, path)
+if TYPE_CHECKING:
+    import astropy.table as atable
+    import numpy as np
+    import pandas as pd
 
 
 class ParquetFormatter(Formatter):
-    """Interface for reading and writing Pandas DataFrames to and from Parquet
-    files.
-
-    This formatter is for the
-    :ref:`lsst.daf.butler-concrete_storage_classes_dataframe` StorageClass.
+    """Interface for reading and writing Arrow Table objects to and from
+    Parquet files.
     """
 
     extension = ".parq"
 
     def read(self, component: Optional[str] = None) -> Any:
         # Docstring inherited from Formatter.read.
-        loader = _ParquetLoader(self.fileDescriptor.location.path)
-        if component == "columns":
-            return loader.columns
+        schema = pq.read_schema(self.fileDescriptor.location.path)
 
-        if not self.fileDescriptor.parameters:
-            return loader.read()
+        if component in ("columns", "schema"):
+            # The schema will be translated to column format
+            # depending on the input type.
+            return schema
+        elif component == "rowcount":
+            # Get the rowcount from the metadata if possible, otherwise count.
+            if b"lsst::arrow::rowcount" in schema.metadata:
+                return int(schema.metadata[b"lsst::arrow::rowcount"])
 
-        return loader.read(**self.fileDescriptor.parameters)
+            temp_table = pq.read_table(
+                self.fileDescriptor.location.path,
+                columns=[schema.names[0]],
+                use_threads=False,
+                use_pandas_metadata=False,
+            )
+
+            return len(temp_table[schema.names[0]])
+
+        par_columns = None
+        if self.fileDescriptor.parameters:
+            par_columns = self.fileDescriptor.parameters.pop("columns", None)
+            if par_columns:
+                has_pandas_multi_index = False
+                if b"pandas" in schema.metadata:
+                    md = json.loads(schema.metadata[b"pandas"])
+                    if len(md["column_indexes"]) > 1:
+                        has_pandas_multi_index = True
+
+                if not has_pandas_multi_index:
+                    # Ensure uniqueness, keeping order.
+                    par_columns = list(dict.fromkeys(ensure_iterable(par_columns)))
+                    file_columns = [name for name in schema.names if not name.startswith("__")]
+
+                    for par_column in par_columns:
+                        if par_column not in file_columns:
+                            raise ValueError(
+                                f"Column {par_column} specified in parameters not available in parquet file."
+                            )
+                else:
+                    par_columns = _standardize_multi_index_columns(schema, par_columns)
+
+            if len(self.fileDescriptor.parameters):
+                raise ValueError(
+                    f"Unsupported parameters {self.fileDescriptor.parameters} in ArrowTable read."
+                )
+
+        metadata = schema.metadata if schema.metadata is not None else {}
+        arrow_table = pq.read_table(
+            self.fileDescriptor.location.path,
+            columns=par_columns,
+            use_threads=False,
+            use_pandas_metadata=(b"pandas" in metadata),
+        )
+
+        return arrow_table
 
     def write(self, inMemoryDataset: Any) -> None:
-        # Docstring inherited from Formatter.write.
+        import numpy as np
+        from astropy.table import Table as astropyTable
+
+        arrow_table = None
+        if isinstance(inMemoryDataset, pa.Table):
+            # This will be the most likely match.
+            arrow_table = inMemoryDataset
+        elif isinstance(inMemoryDataset, astropyTable):
+            arrow_table = astropy_to_arrow(inMemoryDataset)
+        elif isinstance(inMemoryDataset, np.ndarray):
+            arrow_table = numpy_to_arrow(inMemoryDataset)
+        else:
+            if hasattr(inMemoryDataset, "to_parquet"):
+                # This may be a pandas DataFrame
+                try:
+                    import pandas as pd
+                except ImportError:
+                    pd = None
+
+                if pd is not None and isinstance(inMemoryDataset, pd.DataFrame):
+                    arrow_table = pandas_to_arrow(inMemoryDataset)
+
+        if arrow_table is None:
+            raise ValueError(
+                f"Unsupported type {get_full_type_name(inMemoryDataset)} of "
+                "inMemoryDataset for ParquetFormatter."
+            )
+
         location = self.makeUpdatedLocation(self.fileDescriptor.location)
-        _writeParquet(location.path, inMemoryDataset)
+
+        pq.write_table(arrow_table, location.path)
+
+
+def arrow_to_pandas(arrow_table: pa.Table) -> pd.DataFrame:
+    """Convert a pyarrow table to a pandas DataFrame.
+
+    Parameters
+    ----------
+    arrow_table : `pyarrow.Table`
+        Input arrow table to convert. If the table has ``pandas`` metadata
+        in the schema it will be used in the construction of the
+        ``DataFrame``.
+
+    Returns
+    -------
+    dataframe : `pandas.DataFrame`
+    """
+    return arrow_table.to_pandas(use_threads=False)
+
+
+def arrow_to_astropy(arrow_table: pa.Table) -> atable.Table:
+    """Convert a pyarrow table to an `astropy.Table`.
+
+    Parameters
+    ----------
+    arrow_table : `pyarrow.Table`
+        Input arrow table to convert. If the table has astropy unit
+        metadata in the schema it will be used in the construction
+        of the ``astropy.Table``.
+
+    Returns
+    -------
+    table : `astropy.Table`
+    """
+    from astropy.table import Table
+
+    astropy_table = Table(arrow_to_numpy_dict(arrow_table))
+
+    metadata = arrow_table.schema.metadata if arrow_table.schema.metadata is not None else {}
+
+    _apply_astropy_metadata(astropy_table, metadata)
+
+    return astropy_table
+
+
+def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray:
+    """Convert a pyarrow table to a structured numpy array.
+
+    Parameters
+    ----------
+    arrow_table : `pyarrow.Table`
+
+    Returns
+    -------
+    array : `numpy.ndarray` (N,)
+        Numpy array table with N rows and the same column names
+        as the input arrow table.
+    """
+    import numpy as np
+
+    numpy_dict = arrow_to_numpy_dict(arrow_table)
+
+    dtype = []
+    for name, col in numpy_dict.items():
+        dtype.append((name, col.dtype))
+
+    array = np.rec.fromarrays(numpy_dict.values(), dtype=dtype)
+
+    return array
+
+
+def arrow_to_numpy_dict(arrow_table: pa.Table) -> Dict[str, np.ndarray]:
+    """Convert a pyarrow table to a dict of numpy arrays.
+
+    Parameters
+    ----------
+    arrow_table : `pyarrow.Table`
+
+    Returns
+    -------
+    numpy_dict : `dict` [`str`, `numpy.ndarray`]
+        Dict with keys as the column names, values as the arrays.
+    """
+    schema = arrow_table.schema
+
+    numpy_dict = {}
+
+    for name in schema.names:
+        col = arrow_table[name].to_numpy()
+
+        if schema.field(name).type in (pa.string(), pa.binary()):
+            col = col.astype(_arrow_string_to_numpy_dtype(schema, name, col))
+
+        numpy_dict[name] = col
+
+    return numpy_dict
+
+
+def numpy_to_arrow(np_array: np.ndarray) -> pa.Table:
+    """Convert a numpy array table to an arrow table.
+
+    Parameters
+    ----------
+    np_array : `numpy.ndarray`
+
+    Returns
+    -------
+    arrow_table : `pyarrow.Table`
+    """
+    type_list = [(name, pa.from_numpy_dtype(np_array.dtype[name].type)) for name in np_array.dtype.names]
+
+    md = {}
+    md[b"lsst::arrow::rowcount"] = str(len(np_array))
+
+    for name in np_array.dtype.names:
+        _append_numpy_string_metadata(md, name, np_array.dtype[name])
+
+    schema = pa.schema(type_list, metadata=md)
+
+    arrays = [pa.array(np_array[col]) for col in np_array.dtype.names]
+    arrow_table = pa.Table.from_arrays(arrays, schema=schema)
+
+    return arrow_table
+
+
+def numpy_dict_to_arrow(numpy_dict: Dict[str, np.ndarray]) -> pa.Table:
+    """Convert a dict of numpy arrays to an arrow table.
+
+    Parameters
+    ----------
+    numpy_dict : `dict` [`str`, `numpy.ndarray`]
+        Dict with keys as the column names, values as the arrays.
+
+    Returns
+    -------
+    arrow_table : `pyarrow.Table`
+    """
+    type_list = [(name, pa.from_numpy_dtype(col.dtype.type)) for name, col in numpy_dict.items()]
+
+    md = {}
+    md[b"lsst::arrow::rowcount"] = str(len(numpy_dict[list(numpy_dict.keys())[0]]))
+
+    for name, col in numpy_dict.items():
+        _append_numpy_string_metadata(md, name, col.dtype)
+
+    schema = pa.schema(type_list, metadata=md)
+
+    arrays = [pa.array(col) for col in numpy_dict.values()]
+    arrow_table = pa.Table.from_arrays(arrays, schema=schema)
+
+    return arrow_table
+
+
+def astropy_to_arrow(astropy_table: atable.Table) -> pa.Table:
+    """Convert an astropy table to an arrow table.
+
+    Parameters
+    ----------
+    astropy_table : `astropy.Table`
+
+    Returns
+    -------
+    arrow_table : `pyarrow.Table`
+    """
+    from astropy.table import meta
+
+    type_list = [
+        (name, pa.from_numpy_dtype(astropy_table.dtype[name].type)) for name in astropy_table.dtype.names
+    ]
+
+    md = {}
+    md[b"lsst::arrow::rowcount"] = str(len(astropy_table))
+
+    for name, col in astropy_table.columns.items():
+        _append_numpy_string_metadata(md, name, col.dtype)
+
+    meta_yaml = meta.get_yaml_from_table(astropy_table)
+    meta_yaml_str = "\n".join(meta_yaml)
+    md[b"table_meta_yaml"] = meta_yaml_str
+
+    schema = pa.schema(type_list, metadata=md)
+
+    arrays = [pa.array(col) for col in astropy_table.itercols()]
+    arrow_table = pa.Table.from_arrays(arrays, schema=schema)
+
+    return arrow_table
+
+
+def pandas_to_arrow(dataframe: pd.DataFrame, default_length: int = 10) -> pa.Table:
+    """Convert a pandas dataframe to an arrow table.
+
+    Parameters
+    ----------
+    dataframe : `pandas.DataFrame`
+    default_length : `int`, optional
+        Default string length when not in metadata or can be inferred
+        from column.
+
+    Returns
+    -------
+    arrow_table : `pyarrow.Table`
+    """
+    import numpy as np
+    import pandas as pd
+
+    arrow_table = pa.Table.from_pandas(dataframe)
+
+    # Update the metadata
+    md = arrow_table.schema.metadata
+
+    md[b"lsst::arrow::rowcount"] = str(arrow_table.num_rows)
+
+    if not isinstance(dataframe.columns, pd.MultiIndex):
+        for name in dataframe.columns:
+            if dataframe[name].dtype.type is np.object_:
+                if len(dataframe[name].values) > 0:
+                    strlen = max(len(row) for row in dataframe[name].values)
+                else:
+                    strlen = default_length
+                md[f"lsst::arrow::len::{name}".encode("UTF-8")] = str(strlen)
+
+    arrow_table = arrow_table.replace_schema_metadata(md)
+
+    return arrow_table
+
+
+def pandas_to_astropy(dataframe: pd.DataFrame) -> atable.Table:
+    """Convert a pandas dataframe to an astropy table, preserving indexes.
+
+    Parameters
+    ----------
+    dataframe : `pandas.DataFrame`
+
+    Returns
+    -------
+    astropy_table : `astropy.table.Table`
+    """
+    import pandas as pd
+    from astropy.table import Table
+
+    if isinstance(dataframe.columns, pd.MultiIndex):
+        raise ValueError("Cannot convert a multi-index dataframe to an astropy table.")
+
+    return Table.from_pandas(dataframe, index=True)
+
+
+def numpy_to_astropy(np_array: np.ndarray) -> atable.Table:
+    """Convert a numpy table to an astropy table.
+
+    Parameters
+    ----------
+    np_array : `numpy.ndarray`
+
+    Returns
+    -------
+    astropy_table : `astropy.table.Table`
+    """
+    from astropy.table import Table
+
+    return Table(data=np_array, copy=False)
+
+
+def arrow_schema_to_pandas_index(schema: pa.Schema) -> pd.Index | pd.MultiIndex:
+    """Convert an arrow schema to a pandas index/multiindex.
+
+    Parameters
+    ----------
+    schema : `pyarrow.Schema`
+
+    Returns
+    -------
+    index : `pandas.Index` or `pandas.MultiIndex`
+    """
+    import pandas as pd
+
+    if b"pandas" in schema.metadata:
+        md = json.loads(schema.metadata[b"pandas"])
+        indexes = md["column_indexes"]
+        len_indexes = len(indexes)
+    else:
+        len_indexes = 0
+
+    if len_indexes <= 1:
+        return pd.Index(name for name in schema.names if not name.startswith("__"))
+    else:
+        raw_columns = _split_multi_index_column_names(len(indexes), schema.names)
+        return pd.MultiIndex.from_tuples(raw_columns, names=[f["name"] for f in indexes])
+
+
+def arrow_schema_to_column_list(schema: pa.Schema) -> list[str]:
+    """Convert an arrow schema to a list of string column names.
+
+    Parameters
+    ----------
+    schema : `pyarrow.Schema`
+
+    Returns
+    -------
+    column_list : `list` [`str`]
+    """
+    return [name for name in schema.names]
+
+
+class DataFrameSchema:
+    """Wrapper class for a schema for a pandas DataFrame.
+
+    Parameters
+    ----------
+    dataframe : `pandas.DataFrame`
+        Dataframe to turn into a schema.
+    """
+
+    def __init__(self, dataframe: pd.DataFrame) -> None:
+        self._schema = dataframe.loc[[False] * len(dataframe)]
+
+    @classmethod
+    def from_arrow(cls, schema: pa.Schema) -> DataFrameSchema:
+        """Convert an arrow schema into a `DataFrameSchema`.
+
+        Parameters
+        ----------
+        schema : `pyarrow.Schema`
+            The pyarrow schema to convert.
+
+        Returns
+        -------
+        dataframe_schema : `DataFrameSchema`
+        """
+        empty_table = pa.Table.from_pylist([] * len(schema.names), schema=schema)
+
+        return cls(empty_table.to_pandas())
+
+    def to_arrow_schema(self) -> pa.Schema:
+        """Convert to an arrow schema.
+
+        Returns
+        -------
+        arrow_schema : `pyarrow.Schema`
+        """
+        arrow_table = pa.Table.from_pandas(self._schema)
+
+        return arrow_table.schema
+
+    def to_arrow_numpy_schema(self) -> ArrowNumpySchema:
+        """Convert to an `ArrowNumpySchema`.
+
+        Returns
+        -------
+        arrow_numpy_schema : `ArrowNumpySchema`
+        """
+        return ArrowNumpySchema.from_arrow(self.to_arrow_schema())
+
+    def to_arrow_astropy_schema(self) -> ArrowAstropySchema:
+        """Convert to an ArrowAstropySchema.
+
+        Returns
+        -------
+        arrow_astropy_schema : `ArrowAstropySchema`
+        """
+        return ArrowAstropySchema.from_arrow(self.to_arrow_schema())
+
+    @property
+    def schema(self) -> np.dtype:
+        return self._schema
+
+    def __repr__(self) -> str:
+        return repr(self._schema)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DataFrameSchema):
+            return NotImplemented
+
+        return self._schema.equals(other._schema)
+
+
+class ArrowAstropySchema:
+    """Wrapper class for a schema for an astropy table.
+
+    Parameters
+    ----------
+    astropy_table : `astropy.table.Table`
+    """
+
+    def __init__(self, astropy_table: atable.Table) -> None:
+        self._schema = astropy_table[:0]
+
+    @classmethod
+    def from_arrow(cls, schema: pa.Schema) -> ArrowAstropySchema:
+        """Convert an arrow schema into a ArrowAstropySchema.
+
+        Parameters
+        ----------
+        schema : `pyarrow.Schema`
+
+        Returns
+        -------
+        astropy_schema : `ArrowAstropySchema`
+        """
+        import numpy as np
+        from astropy.table import Table
+
+        dtype = []
+        for name in schema.names:
+            if schema.field(name).type not in (pa.string(), pa.binary()):
+                dtype.append(schema.field(name).type.to_pandas_dtype())
+                continue
+
+            dtype.append(_arrow_string_to_numpy_dtype(schema, name))
+
+        data = np.zeros(0, dtype=list(zip(schema.names, dtype)))
+
+        astropy_table = Table(data=data)
+
+        metadata = schema.metadata if schema.metadata is not None else {}
+
+        _apply_astropy_metadata(astropy_table, metadata)
+
+        return cls(astropy_table)
+
+    def to_arrow_schema(self) -> pa.Schema:
+        """Convert to an arrow schema.
+
+        Returns
+        -------
+        arrow_schema : `pyarrow.Schema`
+        """
+        return astropy_to_arrow(self._schema).schema
+
+    def to_dataframe_schema(self) -> DataFrameSchema:
+        """Convert to a DataFrameSchema.
+
+        Returns
+        -------
+        dataframe_schema : `DataFrameSchema`
+        """
+        return DataFrameSchema.from_arrow(astropy_to_arrow(self._schema).schema)
+
+    def to_arrow_numpy_schema(self) -> ArrowNumpySchema:
+        """Convert to an `ArrowNumpySchema`.
+
+        Returns
+        -------
+        arrow_numpy_schema : `ArrowNumpySchema`
+        """
+        return ArrowNumpySchema.from_arrow(astropy_to_arrow(self._schema).schema)
+
+    @property
+    def schema(self) -> atable.Table:
+        return self._schema
+
+    def __repr__(self) -> str:
+        return repr(self._schema)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ArrowAstropySchema):
+            return NotImplemented
+
+        # If this comparison passes then the two tables have the
+        # same column names.
+        if self._schema.dtype != other._schema.dtype:
+            return False
+
+        for name in self._schema.columns:
+            if not self._schema[name].unit == other._schema[name].unit:
+                return False
+            if not self._schema[name].description == other._schema[name].description:
+                return False
+            if not self._schema[name].format == other._schema[name].format:
+                return False
+
+        return True
+
+
+class ArrowNumpySchema:
+    """Wrapper class for a schema for a numpy ndarray.
+
+    Parameters
+    ----------
+    numpy_dtype : `numpy.dtype`
+         Numpy dtype to convert.
+    """
+
+    def __init__(self, numpy_dtype: np.dtype) -> None:
+        self._dtype = numpy_dtype
+
+    @classmethod
+    def from_arrow(cls, schema: pa.Schema) -> ArrowNumpySchema:
+        """Convert an arrow schema into an `ArrowNumpySchema`.
+
+        Parameters
+        ----------
+        schema : `pyarrow.Schema`
+            Pyarrow schema to convert.
+
+        Returns
+        -------
+        numpy_schema : `ArrowNumpySchema`
+        """
+        import numpy as np
+
+        dtype = []
+        for name in schema.names:
+            if schema.field(name).type not in (pa.string(), pa.binary()):
+                dtype.append((name, schema.field(name).type.to_pandas_dtype()))
+                continue
+
+            dtype.append((name, _arrow_string_to_numpy_dtype(schema, name)))
+
+        return cls(np.dtype(dtype))
+
+    def to_arrow_astropy_schema(self) -> ArrowAstropySchema:
+        """Convert to an `ArrowAstropySchema`.
+
+        Returns
+        -------
+        astropy_schema : `ArrowAstropySchema`
+        """
+        import numpy as np
+
+        return ArrowAstropySchema.from_arrow(numpy_to_arrow(np.zeros(0, dtype=self._dtype)).schema)
+
+    def to_dataframe_schema(self) -> DataFrameSchema:
+        """Convert to a `DataFrameSchema`.
+
+        Returns
+        -------
+        dataframe_schema : `DataFrameSchema`
+        """
+        import numpy as np
+
+        return DataFrameSchema.from_arrow(numpy_to_arrow(np.zeros(0, dtype=self._dtype)).schema)
+
+    def to_arrow_schema(self) -> pa.Schema:
+        """Convert to a `pyarrow.Schema`.
+
+        Returns
+        -------
+        arrow_schema : `pyarrow.Schema`
+        """
+        import numpy as np
+
+        return numpy_to_arrow(np.zeros(0, dtype=self._dtype)).schema
+
+    @property
+    def schema(self) -> np.dtype:
+        return self._dtype
+
+    def __repr__(self) -> str:
+        return repr(self._dtype)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ArrowNumpySchema):
+            return NotImplemented
+
+        if not self._dtype == other._dtype:
+            return False
+
+        return True
+
+
+def _split_multi_index_column_names(n: int, names: Iterable[str]) -> List[Sequence[str]]:
+    """Split a string that represents a multi-index column.
+
+    PyArrow maps Pandas' multi-index column names (which are tuples in Python)
+    to flat strings on disk. This routine exists to reconstruct the original
+    tuple.
+
+    Parameters
+    ----------
+    n : `int`
+        Number of levels in the `pandas.MultiIndex` that is being
+        reconstructed.
+    names : `~collections.abc.Iterable` [`str`]
+        Strings to be split.
+
+    Returns
+    -------
+    column_names : `list` [`tuple` [`str`]]
+        A list of multi-index column name tuples.
+    """
+    column_names: List[Sequence[str]] = []
+
+    pattern = re.compile(r"\({}\)".format(", ".join(["'(.*)'"] * n)))
+    for name in names:
+        m = re.search(pattern, name)
+        if m is not None:
+            column_names.append(m.groups())
+
+    return column_names
+
+
+def _standardize_multi_index_columns(
+    schema: pa.Schema, columns: Union[List[tuple], Dict[str, Union[str, List[str]]]]
+) -> List[str]:
+    """Transform a dictionary/iterable index from a multi-index column list
+    into a string directly understandable by PyArrow.
+
+    Parameters
+    ----------
+    schema : `pyarrow.Schema`
+    columns : `list` [`tuple`] or `dict` [`str`, `str` or `list` [`str`]]
+
+    Returns
+    -------
+    names : `list` [`str`]
+        Stringified representation of a multi-index column name.
+    """
+    pd_index = arrow_schema_to_pandas_index(schema)
+    index_level_names = tuple(pd_index.names)
+
+    names = []
+
+    if isinstance(columns, list):
+        for requested in columns:
+            if not isinstance(requested, tuple):
+                raise ValueError(
+                    "Columns parameter for multi-index data frame must be a dictionary or list of tuples. "
+                    f"Instead got a {get_full_type_name(requested)}."
+                )
+            names.append(str(requested))
+    else:
+        if not isinstance(columns, collections.abc.Mapping):
+            raise ValueError(
+                "Columns parameter for multi-index data frame must be a dictionary or list of tuples. "
+                f"Instead got a {get_full_type_name(columns)}."
+            )
+        if not set(index_level_names).issuperset(columns.keys()):
+            raise ValueError(
+                f"Cannot use dict with keys {set(columns.keys())} "
+                f"to select columns from {index_level_names}."
+            )
+        factors = [
+            ensure_iterable(columns.get(level, pd_index.levels[i]))
+            for i, level in enumerate(index_level_names)
+        ]
+        for requested in itertools.product(*factors):
+            for i, value in enumerate(requested):
+                if value not in pd_index.levels[i]:
+                    raise ValueError(f"Unrecognized value {value!r} for index {index_level_names[i]!r}.")
+            names.append(str(requested))
+
+    return names
+
+
+def _apply_astropy_metadata(astropy_table: atable.Table, metadata: Dict) -> None:
+    """Apply any astropy metadata from the schema metadata.
+
+    Parameters
+    ----------
+    astropy_table : `astropy.table.Table`
+        Table to apply metadata.
+    metadata : `dict` [`bytes`]
+        Metadata dict.
+    """
+    from astropy.table import meta
+
+    meta_yaml = metadata.get(b"table_meta_yaml", None)
+    if meta_yaml:
+        meta_yaml = meta_yaml.decode("UTF8").split("\n")
+        meta_hdr = meta.get_header_from_yaml(meta_yaml)
+
+        # Set description, format, unit, meta from the column
+        # metadata that was serialized with the table.
+        header_cols = {x["name"]: x for x in meta_hdr["datatype"]}
+        for col in astropy_table.columns.values():
+            for attr in ("description", "format", "unit", "meta"):
+                if attr in header_cols[col.name]:
+                    setattr(col, attr, header_cols[col.name][attr])
+
+
+def _arrow_string_to_numpy_dtype(
+    schema: pa.Schema, name: str, numpy_column: np.ndarray | None = None, default_length: int = 10
+) -> str:
+    """Get the numpy dtype string associated with an arrow column.
+
+    Parameters
+    ----------
+    schema : `pyarrow.Schema`
+        Arrow table schema.
+    name : `str`
+        Column name.
+    numpy_column : `numpy.ndarray`, optional
+        Column to determine numpy string dtype.
+    default_length : `int`, optional
+        Default string length when not in metadata or can be inferred
+        from column.
+
+    Returns
+    -------
+    dtype_str : `str`
+        Numpy dtype string.
+    """
+    # Special-case for string and binary columns
+    md_name = f"lsst::arrow::len::{name}"
+    strlen = default_length
+    metadata = schema.metadata if schema.metadata is not None else {}
+    if (encoded := md_name.encode("UTF-8")) in metadata:
+        # String/bytes length from header.
+        strlen = int(schema.metadata[encoded])
+    elif numpy_column is not None:
+        if len(numpy_column) > 0:
+            strlen = max(len(row) for row in numpy_column)
+
+    dtype = f"U{strlen}" if schema.field(name).type == pa.string() else f"|S{strlen}"
+
+    return dtype
+
+
+def _append_numpy_string_metadata(metadata: Dict[bytes, str], name: str, dtype: np.dtype) -> None:
+    """Append numpy string length keys to arrow metadata.
+
+    All column types are handled, but only the metadata is only modified for
+    string and byte columns.
+
+    Parameters
+    ----------
+    metadata : `dict` [`bytes`, `str`]
+        Metadata dictionary; modified in place.
+    name : `str`
+        Column name.
+    dtype : `np.dtype`
+        Numpy dtype.
+    """
+    import numpy as np
+
+    if dtype.type is np.str_:
+        metadata[f"lsst::arrow::len::{name}".encode("UTF-8")] = str(dtype.itemsize // 4)
+    elif dtype.type is np.bytes_:
+        metadata[f"lsst::arrow::len::{name}".encode("UTF-8")] = str(dtype.itemsize)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -28,21 +28,84 @@ import os
 import unittest
 
 try:
+    import pyarrow as pa
+except ImportError:
+    pa = None
+try:
+    import astropy.table as atable
+    from astropy import units
+except ImportError:
+    atable = None
+try:
     import numpy as np
+except ImportError:
+    np = None
+try:
     import pandas as pd
 except ImportError:
-    pd = None
+    np = None
 
-try:
-    import pyarrow.parquet
-except ImportError:
-    pyarrow = None
-
-from lsst.daf.butler import Butler, Config, DatasetType, StorageClassConfig, StorageClassFactory
+from lsst.daf.butler import (
+    Butler,
+    Config,
+    DatasetRef,
+    DatasetType,
+    FileDataset,
+    StorageClassConfig,
+    StorageClassFactory,
+)
+from lsst.daf.butler.delegates.arrowastropy import ArrowAstropyDelegate
+from lsst.daf.butler.delegates.arrownumpy import ArrowNumpyDelegate
+from lsst.daf.butler.delegates.arrowtable import ArrowTableDelegate
 from lsst.daf.butler.delegates.dataframe import DataFrameDelegate
+from lsst.daf.butler.formatters.parquet import (
+    ArrowAstropySchema,
+    ArrowNumpySchema,
+    DataFrameSchema,
+    ParquetFormatter,
+    arrow_to_astropy,
+    arrow_to_numpy,
+    arrow_to_numpy_dict,
+    arrow_to_pandas,
+    astropy_to_arrow,
+    numpy_dict_to_arrow,
+    numpy_to_arrow,
+    pandas_to_arrow,
+)
 from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def _makeSimpleNumpyTable():
+    """Make a simple numpy table with random data.
+
+    Returns
+    -------
+    numpyTable : `numpy.ndarray`
+    """
+    nrow = 5
+    data = np.zeros(
+        nrow,
+        dtype=[
+            ("index", "i4"),
+            ("a", "f8"),
+            ("b", "f8"),
+            ("c", "f8"),
+            ("ddd", "f8"),
+            ("strcol", "U10"),
+            ("bytecol", "a10"),
+        ],
+    )
+    data["index"][:] = np.arange(nrow)
+    data["a"] = np.random.randn(nrow)
+    data["b"] = np.random.randn(nrow)
+    data["c"] = np.random.randn(nrow)
+    data["ddd"] = np.random.randn(nrow)
+    data["strcol"][:] = "teststring"
+    data["bytecol"][:] = "teststring"
+
+    return data
 
 
 def _makeSingleIndexDataFrame():
@@ -55,13 +118,7 @@ def _makeSingleIndexDataFrame():
     allColumns : `list` [`str`]
         List of all the columns (including index columns).
     """
-    nrow = 5
-    data = np.zeros(nrow, dtype=[("index", "i4"), ("a", "f8"), ("b", "f8"), ("c", "f8"), ("ddd", "f8")])
-    data["index"][:] = np.arange(nrow)
-    data["a"] = np.random.randn(nrow)
-    data["b"] = np.random.randn(nrow)
-    data["c"] = np.random.randn(nrow)
-    data["ddd"] = np.random.randn(nrow)
+    data = _makeSimpleNumpyTable()
     df = pd.DataFrame(data)
     df = df.set_index("index")
     allColumns = df.columns.append(pd.Index(df.index.names))
@@ -93,10 +150,38 @@ def _makeMultiIndexDataFrame():
     return df
 
 
-@unittest.skipUnless(pd is not None, "Cannot test ParquetFormatter without pandas.")
-@unittest.skipUnless(pyarrow is not None, "Cannot test ParquetFormatter without pyarrow.")
-class ParquetFormatterTestCase(unittest.TestCase):
-    """Tests for ParquetFormatter, using local file datastore."""
+def _makeSimpleAstropyTable():
+    """Make an astropy table for testing.
+
+    Returns
+    -------
+    astropyTable : `astropy.table.Table`
+        The test table.
+    """
+    data = _makeSimpleNumpyTable()
+    # Add a couple of units.
+    table = atable.Table(data)
+    table["a"].unit = units.degree
+    table["b"].unit = units.meter
+    return table
+
+
+def _makeSimpleArrowTable():
+    """Make an arrow table for testing.
+
+    Returns
+    -------
+    arrowTable : `pyarrow.Table`
+        The test table.
+    """
+    data = _makeSimpleNumpyTable()
+    return numpy_to_arrow(data)
+
+
+@unittest.skipUnless(pd is not None, "Cannot test ParquetFormatterDataFrame without pandas.")
+@unittest.skipUnless(pa is not None, "Cannot test ParquetFormatterDataFrame without pyarrow.")
+class ParquetFormatterDataFrameTestCase(unittest.TestCase):
+    """Tests for ParquetFormatter, DataFrame, using local file datastore."""
 
     configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
 
@@ -125,6 +210,12 @@ class ParquetFormatterTestCase(unittest.TestCase):
         # Read just the column descriptions.
         columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
         self.assertTrue(allColumns.equals(columns2))
+        # Read the rowcount.
+        rowcount = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        self.assertEqual(rowcount, len(df1))
+        # Read the schema.
+        schema = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        self.assertEqual(schema, DataFrameSchema(df1))
         # Read just some columns a few different ways.
         df3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "c"]})
         self.assertTrue(df1.loc[:, ["a", "c"]].equals(df3))
@@ -134,6 +225,8 @@ class ParquetFormatterTestCase(unittest.TestCase):
         self.assertTrue(df1.loc[:, ["a"]].equals(df5))
         df6 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "ddd"})
         self.assertTrue(df1.loc[:, ["ddd"]].equals(df6))
+        df7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
+        self.assertTrue(df1.loc[:, ["a"]].equals(df7))
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
@@ -148,6 +241,12 @@ class ParquetFormatterTestCase(unittest.TestCase):
         # Read just the column descriptions.
         columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
         self.assertTrue(df1.columns.equals(columns2))
+        # Read the rowcount.
+        rowcount = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        self.assertEqual(rowcount, len(df1))
+        # Read the schema.
+        schema = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        self.assertEqual(schema, DataFrameSchema(df1))
         # Read just some columns a few different ways.
         df3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": {"filter": "g"}})
         self.assertTrue(df1.loc[:, ["g"]].equals(df3))
@@ -162,10 +261,203 @@ class ParquetFormatterTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d"]})
 
+    def testLegacyDataFrame(self):
+        """Test writing a dataframe to parquet via pandas (without additional
+        metadata) and ensure that we can read it back with all the new
+        functionality.
+        """
+        df1, allColumns = _makeSingleIndexDataFrame()
 
-@unittest.skipUnless(pd is not None, "Cannot test parquet InMemoryDatastore without pandas.")
-class InMemoryParquetFormatterTestCase(ParquetFormatterTestCase):
-    """Tests for InMemoryDatastore, using DataFrameDelegate"""
+        fname = os.path.join(self.root, "test_dataframe.parq")
+        df1.to_parquet(fname)
+
+        legacy_type = DatasetType(
+            "legacy_dataframe",
+            dimensions=(),
+            storageClass="DataFrame",
+            universe=self.butler.registry.dimensions,
+        )
+        self.butler.registry.registerDatasetType(legacy_type)
+
+        data_id = {}
+        ref = DatasetRef(legacy_type, data_id, id=None)
+        dataset = FileDataset(path=fname, refs=[ref], formatter=ParquetFormatter)
+
+        self.butler.ingest(dataset, transfer="copy")
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        df2a = self.butler.get(self.datasetType, dataId={})
+        df2b = self.butler.get("legacy_dataframe", dataId={})
+        self.assertTrue(df2a.equals(df2b))
+
+        df3a = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a"]})
+        df3b = self.butler.get("legacy_dataframe", dataId={}, parameters={"columns": ["a"]})
+        self.assertTrue(df3a.equals(df3b))
+
+        columns2a = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
+        columns2b = self.butler.get("legacy_dataframe.columns", dataId={})
+        self.assertTrue(columns2a.equals(columns2b))
+
+        rowcount2a = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        rowcount2b = self.butler.get("legacy_dataframe.rowcount", dataId={})
+        self.assertEqual(rowcount2a, rowcount2b)
+
+        schema2a = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        schema2b = self.butler.get("legacy_dataframe.schema", dataId={})
+        self.assertEqual(schema2a, schema2b)
+
+    def testDataFrameSchema(self):
+        tab1 = _makeSimpleArrowTable()
+
+        schema = DataFrameSchema.from_arrow(tab1.schema)
+
+        self.assertIsInstance(schema.schema, pd.DataFrame)
+        self.assertEqual(repr(schema), repr(schema._schema))
+        self.assertNotEqual(schema, "not_a_schema")
+        self.assertEqual(schema, schema)
+
+        tab2 = _makeMultiIndexDataFrame()
+        schema2 = DataFrameSchema(tab2)
+
+        self.assertNotEqual(schema, schema2)
+
+    @unittest.skipUnless(atable is not None, "Cannot test reading as astropy without astropy.")
+    def testWriteSingleIndexDataFrameReadAsAstropyTable(self):
+        df1, allColumns = _makeSingleIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
+
+        tab2_df = tab2.to_pandas(index="index")
+        self.assertTrue(df1.equals(tab2_df))
+
+        # Check reading the columns.
+        columns = list(tab2.columns.keys())
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        # We check the set because pandas reorders the columns.
+        self.assertEqual(set(columns2), set(columns))
+
+        # Check reading the schema.
+        schema = ArrowAstropySchema(tab2)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowAstropySchema"
+        )
+
+        # The string types are objectified by pandas, and the order
+        # will be changed because of pandas indexing.
+        self.assertEqual(len(schema2.schema.columns), len(schema.schema.columns))
+        for name in schema.schema.columns:
+            self.assertIn(name, schema2.schema.columns)
+            if schema2.schema[name].dtype != np.dtype("O"):
+                self.assertEqual(schema2.schema[name].dtype, schema.schema[name].dtype)
+
+    @unittest.skipUnless(atable is not None, "Cannot test reading as astropy without astropy.")
+    def testWriteMultiIndexDataFrameReadAsAstropyTable(self):
+        df1 = _makeMultiIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        _ = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
+
+        # This is an odd duck, it doesn't really round-trip.
+        # This test simply checks that it's readable, but definitely not
+        # recommended.
+
+    @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
+    def testWriteSingleIndexDataFrameReadAsArrowTable(self):
+        df1, allColumns = _makeSingleIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowTable")
+
+        tab2_df = arrow_to_pandas(tab2)
+        self.assertTrue(df1.equals(tab2_df))
+
+        # Check reading the columns.
+        columns = list(tab2.schema.names)
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        # We check the set because pandas reorders the columns.
+        self.assertEqual(set(columns), set(columns2))
+
+        # Check reading the schema.
+        schema = tab2.schema
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowSchema"
+        )
+
+        # These will not have the same metadata, nor will the string column
+        # information be maintained.
+        self.assertEqual(len(schema.names), len(schema2.names))
+        for name in schema.names:
+            if schema.field(name).type not in (pa.string(), pa.binary()):
+                self.assertEqual(schema.field(name).type, schema2.field(name).type)
+
+    @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
+    def testWriteMultiIndexDataFrameReadAsArrowTable(self):
+        df1 = _makeMultiIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowTable")
+
+        tab2_df = arrow_to_pandas(tab2)
+        self.assertTrue(df1.equals(tab2_df))
+
+    @unittest.skipUnless(np is not None, "Cannot test reading as numpy without numpy.")
+    def testWriteSingleIndexDataFrameReadAsNumpyTable(self):
+        df1, allColumns = _makeSingleIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowNumpy")
+
+        tab2_df = pd.DataFrame.from_records(tab2, index=["index"])
+        self.assertTrue(df1.equals(tab2_df))
+
+        # Check reading the columns.
+        columns = list(tab2.dtype.names)
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        # We check the set because pandas reorders the columns.
+        self.assertEqual(set(columns2), set(columns))
+
+        # Check reading the schema.
+        schema = ArrowNumpySchema(tab2.dtype)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowNumpySchema"
+        )
+
+        # The string types will be objectified by pandas, and the order
+        # will be changed because of pandas indexing.
+        self.assertEqual(len(schema.schema.names), len(schema2.schema.names))
+        for name in schema.schema.names:
+            self.assertIn(name, schema2.schema.names)
+            self.assertEqual(schema2.schema[name].type, schema.schema[name].type)
+
+    @unittest.skipUnless(np is not None, "Cannot test reading as numpy without numpy.")
+    def testWriteMultiIndexDataFrameReadAsNumpyTable(self):
+        df1 = _makeMultiIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        _ = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowNumpy")
+
+        # This is an odd duck, it doesn't really round-trip.
+        # This test simply checks that it's readable, but definitely not
+        # recommended.
+
+
+@unittest.skipUnless(pd is not None, "Cannot test InMemoryDataFrameDelegate without pandas.")
+class InMemoryDataFrameDelegateTestCase(ParquetFormatterDataFrameTestCase):
+    """Tests for InMemoryDatastore, using DataFrameDelegate."""
 
     configFile = os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml")
 
@@ -191,11 +483,27 @@ class InMemoryParquetFormatterTestCase(ParquetFormatterTestCase):
             )
         self.assertIn("only supports string column names", str(cm.exception))
 
+    def testWriteMultiIndexDataFrameReadAsAstropyTable(self):
+        df1 = _makeMultiIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        with self.assertRaises(ValueError):
+            _ = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
+
+    def testLegacyDataFrame(self):
+        # This test does not work with an inMemoryDatastore.
+        pass
+
     def testBadInput(self):
+        df1, _ = _makeSingleIndexDataFrame()
         delegate = DataFrameDelegate("DataFrame")
 
         with self.assertRaises(ValueError):
             delegate.handleParameters(inMemoryDataset="not_a_dataframe")
+
+        with self.assertRaises(AttributeError):
+            delegate.getComponent(composite=df1, componentName="nothing")
 
     def testStorageClass(self):
         df1, allColumns = _makeSingleIndexDataFrame()
@@ -204,14 +512,775 @@ class InMemoryParquetFormatterTestCase(ParquetFormatterTestCase):
         factory.addFromConfig(StorageClassConfig())
 
         storageClass = factory.findStorageClass(type(df1), compare_types=False)
-        # Force the name lookup to do name matching
+        # Force the name lookup to do name matching.
         storageClass._pytype = None
         self.assertEqual(storageClass.name, "DataFrame")
 
         storageClass = factory.findStorageClass(type(df1), compare_types=True)
-        # Force the name lookup to do name matching
+        # Force the name lookup to do name matching.
         storageClass._pytype = None
         self.assertEqual(storageClass.name, "DataFrame")
+
+
+@unittest.skipUnless(atable is not None, "Cannot test ParquetFormatterArrowAstropy without astropy.")
+@unittest.skipUnless(pa is not None, "Cannot test ParquetFormatterArrowAstropy without pyarrow.")
+class ParquetFormatterArrowAstropyTestCase(unittest.TestCase):
+    """Tests for ParquetFormatter, ArrowAstropy, using local file datastore."""
+
+    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
+
+    def setUp(self):
+        """Create a new butler root for each test."""
+        self.root = makeTestTempDir(TESTDIR)
+        config = Config(self.configFile)
+        self.butler = Butler(Butler.makeRepo(self.root, config=config), writeable=True, run="test_run")
+        # No dimensions in dataset type so we don't have to worry about
+        # inserting dimension data or defining data IDs.
+        self.datasetType = DatasetType(
+            "data", dimensions=(), storageClass="ArrowAstropy", universe=self.butler.registry.dimensions
+        )
+        self.butler.registry.registerDatasetType(self.datasetType)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def testAstropyTable(self):
+        tab1 = _makeSimpleAstropyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+        # Read the whole Table.
+        tab2 = self.butler.get(self.datasetType, dataId={})
+        self._checkAstropyTableEquality(tab1, tab2)
+        # Read the columns.
+        columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
+        self.assertEqual(len(columns2), len(tab1.dtype.names))
+        for i, name in enumerate(tab1.dtype.names):
+            self.assertEqual(columns2[i], name)
+        # Read the rowcount.
+        rowcount = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        self.assertEqual(rowcount, len(tab1))
+        # Read the schema.
+        schema = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        self.assertEqual(schema, ArrowAstropySchema(tab1))
+        # Read just some columns a few different ways.
+        tab3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "c"]})
+        self._checkAstropyTableEquality(tab1[("a", "c")], tab3)
+        tab4 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "a"})
+        self._checkAstropyTableEquality(tab1[("a",)], tab4)
+        tab5 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["index", "a"]})
+        self._checkAstropyTableEquality(tab1[("index", "a")], tab5)
+        tab6 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "ddd"})
+        self._checkAstropyTableEquality(tab1[("ddd",)], tab6)
+        tab7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
+        self._checkAstropyTableEquality(tab1[("a",)], tab7)
+        # Passing an unrecognized column should be a ValueError.
+        with self.assertRaises(ValueError):
+            self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
+
+    def testArrowAstropySchema(self):
+        tab1 = _makeSimpleAstropyTable()
+        tab1_arrow = astropy_to_arrow(tab1)
+        schema = ArrowAstropySchema.from_arrow(tab1_arrow.schema)
+
+        self.assertIsInstance(schema.schema, atable.Table)
+        self.assertEqual(repr(schema), repr(schema._schema))
+        self.assertNotEqual(schema, "not_a_schema")
+        self.assertEqual(schema, schema)
+
+        # Test various inequalities
+        tab2 = tab1.copy()
+        tab2.rename_column("index", "index2")
+        schema2 = ArrowAstropySchema(tab2)
+        self.assertNotEqual(schema2, schema)
+
+        tab2 = tab1.copy()
+        tab2["index"].unit = units.micron
+        schema2 = ArrowAstropySchema(tab2)
+        self.assertNotEqual(schema2, schema)
+
+        tab2 = tab1.copy()
+        tab2["index"].description = "Index column"
+        schema2 = ArrowAstropySchema(tab2)
+        self.assertNotEqual(schema2, schema)
+
+        tab2 = tab1.copy()
+        tab2["index"].format = "%05d"
+        schema2 = ArrowAstropySchema(tab2)
+        self.assertNotEqual(schema2, schema)
+
+    def testAstropyParquet(self):
+        """Test writing a dataframe to parquet via pandas (without additional
+        metadata) and ensure that we can read it back with all the new
+        functionality.
+        """
+        tab1 = _makeSimpleAstropyTable()
+
+        fname = os.path.join(self.root, "test_astropy.parq")
+        tab1.write(fname)
+
+        astropy_type = DatasetType(
+            "astropy_parquet",
+            dimensions=(),
+            storageClass="ArrowAstropy",
+            universe=self.butler.registry.dimensions,
+        )
+        self.butler.registry.registerDatasetType(astropy_type)
+
+        data_id = {}
+        ref = DatasetRef(astropy_type, data_id, id=None)
+        dataset = FileDataset(path=fname, refs=[ref], formatter=ParquetFormatter)
+
+        self.butler.ingest(dataset, transfer="copy")
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2a = self.butler.get(self.datasetType, dataId={})
+        tab2b = self.butler.get("astropy_parquet", dataId={})
+        self._checkAstropyTableEquality(tab2a, tab2b)
+
+        columns2a = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
+        columns2b = self.butler.get("astropy_parquet.columns", dataId={})
+        self.assertEqual(len(columns2b), len(columns2a))
+        for i, name in enumerate(columns2a):
+            self.assertEqual(columns2b[i], name)
+
+        rowcount2a = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        rowcount2b = self.butler.get("astropy_parquet.rowcount", dataId={})
+        self.assertEqual(rowcount2a, rowcount2b)
+
+        schema2a = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        schema2b = self.butler.get("astropy_parquet.schema", dataId={})
+        self.assertEqual(schema2a, schema2b)
+
+    @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
+    def testWriteAstropyReadAsArrowTable(self):
+        tab1 = _makeSimpleAstropyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowTable")
+
+        tab2_astropy = arrow_to_astropy(tab2)
+        self._checkAstropyTableEquality(tab1, tab2_astropy)
+
+        # Check reading the columns.
+        columns = tab2.schema.names
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        self.assertEqual(columns2, columns)
+
+        # Check reading the schema.
+        schema = tab2.schema
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowSchema"
+        )
+
+        self.assertEqual(schema, schema2)
+
+    @unittest.skipUnless(pd is not None, "Cannot test reading as a dataframe without pandas.")
+    def testWriteAstropyReadAsDataFrame(self):
+        tab1 = _makeSimpleAstropyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="DataFrame")
+
+        # This is tricky because it loses the units and gains a bonus pandas
+        # _index_ column, so we just test the dataframe form.
+
+        tab1_df = tab1.to_pandas()
+        self.assertTrue(tab1_df.equals(tab2))
+
+        # Check reading the columns.
+        columns = tab2.columns
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="DataFrameIndex"
+        )
+        self.assertTrue(columns.equals(columns2))
+
+        # Check reading the schema.
+        schema = DataFrameSchema(tab2)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="DataFrameSchema"
+        )
+
+        self.assertEqual(schema2, schema)
+
+    @unittest.skipUnless(np is not None, "Cannot test reading as numpy without numpy.")
+    def testWriteAstropyReadAsNumpyTable(self):
+        tab1 = _makeSimpleAstropyTable()
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowNumpy")
+
+        # This is tricky because it loses the units.
+        tab2_astropy = atable.Table(tab2)
+
+        self._checkAstropyTableEquality(tab1, tab2_astropy, skip_units=True)
+
+        # Check reading the columns.
+        columns = list(tab2.dtype.names)
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        self.assertEqual(columns2, columns)
+
+        # Check reading the schema.
+        schema = ArrowNumpySchema(tab2.dtype)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowNumpySchema"
+        )
+
+        self.assertEqual(schema2, schema)
+
+    def _checkAstropyTableEquality(self, table1, table2, skip_units=False):
+        """Check if two astropy tables have the same columns/values.
+
+        Parameters
+        ----------
+        table1 : `astropy.table.Table`
+        table2 : `astropy.table.Table`
+        skip_units : `bool`
+        """
+        self.assertEqual(table1.dtype, table2.dtype)
+        if not skip_units:
+            for name in table1.columns:
+                self.assertEqual(table1[name].unit, table2[name].unit)
+                self.assertEqual(table1[name].description, table2[name].description)
+                self.assertEqual(table1[name].format, table2[name].format)
+        self.assertTrue(np.all(table1 == table2))
+
+
+@unittest.skipUnless(atable is not None, "Cannot test InMemoryArrowAstropyDelegate without astropy.")
+class InMemoryArrowAstropyDelegateTestCase(ParquetFormatterArrowAstropyTestCase):
+    """Tests for InMemoryDatastore, using ArrowAstropyDelegate."""
+
+    configFile = os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml")
+
+    def testAstropyParquet(self):
+        # This test does not work with an inMemoryDatastore.
+        pass
+
+    def testBadInput(self):
+        tab1 = _makeSimpleAstropyTable()
+        delegate = ArrowAstropyDelegate("ArrowAstropy")
+
+        with self.assertRaises(ValueError):
+            delegate.handleParameters(inMemoryDataset="not_an_astropy_table")
+
+        with self.assertRaises(NotImplementedError):
+            delegate.handleParameters(inMemoryDataset=tab1, parameters={"columns": [("a", "b")]})
+
+        with self.assertRaises(AttributeError):
+            delegate.getComponent(composite=tab1, componentName="nothing")
+
+
+@unittest.skipUnless(np is not None, "Cannot test ParquetFormatterArrowNumpy without numpy.")
+@unittest.skipUnless(pa is not None, "Cannot test ParquetFormatterArrowNumpy without pyarrow.")
+class ParquetFormatterArrowNumpyTestCase(unittest.TestCase):
+    """Tests for ParquetFormatter, ArrowNumpy, using local file datastore."""
+
+    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
+
+    def setUp(self):
+        """Create a new butler root for each test."""
+        self.root = makeTestTempDir(TESTDIR)
+        config = Config(self.configFile)
+        self.butler = Butler(Butler.makeRepo(self.root, config=config), writeable=True, run="test_run")
+        # No dimensions in dataset type so we don't have to worry about
+        # inserting dimension data or defining data IDs.
+        self.datasetType = DatasetType(
+            "data", dimensions=(), storageClass="ArrowNumpy", universe=self.butler.registry.dimensions
+        )
+        self.butler.registry.registerDatasetType(self.datasetType)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def testNumpyTable(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+        # Read the whole Table.
+        tab2 = self.butler.get(self.datasetType, dataId={})
+        self._checkNumpyTableEquality(tab1, tab2)
+        # Read the columns.
+        columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
+        self.assertEqual(len(columns2), len(tab1.dtype.names))
+        for i, name in enumerate(tab1.dtype.names):
+            self.assertEqual(columns2[i], name)
+        # Read the rowcount.
+        rowcount = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        self.assertEqual(rowcount, len(tab1))
+        # Read the schema.
+        schema = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        self.assertEqual(schema, ArrowNumpySchema(tab1.dtype))
+        # Read just some columns a few different ways.
+        tab3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "c"]})
+        self._checkNumpyTableEquality(tab1[["a", "c"]], tab3)
+        tab4 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "a"})
+        self._checkNumpyTableEquality(
+            tab1[
+                [
+                    "a",
+                ]
+            ],
+            tab4,
+        )
+        tab5 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["index", "a"]})
+        self._checkNumpyTableEquality(tab1[["index", "a"]], tab5)
+        tab6 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "ddd"})
+        self._checkNumpyTableEquality(
+            tab1[
+                [
+                    "ddd",
+                ]
+            ],
+            tab6,
+        )
+        tab7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
+        self._checkNumpyTableEquality(
+            tab1[
+                [
+                    "a",
+                ]
+            ],
+            tab7,
+        )
+        # Passing an unrecognized column should be a ValueError.
+        with self.assertRaises(ValueError):
+            self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
+
+    def testArrowNumpySchema(self):
+        tab1 = _makeSimpleNumpyTable()
+        tab1_arrow = numpy_to_arrow(tab1)
+        schema = ArrowNumpySchema.from_arrow(tab1_arrow.schema)
+
+        self.assertIsInstance(schema.schema, np.dtype)
+        self.assertEqual(repr(schema), repr(schema._dtype))
+        self.assertNotEqual(schema, "not_a_schema")
+        self.assertEqual(schema, schema)
+
+        # Test inequality
+        tab2 = tab1.copy()
+        names = list(tab2.dtype.names)
+        names[0] = "index2"
+        tab2.dtype.names = names
+        schema2 = ArrowNumpySchema(tab2.dtype)
+        self.assertNotEqual(schema2, schema)
+
+    @unittest.skipUnless(pa is not None, "Cannot test arrow conversions without pyarrow.")
+    def testNumpyDictConversions(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        # Verify that everything round-trips, including the schema.
+        tab1_arrow = numpy_to_arrow(tab1)
+        tab1_dict = arrow_to_numpy_dict(tab1_arrow)
+        tab1_dict_arrow = numpy_dict_to_arrow(tab1_dict)
+
+        self.assertEqual(tab1_arrow.schema, tab1_dict_arrow.schema)
+        self.assertEqual(tab1_arrow, tab1_dict_arrow)
+
+    @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
+    def testWriteNumpyTableReadAsArrowTable(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowTable")
+
+        tab2_numpy = arrow_to_numpy(tab2)
+
+        self._checkNumpyTableEquality(tab1, tab2_numpy)
+
+        # Check reading the columns.
+        columns = tab2.schema.names
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        self.assertEqual(columns2, columns)
+
+        # Check reading the schema.
+        schema = tab2.schema
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowSchema"
+        )
+        self.assertEqual(schema2, schema)
+
+    @unittest.skipUnless(pd is not None, "Cannot test reading as a dataframe without pandas.")
+    def testWriteNumpyTableReadAsDataFrame(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="DataFrame")
+
+        # Converting this back to numpy gets confused with the index column
+        # and changes the datatype of the string column.
+
+        tab1_df = pd.DataFrame(tab1)
+
+        self.assertTrue(tab1_df.equals(tab2))
+
+        # Check reading the columns.
+        columns = tab2.columns
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="DataFrameIndex"
+        )
+        self.assertTrue(columns.equals(columns2))
+
+        # Check reading the schema.
+        schema = DataFrameSchema(tab2)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="DataFrameSchema"
+        )
+
+        self.assertEqual(schema2, schema)
+
+    @unittest.skipUnless(atable is not None, "Cannot test reading as astropy without astropy.")
+    def testWriteNumpyTableReadAsAstropyTable(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
+        tab2_numpy = tab2.as_array()
+
+        self._checkNumpyTableEquality(tab1, tab2_numpy)
+
+        # Check reading the columns.
+        columns = list(tab2.columns.keys())
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        self.assertEqual(columns2, columns)
+
+        # Check reading the schema.
+        schema = ArrowAstropySchema(tab2)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowAstropySchema"
+        )
+
+        self.assertEqual(schema2, schema)
+
+    def _checkNumpyTableEquality(self, table1, table2):
+        """Check if two numpy tables have the same columns/values
+
+        Parameters
+        ----------
+        table1 : `numpy.ndarray`
+        table2 : `numpy.ndarray`
+        """
+        self.assertEqual(table1.dtype.names, table2.dtype.names)
+        for name in table1.dtype.names:
+            self.assertEqual(table1.dtype[name], table2.dtype[name])
+        self.assertTrue(np.all(table1 == table2))
+
+
+@unittest.skipUnless(np is not None, "Cannot test ParquetFormatterArrowNumpy without numpy.")
+class InMemoryArrowNumpyDelegateTestCase(ParquetFormatterArrowNumpyTestCase):
+    """Tests for InMemoryDatastore, using ArrowNumpyDelegate."""
+
+    configFile = os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml")
+
+    def testBadInput(self):
+        tab1 = _makeSimpleNumpyTable()
+        delegate = ArrowNumpyDelegate("ArrowNumpy")
+
+        with self.assertRaises(ValueError):
+            delegate.handleParameters(inMemoryDataset="not_a_numpy_table")
+
+        with self.assertRaises(NotImplementedError):
+            delegate.handleParameters(inMemoryDataset=tab1, parameters={"columns": [("a", "b")]})
+
+        with self.assertRaises(AttributeError):
+            delegate.getComponent(composite=tab1, componentName="nothing")
+
+    def testStorageClass(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        factory = StorageClassFactory()
+        factory.addFromConfig(StorageClassConfig())
+
+        storageClass = factory.findStorageClass(type(tab1), compare_types=False)
+        # Force the name lookup to do name matching.
+        storageClass._pytype = None
+        self.assertEqual(storageClass.name, "ArrowNumpy")
+
+        storageClass = factory.findStorageClass(type(tab1), compare_types=True)
+        # Force the name lookup to do name matching.
+        storageClass._pytype = None
+        self.assertEqual(storageClass.name, "ArrowNumpy")
+
+
+@unittest.skipUnless(pa is not None, "Cannot test ParquetFormatterArrowTable without pyarrow.")
+class ParquetFormatterArrowTableTestCase(unittest.TestCase):
+    """Tests for ParquetFormatter, ArrowTable, using local file datastore."""
+
+    configFile = os.path.join(TESTDIR, "config/basic/butler.yaml")
+
+    def setUp(self):
+        """Create a new butler root for each test."""
+        self.root = makeTestTempDir(TESTDIR)
+        config = Config(self.configFile)
+        self.butler = Butler(Butler.makeRepo(self.root, config=config), writeable=True, run="test_run")
+        # No dimensions in dataset type so we don't have to worry about
+        # inserting dimension data or defining data IDs.
+        self.datasetType = DatasetType(
+            "data", dimensions=(), storageClass="ArrowTable", universe=self.butler.registry.dimensions
+        )
+        self.butler.registry.registerDatasetType(self.datasetType)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def testArrowTable(self):
+        tab1 = _makeSimpleArrowTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+        # Read the whole Table.
+        tab2 = self.butler.get(self.datasetType, dataId={})
+        self.assertEqual(tab2, tab1)
+        # Read the columns.
+        columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
+        self.assertEqual(len(columns2), len(tab1.schema.names))
+        for i, name in enumerate(tab1.schema.names):
+            self.assertEqual(columns2[i], name)
+        # Read the rowcount.
+        rowcount = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
+        self.assertEqual(rowcount, len(tab1))
+        # Read the schema.
+        schema = self.butler.get(self.datasetType.componentTypeName("schema"), dataId={})
+        self.assertEqual(schema, tab1.schema)
+        # Read just some columns a few different ways.
+        tab3 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "c"]})
+        self.assertEqual(tab3, tab1.select(("a", "c")))
+        tab4 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "a"})
+        self.assertEqual(tab4, tab1.select(("a",)))
+        tab5 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["index", "a"]})
+        self.assertEqual(tab5, tab1.select(("index", "a")))
+        tab6 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": "ddd"})
+        self.assertEqual(tab6, tab1.select(("ddd",)))
+        tab7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
+        self.assertEqual(tab7, tab1.select(("a",)))
+        # Passing an unrecognized column should be a ValueError.
+        with self.assertRaises(ValueError):
+            self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
+
+    def testEmptyArrowTable(self):
+        data = _makeSimpleNumpyTable()
+        type_list = [(name, pa.from_numpy_dtype(data.dtype[name].type)) for name in data.dtype.names]
+
+        schema = pa.schema(type_list)
+        arrays = [[]] * len(schema.names)
+
+        tab1 = pa.Table.from_arrays(arrays, schema=schema)
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+        tab2 = self.butler.get(self.datasetType, dataId={})
+        self.assertEqual(tab2, tab1)
+
+        tab1_numpy = arrow_to_numpy(tab1)
+        self.assertEqual(len(tab1_numpy), 0)
+        tab1_numpy_arrow = numpy_to_arrow(tab1_numpy)
+        self.assertEqual(tab1_numpy_arrow, tab1)
+
+        tab1_pandas = arrow_to_pandas(tab1)
+        self.assertEqual(len(tab1_pandas), 0)
+        tab1_pandas_arrow = pandas_to_arrow(tab1_pandas)
+        # Unfortunately, string/byte columns get mangled when translated
+        # through empty pandas dataframes.
+        self.assertEqual(
+            tab1_pandas_arrow.select(("index", "a", "b", "c", "ddd")),
+            tab1.select(("index", "a", "b", "c", "ddd")),
+        )
+
+        tab1_astropy = arrow_to_astropy(tab1)
+        self.assertEqual(len(tab1_astropy), 0)
+        tab1_astropy_arrow = astropy_to_arrow(tab1_astropy)
+        self.assertEqual(tab1_astropy_arrow, tab1)
+
+    @unittest.skipUnless(pd is not None, "Cannot test reading as a dataframe without pandas.")
+    def testWriteArrowTableReadAsSingleIndexDataFrame(self):
+        df1, allColumns = _makeSingleIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        # Read back out as a dataframe.
+        df2 = self.butler.get(self.datasetType, dataId={}, storageClass="DataFrame")
+        self.assertTrue(df1.equals(df2))
+
+        # Read back out as an arrow table, convert to dataframe.
+        tab3 = self.butler.get(self.datasetType, dataId={})
+        df3 = arrow_to_pandas(tab3)
+        self.assertTrue(df1.equals(df3))
+
+        # Check reading the columns.
+        columns = df2.reset_index().columns
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="DataFrameIndex"
+        )
+        # We check the set because pandas reorders the columns.
+        self.assertEqual(set(columns2.to_list()), set(columns.to_list()))
+
+        # Check reading the schema.
+        schema = DataFrameSchema(df1)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="DataFrameSchema"
+        )
+        self.assertEqual(schema2, schema)
+
+    @unittest.skipUnless(pd is not None, "Cannot test reading as a dataframe without pandas.")
+    def testWriteArrowTableReadAsMultiIndexDataFrame(self):
+        df1 = _makeMultiIndexDataFrame()
+
+        self.butler.put(df1, self.datasetType, dataId={})
+
+        # Read back out as a dataframe.
+        df2 = self.butler.get(self.datasetType, dataId={}, storageClass="DataFrame")
+        self.assertTrue(df1.equals(df2))
+
+        # Read back out as an arrow table, convert to dataframe.
+        atab3 = self.butler.get(self.datasetType, dataId={})
+        df3 = arrow_to_pandas(atab3)
+        self.assertTrue(df1.equals(df3))
+
+        # Check reading the columns.
+        columns = df2.columns
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="DataFrameIndex"
+        )
+        self.assertTrue(columns2.equals(columns))
+
+        # Check reading the schema.
+        schema = DataFrameSchema(df1)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="DataFrameSchema"
+        )
+        self.assertEqual(schema2, schema)
+
+    @unittest.skipUnless(atable is not None, "Cannot test reading as astropy without astropy.")
+    def testWriteArrowTableReadAsAstropyTable(self):
+        tab1 = _makeSimpleAstropyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        # Read back out as an astropy table.
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
+        self._checkAstropyTableEquality(tab1, tab2)
+
+        # Read back out as an arrow table, convert to astropy table.
+        atab3 = self.butler.get(self.datasetType, dataId={})
+        tab3 = arrow_to_astropy(atab3)
+        self._checkAstropyTableEquality(tab1, tab3)
+
+        # Check reading the columns.
+        columns = list(tab2.columns.keys())
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        self.assertEqual(columns2, columns)
+
+        # Check reading the schema.
+        schema = ArrowAstropySchema(tab1)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowAstropySchema"
+        )
+        self.assertEqual(schema2, schema)
+
+    @unittest.skipUnless(np is not None, "Cannot test reading as numpy without numpy.")
+    def testWriteArrowTableReadAsNumpyTable(self):
+        tab1 = _makeSimpleNumpyTable()
+
+        self.butler.put(tab1, self.datasetType, dataId={})
+
+        # Read back out as a numpy table.
+        tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowNumpy")
+        self._checkNumpyTableEquality(tab1, tab2)
+
+        # Read back out as an arrow table, convert to numpy table.
+        atab3 = self.butler.get(self.datasetType, dataId={})
+        tab3 = arrow_to_numpy(atab3)
+        self._checkNumpyTableEquality(tab1, tab3)
+
+        # Check reading the columns.
+        columns = list(tab2.dtype.names)
+        columns2 = self.butler.get(
+            self.datasetType.componentTypeName("columns"), dataId={}, storageClass="ArrowColumnList"
+        )
+        self.assertEqual(columns2, columns)
+
+        # Check reading the schema.
+        schema = ArrowNumpySchema(tab1.dtype)
+        schema2 = self.butler.get(
+            self.datasetType.componentTypeName("schema"), dataId={}, storageClass="ArrowNumpySchema"
+        )
+        self.assertEqual(schema2, schema)
+
+    def _checkAstropyTableEquality(self, table1, table2):
+        """Check if two astropy tables have the same columns/values
+
+        Parameters
+        ----------
+        table1 : `astropy.table.Table`
+        table2 : `astropy.table.Table`
+        """
+        self.assertEqual(table1.dtype, table2.dtype)
+        for name in table1.columns:
+            self.assertEqual(table1[name].unit, table2[name].unit)
+            self.assertEqual(table1[name].description, table2[name].description)
+            self.assertEqual(table1[name].format, table2[name].format)
+        self.assertTrue(np.all(table1 == table2))
+
+    def _checkNumpyTableEquality(self, table1, table2):
+        """Check if two numpy tables have the same columns/values
+
+        Parameters
+        ----------
+        table1 : `numpy.ndarray`
+        table2 : `numpy.ndarray`
+        """
+        self.assertEqual(table1.dtype.names, table2.dtype.names)
+        for name in table1.dtype.names:
+            self.assertEqual(table1.dtype[name], table2.dtype[name])
+        self.assertTrue(np.all(table1 == table2))
+
+
+@unittest.skipUnless(pa is not None, "Cannot test InMemoryArrowTableDelegate without pyarrow.")
+class InMemoryArrowTableDelegateTestCase(ParquetFormatterArrowTableTestCase):
+    """Tests for InMemoryDatastore, using ArrowTableDelegate."""
+
+    configFile = os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml")
+
+    def testBadInput(self):
+        tab1 = _makeSimpleArrowTable()
+        delegate = ArrowTableDelegate("ArrowTable")
+
+        with self.assertRaises(ValueError):
+            delegate.handleParameters(inMemoryDataset="not_an_arrow_table")
+
+        with self.assertRaises(NotImplementedError):
+            delegate.handleParameters(inMemoryDataset=tab1, parameters={"columns": [("a", "b")]})
+
+        with self.assertRaises(AttributeError):
+            delegate.getComponent(composite=tab1, componentName="nothing")
+
+    def testStorageClass(self):
+        tab1 = _makeSimpleArrowTable()
+
+        factory = StorageClassFactory()
+        factory.addFromConfig(StorageClassConfig())
+
+        storageClass = factory.findStorageClass(type(tab1), compare_types=False)
+        # Force the name lookup to do name matching.
+        storageClass._pytype = None
+        self.assertEqual(storageClass.name, "ArrowTable")
+
+        storageClass = factory.findStorageClass(type(tab1), compare_types=True)
+        # Force the name lookup to do name matching.
+        storageClass._pytype = None
+        self.assertEqual(storageClass.name, "ArrowTable")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
