### PR TITLE
DM-36410: Support "move" ingest into chained datastore

### DIFF
--- a/doc/changes/DM-36410.misc.rst
+++ b/doc/changes/DM-36410.misc.rst
@@ -1,0 +1,2 @@
+Chained Datastore can now support "move" transfer mode for ingest.
+Files are copied to each child datastore unless only one child datastore is accepting the incoming files, in which case "move" is used.

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1070,7 +1070,7 @@ class ChainedDatastoreTestCase(PosixDatastoreTestCase):
     configFile = os.path.join(TESTDIR, "config/basic/chainedDatastore.yaml")
     hasUnsupportedPut = False
     canIngestNoTransferAuto = False
-    ingestTransferModes = ("copy", "hardlink", "symlink", "relsymlink", "link", "auto")
+    ingestTransferModes = ("copy", "move", "hardlink", "symlink", "relsymlink", "link", "auto")
     isEphemeral = False
     rootKeys = (".datastores.1.root", ".datastores.2.root")
     validationCanFail = True


### PR DESCRIPTION
Treat it as a copy and then clean up.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
