### PR TITLE
DM-36489: Add pgSphere support to obscore manager

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,10 +38,16 @@ jobs:
         run: |
           conda install -y -q sqlite
 
+      # Postgres-14 is already installed from official postgres repo, but we
+      # also need pgsphere which is not installed. The repo is not in the list,
+      # so we need to re-add it first.
       - name: Install postgresql (server)
         run: |
+          sudo sh -c \
+            'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install postgresql
+          sudo apt-get install postgresql-14 postgresql-14-pgsphere
 
       - name: Install postgresql Python packages
         shell: bash -l {0}

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -237,7 +237,7 @@ class FileDatastore(GenericBaseDatastore):
                 ddl.FieldSpec(name="file_size", dtype=BigInteger, nullable=True),
             ],
             unique=frozenset(),
-            indexes=[tuple(["path"])],
+            indexes=[ddl.IndexSpec("path")],
         )
 
     def __init__(

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
@@ -450,5 +450,5 @@ def makeCalibTableSpec(
         # in our DatasetRecordStorage.certify() implementation, and just create
         # a regular index here in the hope that helps with lookups.
         index.extend(fieldSpec.name for fieldSpec in tsFieldSpecs)
-        tableSpec.indexes.add(tuple(index))  # type: ignore
+        tableSpec.indexes.add(ddl.IndexSpec(*index))  # type: ignore
     return tableSpec

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -562,12 +562,12 @@ class _SkyPixOverlapTables:
                 # This index has the same fields as the PK, in a different
                 # order, to facilitate queries that know skypix_index and want
                 # to find the other element.
-                (
+                ddl.IndexSpec(
                     "skypix_system",
                     "skypix_level",
                     "skypix_index",
-                )
-                + tuple(element.graph.required.names),
+                    *element.graph.required.names,
+                ),
             },
             foreignKeys=[
                 # Foreign key to summary table.  This makes sure we don't

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -621,7 +621,7 @@ class CollectionManager(VersionedExtension):
             their children, but not both.
 
         Returns
-        ------
+        -------
         records : `list` [ `CollectionRecord` ]
             Matching collection records.
         """

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -975,14 +975,15 @@ class Database(ABC):
         allIndexes.update(spec.unique)
         args.extend(
             sqlalchemy.schema.Index(
-                self.shrinkDatabaseEntityName("_".join([name, "idx"] + list(columns))),
-                *columns,
-                unique=(columns in spec.unique),
+                self.shrinkDatabaseEntityName("_".join([name, "idx"] + list(index.columns))),
+                *index.columns,
+                unique=(index.columns in spec.unique),
+                **index.kwargs,
             )
-            for columns in spec.indexes
-            if columns not in allIndexes
+            for index in spec.indexes
+            if index.columns not in allIndexes
         )
-        allIndexes.update(spec.indexes)
+        allIndexes.update(index.columns for index in spec.indexes)
         args.extend(
             sqlalchemy.schema.Index(
                 self.shrinkDatabaseEntityName("_".join((name, "fkidx") + fk.source)),

--- a/python/lsst/daf/butler/registry/obscore/__init__.py
+++ b/python/lsst/daf/butler/registry/obscore/__init__.py
@@ -23,3 +23,4 @@ from ._config import *
 from ._manager import *
 from ._records import *
 from ._schema import *
+from ._spatial import *

--- a/python/lsst/daf/butler/registry/obscore/_config.py
+++ b/python/lsst/daf/butler/registry/obscore/_config.py
@@ -28,6 +28,7 @@ __all__ = [
     "ExtraColumnType",
     "ObsCoreConfig",
     "ObsCoreManagerConfig",
+    "SpatialPluginConfig",
 ]
 
 import enum
@@ -59,6 +60,9 @@ class ExtraColumnConfig(BaseModel):
 
     length: Optional[int] = None
     """Optional length qualifier for a column, only used for strings."""
+
+    doc: Optional[str] = None
+    """Documentation string for this column."""
 
 
 class DatasetTypeConfig(BaseModel):
@@ -98,6 +102,16 @@ class DatasetTypeConfig(BaseModel):
 
     Keys are the names of the columns, values can be literal constants with the
     values, or ExtraColumnConfig mappings."""
+
+
+class SpatialPluginConfig(BaseModel):
+    """Configuration class for a spatial plugin."""
+
+    cls: str
+    """Name of the class implementing plugin methods."""
+
+    config: Dict[str, Any] = {}
+    """Configuration object passed to plugin ``initialize()`` method."""
 
 
 class ObsCoreConfig(BaseModel):
@@ -143,9 +157,10 @@ class ObsCoreConfig(BaseModel):
     spectral_ranges: Dict[str, Tuple[float, float]] = {}
     """Maps band name or filter name to a min/max of spectral range."""
 
-    spatial_backend: Optional[str] = None
-    """The name of a spatial backend which manages additional spatial
-    columns and indices (e.g. "pgsphere"). By default there is no spatial
+    spatial_plugins: Dict[str, SpatialPluginConfig] = {}
+    """Optional configuration for plugins managing spatial columns and
+    indices. The key is an arbitrary name and the value is an object describing
+    plugin class and its configuration options. By default there is no spatial
     indexing support, but a standard ``s_region`` column is always included.
     """
 

--- a/python/lsst/daf/butler/registry/obscore/_records.py
+++ b/python/lsst/daf/butler/registry/obscore/_records.py
@@ -21,20 +21,26 @@
 
 from __future__ import annotations
 
-__all__ = ["ExposureRegionFactory", "RecordFactory"]
+__all__ = ["ExposureRegionFactory", "Record", "RecordFactory"]
 
 import logging
 from abc import abstractmethod
-from collections.abc import Mapping
-from typing import Any, Callable, Dict, Optional, cast
+from collections import defaultdict
+from collections.abc import Collection, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, cast
 from uuid import UUID
 
 import astropy.time
+import sqlalchemy
 from lsst.daf.butler import DataCoordinate, DatasetRef, Dimension, DimensionRecord, DimensionUniverse
-from lsst.sphgeom import ConvexPolygon, LonLat, Region
 
 from ._config import ExtraColumnConfig, ExtraColumnType, ObsCoreConfig
-from ._schema import ObsCoreSchema
+
+if TYPE_CHECKING:
+    from lsst.sphgeom import Region
+
+    from ._schema import ObsCoreSchema
+    from ._spatial import SpatialObsCorePlugin
 
 _LOG = logging.getLogger(__name__)
 
@@ -67,6 +73,9 @@ class ExposureRegionFactory:
         raise NotImplementedError()
 
 
+Record = Dict[str, Any]
+
+
 class RecordFactory:
     """Class that implements conversion of dataset information to ObsCore.
 
@@ -87,12 +96,14 @@ class RecordFactory:
         config: ObsCoreConfig,
         schema: ObsCoreSchema,
         universe: DimensionUniverse,
+        spatial_plugins: Collection[SpatialObsCorePlugin],
         exposure_region_factory: Optional[ExposureRegionFactory] = None,
     ):
         self.config = config
         self.schema = schema
         self.universe = universe
         self.exposure_region_factory = exposure_region_factory
+        self.spatial_plugins = spatial_plugins
 
         # All dimension elements used below.
         self.band = cast(Dimension, universe["band"])
@@ -100,7 +111,9 @@ class RecordFactory:
         self.visit = universe["visit"]
         self.physical_filter = cast(Dimension, universe["physical_filter"])
 
-    def __call__(self, ref: DatasetRef) -> Optional[Dict[str, str | int | float | UUID | None]]:
+    def __call__(
+        self, ref: DatasetRef
+    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
         """Make an ObsCore record from a dataset.
 
         Parameters
@@ -114,6 +127,9 @@ class RecordFactory:
             ObsCore record represented as a dictionary. `None` is returned if
             dataset does not need to be stored in the obscore table, e.g. when
             dataset type is not in obscore configuration.
+        extra_records : `dict` [ `sqlalchemy.Table`, `list` [ `Record` ] ]
+            Records to store in additional plugin-specific tables, indexed by
+            the corresponding table object.
 
         Notes
         -----
@@ -126,7 +142,7 @@ class RecordFactory:
         dataset_type_name = ref.datasetType.name
         dataset_config = self.config.dataset_types.get(dataset_type_name)
         if dataset_config is None:
-            return None
+            return None, None
 
         dataId = ref.dataId
         # _LOG.debug("New record, dataId=%s", dataId.full)
@@ -168,7 +184,16 @@ class RecordFactory:
             if (dimension_record := dataId.records[self.visit]) is not None:
                 self._visit_records(dimension_record, record)
 
-        self.region_to_columns(region, record)
+        # ask each plugin for its values to add to a record.
+        extra_plugin_records: Dict[sqlalchemy.schema.Table, List[Record]] = defaultdict(list)
+        for plugin in self.spatial_plugins:
+            assert ref.id is not None, "Datasett ID must be defined"
+            plugin_record, extra_records = plugin.make_records(ref.id, region)
+            if plugin_record is not None:
+                record.update(plugin_record)
+            if extra_records is not None:
+                for table, table_records in extra_records.items():
+                    extra_plugin_records[table].extend(table_records)
 
         if self.band in dataId:
             em_range = None
@@ -218,48 +243,7 @@ class RecordFactory:
                 # Just a static value.
                 record[key] = column_value
 
-        return record
-
-    @classmethod
-    def region_to_columns(cls, region: Optional[Region], record: Dict[str, Any]) -> None:
-        """Fill obscore column values from sphgeom region.
-
-        Parameters
-        ----------
-        region : `lsst.sphgeom.Region`
-            Spatial region, expected to be a ``ConvexPolygon`` instance,
-            warning will be logged for other types.
-        record : `dict` [ `str`, `Any` ]
-            Obscore record that will be expanded with the new columns.
-
-        Notes
-        -----
-        This method adds ``s_ra``, ``s_dec``, and ``s_fov`` values to the
-        record, they are computed from the region bounding circle. If the
-        region is a ``ConvexPolygon`` instance, then ``s_region`` value is
-        added as well representing the polygon in ADQL format.
-        """
-        if region is None:
-            return
-
-        # Get spatial parameters from the bounding circle.
-        circle = region.getBoundingCircle()
-        center = LonLat(circle.getCenter())
-        record["s_ra"] = center.getLon().asDegrees()
-        record["s_dec"] = center.getLat().asDegrees()
-        record["s_fov"] = circle.getOpeningAngle().asDegrees() * 2
-
-        if isinstance(region, ConvexPolygon):
-            poly = ["POLYGON ICRS"]
-            for vertex in region.getVertices():
-                lon_lat = LonLat(vertex)
-                poly += [
-                    f"{lon_lat.getLon().asDegrees():.6f}",
-                    f"{lon_lat.getLat().asDegrees():.6f}",
-                ]
-            record["s_region"] = " ".join(poly)
-        else:
-            _LOG.warning(f"Unexpected region type: {type(region)}")
+        return record, extra_plugin_records
 
     def _exposure_records(self, dimension_record: DimensionRecord, record: Dict[str, Any]) -> None:
         """Extract all needed info from a visit dimension record."""

--- a/python/lsst/daf/butler/registry/obscore/_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/_spatial.py
@@ -25,19 +25,17 @@ __all__ = ["MissingDatabaseError", "RegionTypeWarning", "SpatialObsCorePlugin"]
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
-import sqlalchemy
 from lsst.daf.butler import DatasetId
 from lsst.sphgeom import Region
 from lsst.utils import doImportType
 
 if TYPE_CHECKING:
     from ...core import ddl
-    from ..interfaces import Database, StaticTablesContext
+    from ..interfaces import Database
     from ._config import SpatialPluginConfig
     from ._records import Record
-    from ._schema import ObsCoreSchema
 
 
 class MissingDatabaseError(Exception):
@@ -105,27 +103,7 @@ class SpatialObsCorePlugin(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def make_extra_tables(self, schema: ObsCoreSchema, context: StaticTablesContext) -> None:
-        """Create any additional tables filled by this plugin.
-
-        Parameters
-        ----------
-        schema : `ObsCoreSchema`
-            Instance of a class controlling obscore table schema.
-        context : `StaticTablesContext`
-            Context object obtained from `Database.declareStaticTables`.
-
-        Notes
-        -----
-        This method is called after the schema of the main obscore table has
-        been created already.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def make_records(
-        self, dataset_id: DatasetId, region: Optional[Region]
-    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
+    def make_records(self, dataset_id: DatasetId, region: Optional[Region]) -> Optional[Record]:
         """Return data for obscore records corresponding to a given region.
 
         Parameters
@@ -140,9 +118,6 @@ class SpatialObsCorePlugin(ABC):
         record : `dict` [ `str`, `Any` ] or `None`
             Data to store in the main obscore table with column values
             corresponding to a region or `None` if there is nothing to store.
-        extra_records : `dict` [ `sqlalchemy.Table`, `list` [ `Record` ] ]
-            Records to store in additional plugin-specific tables, indexed by
-            the corresponding table object.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/obscore/_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/_spatial.py
@@ -1,0 +1,194 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["MissingDatabaseError", "RegionTypeWarning", "SpatialObsCorePlugin"]
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+import sqlalchemy
+from lsst.daf.butler import DatasetId
+from lsst.sphgeom import Region
+from lsst.utils import doImportType
+
+if TYPE_CHECKING:
+    from ...core import ddl
+    from ..interfaces import Database, StaticTablesContext
+    from ._config import SpatialPluginConfig
+    from ._records import Record
+    from ._schema import ObsCoreSchema
+
+
+class MissingDatabaseError(Exception):
+    """Exception raised when database is not provided but plugin implementation
+    requires it.
+    """
+
+
+class RegionTypeWarning(Warning):
+    """Warning category for unsupported region types."""
+
+
+class SpatialObsCorePlugin(ABC):
+    """Interface for classes that implement support for spatial columns and
+    indices in obscore table.
+    """
+
+    @classmethod
+    @abstractmethod
+    def initialize(
+        cls, *, name: str, config: Mapping[str, Any], db: Optional[Database]
+    ) -> SpatialObsCorePlugin:
+        """Construct an instance of the plugin.
+
+        Parameters
+        ----------
+        name : `str`
+            Arbitrary name given to this plugin (usually key in
+            configuration).
+        config : `dict` [ `str`, `Any` ]
+            Plugin configuration dictionary.
+        db : `Database`, optional
+            Interface to the underlying database engine and namespace. In some
+            contexts the database may not be available and will be set to
+            `None`. If plugin class requires access to the database, it should
+            raise a `MissingDatabaseError` exception when ``db`` is `None`.
+
+        Returns
+        -------
+        manager : `ObsCoreTableManager`
+            Plugin instance.
+
+        Raises
+        ------
+        MissingDatabaseError
+            Raised if plugin requires access to database, but ``db`` is `None`.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def extend_table_spec(self, table_spec: ddl.TableSpec) -> None:
+        """Update obscore table specification with any new columns that are
+        needed for this plugin.
+
+        Parameters
+        ----------
+        table : `ddl.TableSpec`
+            ObsCore table specification.
+
+        Notes
+        -----
+        Table specification is updated in place. Plugins should not remove
+        columns, normally updates are limited to adding new columns or indices.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def make_extra_tables(self, schema: ObsCoreSchema, context: StaticTablesContext) -> None:
+        """Create any additional tables filled by this plugin.
+
+        Parameters
+        ----------
+        schema : `ObsCoreSchema`
+            Instance of a class controlling obscore table schema.
+        context : `StaticTablesContext`
+            Context object obtained from `Database.declareStaticTables`.
+
+        Notes
+        -----
+        This method is called after the schema of the main obscore table has
+        been created already.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def make_records(
+        self, dataset_id: DatasetId, region: Optional[Region]
+    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
+        """Return data for obscore records corresponding to a given region.
+
+        Parameters
+        ----------
+        dataset_id : `DatasetId`
+            ID of the corresponding dataset.
+        region : `Region`, optional
+            Spatial region, can be `None` if dataset has no associated region.
+
+        Returns
+        -------
+        record : `dict` [ `str`, `Any` ] or `None`
+            Data to store in the main obscore table with column values
+            corresponding to a region or `None` if there is nothing to store.
+        extra_records : `dict` [ `sqlalchemy.Table`, `list` [ `Record` ] ]
+            Records to store in additional plugin-specific tables, indexed by
+            the corresponding table object.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def load_plugins(
+        cls, config: Mapping[str, SpatialPluginConfig], db: Optional[Database]
+    ) -> Sequence[SpatialObsCorePlugin]:
+        """Load all plugins based on plugin configurations.
+
+        Parameters
+        ----------
+        config : `Mapping` [ `str`, `SpatialPluginConfig` ]
+            Configuration for plugins. The key is an arbitrary name and the
+            value is an object describing plugin class and its configuration
+            options.
+        db : `Database`, optional
+            Interface to the underlying database engine and namespace.
+
+        Raises
+        ------
+        MissingDatabaseError
+            Raised if one of the plugins requires access to database, but
+            ``db`` is `None`.
+        """
+        # We have to always load default plugin even if it does not appear in
+        # configuration.
+        from .default_spatial import DefaultSpatialObsCorePlugin
+
+        spatial_plugins: list[SpatialObsCorePlugin] = []
+        has_default = False
+        for plugin_name, plugin_config in config.items():
+            class_name = plugin_config.cls
+            plugin_class = doImportType(class_name)
+            if not issubclass(plugin_class, SpatialObsCorePlugin):
+                raise TypeError(
+                    f"Spatial ObsCore plugin {class_name} is not a subclass of SpatialObsCorePlugin"
+                )
+            plugin = plugin_class.initialize(name=plugin_name, config=plugin_config.config, db=db)
+            spatial_plugins.append(plugin)
+            if plugin_class is DefaultSpatialObsCorePlugin:
+                has_default = True
+
+        if not has_default:
+            # Always create default spatial plugin.
+            spatial_plugins.insert(
+                0, DefaultSpatialObsCorePlugin.initialize(name="default", config={}, db=db)
+            )
+
+        return spatial_plugins

--- a/python/lsst/daf/butler/registry/obscore/default_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/default_spatial.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 __all__ = ["DefaultSpatialObsCorePlugin"]
 
 import warnings
-from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Optional
 
 import sqlalchemy
 from lsst.daf.butler import DatasetId
@@ -35,9 +35,8 @@ from ...core import ddl
 from ._spatial import RegionTypeWarning, SpatialObsCorePlugin
 
 if TYPE_CHECKING:
-    from ..interfaces import Database, StaticTablesContext
+    from ..interfaces import Database
     from ._records import Record
-    from ._schema import ObsCoreSchema
 
 # Columns added/filled by this plugin
 _COLUMNS = (
@@ -72,17 +71,11 @@ class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
         # docstring inherited.
         table_spec.fields.update(_COLUMNS)
 
-    def make_extra_tables(self, schema: ObsCoreSchema, context: StaticTablesContext) -> None:
-        # docstring inherited.
-        return
-
-    def make_records(
-        self, dataset_id: DatasetId, region: Optional[Region]
-    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
+    def make_records(self, dataset_id: DatasetId, region: Optional[Region]) -> Optional[Record]:
         # docstring inherited.
 
         if region is None:
-            return None, None
+            return None
 
         record: Record = {}
 
@@ -108,4 +101,4 @@ class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
                 category=RegionTypeWarning,
             )
 
-        return record, None
+        return record

--- a/python/lsst/daf/butler/registry/obscore/default_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/default_spatial.py
@@ -1,0 +1,111 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["DefaultSpatialObsCorePlugin"]
+
+import warnings
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+import sqlalchemy
+from lsst.daf.butler import DatasetId
+from lsst.sphgeom import ConvexPolygon, LonLat, Region
+
+from ...core import ddl
+from ._spatial import RegionTypeWarning, SpatialObsCorePlugin
+
+if TYPE_CHECKING:
+    from ..interfaces import Database, StaticTablesContext
+    from ._records import Record
+    from ._schema import ObsCoreSchema
+
+# Columns added/filled by this plugin
+_COLUMNS = (
+    ddl.FieldSpec(name="s_ra", dtype=sqlalchemy.Float, doc="Central right ascension, ICRS (deg)"),
+    ddl.FieldSpec(name="s_dec", dtype=sqlalchemy.Float, doc="Central declination, ICRS (deg)"),
+    ddl.FieldSpec(name="s_fov", dtype=sqlalchemy.Float, doc="Diameter (bounds) of the covered region (deg)"),
+    ddl.FieldSpec(
+        name="s_region",
+        dtype=sqlalchemy.String,
+        length=65535,
+        doc="Sky region covered by the data product (expressed in ICRS frame)",
+    ),
+)
+
+
+class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
+    """Class for a spatial ObsCore plugin which creates standard spatial
+    obscore columns.
+    """
+
+    def __init__(self, *, name: str, config: Mapping[str, Any]):
+        self._name = name
+
+    @classmethod
+    def initialize(
+        cls, *, name: str, config: Mapping[str, Any], db: Optional[Database]
+    ) -> SpatialObsCorePlugin:
+        # docstring inherited.
+        return cls(name=name, config=config)
+
+    def extend_table_spec(self, table_spec: ddl.TableSpec) -> None:
+        # docstring inherited.
+        table_spec.fields.update(_COLUMNS)
+
+    def make_extra_tables(self, schema: ObsCoreSchema, context: StaticTablesContext) -> None:
+        # docstring inherited.
+        return
+
+    def make_records(
+        self, dataset_id: DatasetId, region: Optional[Region]
+    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
+        # docstring inherited.
+
+        if region is None:
+            return None, None
+
+        record: Record = {}
+
+        # Get spatial parameters from the bounding circle.
+        circle = region.getBoundingCircle()
+        center = LonLat(circle.getCenter())
+        record["s_ra"] = center.getLon().asDegrees()
+        record["s_dec"] = center.getLat().asDegrees()
+        record["s_fov"] = circle.getOpeningAngle().asDegrees() * 2
+
+        if isinstance(region, ConvexPolygon):
+            poly = ["POLYGON ICRS"]
+            for vertex in region.getVertices():
+                lon_lat = LonLat(vertex)
+                poly += [
+                    f"{lon_lat.getLon().asDegrees():.6f}",
+                    f"{lon_lat.getLat().asDegrees():.6f}",
+                ]
+            record["s_region"] = " ".join(poly)
+        else:
+            warnings.warn(
+                f"Unexpected region type for obscore dataset {dataset_id}: {type(region)}",
+                category=RegionTypeWarning,
+            )
+
+        return record, None

--- a/python/lsst/daf/butler/registry/obscore/pgsphere.py
+++ b/python/lsst/daf/butler/registry/obscore/pgsphere.py
@@ -1,0 +1,188 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["PgSphereObsCorePlugin"]
+
+import warnings
+from collections.abc import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+import sqlalchemy
+from lsst.daf.butler import DatasetId
+from lsst.sphgeom import ConvexPolygon, LonLat, Region
+from sqlalchemy.dialects.postgresql.base import ischema_names
+from sqlalchemy.types import UserDefinedType
+
+from ...core import ddl
+from ._spatial import MissingDatabaseError, RegionTypeWarning, SpatialObsCorePlugin
+
+if TYPE_CHECKING:
+    from ..interfaces import Database, StaticTablesContext
+    from ._records import Record
+    from ._schema import ObsCoreSchema
+
+
+class PgSpherePoint(UserDefinedType):
+    """SQLAlchemy type representing pgSphere point (spoint) type.
+
+    On Python side this type corresponds to `lsst.sphgeom.LonLat`.
+    Only a limited set of methods is implemented, sufficient to store the
+    data in the database.
+    """
+
+    cache_ok = True
+
+    def get_col_spec(self, **kw: Any) -> str:
+        """Return name of the column type"""
+        return "SPOINT"
+
+    def bind_processor(self, dialect: sqlalchemy.engine.Dialect) -> Callable:
+        """Return processor method for bind values"""
+
+        def _process(value: LonLat) -> str:
+            lon = value.getLon().asRadians()
+            lat = value.getLat().asRadians()
+            return f"({lon},{lat})"
+
+        return _process
+
+
+class PgSpherePolygon(UserDefinedType):
+    """SQLAlchemy type representing pgSphere polygon (spoly) type.
+
+    On Python side it corresponds to a sequence of `lsst.sphgeom.LonLat`
+    instances (sphgeom polygons are convex, while pgSphere polygons do not
+    have to be). Only a limited set of methods is implemented, sufficient to
+    store the data in the database.
+    """
+
+    cache_ok = True
+
+    def get_col_spec(self, **kw: Any) -> str:
+        """Return name of the column type"""
+        return "SPOLY"
+
+    def bind_processor(self, dialect: sqlalchemy.engine.Dialect) -> Callable:
+        """Return processor method for bind values"""
+
+        def _process(value: Sequence[LonLat]) -> str:
+            points = []
+            for lonlat in value:
+                lon = lonlat.getLon().asRadians()
+                lat = lonlat.getLat().asRadians()
+                points.append(f"({lon},{lat})")
+            return "{" + ",".join(points) + "}"
+
+        return _process
+
+
+# To suppress SAWarning about unknown types we need to make them known, this
+# is not explicitly documented but it is what other people do.
+ischema_names["spoint"] = PgSpherePoint
+ischema_names["spoly"] = PgSpherePolygon
+
+
+class PgSphereObsCorePlugin(SpatialObsCorePlugin):
+    """Spatial ObsCore plugin which creates pg_sphere geometries.
+
+    This plugin adds and fills two columns to obscore table - one for the
+    region (polygon), another for the position of the center of bounding
+    circle. Both columns are indexed. Column names can be changed via plugin
+    configuration.
+    """
+
+    def __init__(self, *, name: str, config: Mapping[str, Any]):
+        self._name = name
+        self._region_column_name = config.get("region_column", "pgsphere_region")
+        self._position_column_name = config.get("position_column", "pgsphere_position")
+
+    @classmethod
+    def initialize(
+        cls, *, name: str, config: Mapping[str, Any], db: Optional[Database]
+    ) -> SpatialObsCorePlugin:
+        # docstring inherited.
+
+        if db is None:
+            raise MissingDatabaseError("Database access is required for pgSphere plugin")
+
+        # Check that engine is Postgres and pgSphere extension is enabled.
+        if db.dialect.name != "postgresql":
+            raise RuntimeError("PgSphere spatial plugin for obscore requires PostgreSQL database.")
+        query = "SELECT COUNT(*) FROM pg_extension WHERE extname='pg_sphere'"
+        result = db.query(sqlalchemy.sql.text(query))
+        if result.scalar() == 0:
+            raise RuntimeError(
+                "PgSphere spatial plugin for obscore requires the pgSphere extension. "
+                "Please run `CREATE EXTENSION pg_sphere;` on a database containing obscore table "
+                "from a PostgreSQL superuser account."
+            )
+
+        return cls(name=name, config=config)
+
+    def extend_table_spec(self, table_spec: ddl.TableSpec) -> None:
+        # docstring inherited.
+        table_spec.fields.update(
+            (
+                ddl.FieldSpec(
+                    name=self._region_column_name,
+                    dtype=PgSpherePolygon,
+                    doc="pgSphere polygon for this record region.",
+                ),
+                ddl.FieldSpec(
+                    name=self._position_column_name,
+                    dtype=PgSpherePoint,
+                    doc="pgSphere position for this record, center of bounding circle.",
+                ),
+            )
+        )
+        # Spatial columns need GIST index type
+        table_spec.indexes.add(ddl.IndexSpec(self._region_column_name, postgresql_using="gist"))
+        table_spec.indexes.add(ddl.IndexSpec(self._position_column_name, postgresql_using="gist"))
+
+    def make_extra_tables(self, schema: ObsCoreSchema, context: StaticTablesContext) -> None:
+        # docstring inherited.
+        return
+
+    def make_records(
+        self, dataset_id: DatasetId, region: Optional[Region]
+    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
+        # docstring inherited.
+
+        if region is None:
+            return None, None
+
+        record: Record = {}
+        circle = region.getBoundingCircle()
+        record[self._position_column_name] = LonLat(circle.getCenter())
+
+        # Presently we can only handle polygons
+        if isinstance(region, ConvexPolygon):
+            poly_points = [LonLat(vertex) for vertex in region.getVertices()]
+            record[self._region_column_name] = poly_points
+        else:
+            warnings.warn(
+                f"Unexpected region type for obscore dataset {dataset_id}: {type(region)}",
+                category=RegionTypeWarning,
+            )
+
+        return record, None

--- a/python/lsst/daf/butler/registry/obscore/pgsphere.py
+++ b/python/lsst/daf/butler/registry/obscore/pgsphere.py
@@ -25,7 +25,7 @@ __all__ = ["PgSphereObsCorePlugin"]
 
 import warnings
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional
 
 import sqlalchemy
 from lsst.daf.butler import DatasetId
@@ -37,9 +37,8 @@ from ...core import ddl
 from ._spatial import MissingDatabaseError, RegionTypeWarning, SpatialObsCorePlugin
 
 if TYPE_CHECKING:
-    from ..interfaces import Database, StaticTablesContext
+    from ..interfaces import Database
     from ._records import Record
-    from ._schema import ObsCoreSchema
 
 
 class PgSpherePoint(UserDefinedType):
@@ -159,17 +158,11 @@ class PgSphereObsCorePlugin(SpatialObsCorePlugin):
         table_spec.indexes.add(ddl.IndexSpec(self._region_column_name, postgresql_using="gist"))
         table_spec.indexes.add(ddl.IndexSpec(self._position_column_name, postgresql_using="gist"))
 
-    def make_extra_tables(self, schema: ObsCoreSchema, context: StaticTablesContext) -> None:
-        # docstring inherited.
-        return
-
-    def make_records(
-        self, dataset_id: DatasetId, region: Optional[Region]
-    ) -> Tuple[Optional[Record], Optional[Mapping[sqlalchemy.schema.Table, Sequence[Record]]]]:
+    def make_records(self, dataset_id: DatasetId, region: Optional[Region]) -> Optional[Record]:
         # docstring inherited.
 
         if region is None:
-            return None, None
+            return None
 
         record: Record = {}
         circle = region.getBoundingCircle()
@@ -185,4 +178,4 @@ class PgSphereObsCorePlugin(SpatialObsCorePlugin):
                 category=RegionTypeWarning,
             )
 
-        return record, None
+        return record

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -96,7 +96,7 @@ class QueryBackend(ABC):
             their children, but not both.
 
         Returns
-        ------
+        -------
         records : `list` [ `CollectionRecord` ]
             Matching collection records.
         """


### PR DESCRIPTION
Obscore manager adds generic plugin mechanisms to support spatial columns
and indices. A specific implementation using pgSphere extension adds
two columns and corresponding indices that contain pgSphere polygon and
position (center of bounding circle) to obscore table.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
