### PR TITLE
DM-36325L Allow list or tuple as bound value for IN operator

### DIFF
--- a/doc/changes/DM-36325.feature.md
+++ b/doc/changes/DM-36325.feature.md
@@ -1,0 +1,1 @@
+Bind values in Registry queries can now specify list/tuple of numbers for identifiers appearing on the right-hand side of `IN` expression.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -164,6 +164,46 @@ schema and how SQL query is built). A simple identifier with a name
 ``ingest_date`` is used to reference dataset ingest time, which can be used to
 filter query results based on that property of datasets.
 
+Registry methods accepting user expressions also accept ``bind`` parameter which is a mapping from identifier name to its corresponding value.
+Identifiers appearing in a user expressions will be replaced with the corresponding value from this mapping.
+Use of ``bind`` parameter is encouraged when possible to simplify rendering of the query strings.
+A partial example of comparing two approaches, without and with ``bind``:
+
+.. code-block:: Python
+
+    instrument_name = "LSST"
+    visit_id = 12345
+
+    # Direct rendering of query not using bind
+    result = registry.queryDatasets(
+        ...,
+        where=f"instrument = '{instrument_name}' AND visit = {visit_id}",
+    )
+
+    # Same functionality using bind parameter
+    result = registry.queryDatasets(
+        ...,
+        where="instrument = instrument_name AND visit = visit_id",
+        bind={"instrument_name": instrument_name, "visit_id": visit_id},
+    )
+
+Types of values provided in a ``bind`` mapping must correspond to the expected type of the expression, which is usually a scalar type, one of ``int``, ``float``, ``str``, etc.
+There is one context where a bound value can specify a list or a tuple of values, this can be provided for an identifier appearing in the right-hand side of :ref:`expressions-in-operator`.
+Note that parentheses after ``IN`` are still required when identifier is bound to a list or a tuple.
+An example of this feature:
+
+.. code-block:: Python
+
+    instrument_name = "LSST"
+    visit_ids = (12345, 12346, 12350)
+    result = registry.queryDatasets(
+        ...,
+        where="instrument = instrument_name AND visit IN (visit_ids)",
+        bind={"instrument_name": instrument_name, "visit_ids": visit_ids},
+    )
+
+
+
 Unary arithmetic operators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -190,6 +230,7 @@ expressions.
 .. note :: The equality comparison operator is a single ``=`` like in SQL, not
     double ``==`` like in Python or C++.
 
+.. _expressions-in-operator:
 
 IN operator
 ^^^^^^^^^^^

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -164,9 +164,9 @@ schema and how SQL query is built). A simple identifier with a name
 ``ingest_date`` is used to reference dataset ingest time, which can be used to
 filter query results based on that property of datasets.
 
-Registry methods accepting user expressions also accept ``bind`` parameter which is a mapping from identifier name to its corresponding value.
-Identifiers appearing in a user expressions will be replaced with the corresponding value from this mapping.
-Use of ``bind`` parameter is encouraged when possible to simplify rendering of the query strings.
+Registry methods accepting user expressions also accept a ``bind`` parameter, which is a mapping from identifier name to its corresponding value.
+Identifiers appearing in user expressions will be replaced with the corresponding value from this mapping.
+Using the ``bind`` parameter is encouraged when possible to simplify rendering of the query strings.
 A partial example of comparing two approaches, without and with ``bind``:
 
 .. code-block:: Python
@@ -188,7 +188,7 @@ A partial example of comparing two approaches, without and with ``bind``:
     )
 
 Types of values provided in a ``bind`` mapping must correspond to the expected type of the expression, which is usually a scalar type, one of ``int``, ``float``, ``str``, etc.
-There is one context where a bound value can specify a list or a tuple of values, this can be provided for an identifier appearing in the right-hand side of :ref:`expressions-in-operator`.
+There is one context where a bound value can specify a list, tuple or set of values: an identifier appearing in the right-hand side of :ref:`expressions-in-operator`.
 Note that parentheses after ``IN`` are still required when identifier is bound to a list or a tuple.
 An example of this feature:
 

--- a/python/lsst/daf/butler/registry/queries/expressions/check.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/check.py
@@ -184,7 +184,16 @@ class InspectionVisitor(TreeVisitor[TreeSummary]):
     def visitIdentifier(self, name: str, node: Node) -> TreeSummary:
         # Docstring inherited from TreeVisitor.visitIdentifier
         if name in self.bind:
-            return TreeSummary(dataIdValue=self.bind[name])
+            value = self.bind[name]
+            if isinstance(value, (list, tuple)):
+                # This can happen on rhs of IN operator, if there is only one
+                # element in the list then take it.
+                if len(value) == 1:
+                    return TreeSummary(dataIdValue=value[0])
+                else:
+                    return TreeSummary()
+            else:
+                return TreeSummary(dataIdValue=value)
         constant = categorizeConstant(name)
         if constant is ExpressionConstant.INGEST_DATE:
             return TreeSummary(hasIngestDate=True)

--- a/python/lsst/daf/butler/registry/queries/expressions/check.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/check.py
@@ -27,7 +27,8 @@ __all__ = (
 )
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Sequence, Set, Tuple
+from collections.abc import Mapping, Sequence, Set
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from ....core import (
     DataCoordinate,
@@ -72,7 +73,7 @@ class InspectionSummary:
     in this branch (`NamedValueSet` [ `Dimension` ]).
     """
 
-    columns: NamedKeyDict[DimensionElement, Set[str]] = dataclasses.field(default_factory=NamedKeyDict)
+    columns: NamedKeyDict[DimensionElement, set[str]] = dataclasses.field(default_factory=NamedKeyDict)
     """Dimension element tables whose columns were referenced anywhere in this
     branch (`NamedKeyDict` [ `DimensionElement`, `set` [ `str` ] ]).
     """
@@ -185,11 +186,11 @@ class InspectionVisitor(TreeVisitor[TreeSummary]):
         # Docstring inherited from TreeVisitor.visitIdentifier
         if name in self.bind:
             value = self.bind[name]
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, (list, tuple, Set)):
                 # This can happen on rhs of IN operator, if there is only one
                 # element in the list then take it.
                 if len(value) == 1:
-                    return TreeSummary(dataIdValue=value[0])
+                    return TreeSummary(dataIdValue=next(iter(value)))
                 else:
                     return TreeSummary()
             else:

--- a/python/lsst/daf/butler/registry/queries/expressions/convert.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/convert.py
@@ -29,6 +29,7 @@ __all__ = (
 import operator
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Set
 from datetime import datetime
 from typing import (
     TYPE_CHECKING,
@@ -1103,9 +1104,9 @@ class WhereClauseConverterVisitor(TreeVisitor[WhereClauseConverter]):
             value = self.bind[name]
             if isinstance(value, Timespan):
                 return TimespanWhereClauseConverter(self._TimespanReprClass.fromLiteral(value))
-            elif isinstance(value, (list, tuple)):
-                # Only accept lists and tuples, general test for Iterables is
-                # not reliable (e.g. astropy Time is Iterable).
+            elif isinstance(value, (list, tuple, Set)):
+                # Only accept list, tuple, and Set, general test for Iterables
+                # is not reliable (e.g. astropy Time is Iterable).
                 return SequenceWhereClauseConverter.fromLiteral(value)
             return ScalarWhereClauseConverter.fromLiteral(value)
         constant = categorizeConstant(name)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -132,7 +132,7 @@ class ConvertExpressionToSqlTestCase(unittest.TestCase):
         )
 
     def test_bind_list(self):
-        """Test with bind parameter which is list inside IN rhs."""
+        """Test with bind parameter which is list/tuple/set inside IN rhs."""
 
         parser = ParserYacc()
         columns = QueryColumns()
@@ -195,16 +195,16 @@ class ConvertExpressionToSqlTestCase(unittest.TestCase):
             self.universe,
             columns,
             elements,
-            {"a": 1, "b": 2, "t": 0, "x": (10, 30), "y": (20, 40)},
+            {"a": 1, "b": 2, "t": 0, "x": (10, 30), "y": {20}},
             TimespanDatabaseRepresentation.Compound,
         )
         self.assertEqual(
             str(column_element.compile()),
-            ":param_1 > :param_2 OR :param_3 IN (:param_4, :param_5, :param_6, :param_7)",
+            ":param_1 > :param_2 OR :param_3 IN (:param_4, :param_5, :param_6)",
         )
         self.assertEqual(
             str(column_element.compile(compile_kwargs={"literal_binds": True})),
-            "1 > 2 OR 0 IN (10, 30, 20, 40)",
+            "1 > 2 OR 0 IN (10, 30, 20)",
         )
 
 


### PR DESCRIPTION
An identifier appearing on the right-hand side of `IN` operator can be bound to a list or a tuple of numbers.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
