### PR TITLE
DM-36974: Clean up mypy annotations in lsst.daf.butler.script

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -85,9 +85,6 @@ ignore_errors = True
 [mypy-lsst.daf.butler.cli.*]
 ignore_errors = True
 
-[mypy-lsst.daf.butler.script.*]
-disallow_untyped_defs = False
-
 [mypy-lsst.daf.butler.registry.tests.*]
 ignore_errors = True
 

--- a/python/lsst/daf/butler/script/_associate.py
+++ b/python/lsst/daf/butler/script/_associate.py
@@ -18,13 +18,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from collections.abc import Iterable
 
 from .._butler import Butler
 from ..registry import CollectionType
 from .queryDatasets import QueryDatasets
 
 
-def associate(repo, collection, dataset_type, collections, where, find_first):
+def associate(
+    repo: str,
+    collection: str,
+    dataset_type: Iterable[str],
+    collections: Iterable[str],
+    where: str | None,
+    find_first: bool,
+) -> None:
     """Add existing datasets to a CHAINED collection."""
 
     butler = Butler(repo, writeable=True)

--- a/python/lsst/daf/butler/script/butlerImport.py
+++ b/python/lsst/daf/butler/script/butlerImport.py
@@ -18,11 +18,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import TextIO
 
 from .._butler import Butler
 
 
-def butlerImport(repo, directory, export_file, transfer, skip_dimensions, reuse_ids):
+def butlerImport(
+    repo: str,
+    directory: str | None,
+    export_file: str | TextIO | None,
+    transfer: str | None,
+    skip_dimensions: Iterable[str] | None,
+    reuse_ids: bool,
+) -> None:
     """Import data into a butler repository.
 
     Parameters

--- a/python/lsst/daf/butler/script/certifyCalibrations.py
+++ b/python/lsst/daf/butler/script/certifyCalibrations.py
@@ -18,6 +18,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import astropy.time
 
 from .._butler import Butler
@@ -26,8 +28,14 @@ from ..registry import CollectionType
 
 
 def certifyCalibrations(
-    repo, input_collection, output_collection, dataset_type_name, begin_date, end_date, search_all_inputs
-):
+    repo: str,
+    input_collection: str,
+    output_collection: str,
+    dataset_type_name: str,
+    begin_date: str | None,
+    end_date: str | None,
+    search_all_inputs: bool,
+) -> None:
     """Certify a set of calibrations with a validity range.
 
     Parameters

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -21,11 +21,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from .._butler import Butler
 from ..registry import CollectionType, MissingCollectionError
 
 
-def collectionChain(repo, mode, parent, children, doc, flatten):
+def collectionChain(
+    repo: str, mode: str, parent: str, children: Iterable[str], doc: str | None, flatten: bool
+) -> tuple[str, ...]:
     """Get the collections whose names match an expression.
 
     Parameters
@@ -52,7 +56,7 @@ def collectionChain(repo, mode, parent, children, doc, flatten):
     doc : `str`
         If the chained collection is being created, the documentation string
         that will be associated with it.
-    flatten : `str`
+    flatten : `bool`
         If `True`, recursively flatten out any nested
         `~CollectionType.CHAINED` collections in ``children`` first.
 
@@ -99,7 +103,7 @@ def collectionChain(repo, mode, parent, children, doc, flatten):
         if children:
             n_current = len(current)
 
-            def convert_index(i):
+            def convert_index(i: int) -> int:
                 """Convert negative index to positive."""
                 if i >= 0:
                     return i
@@ -108,16 +112,16 @@ def collectionChain(repo, mode, parent, children, doc, flatten):
             # For this mode the children should be integers.
             # Convert negative integers to positive ones to allow
             # sorting.
-            children = [convert_index(int(child)) for child in children]
+            indices = [convert_index(int(child)) for child in children]
 
             # Reverse sort order so we can remove from the end first
-            children = reversed(sorted(children))
+            indices = list(reversed(sorted(indices)))
 
         else:
-            # Nothing specified, pop from the front of the chin.
-            children = [0]
+            # Nothing specified, pop from the front of the chain.
+            indices = [0]
 
-        for i in children:
+        for i in indices:
             current.pop(i)
 
         children = current

--- a/python/lsst/daf/butler/script/configDump.py
+++ b/python/lsst/daf/butler/script/configDump.py
@@ -19,10 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
+from typing import IO
+
 from .._butlerConfig import ButlerConfig
 
 
-def configDump(repo, subset, searchpath, outfile):
+def configDump(repo: str, subset: str, searchpath: str, outfile: IO) -> None:
     """Dump either a subset or full Butler configuration to standard output.
 
     Parameters

--- a/python/lsst/daf/butler/script/configValidate.py
+++ b/python/lsst/daf/butler/script/configValidate.py
@@ -19,11 +19,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from .._butler import Butler
 from ..core import ValidationError
 
 
-def configValidate(repo, quiet, dataset_type, ignore):
+def configValidate(repo: str, quiet: bool, dataset_type: list[str], ignore: list[str]) -> bool:
     """Validate the configuration files for a Gen3 Butler repository.
 
     Parameters
@@ -32,9 +34,9 @@ def configValidate(repo, quiet, dataset_type, ignore):
         URI to the location to create the repo.
     quiet : `bool`
         Do not report individual failures if True.
-    dataset_type : [`str`]
+    dataset_type : `list`[`str`]
         Specific DatasetTypes to validate.
-    ignore : [`str`]
+    ignore : `list`[`str`]
         "DatasetTypes to ignore for validation."
 
     Returns

--- a/python/lsst/daf/butler/script/createRepo.py
+++ b/python/lsst/daf/butler/script/createRepo.py
@@ -18,12 +18,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 from .._butler import Butler
 from ..core import Config
 
 
-def createRepo(repo, seed_config=None, dimension_config=None, standalone=False, override=False, outfile=None):
+def createRepo(
+    repo: str,
+    seed_config: str | None = None,
+    dimension_config: str | None = None,
+    standalone: bool = False,
+    override: bool = False,
+    outfile: str | None = None,
+) -> None:
     """Create an empty Gen3 Butler repository.
 
     Parameters

--- a/python/lsst/daf/butler/script/ingest_files.py
+++ b/python/lsst/daf/butler/script/ingest_files.py
@@ -24,7 +24,7 @@ __all__ = ("ingest_files",)
 
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 
 from astropy.table import Table
 from lsst.resources import ResourcePath
@@ -45,10 +45,10 @@ def ingest_files(
     dataset_type: str,
     run: str,
     table_file: str,
-    data_id: Tuple[str, ...] = (),
-    formatter: Optional[str] = None,
+    data_id: tuple[str, ...] = (),
+    formatter: str | None = None,
     id_generation_mode: str = "UNIQUE",
-    prefix: Optional[str] = None,
+    prefix: str | None = None,
     transfer: str = "auto",
 ) -> None:
     """Ingest files from a table.
@@ -117,11 +117,11 @@ def ingest_files(
 
 def extract_datasets_from_table(
     table: Table,
-    common_data_id: Dict,
+    common_data_id: dict,
     datasetType: DatasetType,
-    formatter: Optional[str] = None,
-    prefix: Optional[str] = None,
-) -> List[FileDataset]:
+    formatter: str | None = None,
+    prefix: str | None = None,
+) -> list[FileDataset]:
     """Extract datasets from the supplied table.
 
     Parameters
@@ -193,10 +193,10 @@ def extract_datasets_from_table(
     return datasets
 
 
-def parse_data_id_tuple(data_ids: Tuple[str, ...], universe: DimensionUniverse) -> Dict[str, Any]:
+def parse_data_id_tuple(data_ids: tuple[str, ...], universe: DimensionUniverse) -> dict[str, Any]:
     # Convert any additional k=v strings in the dataId tuple to dict
     # form.
-    data_id: Dict[str, Any] = {}
+    data_id: dict[str, Any] = {}
     for id_str in data_ids:
         dimension_str, value = id_str.split("=")
 

--- a/python/lsst/daf/butler/script/pruneCollection.py
+++ b/python/lsst/daf/butler/script/pruneCollection.py
@@ -19,9 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Union
+from typing import Optional, Union
 
 from astropy.table import Table
 
@@ -48,7 +50,7 @@ class PruneCollectionResult:
 
 
 def pruneCollection(
-    repo: str, collection: str, purge: bool, unstore: bool, unlink: List[str], confirm: bool
+    repo: str, collection: str, purge: bool, unstore: bool, unlink: list[str], confirm: bool
 ) -> Table:
     """Remove a collection and possibly prune datasets within it.
 
@@ -102,7 +104,7 @@ def pruneCollection(
             )
         )
 
-        collections: Dict[str, CollectionInfo] = {}
+        collections: dict[str, CollectionInfo] = {}
 
         def addCollection(name: str) -> None:
             """Add a collection to the collections, recursive if the collection
@@ -120,13 +122,14 @@ def pruneCollection(
 
         queryDatasets = QueryDatasets(
             repo=repo,
-            glob=None,
+            glob=[],
             collections=[collection],
             where=None,
             find_first=True,
             show_uri=False,
         )
         for datasetRef in queryDatasets.getDatasets():
+            assert datasetRef.run is not None, "This must be a resolved dataset ref"
             collectionInfo = collections[datasetRef.run]
             if collectionInfo.count is None:
                 raise RuntimeError(f"Unexpected dataset in collection of type {collectionInfo.type}")

--- a/python/lsst/daf/butler/script/pruneCollection.py
+++ b/python/lsst/daf/butler/script/pruneCollection.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Optional, Union
 
 from astropy.table import Table
 
@@ -41,9 +40,9 @@ class PruneCollectionResult:
     def __init__(self, confirm: bool) -> None:
         # if `confirm == True`, will contain the astropy table describing data
         # that will be removed.
-        self.removeTable: Union[None, Table] = None
+        self.removeTable: None | Table = None
         # the callback function to do the work
-        self.onConfirmation: Union[None, Callable[[], None]] = None
+        self.onConfirmation: None | Callable[[], None] = None
         # true if the user should be shown what will be removed before pruning
         # the collection.
         self.confirm: bool = confirm
@@ -82,7 +81,7 @@ def pruneCollection(
         """Lightweight container to hold the type of collection and the number
         of datasets in the collection if applicable."""
 
-        count: Optional[int]
+        count: int | None
         type: str
 
     result = PruneCollectionResult(confirm)

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from astropy.table import Table
 

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -133,10 +133,10 @@ def queryDataIds(
     )
 
     if order_by:
-        results.order_by(*order_by)
+        results = results.order_by(*order_by)
     if limit > 0:
         new_offset = offset if offset > 0 else None
-        results.limit(limit, new_offset)
+        results = results.limit(limit, new_offset)
 
     if results.count() > 0 and len(results.graph) > 0:
         table = _Table(results)

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -18,14 +18,20 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import numpy as np
 from astropy.table import Table as AstropyTable
 
-from .._butler import Butler
+from .._butler import Butler, DataCoordinate
 from ..cli.utils import sortAstropyTable
+
+if TYPE_CHECKING:
+    from lsst.daf.butler import DimensionGraph
 
 _LOG = logging.getLogger(__name__)
 
@@ -40,20 +46,23 @@ class _Table:
         The DataIds to add to the table.
     """
 
-    def __init__(self, dataIds):
+    def __init__(self, dataIds: Iterable[DataCoordinate]):
         # use dict to store dataIds as keys to preserve ordering
         self.dataIds = dict.fromkeys(dataIds)
 
-    def getAstropyTable(self, order):
+    def getAstropyTable(self, order: bool) -> AstropyTable:
         """Get the table as an astropy table.
+
+        Parameters
+        ----------
+        order : `bool`
+            If True then order rows based on DataIds.
 
         Returns
         -------
         table : `astropy.table.Table`
             The dataIds, sorted by spatial and temporal columns first, and then
             the rest of the columns, with duplicate dataIds removed.
-        order : `bool`
-            If True then order rows based on DataIds.
         """
         # Should never happen; adding a dataset should be the action that
         # causes a _Table to be created.
@@ -78,7 +87,16 @@ class _Table:
         return table
 
 
-def queryDataIds(repo, dimensions, datasets, where, collections, order_by, limit, offset):
+def queryDataIds(
+    repo: str,
+    dimensions: Iterable[str],
+    datasets: tuple[str, ...],
+    where: str | None,
+    collections: Iterable[str],
+    order_by: tuple[str, ...],
+    limit: int,
+    offset: int,
+) -> tuple[AstropyTable | None, str | None]:
     # Docstring for supported parameters is the same as Registry.queryDataIds
 
     butler = Butler(repo)
@@ -87,7 +105,7 @@ def queryDataIds(repo, dimensions, datasets, where, collections, order_by, limit
         # Determine the dimensions relevant to all given dataset types.
         # Since we are going to AND together all dimensions, we can not
         # seed the result with an empty set.
-        graph = None
+        graph: DimensionGraph | None = None
         dataset_types = list(butler.registry.queryDatasetTypes(datasets))
         for dataset_type in dataset_types:
             if graph is None:
@@ -117,9 +135,8 @@ def queryDataIds(repo, dimensions, datasets, where, collections, order_by, limit
     if order_by:
         results.order_by(*order_by)
     if limit > 0:
-        if offset <= 0:
-            offset = None
-        results.limit(limit, offset)
+        new_offset = offset if offset > 0 else None
+        results.limit(limit, new_offset)
 
     if results.count() > 0 and len(results.graph) > 0:
         table = _Table(results)

--- a/python/lsst/daf/butler/script/queryDatasetTypes.py
+++ b/python/lsst/daf/butler/script/queryDatasetTypes.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from typing import Any, List
+from collections.abc import Iterable
 
 from astropy.table import Table
 from numpy import array
@@ -28,7 +28,7 @@ from numpy import array
 from .._butler import Butler
 
 
-def queryDatasetTypes(repo, verbose, glob, components):
+def queryDatasetTypes(repo: str, verbose: bool, glob: Iterable[str], components: bool | None) -> Table:
     """Get the dataset types in a repository.
 
     Parameters
@@ -51,15 +51,13 @@ def queryDatasetTypes(repo, verbose, glob, components):
 
     Returns
     -------
-    collections : `dict` [`str`, [`str`]]
+    collections : `astropy.table.Table`
         A dict whose key is "datasetTypes" and whose value is a list of
         collection names.
     """
     butler = Butler(repo)
-    if not glob:
-        glob = ...
-    datasetTypes = butler.registry.queryDatasetTypes(components=components, expression=glob)
-    info: List[Any]
+    expression = glob if glob else ...
+    datasetTypes = butler.registry.queryDatasetTypes(components=components, expression=expression)
     if verbose:
         table = Table(
             array(

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -19,31 +19,44 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
+from typing import Any
+
 from astropy.table import Table
 
 from .._butler import Butler
 from ..core import Timespan
 
 
-def queryDimensionRecords(repo, element, datasets, collections, where, no_check, order_by, limit, offset):
+def queryDimensionRecords(
+    repo: str,
+    element: str,
+    datasets: tuple[str, ...],
+    collections: tuple[str, ...],
+    where: str,
+    no_check: bool,
+    order_by: tuple[str, ...],
+    limit: int,
+    offset: int,
+) -> Table | None:
     # Docstring for supported parameters is the same as
     # Registry.queryDimensionRecords except for ``no_check``, which is the
     # inverse of ``check``.
 
     butler = Butler(repo)
 
-    records = butler.registry.queryDimensionRecords(
+    query_results = butler.registry.queryDimensionRecords(
         element, datasets=datasets, collections=collections, where=where, check=not no_check
     )
 
     if order_by:
-        records.order_by(*order_by)
+        query_results.order_by(*order_by)
     if limit > 0:
-        if offset <= 0:
-            offset = None
-        records.limit(limit, offset)
+        new_offset = offset if offset > 0 else None
+        query_results.limit(limit, new_offset)
 
-    records = list(records)
+    records = list(query_results)
 
     if not records:
         return None
@@ -54,7 +67,7 @@ def queryDimensionRecords(repo, element, datasets, collections, where, no_check,
 
     keys = records[0].fields.names  # order the columns the same as the record's `field.names`
 
-    def conform(v):
+    def conform(v: Any) -> Any:
         if isinstance(v, Timespan):
             v = (v.begin, v.end)
         elif isinstance(v, bytes):

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -51,10 +51,10 @@ def queryDimensionRecords(
     )
 
     if order_by:
-        query_results.order_by(*order_by)
+        query_results = query_results.order_by(*order_by)
     if limit > 0:
         new_offset = offset if offset > 0 else None
-        query_results.limit(limit, new_offset)
+        query_results = query_results.limit(limit, new_offset)
 
     records = list(query_results)
 

--- a/python/lsst/daf/butler/script/register_dataset_type.py
+++ b/python/lsst/daf/butler/script/register_dataset_type.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 
 __all__ = ("register_dataset_type",)
 
-from typing import Tuple
-
 from .._butler import Butler
 from ..core import DatasetType
 
@@ -32,7 +30,7 @@ def register_dataset_type(
     repo: str,
     dataset_type: str,
     storage_class: str,
-    dimensions: Tuple[str, ...],
+    dimensions: tuple[str, ...],
     is_calibration: bool = False,
 ) -> bool:
     """Register a new dataset type.

--- a/python/lsst/daf/butler/script/removeCollections.py
+++ b/python/lsst/daf/butler/script/removeCollections.py
@@ -18,11 +18,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
-
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable
 
 from astropy.table import Table
 

--- a/python/lsst/daf/butler/script/removeDatasetType.py
+++ b/python/lsst/daf/butler/script/removeDatasetType.py
@@ -19,12 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 __all__ = ("removeDatasetType",)
 
 from .._butler import Butler
 
 
-def removeDatasetType(repo, dataset_type_name):
+def removeDatasetType(repo: str, dataset_type_name: str) -> None:
     """Remove the named dataset type definition.
 
     Parameters

--- a/python/lsst/daf/butler/script/removeRuns.py
+++ b/python/lsst/daf/butler/script/removeRuns.py
@@ -18,12 +18,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Dict, List, Mapping, Sequence, Tuple
+from typing import Dict, List, Tuple
 
 from .._butler import Butler
 from ..registry import CollectionType, MissingCollectionError

--- a/python/lsst/daf/butler/script/removeRuns.py
+++ b/python/lsst/daf/butler/script/removeRuns.py
@@ -24,7 +24,6 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
-from typing import Dict, List, Tuple
 
 from .._butler import Butler
 from ..registry import CollectionType, MissingCollectionError
@@ -38,7 +37,7 @@ class RemoveRun:
     # the name of the run:
     name: str
     # parent CHAINED collections the RUN belongs to:
-    parents: List[str]
+    parents: list[str]
 
 
 @dataclass
@@ -61,7 +60,7 @@ class RemoveRunsResult:
 def _getCollectionInfo(
     repo: str,
     collection: str,
-) -> Tuple[List[RemoveRun], Mapping[str, int]]:
+) -> tuple[list[RemoveRun], Mapping[str, int]]:
     """Get the names and types of collections that match the collection
     string.
 
@@ -92,7 +91,7 @@ def _getCollectionInfo(
     except MissingCollectionError:
         collectionNames = list()
     runs = []
-    datasets: Dict[str, int] = defaultdict(int)
+    datasets: dict[str, int] = defaultdict(int)
     for collectionName in collectionNames:
         assert butler.registry.getCollectionType(collectionName).name == "RUN"
         parents = butler.registry.getCollectionParentChains(collectionName)

--- a/python/lsst/daf/butler/script/retrieveArtifacts.py
+++ b/python/lsst/daf/butler/script/retrieveArtifacts.py
@@ -19,18 +19,32 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 __all__ = ("retrieveArtifacts",)
 
 import logging
+from typing import TYPE_CHECKING
 
 from .._butler import Butler
+
+if TYPE_CHECKING:
+    from lsst.resources import ResourcePath
 
 log = logging.getLogger(__name__)
 
 
 def retrieveArtifacts(
-    repo, destination, dataset_type, collections, where, find_first, transfer, preserve_path, clobber
-):
+    repo: str,
+    destination: str,
+    dataset_type: tuple[str, ...],
+    collections: tuple[str, ...],
+    where: str,
+    find_first: bool,
+    transfer: str,
+    preserve_path: bool,
+    clobber: bool,
+) -> list[ResourcePath]:
     """Parameters are those required for querying datasets plus a destination
     URI.
 
@@ -62,11 +76,8 @@ def retrieveArtifacts(
     transferred : `list` of `lsst.resources.ResourcePath`
         The destination URIs of every transferred artifact.
     """
-    if not dataset_type:
-        dataset_type = ...
-
-    if not collections:
-        collections = ...
+    query_types = dataset_type if dataset_type else ...
+    query_collections = collections if collections else ...
 
     butler = Butler(repo, writeable=False)
 
@@ -74,7 +85,7 @@ def retrieveArtifacts(
     # to caller.
     refs = list(
         butler.registry.queryDatasets(
-            datasetType=dataset_type, collections=collections, where=where, findFirst=find_first
+            datasetType=query_types, collections=query_collections, where=where, findFirst=find_first
         )
     )
 

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 __all__ = ("transferDatasets",)
 
 import logging
-from typing import Tuple
 
 from .._butler import Butler
 from ..registry.queries import DatasetQueryResults
@@ -34,8 +33,8 @@ log = logging.getLogger(__name__)
 def transferDatasets(
     source: str,
     dest: str,
-    dataset_type: Tuple[str, ...],
-    collections: Tuple[str, ...],
+    dataset_type: tuple[str, ...],
+    collections: tuple[str, ...],
     where: str,
     find_first: bool,
     transfer: str,

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -18,6 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 __all__ = ("transferDatasets",)
 


### PR DESCRIPTION
We were using annotations in many of the files but allowed mypy to ignore them if they were not in typed functions. This fixes the entire directory so that everything is annotated. Mostly annotations and some very minor code rearrangements to let the annotations work (and some new variables created for the same reason)

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
