### PR TITLE
DM-37092: Include temporary component in file name when exempting from cache removal

### DIFF
--- a/doc/changes/DM-37092.bugfix.rst
+++ b/doc/changes/DM-37092.bugfix.rst
@@ -1,0 +1,1 @@
+Fix race condition in datastore cache involving the possibility of multiple processes trying to retrieve the same file simultaneously and one of those processes deleting the file on exit of the context manager.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -13,7 +13,6 @@ The ``<TYPE>`` should be one of:
 * ``perf``: A performance enhancement.
 * ``doc``: A documentation improvement.
 * ``removal``: An API removal or deprecation.
-* ``other``: Other Changes and Additions of interest to general users.
 * ``misc``: Changes that are of minor interest.
 
 An example file name would therefore look like ``DM-30291.misc.rst``.


### PR DESCRIPTION
Allows multiple processes to be reading the same cache file simultaneously.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
