### PR TITLE
DM-37214: Fix problem with JSON formatter when Pydantic is used but Dict requested

### DIFF
--- a/doc/changes/DM-37214.misc.rst
+++ b/doc/changes/DM-37214.misc.rst
@@ -1,0 +1,3 @@
+* Enhanced the JSON and YAML formatters so that they can both handle dataclasses and Pydantic models (previously JSON supported Pydantic and YAML supported dataclasses).
+* Rationalized the storage class conversion handling to always convert from a `dict` to the original type even if the caller is requesting a `dict`.
+  Without this change it was possible to some confusion where a Pydantic model's serialization did not match the `dict`-like view it was emulating.

--- a/python/lsst/daf/butler/formatters/json.py
+++ b/python/lsst/daf/butler/formatters/json.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 __all__ = ("JsonFormatter",)
 
+import dataclasses
 import json
 from typing import Any, Optional, Type
 
@@ -122,6 +123,8 @@ class JsonFormatter(FileFormatter):
         except AttributeError:
             pass
 
-        if hasattr(inMemoryDataset, "_asdict"):
+        if dataclasses.is_dataclass(inMemoryDataset):
+            inMemoryDataset = dataclasses.asdict(inMemoryDataset)
+        elif hasattr(inMemoryDataset, "_asdict"):
             inMemoryDataset = inMemoryDataset._asdict()
         return json.dumps(inMemoryDataset, ensure_ascii=False).encode()

--- a/python/lsst/daf/butler/formatters/json.py
+++ b/python/lsst/daf/butler/formatters/json.py
@@ -23,15 +23,10 @@ from __future__ import annotations
 
 __all__ = ("JsonFormatter",)
 
-import builtins
-import dataclasses
 import json
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import Any, Optional, Type
 
 from .file import FileFormatter
-
-if TYPE_CHECKING:
-    from lsst.daf.butler import StorageClass
 
 
 class JsonFormatter(FileFormatter):
@@ -130,45 +125,3 @@ class JsonFormatter(FileFormatter):
         if hasattr(inMemoryDataset, "_asdict"):
             inMemoryDataset = inMemoryDataset._asdict()
         return json.dumps(inMemoryDataset, ensure_ascii=False).encode()
-
-    def _coerceType(
-        self, inMemoryDataset: Any, writeStorageClass: StorageClass, readStorageClass: StorageClass
-    ) -> Any:
-        """Coerce the supplied inMemoryDataset to the correct python type.
-
-        Parameters
-        ----------
-        inMemoryDataset : `object`
-            Object to coerce to expected type.
-        writeStorageClass : `StorageClass`
-            Storage class used to serialize this data.
-        readStorageClass : `StorageClass`
-            Storage class requested as the outcome.
-
-        Returns
-        -------
-        inMemoryDataset : `object`
-            Object of expected type ``readStorageClass.pytype``.
-        """
-        if inMemoryDataset is not None and not hasattr(builtins, readStorageClass.pytype.__name__):
-            if writeStorageClass.isComposite():
-                # We know we must be able to assemble the written
-                # storage class. Coerce later to the read type.
-                inMemoryDataset = writeStorageClass.delegate().assemble(
-                    inMemoryDataset, pytype=writeStorageClass.pytype
-                )
-            elif not isinstance(inMemoryDataset, readStorageClass.pytype):
-                # JSON data are returned as simple python types.
-                # The content will match the written storage class.
-                # Pydantic models have their own scheme.
-                try:
-                    inMemoryDataset = writeStorageClass.pytype.parse_obj(inMemoryDataset)
-                except AttributeError:
-                    if dataclasses.is_dataclass(writeStorageClass.pytype):
-                        # dataclasses accept key/value parameters.
-                        inMemoryDataset = writeStorageClass.pytype(**inMemoryDataset)
-                    else:
-                        # Hope that we can pass the arguments in directly
-                        inMemoryDataset = writeStorageClass.pytype(inMemoryDataset)
-        # Coerce to the read storage class if necessary.
-        return readStorageClass.coerce_type(inMemoryDataset)

--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -152,6 +152,13 @@ class YamlFormatter(FileFormatter):
         This will fail for data structures that have complex python classes
         without a registered YAML representer.
         """
+        if hasattr(inMemoryDataset, "dict") and hasattr(inMemoryDataset, "json"):
+            # Pydantic-like model if both dict() and json() exist.
+            try:
+                inMemoryDataset = inMemoryDataset.dict()
+            except Exception:
+                pass
+
         if dataclasses.is_dataclass(inMemoryDataset):
             inMemoryDataset = dataclasses.asdict(inMemoryDataset)
         elif hasattr(inMemoryDataset, "_asdict"):

--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -23,16 +23,12 @@ from __future__ import annotations
 
 __all__ = ("YamlFormatter",)
 
-import builtins
 import dataclasses
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import Any, Optional, Type
 
 import yaml
 
 from .file import FileFormatter
-
-if TYPE_CHECKING:
-    from lsst.daf.butler import StorageClass
 
 
 class YamlFormatter(FileFormatter):
@@ -166,43 +162,3 @@ class YamlFormatter(FileFormatter):
         else:
             serialized = yaml.safe_dump(inMemoryDataset)
         return serialized.encode()
-
-    def _coerceType(
-        self, inMemoryDataset: Any, writeStorageClass: StorageClass, readStorageClass: StorageClass
-    ) -> Any:
-        """Coerce the supplied inMemoryDataset to the correct python type.
-
-        Parameters
-        ----------
-        inMemoryDataset : `object`
-            Object to coerce to expected type.
-        writeStorageClass : `StorageClass`
-            Storage class used to serialize this data.
-        readStorageClass : `StorageClass`
-            Storage class requested as the outcome.
-
-        Returns
-        -------
-        inMemoryDataset : `object`
-            Object of expected type ``readStorageClass.pytype``.
-        """
-        if inMemoryDataset is not None and not hasattr(builtins, readStorageClass.pytype.__name__):
-            if writeStorageClass.isComposite():
-                # We know that the write storage class should work,
-                # then we convert to read storage class.
-                inMemoryDataset = writeStorageClass.delegate().assemble(
-                    inMemoryDataset, pytype=writeStorageClass.pytype
-                )
-            elif not isinstance(inMemoryDataset, readStorageClass.pytype):
-                if not isinstance(inMemoryDataset, writeStorageClass.pytype):
-                    # This does not look like the written type or the required
-                    # type. Try to cast it to the written type and then coerce
-                    # to requested type.
-                    if dataclasses.is_dataclass(writeStorageClass.pytype):
-                        # dataclasses accept key/value parameters.
-                        inMemoryDataset = writeStorageClass.pytype(**inMemoryDataset)
-                    else:
-                        # Hope that we can pass the arguments in directly.
-                        inMemoryDataset = writeStorageClass.pytype(inMemoryDataset)
-        # Coerce to the read storage class if necessary.
-        return readStorageClass.coerce_type(inMemoryDataset)

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -32,10 +32,12 @@ __all__ = (
     "MetricsExample",
     "registerMetricsExample",
     "MetricsExampleModel",
+    "MetricsExampleDataclass",
 )
 
 
 import copy
+import dataclasses
 import types
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
@@ -272,6 +274,15 @@ class MetricsExampleModel(BaseModel):
     def from_metrics(cls, metrics: MetricsExample) -> "MetricsExampleModel":
         """Create a model based on an example."""
         return cls.parse_obj(metrics.exportAsDict())
+
+
+@dataclasses.dataclass
+class MetricsExampleDataclass:
+    """A variant of `MetricsExample` based on a dataclass."""
+
+    summary: dict[str, Any] | None
+    output: dict[str, Any] | None
+    data: list[Any] | None
 
 
 class ListDelegate(StorageClassDelegate):

--- a/python/lsst/daf/butler/tests/dict_convertible_model.py
+++ b/python/lsst/daf/butler/tests/dict_convertible_model.py
@@ -1,0 +1,71 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ()
+
+from collections.abc import Mapping
+
+from pydantic import BaseModel, Field
+
+
+class DictConvertibleModel(BaseModel):
+    """A pydantic model to/from dict conversion in which the dict
+    representation is intentionally different from pydantics' own dict
+    conversions.
+    """
+
+    content: dict[str, str] = Field(default_factory=dict)
+    """Content of the logical dict that this object converts to (`dict`).
+    """
+
+    extra: str = Field(default="")
+    """Extra content that is not included in the dict representation (`str`).
+    """
+
+    @classmethod
+    def from_dict(cls, content: Mapping[str, str], extra: str = "from_dict") -> "DictConvertibleModel":
+        """Construct an instance from a `dict`.
+
+        Parameters
+        ----------
+        content : `~collections.abc.Mapping`
+            Content of the logical dict that this object converts to.
+        extra : `str`, optional
+            Extra content that is not included in the dict representation
+
+        Returns
+        -------
+        model : `DictConvertibleModel`
+            New model.
+        """
+        return cls(content=dict(content), extra=extra)
+
+    def to_dict(self) -> dict[str, str]:
+        """Convert the model to a dictionary.
+
+        Returns
+        -------
+        content : `dict`
+            Copy of ``self.content``.
+        """
+        return self.content.copy()

--- a/tests/config/basic/formatters.yaml
+++ b/tests/config/basic/formatters.yaml
@@ -37,3 +37,4 @@ StructuredCompositeReadComp: lsst.daf.butler.tests.testFormatters.MetricsExample
 StructuredCompositeReadCompNoDisassembly: lsst.daf.butler.tests.testFormatters.MetricsExampleFormatter
 StructuredDataDataTest: lsst.daf.butler.tests.testFormatters.MetricsExampleDataFormatter
 StructuredDataNoComponentsModel: lsst.daf.butler.formatters.json.JsonFormatter
+DictConvertibleModel: lsst.daf.butler.formatters.json.JsonFormatter

--- a/tests/config/basic/formatters.yaml
+++ b/tests/config/basic/formatters.yaml
@@ -38,3 +38,11 @@ StructuredCompositeReadCompNoDisassembly: lsst.daf.butler.tests.testFormatters.M
 StructuredDataDataTest: lsst.daf.butler.tests.testFormatters.MetricsExampleDataFormatter
 StructuredDataNoComponentsModel: lsst.daf.butler.formatters.json.JsonFormatter
 DictConvertibleModel: lsst.daf.butler.formatters.json.JsonFormatter
+MetricsExampleA: lsst.daf.butler.formatters.json.JsonFormatter
+MetricsExampleB: lsst.daf.butler.formatters.yaml.YamlFormatter
+MetricsExampleDataclassA: lsst.daf.butler.formatters.json.JsonFormatter
+MetricsExampleDataclassB: lsst.daf.butler.formatters.yaml.YamlFormatter
+MetricsExampleModelA: lsst.daf.butler.formatters.json.JsonFormatter
+MetricsExampleModelB: lsst.daf.butler.formatters.yaml.YamlFormatter
+TupleExampleA: lsst.daf.butler.formatters.json.JsonFormatter
+TupleExampleB: lsst.daf.butler.formatters.yaml.YamlFormatter

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -125,3 +125,21 @@ storageClasses:
     pytype: dict
     converters:
       lsst.daf.butler.tests.dict_convertible_model.DictConvertibleModel: lsst.daf.butler.tests.dict_convertible_model.DictConvertibleModel.to_dict
+  # Simple storage classes that can be used for testing with JSON and
+  # YAML serialization. Need two storage classes for each python type.
+  MetricsExampleA:
+    pytype: lsst.daf.butler.tests.MetricsExample
+  MetricsExampleB:
+    pytype: lsst.daf.butler.tests.MetricsExample
+  MetricsExampleDataclassA:
+    pytype: lsst.daf.butler.tests.MetricsExampleDataclass
+  MetricsExampleDataclassB:
+    pytype: lsst.daf.butler.tests.MetricsExampleDataclass
+  MetricsExampleModelA:
+    pytype: lsst.daf.butler.tests.MetricsExampleModel
+  MetricsExampleModelB:
+    pytype: lsst.daf.butler.tests.MetricsExampleModel
+  TupleExampleA:
+    pytype: tuple
+  TupleExampleB:
+    pytype: tuple

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -113,3 +113,15 @@ storageClasses:
       data: StructuredDataDataTestTuple
     converters:
       lsst.daf.butler.tests.MetricsExample: lsst.daf.butler.tests.MetricsExampleModel.from_metrics
+  DictConvertibleModel:
+    # Special storage class to test Pydantic model conversions to/from dict,
+    # when that's also what the formatter returns natively.
+    pytype: lsst.daf.butler.tests.dict_convertible_model.DictConvertibleModel
+    converters:
+      dict: lsst.daf.butler.tests.dict_convertible_model.DictConvertibleModel.from_dict
+  NativeDictForConvertibleModel:
+    # Variant of StructuredDataDict for tests with DictConvertibleModel, to
+    # avoid disruption from unexpected conversions in other storage classes.
+    pytype: dict
+    converters:
+      lsst.daf.butler.tests.dict_convertible_model.DictConvertibleModel: lsst.daf.butler.tests.dict_convertible_model.DictConvertibleModel.to_dict

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -59,6 +59,8 @@ from lsst.daf.butler.tests import (
     DatastoreTestHelper,
     DummyRegistry,
     MetricsExample,
+    MetricsExampleDataclass,
+    MetricsExampleModel,
 )
 from lsst.daf.butler.tests.dict_convertible_model import DictConvertibleModel
 from lsst.resources import ResourcePath
@@ -918,9 +920,52 @@ class DatastoreTests(DatastoreTestsBase):
         content = {"a": "one", "b": "two"}
         model = DictConvertibleModel.from_dict(content, extra="original content")
         datastore.put(model, store_as_model)
+        retrieved_model = datastore.get(store_as_model)
+        self.assertEqual(retrieved_model, model)
         loaded = datastore.get(store_as_model.overrideStorageClass("NativeDictForConvertibleModel"))
         self.assertEqual(type(loaded), dict)
         self.assertEqual(loaded, content)
+
+    def test_simple_class_put_get(self):
+        """Test that we can put and get a simple class with dict()
+        constructor."""
+        datastore = self.makeDatastore()
+        data = MetricsExample(summary={"a": 1}, data=[1, 2, 3], output={"b": 2})
+        self._assert_different_puts(datastore, "MetricsExample", data)
+
+    def test_dataclass_put_get(self):
+        """Test that we can put and get a simple dataclass."""
+        datastore = self.makeDatastore()
+        data = MetricsExampleDataclass(summary={"a": 1}, data=[1, 2, 3], output={"b": 2})
+        self._assert_different_puts(datastore, "MetricsExampleDataclass", data)
+
+    def test_pydantic_put_get(self):
+        """Test that we can put and get a simple Pydantic model."""
+        datastore = self.makeDatastore()
+        data = MetricsExampleModel(summary={"a": 1}, data=[1, 2, 3], output={"b": 2})
+        self._assert_different_puts(datastore, "MetricsExampleModel", data)
+
+    def test_tuple_put_get(self):
+        """Test that we can put and get a tuple."""
+        datastore = self.makeDatastore()
+        data = tuple(["a", "b", 1])
+        self._assert_different_puts(datastore, "TupleExample", data)
+
+    def _assert_different_puts(self, datastore: Datastore, storageClass_root: str, data) -> None:
+        refs = {
+            x: self.makeDatasetRef(
+                f"stora_as_{x}",
+                dimensions=self.universe.empty,
+                storageClass=f"{storageClass_root}{x}",
+                dataId=DataCoordinate.makeEmpty(self.universe),
+            )
+            for x in ["A", "B"]
+        }
+
+        for ref in refs.values():
+            datastore.put(data, ref)
+
+        self.assertEqual(datastore.get(refs["A"]), datastore.get(refs["B"]))
 
 
 class PosixDatastoreTestCase(DatastoreTests, unittest.TestCase):


### PR DESCRIPTION
JSON natively reads `dict` and so was never triggering the conversion code to the proper internal type before converting that to a dict. For `TaskMetadata` this could lead to oddities because the dict view of `TaskMetadata` does not match the internal model layout.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
