### PR TITLE
DM-35063: continue deprecation and removal of integer dataset IDs

### DIFF
--- a/doc/changes/DM-35063.api.md
+++ b/doc/changes/DM-35063.api.md
@@ -1,0 +1,1 @@
+Deprecate support for accessing data repositories with integer dataset IDs, and disable creation of new data repositories with integer dataset IDs, as per RFC-854.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
+from deprecated.sphinx import deprecated
 from lsst.utils.ellipsis import Ellipsis
 
 from ....core import DatasetId, DatasetRef, DatasetType, DimensionUniverse, ddl
@@ -471,6 +472,12 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
     """Type of dataset column used to store dataset ID."""
 
 
+@deprecated(
+    "Integer dataset IDs are deprecated in favor of UUIDs; support will be removed after v26. "
+    "Please migrate or re-create this data repository.",
+    version="v25.0",
+    category=FutureWarning,
+)
 class ByDimensionsDatasetRecordStorageManager(ByDimensionsDatasetRecordStorageManagerBase):
     """Implementation of ByDimensionsDatasetRecordStorageManagerBase which uses
     auto-incremental integer for dataset primary key.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -29,6 +29,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
+from deprecated.sphinx import deprecated
 
 from ....core import (
     DataCoordinate,
@@ -577,6 +578,12 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
         )
 
 
+@deprecated(
+    "Integer dataset IDs are deprecated in favor of UUIDs; support will be removed after v26. "
+    "Please migrate or re-create this data repository.",
+    version="v25.0",
+    category=FutureWarning,
+)
 class ByDimensionsDatasetRecordStorageInt(ByDimensionsDatasetRecordStorage):
     """Implementation of ByDimensionsDatasetRecordStorage which uses integer
     auto-incremented column for dataset IDs.

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -28,7 +28,6 @@ __all__ = (
 
 import dataclasses
 import logging
-import warnings
 from collections.abc import Mapping
 from typing import Any, Dict, Generic, Optional, Type, TypeVar
 
@@ -201,10 +200,9 @@ class RegistryManagerTypes(
         universe = DimensionUniverse(dimensionConfig)
         with database.declareStaticTables(create=True) as context:
             if self.datasets.getIdColumnType() == sqlalchemy.BigInteger:
-                warnings.warn(
+                raise RuntimeError(
                     "New data repositories should be created with UUID dataset IDs instead of autoincrement "
-                    "integer dataset IDs; support for integers will be removed after v25.",
-                    FutureWarning,
+                    "integer dataset IDs.",
                 )
             instances = RegistryManagerInstances.initialize(database, context, types=self, universe=universe)
             versions = instances.getVersions()

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -512,41 +512,6 @@ class RegistryTests(ABC):
                     # DATAID_TYPE_RUN ref can be imported into a new run
                     (ref2,) = registry._importDatasets([ref], idGenerationMode=idGenMode)
 
-    def testImportDatasetsInt(self):
-        """Test for `Registry._importDatasets` with integer dataset ID."""
-        if not self.datasetsManager.endswith(".ByDimensionsDatasetRecordStorageManager"):
-            self.skipTest(f"Unexpected dataset manager {self.datasetsManager}")
-
-        registry = self.makeRegistry()
-        self.loadData(registry, "base.yaml")
-        run = "tésτ"
-        registry.registerRun(run)
-        datasetTypeBias = registry.getDatasetType("bias")
-        datasetTypeFlat = registry.getDatasetType("flat")
-        dataIdBias1 = {"instrument": "Cam1", "detector": 1}
-        dataIdBias2 = {"instrument": "Cam1", "detector": 2}
-        dataIdFlat1 = {"instrument": "Cam1", "detector": 1, "physical_filter": "Cam1-G", "band": "g"}
-        dataset_id = 999999999
-
-        ref = DatasetRef(datasetTypeBias, dataIdBias1, id=dataset_id, run=run)
-        (ref1,) = registry._importDatasets([ref])
-        # Should make new integer ID.
-        self.assertNotEqual(ref1.id, ref.id)
-
-        # Ingesting same dataId with different dataset ID is an error
-        ref2 = ref1.unresolved().resolved(dataset_id, run=run)
-        with self.assertRaises(ConflictingDefinitionError):
-            registry._importDatasets([ref2])
-
-        # Ingesting different dataId with the same dataset ID should work
-        ref3 = DatasetRef(datasetTypeBias, dataIdBias2, id=ref1.id, run=run)
-        (ref4,) = registry._importDatasets([ref3])
-        self.assertNotEqual(ref4.id, ref1.id)
-
-        ref3 = DatasetRef(datasetTypeFlat, dataIdFlat1, id=ref1.id, run=run)
-        (ref4,) = registry._importDatasets([ref3])
-        self.assertNotEqual(ref4.id, ref1.id)
-
     def testDatasetTypeComponentQueries(self):
         """Test component options when querying for dataset types.
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2083,23 +2083,6 @@ class PosixDatastoreTransfers(unittest.TestCase):
         # Setting id_gen_map should have no effect here
         self.assertButlerTransfers(id_gen_map={"random_data_2": DatasetIdGenEnum.DATAID_TYPE})
 
-    def testTransferIntToInt(self):
-        with self.assertWarns(FutureWarning):
-            self.create_butlers(
-                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
-                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
-            )
-        # int dataset ID only allows UNIQUE
-        self.assertButlerTransfers()
-
-    def testTransferIntToUuid(self):
-        with self.assertWarns(FutureWarning):
-            self.create_butlers(
-                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager",
-                "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-            )
-        self.assertButlerTransfers(id_gen_map={"random_data_2": DatasetIdGenEnum.DATAID_TYPE})
-
     def testTransferMissing(self):
         """Test transfers where datastore records are missing.
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -248,24 +248,6 @@ class PostgresqlRegistryTests(RegistryTests):
             return Registry.fromConfig(config)
 
 
-class PostgresqlRegistryNameKeyCollMgrTestCase(PostgresqlRegistryTests, unittest.TestCase):
-    """Tests for `Registry` backed by a PostgreSQL database.
-
-    This test case uses NameKeyCollectionManager and
-    ByDimensionsDatasetRecordStorageManager.
-    """
-
-    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Registry:
-        if share_repo_with is None:
-            with self.assertWarns(FutureWarning):
-                return super().makeRegistry()
-        else:
-            return super().makeRegistry(share_repo_with)
-
-    collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
-
-
 class PostgresqlRegistryNameKeyCollMgrUUIDTestCase(PostgresqlRegistryTests, unittest.TestCase):
     """Tests for `Registry` backed by a PostgreSQL database.
 

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -49,9 +49,11 @@ class SimpleButlerTestCase(unittest.TestCase):
     can instead utilize an in-memory SQLite Registry and a mocked Datastore.
     """
 
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
-    datasetsImportFile = "datasets.yaml"
-    datasetsIdType = int
+    datasetsManager = (
+        "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID"
+    )
+    datasetsImportFile = "datasets-uuid.yaml"
+    datasetsIdType = uuid.UUID
 
     def setUp(self):
         self.root = makeTestTempDir(TESTDIR)
@@ -673,18 +675,6 @@ class SimpleButlerTestCase(unittest.TestCase):
         for expression, expected in expressions:
             result = butler.registry.queryCollections(expression)
             self.assertEqual(set(result), expected)
-
-
-class SimpleButlerUUIDTestCase(SimpleButlerTestCase):
-    """Same as SimpleButlerTestCase but uses UUID-based datasets manager and
-    loads datasets from YAML file with UUIDs.
-    """
-
-    datasetsManager = (
-        "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID"
-    )
-    datasetsImportFile = "datasets-uuid.yaml"
-    datasetsIdType = uuid.UUID
 
 
 class SimpleButlerMixedUUIDTestCase(SimpleButlerTestCase):

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -209,24 +209,6 @@ class SqliteFileRegistryTests(RegistryTests):
             return Registry.fromConfig(config, butlerRoot=self.root)
 
 
-class SqliteFileRegistryNameKeyCollMgrTestCase(SqliteFileRegistryTests, unittest.TestCase):
-    """Tests for `Registry` backed by a SQLite file-based database.
-
-    This test case uses NameKeyCollectionManager and
-    ByDimensionsDatasetRecordStorageManager.
-    """
-
-    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Registry:
-        if share_repo_with is None:
-            with self.assertWarns(FutureWarning):
-                return super().makeRegistry()
-        else:
-            return super().makeRegistry(share_repo_with)
-
-    collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
-    datasetsManager = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManager"
-
-
 class SqliteFileRegistryNameKeyCollMgrUUIDTestCase(SqliteFileRegistryTests, unittest.TestCase):
     """Tests for `Registry` backed by a SQLite file-based database.
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
