### PR TITLE
DM-37504: Improve edge-case handling in Registry.findDatasets.

### DIFF
--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -482,22 +482,25 @@ class SqlRegistry(Registry):
                     tail_collections.extend(filtered_collections[n:])
                     del filtered_collections[n:]
                     break
-        requested_columns = {"dataset_id", "run", "collection"}
-        with backend.context() as context:
-            predicate = context.make_data_coordinate_predicate(
-                dataId.subset(parent_dataset_type.dimensions), full=False
-            )
-            if timespan is not None:
-                requested_columns.add("timespan")
-                predicate = predicate.logical_and(
-                    context.make_timespan_overlap_predicate(
-                        DatasetColumnTag(parent_dataset_type.name, "timespan"), timespan
-                    )
+        if filtered_collections:
+            requested_columns = {"dataset_id", "run", "collection"}
+            with backend.context() as context:
+                predicate = context.make_data_coordinate_predicate(
+                    dataId.subset(parent_dataset_type.dimensions), full=False
                 )
-            relation = backend.make_dataset_query_relation(
-                parent_dataset_type, filtered_collections, requested_columns, context
-            ).with_rows_satisfying(predicate)
-            rows = list(context.fetch_iterable(relation))
+                if timespan is not None:
+                    requested_columns.add("timespan")
+                    predicate = predicate.logical_and(
+                        context.make_timespan_overlap_predicate(
+                            DatasetColumnTag(parent_dataset_type.name, "timespan"), timespan
+                        )
+                    )
+                relation = backend.make_dataset_query_relation(
+                    parent_dataset_type, filtered_collections, requested_columns, context
+                ).with_rows_satisfying(predicate)
+                rows = list(context.fetch_iterable(relation))
+        else:
+            rows = []
         if not rows:
             if tail_collections:
                 msg = (


### PR DESCRIPTION
This was originally supposed to just add a test case for DM-37504, in which attempting to search both a CALIBRATION collection and a non-CALIBRATION collection for the same dataset type (with collection- summary optimization not in play) triggered a bug in daf_relation.

But while writing the test I also discovered an unhelpful error message when trying perform that search without the needed timespan argument, so I've updated the logic in findDataset to ensure the better error message already there is emitted in more (now, hopefully all) cases.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
