### PR TITLE
DM-37913: Check for big-endian arrays when serializing to Parquet.

### DIFF
--- a/doc/changes/DM-37913.bugfix.md
+++ b/doc/changes/DM-37913.bugfix.md
@@ -1,0 +1,2 @@
+Check for big-endian arrays when serializing to parquet.
+This allows astropy FITS tables to be easily serialized.


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
