### PR TITLE
DM-38062: Allow test to pass if `--log-level` is used for pytest

### DIFF
--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -151,7 +151,9 @@ class CliLogTestBase:
             result = cmd()
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
-        self.assertEqual(pyRoot.logger.level, logging.WARNING)
+        # The test environment may have changed the python root logger
+        # so we can not assume it will be WARNING.
+        self.assertEqual(pyRoot.logger.level, logging.getLogger().getEffectiveLevel())
         self.assertEqual(pyLsstRoot.logger.level, logging.INFO)
         self.assertEqual(pyButler.logger.level, pyButler.initialLevel)
         if lsstLog is not None:


### PR DESCRIPTION
There is still a confusing problem if `pytest --log-cli-level` is used.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
