### PR TITLE
DM-37995: Improve storage class override logic

### DIFF
--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -207,7 +207,7 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
-        dataset_types: `Mapping` [`str`, `DatasetType`]
+        dataset_types: `Mapping` [`str`, `DatasetType`], optional
             Mapping of the dataset type name to its registry definition.
         """
         predicted_inputs = [
@@ -272,7 +272,7 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
-        dataset_types: `Mapping` [`str`, `DatasetType`]
+        dataset_types: `Mapping` [`str`, `DatasetType`], optional
             Mapping of the dataset type name to its registry definition.
         """
         return cls._initialize(

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -38,6 +38,7 @@ from .core import (
     Config,
     DatasetId,
     DatasetRef,
+    DatasetType,
     Datastore,
     DatastoreRecordData,
     DimensionUniverse,
@@ -153,6 +154,7 @@ class QuantumBackedButler(LimitedButler):
         dimensions: DimensionUniverse,
         datastore: Datastore,
         storageClasses: StorageClassFactory,
+        dataset_types: Mapping[str, DatasetType] | None = None,
     ):
         self._dimensions = dimensions
         self._predicted_inputs = set(predicted_inputs)
@@ -163,6 +165,10 @@ class QuantumBackedButler(LimitedButler):
         self._actual_output_refs: Set[DatasetRef] = set()
         self.datastore = datastore
         self.storageClasses = storageClasses
+        self._dataset_types: Mapping[str, DatasetType] = {}
+        if dataset_types is not None:
+            self._dataset_types = dataset_types
+        self.datastore.set_retrieve_dataset_type_method(self._retrieve_dataset_type)
 
     @classmethod
     def initialize(
@@ -174,6 +180,7 @@ class QuantumBackedButler(LimitedButler):
         OpaqueManagerClass: Type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
         BridgeManagerClass: Type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
         search_paths: Optional[List[str]] = None,
+        dataset_types: Mapping[str, DatasetType] | None = None,
     ) -> QuantumBackedButler:
         """Construct a new `QuantumBackedButler` from repository configuration
         and helper types.
@@ -200,6 +207,8 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
+        dataset_types: `Mapping` [`str`, `DatasetType`]
+            Mapping of the dataset type name to its registry definition.
         """
         predicted_inputs = [
             ref.getCheckedId() for ref in itertools.chain.from_iterable(quantum.inputs.values())
@@ -218,6 +227,7 @@ class QuantumBackedButler(LimitedButler):
             OpaqueManagerClass=OpaqueManagerClass,
             BridgeManagerClass=BridgeManagerClass,
             search_paths=search_paths,
+            dataset_types=dataset_types,
         )
 
     @classmethod
@@ -232,6 +242,7 @@ class QuantumBackedButler(LimitedButler):
         OpaqueManagerClass: Type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
         BridgeManagerClass: Type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
         search_paths: Optional[List[str]] = None,
+        dataset_types: Mapping[str, DatasetType] | None = None,
     ) -> QuantumBackedButler:
         """Construct a new `QuantumBackedButler` from sets of input and output
         dataset IDs.
@@ -261,6 +272,8 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
+        dataset_types: `Mapping` [`str`, `DatasetType`]
+            Mapping of the dataset type name to its registry definition.
         """
         return cls._initialize(
             config=config,
@@ -272,6 +285,7 @@ class QuantumBackedButler(LimitedButler):
             OpaqueManagerClass=OpaqueManagerClass,
             BridgeManagerClass=BridgeManagerClass,
             search_paths=search_paths,
+            dataset_types=dataset_types,
         )
 
     @classmethod
@@ -287,6 +301,7 @@ class QuantumBackedButler(LimitedButler):
         OpaqueManagerClass: Type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
         BridgeManagerClass: Type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
         search_paths: Optional[List[str]] = None,
+        dataset_types: Mapping[str, DatasetType] | None = None,
     ) -> QuantumBackedButler:
         """Internal method with common implementation used by `initialize` and
         `for_output`.
@@ -315,6 +330,8 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
+        dataset_types: `Mapping` [`str`, `DatasetType`]
+            Mapping of the dataset type name to its registry definition.
         """
         butler_config = ButlerConfig(config, searchPaths=search_paths)
         if "root" in butler_config:
@@ -342,7 +359,18 @@ class QuantumBackedButler(LimitedButler):
             datastore.import_records(datastore_records)
         storageClasses = StorageClassFactory()
         storageClasses.addFromConfig(butler_config)
-        return cls(predicted_inputs, predicted_outputs, dimensions, datastore, storageClasses=storageClasses)
+        return cls(
+            predicted_inputs,
+            predicted_outputs,
+            dimensions,
+            datastore,
+            storageClasses=storageClasses,
+            dataset_types=dataset_types,
+        )
+
+    def _retrieve_dataset_type(self, name: str) -> DatasetType | None:
+        """Return DatasetType defined in registry given dataset type name."""
+        return self._dataset_types.get(name)
 
     def isWriteable(self) -> bool:
         # Docstring inherited.

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -1201,3 +1201,22 @@ class Datastore(metaclass=ABCMeta):
             Exported datastore records indexed by datastore name.
         """
         raise NotImplementedError()
+
+    def set_retrieve_dataset_type_method(self, method: Callable[[str], DatasetType | None] | None) -> None:
+        """Specify a method that can be used by datastore to retrieve
+        registry-defined dataset type.
+
+        Parameters
+        ----------
+        method : `~collections.abc.Callable` | `None`
+            Method that takes a name of the dataset type and returns a
+            corresponding `DatasetType` instance as defined in Registry. If
+            dataset type name is not known to registry `None` is returned.
+
+        Notes
+        -----
+        This method si only needed for a Datastore supporting a "trusted" mode
+        when it does not have an access to datastore records and needs to
+        guess dataset location based on its stored dataset type.
+        """
+        pass

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -1215,7 +1215,7 @@ class Datastore(metaclass=ABCMeta):
 
         Notes
         -----
-        This method si only needed for a Datastore supporting a "trusted" mode
+        This method is only needed for a Datastore supporting a "trusted" mode
         when it does not have an access to datastore records and needs to
         guess dataset location based on its stored dataset type.
         """

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -452,7 +452,7 @@ class DatastoreTests(DatastoreTestsBase):
             self.assertEqual(primaryURI2, primaryURI)
             self.assertEqual(componentURIs2, componentURIs)
 
-            # Check for compatible storage class
+            # Check for compatible storage class.
             if sc_name in ("StructuredDataNoComponents", "StructuredData"):
                 # Make new dataset ref with compatible storage class.
                 ref_comp = ref.overrideStorageClass("StructuredDataDictJson")
@@ -465,7 +465,7 @@ class DatastoreTests(DatastoreTestsBase):
                 with self.assertRaises(FileNotFoundError):
                     datastore.get(ref, storageClass="StructuredDataDictJson")
 
-                # need a special method to generate stored dataset type
+                # Need a special method to generate stored dataset type.
                 def _stored_dataset_type(name: str) -> DatasetType:
                     if name == ref.datasetType.name:
                         return ref.datasetType
@@ -473,15 +473,15 @@ class DatastoreTests(DatastoreTestsBase):
 
                 datastore.set_retrieve_dataset_type_method(_stored_dataset_type)
 
-                # Storage class override with original dataset ref
+                # Storage class override with original dataset ref.
                 metrics_as_dict = datastore.get(ref, storageClass="StructuredDataDictJson")
                 self.assertIsInstance(metrics_as_dict, dict)
 
-                # get() should return a dict now
+                # get() should return a dict now.
                 metrics_as_dict = datastore.get(ref_comp)
                 self.assertIsInstance(metrics_as_dict, dict)
 
-                # exists() should work as well
+                # exists() should work as well.
                 self.assertTrue(datastore.exists(ref_comp))
 
                 datastore.set_retrieve_dataset_type_method(None)

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -66,11 +66,18 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.datasetTypeOutput = DatasetType("test_ds_output", graph, storageClass)
         self.datasetTypeOutput2 = DatasetType("test_ds_output2", graph, storageClass)
         self.datasetTypeExtra = DatasetType("test_ds_extra", graph, storageClass)
-        self.butler.registry.registerDatasetType(self.datasetTypeInit)
-        self.butler.registry.registerDatasetType(self.datasetTypeInput)
-        self.butler.registry.registerDatasetType(self.datasetTypeOutput)
-        self.butler.registry.registerDatasetType(self.datasetTypeOutput2)
-        self.butler.registry.registerDatasetType(self.datasetTypeExtra)
+
+        self.dataset_types: dict[str, DatasetType] = {}
+        dataset_types = (
+            self.datasetTypeInit,
+            self.datasetTypeInput,
+            self.datasetTypeOutput,
+            self.datasetTypeOutput2,
+            self.datasetTypeExtra,
+        )
+        for dataset_type in dataset_types:
+            self.butler.registry.registerDatasetType(dataset_type)
+            self.dataset_types[dataset_type.name] = dataset_type
 
         dataIds = [
             self.butler.registry.expandDataId(dict(instrument="Cam1", detector=detector_id))
@@ -128,7 +135,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for initialize factory method"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
         self._test_factory(qbb)
 
     def test_from_predicted(self) -> None:
@@ -141,6 +150,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             predicted_outputs=[ref.getCheckedId() for ref in self.output_refs],
             dimensions=self.universe,
             datastore_records=datastore_records,
+            dataset_types=self.dataset_types,
         )
         self._test_factory(qbb)
 
@@ -159,7 +169,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for getDirect/putDirect methods"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # Verify all input data are readable.
         for ref in self.input_refs:
@@ -191,7 +203,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for getDirectDeferred method"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # get some input data
         input_refs = self.input_refs[:2]
@@ -215,7 +229,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for datasetExistsDirect method"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # get some input data
         input_refs = self.input_refs[:2]
@@ -238,7 +254,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for markInputUnused method"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # get some input data
         for ref in self.input_refs:
@@ -260,7 +278,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for pruneDatasets methods"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # Write all expected outputs.
         for ref in self.output_refs:
@@ -303,7 +323,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for extract_provenance_data method"""
 
         quantum = self.make_quantum()
-        qbb = QuantumBackedButler.initialize(config=self.config, quantum=quantum, dimensions=self.universe)
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # read/store everything
         for ref in self.input_refs:
@@ -341,10 +363,14 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test for collect_and_transfer method"""
 
         quantum1 = self.make_quantum(1)
-        qbb1 = QuantumBackedButler.initialize(config=self.config, quantum=quantum1, dimensions=self.universe)
+        qbb1 = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum1, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         quantum2 = self.make_quantum(2)
-        qbb2 = QuantumBackedButler.initialize(config=self.config, quantum=quantum2, dimensions=self.universe)
+        qbb2 = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum2, dimensions=self.universe, dataset_types=self.dataset_types
+        )
 
         # read/store everything
         for ref in self.input_refs:


### PR DESCRIPTION
In trusted mode the datastore has to use original registry storage class
to search for artifacts. Because datastore has no access to registry
a new method was added to Datastore class to specify a way to retrieve
registry dataset type based on its name (dependency inversion).

Butler instances use this new method to provide access to to dataset
type mapping. In case of QBB, when registry does not exist this mapping
has to be provided when constructing QBB.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
