### PR TITLE
DM-38054: Add DataCoordinate attribute access to DimensionRecords.

### DIFF
--- a/doc/changes/DM-38054.feature.md
+++ b/doc/changes/DM-38054.feature.md
@@ -1,0 +1,1 @@
+`Dimension records` are now available via attribute access on `DataCoordinate` instances, allowing syntax like `data_id.exposure.day_obs`.

--- a/doc/lsst.daf.butler/dimensions.rst
+++ b/doc/lsst.daf.butler/dimensions.rst
@@ -59,7 +59,9 @@ The data IDs returned by the `Butler` or `Registry` (and most of those used inte
 `DataCoordinate` instances can have different states of knowledge about the dimensions they identify.
 They always contain at least the key-value pairs that correspond to its `DimensionGraph`\ 's `~DimensionGraph.required` subset -- that is, the minimal set of keys needed to fully identify all other dimensions in the graph.
 They can also contain key-value pairs for the `~DimensionGraph.implied` subset (a state indicated by `DataCoordinate.hasFull()` returning `True`).
-And if `DataCoordinate.hasRecords` returns `True`, the data ID also holds all of the metadata records associated with its dimensions.
+And if `DataCoordinate.hasRecords` returns `True`, the data ID also holds all of the metadata records associated with its dimensions, both as a mapping in
+the `~DataCoordinate.records` attribute and via dynamic attribute access, e.g.
+``data_id.exposure.day_obs``.
 
 `DataCoordinate` objects can of course be used with standard Python built-in containers, but an interface (`DataCoordinateIterable`) and a few simple adapters (`DataCoordinateSet`, `DataCoordinateSequence`) also exist to provide a bit more functionality for homogenous collections of data IDs (in which all data IDs identify the same dimensions, and generally have the same `~DataCoordinate.hasFull` / `~DataCoordinate.hasRecords` state).
 

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -156,6 +156,10 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
        between simple `dict` data IDs work, and hence using a `DataCoordinate`
        instance for at least one operand in any data ID comparison is strongly
        recommended.
+
+    See also
+    --------
+    :ref:`lsst.daf.butler-dimensions_data_ids`
     """
 
     __slots__ = ()
@@ -949,6 +953,13 @@ class _BasicTupleDataCoordinate(DataCoordinate):
     def __reduce__(self) -> tuple[Any, ...]:
         return (_BasicTupleDataCoordinate, (self._graph, self._values))
 
+    def __getattr__(self, name: str) -> Any:
+        if name in self.graph.elements.names:
+            raise AttributeError(
+                f"Dimension record attribute {name!r} is only available on expanded DataCoordinates."
+            )
+        raise AttributeError(name)
+
 
 class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
     """A `DataCoordinate` implementation that can hold `DimensionRecord`.
@@ -1051,3 +1062,14 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
 
     def __reduce__(self) -> tuple[Any, ...]:
         return (_ExpandedTupleDataCoordinate, (self._graph, self._values, self._records))
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self._record(name)
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __dir__(self) -> list[str]:
+        result = list(super().__dir__())
+        result.extend(self.graph.elements.names)
+        return result

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -946,6 +946,9 @@ class _BasicTupleDataCoordinate(DataCoordinate):
         # Docstring inherited from DataCoordinate.
         assert False
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (_BasicTupleDataCoordinate, (self._graph, self._values))
+
 
 class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
     """A `DataCoordinate` implementation that can hold `DimensionRecord`.
@@ -1045,3 +1048,6 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
     def _record(self, name: str) -> Optional[DimensionRecord]:
         # Docstring inherited from DataCoordinate.
         return self._records[name]
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (_ExpandedTupleDataCoordinate, (self._graph, self._values, self._records))

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -533,6 +533,22 @@ class DataCoordinateTestCase(unittest.TestCase):
                     self.assertEqual(dataId.graph.dimensions, dataId.full.keys())
                     self.assertEqual(list(dataId.full.values()), [dataId[k] for k in dataId.graph.dimensions])
 
+    def test_pickle(self):
+        for n in range(5):
+            dimensions = self.randomDimensionSubset()
+            dataIds = self.randomDataIds(n=1).subset(dimensions)
+            split = self.splitByStateFlags(dataIds)
+            for data_id in split.chain():
+                s = pickle.dumps(data_id)
+                read_data_id = pickle.loads(s)
+                self.assertEqual(data_id, read_data_id)
+                self.assertEqual(data_id.hasFull(), read_data_id.hasFull())
+                self.assertEqual(data_id.hasRecords(), read_data_id.hasRecords())
+                if data_id.hasFull():
+                    self.assertEqual(data_id.full, read_data_id.full)
+                    if data_id.hasRecords():
+                        self.assertEqual(data_id.records, read_data_id.records)
+
     def testEquality(self):
         """Test that different `DataCoordinate` instances with different state
         flags can be compared with each other and other mappings.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
