### PR TITLE
DM-38210: Make butler.get act like getDirect and deprecate getDirect

### DIFF
--- a/doc/changes/DM-38210.feature.rst
+++ b/doc/changes/DM-38210.feature.rst
@@ -1,0 +1,1 @@
+``Butler.get()`` and ``Butler.put()`` can now be used with resolved ``DatasetRef``.

--- a/doc/changes/DM-38210.removal.rst
+++ b/doc/changes/DM-38210.removal.rst
@@ -1,0 +1,5 @@
+* Deprecated ``Butler.getDirect()`` and ``Butler.putDirect()``.
+  We have modified the ``get()`` and ``put()`` variants to recognize the presence of a resolved ``DatasetRef`` and use it directly.
+  For ``get()`` we no longer unpack the ``DatasetRef`` and re-run the query, but return exactly the dataset being requested.
+* Removed ``Butler.pruneCollections``.
+  This method was replaced by ``Butler.removeRuns`` and ``Registry.removeCollections`` a long time ago and the command-line interface was removed previously.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1335,6 +1335,7 @@ class Butler(LimitedButler):
     def getDeferred(
         self,
         datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        /,
         dataId: Optional[DataId] = None,
         *,
         parameters: Union[dict, None] = None,
@@ -1393,6 +1394,7 @@ class Butler(LimitedButler):
     def get(
         self,
         datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        /,
         dataId: Optional[DataId] = None,
         *,
         parameters: Optional[Dict[str, Any]] = None,

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1673,7 +1673,15 @@ class Butler(LimitedButler):
         TypeError
             Raised if no collections were provided.
         """
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
+        # A resolved ref may be given that is not known to this butler.
+        if isinstance(datasetRefOrType, DatasetRef) and datasetRefOrType.id is not None:
+            ref = self.registry.getDataset(datasetRefOrType.id)
+            if ref is None:
+                raise LookupError(
+                    f"Resolved DatasetRef with id {datasetRefOrType.id} " "is not known to registry."
+                )
+        else:
+            ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
         return self.datastore.exists(ref)
 
     def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1657,7 +1657,7 @@ class Butler(LimitedButler):
             ref = self.registry.getDataset(datasetRefOrType.id)
             if ref is None:
                 raise LookupError(
-                    f"Resolved DatasetRef with id {datasetRefOrType.id} " "is not known to registry."
+                    f"Resolved DatasetRef with id {datasetRefOrType.id} is not known to registry."
                 )
         else:
             ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)

--- a/python/lsst/daf/butler/_deferredDatasetHandle.py
+++ b/python/lsst/daf/butler/_deferredDatasetHandle.py
@@ -85,7 +85,7 @@ class DeferredDatasetHandle:
             storageClass = self.storageClass
 
         ref = self.ref.makeComponentRef(component) if component is not None else self.ref
-        return self.butler.getDirect(ref, parameters=mergedParameters, storageClass=storageClass)
+        return self.butler.get(ref, parameters=mergedParameters, storageClass=storageClass)
 
     @property
     def dataId(self) -> DataCoordinate:

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -60,8 +60,46 @@ class LimitedButler(ABC):
         """Return `True` if this `Butler` supports write operations."""
         raise NotImplementedError()
 
+    @deprecated(
+        reason="Butler.put() now behaves like Butler.putDirect() when given a DatasetRef."
+        " Please use Butler.put(). Will be removed after v27.0.",
+        version="v26.0",
+        category=FutureWarning,
+    )
+    def putDirect(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
+        """Store a dataset that already has a UUID and ``RUN`` collection.
+
+        Parameters
+        ----------
+        obj : `object`
+            The dataset.
+        ref : `DatasetRef`
+            Resolved reference for a not-yet-stored dataset.
+
+        Returns
+        -------
+        ref : `DatasetRef`
+            The same as the given, for convenience and symmetry with
+            `Butler.put`.
+
+        Raises
+        ------
+        TypeError
+            Raised if the butler is read-only.
+        AmbiguousDatasetError
+            Raised if ``ref.id is None``, i.e. the reference is unresolved.
+
+        Notes
+        -----
+        Whether this method inserts the given dataset into a ``Registry`` is
+        implementation defined (some `LimitedButler` subclasses do not have a
+        `Registry`), but it always adds the dataset to a `Datastore`, and the
+        given ``ref.id`` and ``ref.run`` are always preserved.
+        """
+        return self.put(obj, ref)
+
     @abstractmethod
-    def putDirect(self, obj: Any, ref: DatasetRef) -> DatasetRef:
+    def put(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
         """Store a dataset that already has a UUID and ``RUN`` collection.
 
         Parameters

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -32,9 +32,7 @@ from deprecated.sphinx import deprecated
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from .core import (
     AmbiguousDatasetError,
-    DataId,
     DatasetRef,
-    DatasetType,
     Datastore,
     DimensionUniverse,
     StorageClass,
@@ -95,107 +93,29 @@ class LimitedButler(ABC):
         """
         raise NotImplementedError()
 
-    def _findDatasetRef(
-        self,
-        datasetRefOrType: DatasetRef | DatasetType | str,
-        dataId: DataId | None = None,
-        *,
-        collections: Any = None,
-        allowUnresolved: bool = False,
-        **kwargs: Any,
-    ) -> DatasetRef:
-        """Convert the standard get parameters to a `DatasetRef`
-
-        datasetRefOrType : `DatasetRef`, `DatasetType`, or `str`
-            Either a dataset reference, a dataset type, or the name of
-            a dataset type.
-            For the default implementation of a `LimitedButler`, the only
-            acceptable parameter is a resolved `DatasetRef`.
-        dataId : `dict` or `DataCoordinate`
-            A `dict` of `Dimension` link name, value pairs that label the
-            `DatasetRef` within a Collection. When `None`, a `DatasetRef`
-            should be provided as the first argument.
-        collections : Any, optional
-            Collections to be searched, overriding ``self.collections``.
-            Can be any of the types supported by the ``collections`` argument
-            to butler construction. Not used in a `LimitedButler`.
-        allowUnresolved : `bool`, optional
-            If `True`, return an unresolved `DatasetRef` if finding a resolved
-            one in the `Registry` fails.  Defaults to `False`.
-            For `LimitedButler` must always be `False`.
-        **kwargs
-            Additional keyword arguments used to augment or construct a
-            `DataCoordinate`.  See `DataCoordinate.standardize`
-            parameters. Not used in a `LimitedButler`.
-
-        Returns
-        -------
-        ref : `DatasetRef`
-            A resolved `DatasetRef`.
-
-        Raises
-        ------
-        AmbiguousDatasetError
-            Raised if an unresolved `DatasetRef` is passed as an input.
-        ValueError
-            Raised if an unresolved `DatasetRef` is passed as an input.
-
-        Notes
-        -----
-        Should be subclassed if a Butler needs to do a query using the
-        dataId and collections parameters.
-        """
-        if allowUnresolved:
-            raise ValueError("For LimitedButler allowUnresolved must always be False.")
-        if not isinstance(datasetRefOrType, DatasetRef):
-            raise ValueError("A LimitedButler can only retrieve datasets associated with a DatasetRef.")
-        if datasetRefOrType.id is None:
-            raise AmbiguousDatasetError(
-                f"Dataset of type {datasetRefOrType.datasetType.name} with "
-                f"data ID {datasetRefOrType.dataId} is not resolved."
-            )
-        return datasetRefOrType
-
     def get(
         self,
-        datasetRefOrType: DatasetRef | DatasetType | str,
-        dataId: DataId | None = None,
+        ref: DatasetRef,
+        /,
         *,
         parameters: dict[str, Any] | None = None,
-        collections: Any = None,
         storageClass: StorageClass | str | None = None,
-        **kwargs: Any,
     ) -> Any:
         """Retrieve a stored dataset.
 
         Parameters
         ----------
-        datasetRefOrType : `DatasetRef`, `DatasetType`, or `str`
-            Either a dataset reference, a dataset type, or the name of
-            a dataset type.
-            For the default implementation of a `LimitedButler`, the only
-            acceptable parameter is a resolved `DatasetRef`.
-        dataId : `dict` or `DataCoordinate`
-            A `dict` of `Dimension` link name, value pairs that label the
-            `DatasetRef` within a Collection. When `None`, a `DatasetRef`
-            should be provided as the first argument.
+        ref: `DatasetRef`
+            A resolved `DatasetRef` directly associated with a dataset.
         parameters : `dict`
             Additional StorageClass-defined options to control reading,
             typically used to efficiently read only a subset of the dataset.
-        collections : Any, optional
-            Collections to be searched, overriding ``self.collections``.
-            Can be any of the types supported by the ``collections`` argument
-            to butler construction. Not used in a `LimitedButler`.
         storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a
             read `StorageClass` can force a different type to be returned.
             This type must be compatible with the original type.
-        **kwargs
-            Additional keyword arguments used to augment or construct a
-            `DataCoordinate`.  See `DataCoordinate.standardize`
-            parameters. Not used in a `LimitedButler`.
 
         Returns
         -------
@@ -204,18 +124,17 @@ class LimitedButler(ABC):
 
         Raises
         ------
-        LookupError
-            Raised if no matching dataset exists in the `Registry`.
-        TypeError
-            Raised if no collections were provided.
+        AmbiguousDatasetError
+            Raised if the supplied `DatasetRef` is unresolved.
 
         Notes
         -----
         In a `LimitedButler` the only allowable way to specify a dataset is
         to use a resolved `DatasetRef`. Subclasses can support more options.
         """
-        log.debug("Butler get: %s, dataId=%s, parameters=%s", datasetRefOrType, dataId, parameters)
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
+        log.debug("Butler get: %s, parameters=%s, storageClass: %s", ref, parameters, storageClass)
+        if ref.id is None:
+            raise AmbiguousDatasetError(f"Dataset {ref} is not resolved.")
         return self.datastore.get(ref, parameters=parameters, storageClass=storageClass)
 
     @deprecated(
@@ -307,45 +226,29 @@ class LimitedButler(ABC):
 
     def getDeferred(
         self,
-        datasetRefOrType: DatasetRef | DatasetType | str,
-        dataId: DataId | None = None,
+        ref: DatasetRef,
+        /,
         *,
         parameters: dict[str, Any] | None = None,
-        collections: Any = None,
         storageClass: str | StorageClass | None = None,
-        **kwargs: Any,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
         after an immediate registry lookup.
 
         Parameters
         ----------
-        datasetRefOrType : `DatasetRef`, `DatasetType`, or `str`
-            Either a dataset reference, a dataset type, or the name of
-            a dataset type.
+        ref : `DatasetRef`
             For the default implementation of a `LimitedButler`, the only
             acceptable parameter is a resolved `DatasetRef`.
-        dataId : `dict` or `DataCoordinate`, optional
-            A `dict` of `Dimension` link name, value pairs that label the
-            `DatasetRef` within a Collection. When `None`, a `DatasetRef`
-            should be provided as the first argument. Not used in a
-            `LimitedButler`.
         parameters : `dict`
             Additional StorageClass-defined options to control reading,
             typically used to efficiently read only a subset of the dataset.
-        collections : Any, optional
-            Collections to be searched, overriding ``self.collections``.
-            Can be any of the types supported by the ``collections`` argument
-            to butler construction. Not used in a `LimitedButler`.
         storageClass : `StorageClass` or `str`, optional
             The storage class to be used to override the Python type
             returned by this method. By default the returned type matches
             the dataset type definition for this dataset. Specifying a
             read `StorageClass` can force a different type to be returned.
             This type must be compatible with the original type.
-        **kwargs
-            Additional keyword arguments used to augment or construct a
-            `DataId`.  See `DataId` parameters. Not used in a `LimitedButler`.
 
         Returns
         -------
@@ -356,15 +259,14 @@ class LimitedButler(ABC):
         ------
         AmbiguousDatasetError
             Raised if an unresolved `DatasetRef` is passed as an input.
-        ValueError
-            Raised if an unresolved `DatasetRef` is passed as an input.
 
         Notes
         -----
         In a `LimitedButler` the only allowable way to specify a dataset is
         to use a resolved `DatasetRef`. Subclasses can support more options.
         """
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
+        if ref.id is None:
+            raise AmbiguousDatasetError(f"Dataset {ref} is not resolved.")
         return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters, storageClass=storageClass)
 
     def datasetExistsDirect(self, ref: DatasetRef) -> bool:

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -37,7 +37,6 @@ from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._limited_butler import LimitedButler
 from .core import (
     Config,
-    DataId,
     DatasetId,
     DatasetRef,
     DatasetType,
@@ -396,23 +395,17 @@ class QuantumBackedButler(LimitedButler):
 
     def get(
         self,
-        datasetRefOrType: DatasetRef | DatasetType | str,
-        dataId: DataId | None = None,
+        ref: DatasetRef,
+        /,
         *,
         parameters: dict[str, Any] | None = None,
-        collections: Any = None,
         storageClass: StorageClass | str | None = None,
-        **kwargs: Any,
     ) -> Any:
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
         try:
             obj = super().get(
                 ref,
-                dataId,
-                collections=collections,
                 parameters=parameters,
                 storageClass=storageClass,
-                **kwargs,
             )
         except (LookupError, FileNotFoundError, IOError):
             self._unavailable_inputs.add(ref.getCheckedId())
@@ -441,15 +434,12 @@ class QuantumBackedButler(LimitedButler):
 
     def getDeferred(
         self,
-        datasetRefOrType: DatasetRef | DatasetType | str,
-        dataId: DataId | None = None,
+        ref: DatasetRef,
+        /,
         *,
         parameters: dict[str, Any] | None = None,
-        collections: Any = None,
         storageClass: str | StorageClass | None = None,
-        **kwargs: Any,
     ) -> DeferredDatasetHandle:
-        ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
         if ref.id in self._predicted_inputs:
             # Unfortunately, we can't do this after the handle succeeds in
             # loading, so it's conceivable here that we're marking an input

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -466,7 +466,7 @@ class QuantumBackedButler(LimitedButler):
         # Docstring inherited.
         return self._dimensions
 
-    def putDirect(self, obj: Any, ref: DatasetRef) -> DatasetRef:
+    def put(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
         # Docstring inherited.
         if ref.id not in self._predicted_outputs:
             raise RuntimeError("Cannot `put` dataset that was not predicted as an output.")

--- a/python/lsst/daf/butler/script/removeCollections.py
+++ b/python/lsst/daf/butler/script/removeCollections.py
@@ -116,7 +116,7 @@ def removeCollections(
     repo : `str`
         Same as the ``config`` argument to ``Butler.__init__``
     collection : `str`
-        Same as the ``name`` argument to ``Butler.pruneCollection``.
+        Same as the ``name`` argument to ``Registry.removeCollection``.
 
     Returns
     -------

--- a/python/lsst/daf/butler/script/removeRuns.py
+++ b/python/lsst/daf/butler/script/removeRuns.py
@@ -67,7 +67,7 @@ def _getCollectionInfo(
     Parameters
     ----------
     repo : `str`
-        The URI to the repostiory.
+        The URI to the repository.
     collection : `str`
         The collection string to search for. Same as the `expression`
         argument to `registry.queryCollections`.
@@ -115,7 +115,7 @@ def removeRuns(
     repo : `str`
         Same as the ``config`` argument to ``Butler.__init__``
     collection : `str`
-        Same as the ``name`` argument to ``Butler.pruneCollection``.
+        Same as the ``name`` argument to ``Butler.removeRuns``.
 
     Returns
     -------

--- a/tests/test_logFormatter.py
+++ b/tests/test_logFormatter.py
@@ -64,7 +64,7 @@ class ButlerLogRecordsFormatterTestCase(unittest.TestCase):
         log.warning("A WARNING message")
 
         ref = self.butler.put(handler.records, self.datasetType)
-        records = self.butler.getDirect(ref)
+        records = self.butler.get(ref)
 
         self.assertEqual(records, handler.records)
         self.assertEqual(len(records), 2)

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -165,7 +165,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.assertEqual(qbb._actual_inputs, set())
         self.assertEqual(qbb._actual_output_refs, set())
 
-    def test_getPutDirect(self) -> None:
+    def test_getput(self) -> None:
         """Test for getDirect/putDirect methods"""
 
         quantum = self.make_quantum()
@@ -190,7 +190,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # Write all expected outputs.
         for ref in self.output_refs:
-            qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
+            qbb.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
         # Must be able to read them back
         for ref in self.output_refs:
@@ -284,7 +284,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # Write all expected outputs.
         for ref in self.output_refs:
-            qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
+            qbb.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
         # Must be able to read them back
         for ref in self.output_refs:
@@ -307,7 +307,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             data = qbb.get(ref)
 
         # can store it again
-        qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
+        qbb.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
         self.assertTrue(qbb.datasetExistsDirect(ref))
 
         # Purge completely.
@@ -316,7 +316,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.assertFalse(qbb.datasetExistsDirect(ref))
         with self.assertRaises(FileNotFoundError):
             data = qbb.get(ref)
-        qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
+        qbb.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
         self.assertTrue(qbb.datasetExistsDirect(ref))
 
     def test_extract_provenance_data(self) -> None:
@@ -333,7 +333,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         for ref in self.init_inputs_refs:
             qbb.get(ref)
         for ref in self.output_refs:
-            qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
+            qbb.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
         provenance1 = qbb.extract_provenance_data()
         prov_json = provenance1.json()
@@ -378,12 +378,12 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         for ref in self.init_inputs_refs:
             qbb1.get(ref)
         for ref in self.output_refs:
-            qbb1.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
+            qbb1.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
         for ref in self.output_refs:
             qbb2.get(ref)
         for ref in self.output_refs2:
-            qbb2.putDirect({"data": cast(int, ref.dataId["detector"]) ** 3}, ref)
+            qbb2.put({"data": cast(int, ref.dataId["detector"]) ** 3}, ref)
 
         QuantumProvenanceData.collect_and_transfer(
             self.butler,

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -175,14 +175,14 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # Verify all input data are readable.
         for ref in self.input_refs:
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
             self.assertEqual(data, {"data": ref.dataId["detector"]})
         for ref in self.init_inputs_refs:
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
             self.assertEqual(data, {"data": -1})
         for ref in self.missing_refs:
             with self.assertRaises(FileNotFoundError):
-                data = qbb.getDirect(ref)
+                data = qbb.get(ref)
 
         self.assertEqual(qbb._available_inputs, qbb._predicted_inputs)
         self.assertEqual(qbb._actual_inputs, qbb._predicted_inputs)
@@ -194,12 +194,12 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # Must be able to read them back
         for ref in self.output_refs:
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
             self.assertEqual(data, {"data": cast(int, ref.dataId["detector"]) ** 2})
 
         self.assertEqual(qbb._actual_output_refs, set(self.output_refs))
 
-    def test_getDirectDeferred(self) -> None:
+    def test_getDeferred(self) -> None:
         """Test for getDirectDeferred method"""
 
         quantum = self.make_quantum()
@@ -210,13 +210,13 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         # get some input data
         input_refs = self.input_refs[:2]
         for ref in input_refs:
-            data = qbb.getDirectDeferred(ref)
+            data = qbb.getDeferred(ref)
             self.assertEqual(data.get(), {"data": ref.dataId["detector"]})
         for ref in self.init_inputs_refs:
-            data = qbb.getDirectDeferred(ref)
+            data = qbb.getDeferred(ref)
             self.assertEqual(data.get(), {"data": -1})
         for ref in self.missing_refs:
-            data = qbb.getDirectDeferred(ref)
+            data = qbb.getDeferred(ref)
             with self.assertRaises(FileNotFoundError):
                 data.get()
 
@@ -260,10 +260,10 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # get some input data
         for ref in self.input_refs:
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
             self.assertEqual(data, {"data": ref.dataId["detector"]})
         for ref in self.init_inputs_refs:
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
             self.assertEqual(data, {"data": -1})
 
         self.assertEqual(qbb._available_inputs, qbb._predicted_inputs)
@@ -288,7 +288,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # Must be able to read them back
         for ref in self.output_refs:
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
             self.assertEqual(data, {"data": cast(int, ref.dataId["detector"]) ** 2})
 
         # Check for invalid arguments.
@@ -304,7 +304,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb.pruneDatasets([ref], disassociate=False, unstore=True, purge=False)
         self.assertFalse(qbb.datasetExistsDirect(ref))
         with self.assertRaises(FileNotFoundError):
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
 
         # can store it again
         qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
@@ -315,7 +315,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb.pruneDatasets([ref], disassociate=True, unstore=True, purge=True)
         self.assertFalse(qbb.datasetExistsDirect(ref))
         with self.assertRaises(FileNotFoundError):
-            data = qbb.getDirect(ref)
+            data = qbb.get(ref)
         qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
         self.assertTrue(qbb.datasetExistsDirect(ref))
 
@@ -329,9 +329,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # read/store everything
         for ref in self.input_refs:
-            qbb.getDirect(ref)
+            qbb.get(ref)
         for ref in self.init_inputs_refs:
-            qbb.getDirect(ref)
+            qbb.get(ref)
         for ref in self.output_refs:
             qbb.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
@@ -374,14 +374,14 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # read/store everything
         for ref in self.input_refs:
-            qbb1.getDirect(ref)
+            qbb1.get(ref)
         for ref in self.init_inputs_refs:
-            qbb1.getDirect(ref)
+            qbb1.get(ref)
         for ref in self.output_refs:
             qbb1.putDirect({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
         for ref in self.output_refs:
-            qbb2.getDirect(ref)
+            qbb2.get(ref)
         for ref in self.output_refs2:
             qbb2.putDirect({"data": cast(int, ref.dataId["detector"]) ** 3}, ref)
 
@@ -392,11 +392,11 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         )
 
         for ref in self.output_refs:
-            data = self.butler.getDirect(ref)
+            data = self.butler.get(ref)
             self.assertEqual(data, {"data": cast(int, ref.dataId["detector"]) ** 2})
 
         for ref in self.output_refs2:
-            data = self.butler.getDirect(ref)
+            data = self.butler.get(ref)
             self.assertEqual(data, {"data": cast(int, ref.dataId["detector"]) ** 3})
 
 


### PR DESCRIPTION
We now want a resolved DatasetRef to work with butler.get without doing registry lookup. Also change the LimitedButler to add a .get(). .getDirect and deferred form are now deprecated.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
