### PR TITLE
DM-35063: Fix deprecation timeline for accessing integer ID repositories

### DIFF
--- a/doc/lsst.daf.butler/CHANGES.rst
+++ b/doc/lsst.daf.butler/CHANGES.rst
@@ -1,6 +1,9 @@
 Butler v25.0.0 2023-02-27
 =========================
 
+This is the last release that can access data repositories using integer dataset IDs.
+Please either recreate these repositories or convert them to use UUIDs using `the butler migrate tooling <https://github.com/lsst-dm/daf_butler_migrate>`_.
+
 New Features
 ------------
 

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -476,7 +476,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
 
 
 @deprecated(
-    "Integer dataset IDs are deprecated in favor of UUIDs; support will be removed after v26. "
+    "Integer dataset IDs are deprecated in favor of UUIDs; support will be removed after v25. "
     "Please migrate or re-create this data repository.",
     version="v25.0",
     category=FutureWarning,

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -584,7 +584,7 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
 
 
 @deprecated(
-    "Integer dataset IDs are deprecated in favor of UUIDs; support will be removed after v26. "
+    "Integer dataset IDs are deprecated in favor of UUIDs; support will be removed after v25. "
     "Please migrate or re-create this data repository.",
     version="v25.0",
     category=FutureWarning,


### PR DESCRIPTION
RFC-854 agreed to remove support after v25 but the message initially said after v26.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
