### PR TITLE
DM-38205: Add update_exposure_regions method to obscore manager

### DIFF
--- a/doc/changes/DM-38205.misc.md
+++ b/doc/changes/DM-38205.misc.md
@@ -1,0 +1,3 @@
+`Registry` adds an `obsCoreTableManager` property for access to ObsCore table manager.
+This will be set to `None` when repository lacks ObsCore table.
+It should only be used by a limited number of clients, e.g. DefineVisitsTask, which need to update the table.

--- a/doc/changes/DM-38205.misc.md
+++ b/doc/changes/DM-38205.misc.md
@@ -1,3 +1,3 @@
 `Registry` adds an `obsCoreTableManager` property for access to ObsCore table manager.
 This will be set to `None` when repository lacks ObsCore table.
-It should only be used by a limited number of clients, e.g. DefineVisitsTask, which need to update the table.
+It should only be used by a limited number of clients, e.g. `DefineVisitsTask`, which need to update the table.

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -94,7 +94,12 @@ from ..registry.wildcards import CollectionWildcard, DatasetTypeWildcard
 
 if TYPE_CHECKING:
     from .._butlerConfig import ButlerConfig
-    from ..registry.interfaces import CollectionRecord, Database, DatastoreRegistryBridgeManager
+    from ..registry.interfaces import (
+        CollectionRecord,
+        Database,
+        DatastoreRegistryBridgeManager,
+        ObsCoreTableManager,
+    )
 
 
 _LOG = logging.getLogger(__name__)
@@ -1320,6 +1325,11 @@ class SqlRegistry(Registry):
                         # timespan.
                         timespan = None
                     yield DatasetAssociation(ref=ref, collection=collection_record.name, timespan=timespan)
+
+    @property
+    def obsCoreTableManager(self) -> ObsCoreTableManager | None:
+        # Docstring inherited from lsst.daf.butler.registry.Registry
+        return self._managers.obscore
 
     storageClasses: StorageClassFactory
     """All storage classes known to the registry (`StorageClassFactory`).

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -72,7 +72,7 @@ from .queries import DataCoordinateQueryResults, DatasetQueryResults, DimensionR
 
 if TYPE_CHECKING:
     from .._butlerConfig import ButlerConfig
-    from .interfaces import CollectionRecord, DatastoreRegistryBridgeManager
+    from .interfaces import CollectionRecord, DatastoreRegistryBridgeManager, ObsCoreTableManager
 
 _LOG = logging.getLogger(__name__)
 
@@ -1672,6 +1672,16 @@ class Registry(ABC):
             Raised when ``collections`` expression is invalid.
         """
         raise NotImplementedError()
+
+    @property
+    def obsCoreTableManager(self) -> ObsCoreTableManager | None:
+        """ObsCore manager instance for this registry (`ObsCoreTableManager`
+        or `None`).
+
+        ObsCore manager may not be implemented for all registry backend, or
+        may not be enabled for many repositories.
+        """
+        return None
 
     storageClasses: StorageClassFactory
     """All storage classes known to the registry (`StorageClassFactory`).

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -26,8 +26,11 @@ from __future__ import annotations
 __all__ = ["ObsCoreTableManager"]
 
 from abc import abstractmethod
-from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, Type
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Type
+
+import sqlalchemy
 
 from ._versioning import VersionedExtension
 
@@ -94,6 +97,7 @@ class ObsCoreTableManager(VersionedExtension):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def add_datasets(self, refs: Iterable[DatasetRef], context: SqlQueryContext) -> int:
         """Possibly add datasets to the obscore table.
 
@@ -129,6 +133,7 @@ class ObsCoreTableManager(VersionedExtension):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def associate(
         self, refs: Iterable[DatasetRef], collection: CollectionRecord, context: SqlQueryContext
     ) -> int:
@@ -164,6 +169,7 @@ class ObsCoreTableManager(VersionedExtension):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def disassociate(self, refs: Iterable[DatasetRef], collection: CollectionRecord) -> int:
         """Possibly remove datasets from the obscore table.
 
@@ -193,6 +199,7 @@ class ObsCoreTableManager(VersionedExtension):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def update_exposure_regions(self, instrument: str, region_data: Iterable[tuple[int, int, Region]]) -> int:
         """Update existing exposure records with spatial region data.
 
@@ -215,5 +222,30 @@ class ObsCoreTableManager(VersionedExtension):
         are ingested before their corresponding visits are defined. Exposure
         records added when visit are already defined will get their regions
         from their matching visits automatically.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    @contextmanager
+    def query(self, **kwargs: Any) -> Iterator[sqlalchemy.engine.CursorResult]:
+        """Run a SELECT query against obscore table and return reslut rows.
+
+        Parameters
+        ----------
+        **kwargs
+            Restriction on values of individual obscore columns. Key is the
+            column name, value is the required value of the column. Multiple
+            restrictions are ANDed together.
+
+        Returns
+        -------
+        result_context : `sqlalchemy.engine.CursorResult`
+            Context manager that returns the query result object when entered.
+            These results are invalidated when the context is exited.
+
+        Notes
+        -----
+        This method is intended mostly for tests that need to check the
+        contents of obscore table.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -220,7 +220,7 @@ class ObsCoreTableManager(VersionedExtension):
         -----
         This method is needed to update obscore records for raw exposures which
         are ingested before their corresponding visits are defined. Exposure
-        records added when visit are already defined will get their regions
+        records added when visit is already defined will get their regions
         from their matching visits automatically.
         """
         raise NotImplementedError()
@@ -228,7 +228,7 @@ class ObsCoreTableManager(VersionedExtension):
     @abstractmethod
     @contextmanager
     def query(self, **kwargs: Any) -> Iterator[sqlalchemy.engine.CursorResult]:
-        """Run a SELECT query against obscore table and return reslut rows.
+        """Run a SELECT query against obscore table and return result rows.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -26,12 +26,14 @@ from __future__ import annotations
 __all__ = ["ObsCoreTableManager"]
 
 from abc import abstractmethod
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Iterable, Type
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Type
 
 from ._versioning import VersionedExtension
 
 if TYPE_CHECKING:
+    from lsst.sphgeom import Region
+
     from ...core import DatasetRef, DimensionUniverse
     from ..queries import SqlQueryContext
     from ._collections import CollectionRecord
@@ -188,5 +190,30 @@ class ObsCoreTableManager(VersionedExtension):
 
         When configuration parameter ``collection_type`` is not "TAGGED", this
         method should return immediately.
+        """
+        raise NotImplementedError()
+
+    def update_exposure_regions(self, instrument: str, region_data: Iterable[tuple[int, int, Region]]) -> int:
+        """Update existing exposure records with spatial region data.
+
+        Parameters
+        ----------
+        instrument : `str`
+            Instrument name.
+        region_data : `Iterable`[`tuple`[`int`, `int`, `~lsst.sphgeom.Region`]]
+            Sequence of tuples, each tuple contains three values - exposure ID,
+            detector ID, and corresponding region.
+
+        Returns
+        -------
+        count : `int`
+            Actual number of records updated.
+
+        Notes
+        -----
+        This method is needed to update obscore records for raw exposures which
+        are ingested before their corresponding visits are defined. Exposure
+        records added when visit are already defined will get their regions
+        from their matching visits automatically.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/obscore/_manager.py
+++ b/python/lsst/daf/butler/registry/obscore/_manager.py
@@ -26,6 +26,7 @@ __all__ = ["ObsCoreLiveTableManager"]
 import json
 import re
 import uuid
+import warnings
 from collections import defaultdict
 from collections.abc import Collection, Mapping
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Type, cast
@@ -40,7 +41,7 @@ from ..interfaces import ObsCoreTableManager, VersionTuple
 from ._config import ConfigCollectionType, ObsCoreManagerConfig
 from ._records import ExposureRegionFactory, Record, RecordFactory
 from ._schema import ObsCoreSchema
-from ._spatial import SpatialObsCorePlugin
+from ._spatial import RegionTypeError, RegionTypeWarning, SpatialObsCorePlugin
 
 if TYPE_CHECKING:
     from ..interfaces import (
@@ -294,3 +295,41 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
 
         # Try each pattern in turn.
         return any(pattern.fullmatch(run) for pattern in self.run_patterns)
+
+    def update_exposure_regions(self, instrument: str, region_data: Iterable[tuple[int, int, Region]]) -> int:
+        # Docstring inherited from base class.
+        instrument_column = self.schema.dimension_column("instrument")
+        exposure_column = self.schema.dimension_column("exposure")
+        detector_column = self.schema.dimension_column("detector")
+        if instrument_column is None or exposure_column is None or detector_column is None:
+            # Not all needed columns are in the table.
+            return 0
+
+        update_rows: List[Record] = []
+        for exposure, detector, region in region_data:
+            try:
+                record = self.record_factory.make_spatial_records(region)
+            except RegionTypeError as exc:
+                warnings.warn(
+                    f"Failed to convert region for exposure={exposure} detector={detector}: {exc}",
+                    category=RegionTypeWarning,
+                )
+                continue
+
+            record.update(
+                {
+                    "instrument_column": instrument,
+                    "exposure_column": exposure,
+                    "detector_column": detector,
+                }
+            )
+            update_rows.append(record)
+
+        where_dict: Dict[str, str] = {
+            instrument_column: "instrument_column",
+            exposure_column: "exposure_column",
+            detector_column: "detector_column",
+        }
+
+        count = self.db.update(self.table, where_dict, *update_rows)
+        return count

--- a/python/lsst/daf/butler/registry/obscore/_manager.py
+++ b/python/lsst/daf/butler/registry/obscore/_manager.py
@@ -28,8 +28,9 @@ import re
 import uuid
 import warnings
 from collections import defaultdict
-from collections.abc import Collection, Mapping
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Type, cast
+from collections.abc import Collection, Iterable, Iterator, Mapping
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Type, cast
 
 import sqlalchemy
 from lsst.daf.butler import Config, DataCoordinate, DatasetRef, DimensionRecordColumnTag, DimensionUniverse
@@ -65,7 +66,7 @@ class _ExposureRegionFactory(ExposureRegionFactory):
         self.exposure_dimensions = self.universe["exposure"].graph
         self.exposure_detector_dimensions = self.universe.extract(["exposure", "detector"])
 
-    def exposure_region(self, dataId: DataCoordinate, context: SqlQueryContext) -> Optional[Region]:
+    def exposure_region(self, dataId: DataCoordinate, context: SqlQueryContext) -> Region | None:
         # Docstring is inherited from a base class.
         # Make a relation that starts with visit_definition (mapping between
         # exposure and visit).
@@ -129,7 +130,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
         self.record_factory = RecordFactory(
             config, schema, universe, spatial_plugins, exposure_region_factory
         )
-        self.tagged_collection: Optional[str] = None
+        self.tagged_collection: str | None = None
         self.run_patterns: list[re.Pattern] = []
         if config.collection_type is ConfigCollectionType.TAGGED:
             assert (
@@ -193,11 +194,11 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
         return json.dumps(self.config.dict())
 
     @classmethod
-    def currentVersion(cls) -> Optional[VersionTuple]:
+    def currentVersion(cls) -> VersionTuple | None:
         # Docstring inherited from base class.
         return _VERSION
 
-    def schemaDigest(self) -> Optional[str]:
+    def schemaDigest(self) -> str | None:
         # Docstring inherited from base class.
         return None
 
@@ -215,7 +216,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
             # expensive. Normally references are grouped by run, if there are
             # multiple input references, they should have the same run.
             # Instead of just checking that, we group them by run again.
-            refs_by_run: Dict[str, List[DatasetRef]] = defaultdict(list)
+            refs_by_run: dict[str, list[DatasetRef]] = defaultdict(list)
             for ref in refs:
                 # Record factory will filter dataset types, but to reduce
                 # collection checks we also pre-filter it here.
@@ -225,7 +226,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
                 assert ref.run is not None, "Run cannot be None"
                 refs_by_run[ref.run].append(ref)
 
-            good_refs: List[DatasetRef] = []
+            good_refs: list[DatasetRef] = []
             for run, run_refs in refs_by_run.items():
                 if not self._check_dataset_run(run):
                     continue
@@ -274,7 +275,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
 
     def _populate(self, refs: Iterable[DatasetRef], context: SqlQueryContext) -> int:
         """Populate obscore table with the data from given datasets."""
-        records: List[Record] = []
+        records: list[Record] = []
         for ref in refs:
             record = self.record_factory(ref, context)
             if record is not None:
@@ -305,7 +306,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
             # Not all needed columns are in the table.
             return 0
 
-        update_rows: List[Record] = []
+        update_rows: list[Record] = []
         for exposure, detector, region in region_data:
             try:
                 record = self.record_factory.make_spatial_records(region)
@@ -325,7 +326,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
             )
             update_rows.append(record)
 
-        where_dict: Dict[str, str] = {
+        where_dict: dict[str, str] = {
             instrument_column: "instrument_column",
             exposure_column: "exposure_column",
             detector_column: "detector_column",
@@ -333,3 +334,24 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
 
         count = self.db.update(self.table, where_dict, *update_rows)
         return count
+
+    @contextmanager
+    def query(self, **kwargs: Any) -> Iterator[sqlalchemy.engine.CursorResult]:
+        """Run a SELECT query against obscore table and return reslut rows.
+
+        Parameters
+        ----------
+        **kwargs
+            Restriction on values of individual obscore columns. Key is the
+            column name, value is the required value of the column. Multiple
+            restrictions are ANDed together.
+        """
+        query = self.table.select()
+        if kwargs:
+            query = query.where(
+                sqlalchemy.sql.expression.and_(
+                    *[self.table.columns[column] == value for column, value in kwargs.items()]
+                )
+            )
+        with self.db.query(query) as result:
+            yield result

--- a/python/lsst/daf/butler/registry/obscore/_manager.py
+++ b/python/lsst/daf/butler/registry/obscore/_manager.py
@@ -337,7 +337,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
 
     @contextmanager
     def query(self, **kwargs: Any) -> Iterator[sqlalchemy.engine.CursorResult]:
-        """Run a SELECT query against obscore table and return reslut rows.
+        """Run a SELECT query against obscore table and return result rows.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/registry/obscore/_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/_spatial.py
@@ -27,7 +27,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
-from lsst.daf.butler import DatasetId
 from lsst.sphgeom import Region
 from lsst.utils import doImportType
 
@@ -42,6 +41,10 @@ class MissingDatabaseError(Exception):
     """Exception raised when database is not provided but plugin implementation
     requires it.
     """
+
+
+class RegionTypeError(TypeError):
+    """Exception raised for unsupported region types."""
 
 
 class RegionTypeWarning(Warning):
@@ -103,13 +106,11 @@ class SpatialObsCorePlugin(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def make_records(self, dataset_id: DatasetId, region: Optional[Region]) -> Optional[Record]:
+    def make_records(self, region: Optional[Region]) -> Optional[Record]:
         """Return data for obscore records corresponding to a given region.
 
         Parameters
         ----------
-        dataset_id : `DatasetId`
-            ID of the corresponding dataset.
         region : `Region`, optional
             Spatial region, can be `None` if dataset has no associated region.
 
@@ -118,6 +119,11 @@ class SpatialObsCorePlugin(ABC):
         record : `dict` [ `str`, `Any` ] or `None`
             Data to store in the main obscore table with column values
             corresponding to a region or `None` if there is nothing to store.
+
+        Raises
+        ------
+        RegionTypeError
+            Raised if type of the region is not supported.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/obscore/default_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/default_spatial.py
@@ -23,16 +23,14 @@ from __future__ import annotations
 
 __all__ = ["DefaultSpatialObsCorePlugin"]
 
-import warnings
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional
 
 import sqlalchemy
-from lsst.daf.butler import DatasetId
 from lsst.sphgeom import ConvexPolygon, LonLat, Region
 
 from ...core import ddl
-from ._spatial import RegionTypeWarning, SpatialObsCorePlugin
+from ._spatial import RegionTypeError, SpatialObsCorePlugin
 
 if TYPE_CHECKING:
     from ..interfaces import Database
@@ -71,7 +69,7 @@ class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
         # docstring inherited.
         table_spec.fields.update(_COLUMNS)
 
-    def make_records(self, dataset_id: DatasetId, region: Optional[Region]) -> Optional[Record]:
+    def make_records(self, region: Optional[Region]) -> Optional[Record]:
         # docstring inherited.
 
         if region is None:
@@ -96,9 +94,6 @@ class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
                 ]
             record["s_region"] = " ".join(poly)
         else:
-            warnings.warn(
-                f"Unexpected region type for obscore dataset {dataset_id}: {type(region)}",
-                category=RegionTypeWarning,
-            )
+            raise RegionTypeError(f"Unexpected region type: {type(region)}")
 
         return record

--- a/tests/config/basic/obscore.yaml
+++ b/tests/config/basic/obscore.yaml
@@ -32,6 +32,9 @@ dataset_types:
     access_format: image/fits
     datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"
 extra_columns:
+  lsst_exposure:
+    template: "{exposure}"
+    type: "int"
   lsst_visit:
     template: "{visit}"
     type: "int"

--- a/tests/test_obscore.py
+++ b/tests/test_obscore.py
@@ -464,7 +464,7 @@ class ObsCoreTests:
         for detector in (1, 2, 3, 4):
             self._insert_dataset(registry, "run1", "raw", detector=detector, exposure=4)
 
-        # All spatial columns should be None
+        # All spatial columns should be None.
         with obscore.query() as result:
             rows = list(result)
             self.assertEqual(len(rows), 4)
@@ -473,7 +473,7 @@ class ObsCoreTests:
                 self.assertIsNone(row.s_dec)
                 self.assertIsNone(row.s_region)
 
-        # Assign Region from visit 4
+        # Assign Region from visit 4.
         count = obscore.update_exposure_regions(
             "DummyCam", [(4, 1, self.regions[(4, 1)]), (4, 2, self.regions[(4, 2)])]
         )


### PR DESCRIPTION
This new method will be used by DefineVisitsTask to update existing exposure
records in obscore table. A minor refactoring in spatial plugin interface and
RecordFactory class to support this new method. Unit test updated to check
that it works OK, plus a mypy cleanup in obscore unit test.

Also adds obscore manager property to Registry interface.
Some clients, e.g. DefineVisitsTask, will need access to ObsCore update
methods. I do not want to expose those methods in Registry interface because
they are only relevant for a small set of clients and a small number of repos.
Instead, an `obsCoreTableManager` property is added which will be `None` if
obscore is not configured for a repo.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
