### PR TITLE
DM-38305: Fix race condition in DatasetRecordStorageManager refresh

### DIFF
--- a/doc/changes/DM-38305.bugfix.md
+++ b/doc/changes/DM-38305.bugfix.md
@@ -1,0 +1,1 @@
+Fix occasional crashes in Butler `refresh()` method due to a race condition in dataset types refresh.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -177,6 +177,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         # Docstring inherited from DatasetRecordStorageManager.
         byName: dict[str, ByDimensionsDatasetRecordStorage] = {}
         byId: dict[int, ByDimensionsDatasetRecordStorage] = {}
+        dataset_types: dict[int, DatasetType] = {}
         c = self._static.dataset_type.columns
         with self._db.query(self._static.dataset_type.select()) as sql_result:
             sql_rows = sql_result.mappings().fetchall()
@@ -223,9 +224,10 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
             )
             byName[datasetType.name] = storage
             byId[storage._dataset_type_id] = storage
+            dataset_types[row["id"]] = datasetType
         self._byName = byName
         self._byId = byId
-        self._summaries.refresh(lambda dataset_type_id: self._byId[dataset_type_id].datasetType)
+        self._summaries.refresh(dataset_types)
 
     def remove(self, name: str) -> None:
         # Docstring inherited from DatasetRecordStorageManager.


### PR DESCRIPTION
Refresh of collection summaries could see newly added dataset types which are not picked by the manager refresh. As we only care about consistency between them, the fix is to ignore dataset types which are not known to the manager.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
