### PR TITLE
DM-38409: Remove support for int dataset IDs in Butler.transfer_from

### DIFF
--- a/doc/changes/DM-38409.removal.rst
+++ b/doc/changes/DM-38409.removal.rst
@@ -1,0 +1,2 @@
+Removed support for non-UUID dataset IDs in ``Butler.transfer_from()``.
+The ``id_gen_map`` parameter has been removed and the ``local_refs`` parameter has been removed from ``Datastore.transfer_from()``.

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -739,7 +739,6 @@ class Datastore(metaclass=ABCMeta):
         self,
         source_datastore: Datastore,
         refs: Iterable[DatasetRef],
-        local_refs: Optional[Iterable[DatasetRef]] = None,
         transfer: str = "auto",
         artifact_existence: Optional[Dict[ResourcePath, bool]] = None,
     ) -> tuple[set[DatasetRef], set[DatasetRef]]:
@@ -752,10 +751,6 @@ class Datastore(metaclass=ABCMeta):
             must be compatible with this datastore receiving the artifacts.
         refs : iterable of `DatasetRef`
             The datasets to transfer from the source datastore.
-        local_refs : iterable of `DatasetRef`, optional
-            The dataset refs associated with the registry associated with
-            this datastore. Can be `None` if the source and target datastore
-            are using UUIDs.
         transfer : `str`, optional
             How (and whether) the dataset should be added to the datastore.
             Choices include "move", "copy",

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1966,7 +1966,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
             datasetType = DatasetType(datasetTypeName, dimensions, badStorageClass)
             self.target_butler.registry.registerDatasetType(datasetType)
         with self.assertRaises(ConflictingDefinitionError) as cm:
-            self.target_butler.transfer_from(self.source_butler, source_refs, id_gen_map=id_gen_map)
+            self.target_butler.transfer_from(self.source_butler, source_refs)
         self.assertIn("dataset type differs", str(cm.exception))
 
         # And remove the bad definitions.
@@ -1975,13 +1975,11 @@ class PosixDatastoreTransfers(unittest.TestCase):
 
         # Transfer without creating dataset types should fail.
         with self.assertRaises(KeyError):
-            self.target_butler.transfer_from(self.source_butler, source_refs, id_gen_map=id_gen_map)
+            self.target_butler.transfer_from(self.source_butler, source_refs)
 
         # Transfer without creating dimensions should fail.
         with self.assertRaises(ConflictingDefinitionError) as cm:
-            self.target_butler.transfer_from(
-                self.source_butler, source_refs, id_gen_map=id_gen_map, register_dataset_types=True
-            )
+            self.target_butler.transfer_from(self.source_butler, source_refs, register_dataset_types=True)
         self.assertIn("dimension", str(cm.exception))
 
         # The failed transfer above leaves registry in an inconsistent
@@ -1995,7 +1993,6 @@ class PosixDatastoreTransfers(unittest.TestCase):
             transferred = self.target_butler.transfer_from(
                 self.source_butler,
                 source_refs,
-                id_gen_map=id_gen_map,
                 register_dataset_types=True,
                 transfer_dimensions=True,
             )
@@ -2012,9 +2009,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
         # dataset_id.
         if purge:
             # This should not need to register dataset types.
-            transferred = self.target_butler.transfer_from(
-                self.source_butler, source_refs, id_gen_map=id_gen_map
-            )
+            transferred = self.target_butler.transfer_from(self.source_butler, source_refs)
             self.assertEqual(len(transferred), n_expected)
 
             # Also do an explicit low-level transfer to trigger some
@@ -2048,7 +2043,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
             # Re-importing the run1 datasets can be problematic if they
             # use integer IDs so filter those out.
             to_transfer = [ref for ref in source_refs if ref.run == "run2"]
-            self.target_butler.transfer_from(self.source_butler, to_transfer, id_gen_map=id_gen_map)
+            self.target_butler.transfer_from(self.source_butler, to_transfer)
 
 
 class ChainedDatastoreTransfers(PosixDatastoreTransfers):


### PR DESCRIPTION
This significantly cleans up the code since there is no longer a need to collect the source and target refs separately and make Datastore.transfer_from have to keep track of them. With UUIDs the source ref and the target ref are the same.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
