### PR TITLE
DM-38402: Move projections to SQL when dropping Python-side region filtering.

### DIFF
--- a/doc/changes/DM-38402.bugfix.md
+++ b/doc/changes/DM-38402.bugfix.md
@@ -1,0 +1,3 @@
+Fix query manipulation logic to more aggressively move operations from Python postprocessing to SQL.
+
+This fixes a bug in QuantumGraph generation that occurs when a dataset type that is actually present in an input collection has exactly the same dimensions as the graph as a whole, manifesting as a mismatch between `daf_relation` engines.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
