### PR TITLE
DM-38447: Fix config file used in chained datastore transfer test

### DIFF
--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2047,7 +2047,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
 
 
 class ChainedDatastoreTransfers(PosixDatastoreTransfers):
-    configFile = os.path.join(TESTDIR, "config/basic/chainedDatastore.yaml")
+    configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We need the butler config not just the datastore config because we need to ensure that the storage classes used for the test are defined.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
