### PR TITLE
DM-38412: Improve schema version handling in Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,13 @@ convention = "numpy"
 # D200, D205 and D400 all complain if the first sentence of the docstring does
 # not fit on one line.
 add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/python/lsst/daf/butler/registry/attributes.py
+++ b/python/lsst/daf/butler/registry/attributes.py
@@ -56,7 +56,13 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
         SQLAlchemy representation of the table that stores attributes.
     """
 
-    def __init__(self, db: Database, table: sqlalchemy.schema.Table):
+    def __init__(
+        self,
+        db: Database,
+        table: sqlalchemy.schema.Table,
+        registry_schema_version: VersionTuple | None = None,
+    ):
+        super().__init__(registry_schema_version=registry_schema_version)
         self._db = db
         self._table = table
 
@@ -70,10 +76,12 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
     )
 
     @classmethod
-    def initialize(cls, db: Database, context: StaticTablesContext) -> ButlerAttributeManager:
+    def initialize(
+        cls, db: Database, context: StaticTablesContext, registry_schema_version: VersionTuple | None = None
+    ) -> ButlerAttributeManager:
         # Docstring inherited from ButlerAttributeManager.
         table = context.addTable(cls._TABLE_NAME, cls._TABLE_SPEC)
-        return cls(db=db, table=table)
+        return cls(db=db, table=table, registry_schema_version=registry_schema_version)
 
     def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
         # Docstring inherited from ButlerAttributeManager.
@@ -132,6 +140,6 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
         return count == 0
 
     @classmethod
-    def currentVersion(cls) -> Optional[VersionTuple]:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return _VERSION
+        return [_VERSION]

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -318,8 +318,14 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
         opaque: OpaqueTableStorageManager,
         universe: DimensionUniverse,
         datasetIdColumnType: type,
+        registry_schema_version: VersionTuple | None = None,
     ):
-        super().__init__(opaque=opaque, universe=universe, datasetIdColumnType=datasetIdColumnType)
+        super().__init__(
+            opaque=opaque,
+            universe=universe,
+            datasetIdColumnType=datasetIdColumnType,
+            registry_schema_version=registry_schema_version,
+        )
         self._db = db
         self._tables = tables
         self._ephemeral: Dict[str, EphemeralDatastoreRegistryBridge] = {}
@@ -333,6 +339,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
         opaque: OpaqueTableStorageManager,
         datasets: Type[DatasetRecordStorageManager],
         universe: DimensionUniverse,
+        registry_schema_version: VersionTuple | None = None,
     ) -> DatastoreRegistryBridgeManager:
         # Docstring inherited from DatastoreRegistryBridge
         tables = context.addTableTuple(_makeTableSpecs(datasets))
@@ -342,6 +349,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
             opaque=opaque,
             universe=universe,
             datasetIdColumnType=datasets.getIdColumnType(),
+            registry_schema_version=registry_schema_version,
         )
 
     def refresh(self) -> None:
@@ -372,6 +380,6 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
                 yield name
 
     @classmethod
-    def currentVersion(cls) -> Optional[VersionTuple]:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return _VERSION
+        return [_VERSION]

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -34,7 +34,7 @@ from lsst.utils.ellipsis import Ellipsis
 from ...core import DimensionUniverse, Timespan, TimespanDatabaseRepresentation, ddl
 from .._collectionType import CollectionType
 from .._exceptions import MissingCollectionError
-from ..interfaces import ChainedCollectionRecord, CollectionManager, CollectionRecord, RunRecord
+from ..interfaces import ChainedCollectionRecord, CollectionManager, CollectionRecord, RunRecord, VersionTuple
 from ..wildcards import CollectionWildcard
 
 if TYPE_CHECKING:
@@ -323,8 +323,9 @@ class DefaultCollectionManager(Generic[K], CollectionManager):
         collectionIdName: str,
         *,
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ):
-        super().__init__()
+        super().__init__(registry_schema_version=registry_schema_version)
         self._db = db
         self._tables = tables
         self._collectionIdName = collectionIdName

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -77,6 +77,7 @@ class NameKeyCollectionManager(DefaultCollectionManager):
         context: StaticTablesContext,
         *,
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> NameKeyCollectionManager:
         # Docstring inherited from CollectionManager.
         return cls(
@@ -84,6 +85,7 @@ class NameKeyCollectionManager(DefaultCollectionManager):
             tables=context.addTableTuple(_makeTableSpecs(db.getTimespanRepresentation())),  # type: ignore
             collectionIdName="name",
             dimensions=dimensions,
+            registry_schema_version=registry_schema_version,
         )
 
     @classmethod
@@ -147,6 +149,6 @@ class NameKeyCollectionManager(DefaultCollectionManager):
         return self._records.get(name)
 
     @classmethod
-    def currentVersion(cls) -> VersionTuple | None:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return _VERSION
+        return [_VERSION]

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -91,8 +91,15 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager):
         tables: CollectionTablesTuple,
         collectionIdName: str,
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ):
-        super().__init__(db=db, tables=tables, collectionIdName=collectionIdName, dimensions=dimensions)
+        super().__init__(
+            db=db,
+            tables=tables,
+            collectionIdName=collectionIdName,
+            dimensions=dimensions,
+            registry_schema_version=registry_schema_version,
+        )
         self._nameCache: dict[str, CollectionRecord] = {}  # indexed by collection name
 
     @classmethod
@@ -102,6 +109,7 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager):
         context: StaticTablesContext,
         *,
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> SynthIntKeyCollectionManager:
         # Docstring inherited from CollectionManager.
         return cls(
@@ -109,6 +117,7 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager):
             tables=context.addTableTuple(_makeTableSpecs(db.getTimespanRepresentation())),  # type: ignore
             collectionIdName="collection_id",
             dimensions=dimensions,
+            registry_schema_version=registry_schema_version,
         )
 
     @classmethod
@@ -192,6 +201,6 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager):
         return self._nameCache.get(name)
 
     @classmethod
-    def currentVersion(cls) -> VersionTuple | None:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return _VERSION
+        return [_VERSION]

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
 
 
 # This has to be updated on every schema change
-_VERSION_INT = VersionTuple(1, 0, 0)
 _VERSION_UUID = VersionTuple(1, 0, 0)
 
 _LOG = logging.getLogger(__name__)
@@ -94,7 +93,9 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         dimensions: DimensionRecordStorageManager,
         static: StaticDatasetTablesTuple,
         summaries: CollectionSummaryManager,
+        registry_schema_version: VersionTuple | None = None,
     ):
+        super().__init__(registry_schema_version=registry_schema_version)
         self._db = db
         self._collections = collections
         self._dimensions = dimensions
@@ -111,6 +112,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         *,
         collections: CollectionManager,
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> DatasetRecordStorageManager:
         # Docstring inherited from DatasetRecordStorageManager.
         specs = cls.makeStaticTableSpecs(type(collections), universe=dimensions.universe)
@@ -121,12 +123,19 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
             collections=collections,
             dimensions=dimensions,
         )
-        return cls(db=db, collections=collections, dimensions=dimensions, static=static, summaries=summaries)
+        return cls(
+            db=db,
+            collections=collections,
+            dimensions=dimensions,
+            static=static,
+            summaries=summaries,
+            registry_schema_version=registry_schema_version,
+        )
 
     @classmethod
-    def currentVersion(cls) -> VersionTuple | None:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return cls._version
+        return [cls._version]
 
     @classmethod
     def makeStaticTableSpecs(

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -94,8 +94,9 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
         ],
         dimensionGraphStorage: _DimensionGraphStorage,
         universe: DimensionUniverse,
+        registry_schema_version: VersionTuple | None = None,
     ):
-        super().__init__(universe=universe)
+        super().__init__(universe=universe, registry_schema_version=registry_schema_version)
         self._db = db
         self._records = records
         self._overlaps = overlaps
@@ -103,7 +104,12 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
 
     @classmethod
     def initialize(
-        cls, db: Database, context: StaticTablesContext, *, universe: DimensionUniverse
+        cls,
+        db: Database,
+        context: StaticTablesContext,
+        *,
+        universe: DimensionUniverse,
+        registry_schema_version: VersionTuple | None = None,
     ) -> DimensionRecordStorageManager:
         # Docstring inherited from DimensionRecordStorageManager.
         # Start by initializing governor dimensions; those go both in the main
@@ -180,6 +186,7 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
             universe=universe,
             overlaps=overlaps,
             dimensionGraphStorage=dimensionGraphStorage,
+            registry_schema_version=registry_schema_version,
         )
 
     def get(self, element: DimensionElement | str) -> DimensionRecordStorage | None:
@@ -272,9 +279,9 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
         return overlaps, needs_refinement
 
     @classmethod
-    def currentVersion(cls) -> VersionTuple | None:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return _VERSION
+        return [_VERSION]
 
 
 class _DimensionGraphStorage:

--- a/python/lsst/daf/butler/registry/interfaces/_attributes.py
+++ b/python/lsst/daf/butler/registry/interfaces/_attributes.py
@@ -28,7 +28,7 @@ __all__ = [
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Iterable, Optional, Tuple
 
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from ._database import Database, StaticTablesContext
@@ -58,9 +58,14 @@ class ButlerAttributeManager(VersionedExtension):
     database table with a stable schema.
     """
 
+    def __init__(self, *, registry_schema_version: VersionTuple | None = None) -> None:
+        super().__init__(registry_schema_version=registry_schema_version)
+
     @classmethod
     @abstractmethod
-    def initialize(cls, db: Database, context: StaticTablesContext) -> ButlerAttributeManager:
+    def initialize(
+        cls, db: Database, context: StaticTablesContext, registry_schema_version: VersionTuple | None = None
+    ) -> ButlerAttributeManager:
         """Construct an instance of the manager.
 
         Parameters
@@ -71,6 +76,8 @@ class ButlerAttributeManager(VersionedExtension):
             Context object obtained from `Database.declareStaticTables`; used
             to declare any tables that should always be present in a layer
             implemented with this manager.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Optional, Set, 
 from lsst.utils.classes import immutable
 
 from ...core import DatasetId, DatasetRef
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from ...core import DatasetType, DimensionUniverse, StoredDatastoreItemInfo
@@ -286,8 +286,14 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
     """
 
     def __init__(
-        self, *, opaque: OpaqueTableStorageManager, universe: DimensionUniverse, datasetIdColumnType: type
+        self,
+        *,
+        opaque: OpaqueTableStorageManager,
+        universe: DimensionUniverse,
+        datasetIdColumnType: type,
+        registry_schema_version: VersionTuple | None = None,
     ):
+        super().__init__(registry_schema_version=registry_schema_version)
         self.opaque = opaque
         self.universe = universe
         self.datasetIdColumnType = datasetIdColumnType
@@ -302,6 +308,7 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
         opaque: OpaqueTableStorageManager,
         datasets: Type[DatasetRecordStorageManager],
         universe: DimensionUniverse,
+        registry_schema_version: VersionTuple | None = None,
     ) -> DatastoreRegistryBridgeManager:
         """Construct an instance of the manager.
 
@@ -323,6 +330,8 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
             those tables.
         universe : `DimensionUniverse`
             All dimensions known to the registry.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any
 from ...core import DimensionUniverse, Timespan, ddl
 from .._collectionType import CollectionType
 from ..wildcards import CollectionWildcard
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from ._database import Database, StaticTablesContext
@@ -304,13 +304,19 @@ class CollectionManager(VersionedExtension):
     (to `Registry`) use.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, registry_schema_version: VersionTuple | None = None) -> None:
+        super().__init__(registry_schema_version=registry_schema_version)
         self._parents_by_child: defaultdict[Any, set[Any]] = defaultdict(set)
 
     @classmethod
     @abstractmethod
     def initialize(
-        cls, db: Database, context: StaticTablesContext, *, dimensions: DimensionRecordStorageManager
+        cls,
+        db: Database,
+        context: StaticTablesContext,
+        *,
+        dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> CollectionManager:
         """Construct an instance of the manager.
 
@@ -324,6 +330,8 @@ class CollectionManager(VersionedExtension):
             implemented with this manager.
         dimensions : `DimensionRecordStorageManager`
             Manager object for the dimensions in this `Registry`.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -33,7 +33,7 @@ from lsst.daf.relation import Relation
 
 from ...core import DataCoordinate, DatasetId, DatasetRef, DatasetType, Timespan, ddl
 from .._exceptions import MissingDatasetTypeError
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from .._collection_summary import CollectionSummary
@@ -449,6 +449,9 @@ class DatasetRecordStorageManager(VersionedExtension):
     records for a different `DatasetType`.
     """
 
+    def __init__(self, *, registry_schema_version: VersionTuple | None = None) -> None:
+        super().__init__(registry_schema_version=registry_schema_version)
+
     @classmethod
     @abstractmethod
     def initialize(
@@ -458,6 +461,7 @@ class DatasetRecordStorageManager(VersionedExtension):
         *,
         collections: CollectionManager,
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> DatasetRecordStorageManager:
         """Construct an instance of the manager.
 
@@ -472,6 +476,8 @@ class DatasetRecordStorageManager(VersionedExtension):
             Manager object for the collections in this `Registry`.
         dimensions : `DimensionRecordStorageManager`
             Manager object for the dimensions in this `Registry`.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -49,7 +49,7 @@ from ...core import (
     SkyPixDimension,
 )
 from ...core.named import NamedKeyMapping
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from .. import queries
@@ -656,13 +656,19 @@ class DimensionRecordStorageManager(VersionedExtension):
     across all layers forms the logical table for the full `Registry`.
     """
 
-    def __init__(self, *, universe: DimensionUniverse):
+    def __init__(self, *, universe: DimensionUniverse, registry_schema_version: VersionTuple | None = None):
+        super().__init__(registry_schema_version=registry_schema_version)
         self.universe = universe
 
     @classmethod
     @abstractmethod
     def initialize(
-        cls, db: Database, context: StaticTablesContext, *, universe: DimensionUniverse
+        cls,
+        db: Database,
+        context: StaticTablesContext,
+        *,
+        universe: DimensionUniverse,
+        registry_schema_version: VersionTuple | None = None,
     ) -> DimensionRecordStorageManager:
         """Construct an instance of the manager.
 
@@ -676,6 +682,8 @@ class DimensionRecordStorageManager(VersionedExtension):
             implemented with this manager.
         universe : `DimensionUniverse`
             Universe graph containing dimensions known to this `Registry`.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, Type
 
 import sqlalchemy
 
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from lsst.sphgeom import Region
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
 class ObsCoreTableManager(VersionedExtension):
     """An interface for populating ObsCore tables(s)."""
 
+    def __init__(self, *, registry_schema_version: VersionTuple | None = None):
+        super().__init__(registry_schema_version=registry_schema_version)
+
     @classmethod
     @abstractmethod
     def initialize(
@@ -59,6 +62,7 @@ class ObsCoreTableManager(VersionedExtension):
         config: Mapping,
         datasets: Type[DatasetRecordStorageManager],
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> ObsCoreTableManager:
         """Construct an instance of the manager.
 
@@ -78,6 +82,8 @@ class ObsCoreTableManager(VersionedExtension):
             Type of dataset manager.
         dimensions: `DimensionRecordStorageManager`
             Manager for Registry dimensions.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional
 
 from ...core.ddl import TableSpec
 from ._database import Database, StaticTablesContext
-from ._versioning import VersionedExtension
+from ._versioning import VersionedExtension, VersionTuple
 
 if TYPE_CHECKING:
     from ...core.datastore import DatastoreTransaction
@@ -127,9 +127,14 @@ class OpaqueTableStorageManager(VersionedExtension):
     instances (each with their own opaque table) in a `ChainedDatastore`.
     """
 
+    def __init__(self, *, registry_schema_version: VersionTuple | None = None):
+        super().__init__(registry_schema_version=registry_schema_version)
+
     @classmethod
     @abstractmethod
-    def initialize(cls, db: Database, context: StaticTablesContext) -> OpaqueTableStorageManager:
+    def initialize(
+        cls, db: Database, context: StaticTablesContext, registry_schema_version: VersionTuple | None = None
+    ) -> OpaqueTableStorageManager:
         """Construct an instance of the manager.
 
         Parameters
@@ -140,6 +145,8 @@ class OpaqueTableStorageManager(VersionedExtension):
             Context object obtained from `Database.declareStaticTables`; used
             to declare any tables that should always be present in a layer
             implemented with this manager.
+        registry_schema_version : `VersionTuple` or `None`
+            Schema version of this extension as defined in registry.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/obscore/_manager.py
+++ b/python/lsst/daf/butler/registry/obscore/_manager.py
@@ -119,7 +119,9 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
         config: ObsCoreManagerConfig,
         dimensions: DimensionRecordStorageManager,
         spatial_plugins: Collection[SpatialObsCorePlugin],
+        registry_schema_version: VersionTuple | None = None,
     ):
+        super().__init__(registry_schema_version=registry_schema_version)
         self.db = db
         self.table = table
         self.schema = schema
@@ -157,6 +159,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
         config: Mapping,
         datasets: Type[DatasetRecordStorageManager],
         dimensions: DimensionRecordStorageManager,
+        registry_schema_version: VersionTuple | None = None,
     ) -> ObsCoreTableManager:
         # Docstring inherited from base class.
         config_data = Config(config)
@@ -181,6 +184,7 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
             config=obscore_config,
             dimensions=dimensions,
             spatial_plugins=spatial_plugins,
+            registry_schema_version=registry_schema_version,
         )
 
     def config_json(self) -> str:
@@ -194,9 +198,9 @@ class ObsCoreLiveTableManager(ObsCoreTableManager):
         return json.dumps(self.config.dict())
 
     @classmethod
-    def currentVersion(cls) -> VersionTuple | None:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from base class.
-        return _VERSION
+        return [_VERSION]
 
     def add_datasets(self, refs: Iterable[DatasetRef], context: SqlQueryContext) -> int:
         # Docstring inherited from base class.

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -140,7 +140,13 @@ class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
         logical tables exist.
     """
 
-    def __init__(self, db: Database, metaTable: sqlalchemy.schema.Table):
+    def __init__(
+        self,
+        db: Database,
+        metaTable: sqlalchemy.schema.Table,
+        registry_schema_version: VersionTuple | None = None,
+    ):
+        super().__init__(registry_schema_version=registry_schema_version)
         self._db = db
         self._metaTable = metaTable
         self._storage: Dict[str, OpaqueTableStorage] = {}
@@ -154,10 +160,12 @@ class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
     )
 
     @classmethod
-    def initialize(cls, db: Database, context: StaticTablesContext) -> OpaqueTableStorageManager:
+    def initialize(
+        cls, db: Database, context: StaticTablesContext, registry_schema_version: VersionTuple | None = None
+    ) -> OpaqueTableStorageManager:
         # Docstring inherited from OpaqueTableStorageManager.
         metaTable = context.addTable(cls._META_TABLE_NAME, cls._META_TABLE_SPEC)
-        return cls(db=db, metaTable=metaTable)
+        return cls(db=db, metaTable=metaTable, registry_schema_version=registry_schema_version)
 
     def get(self, name: str) -> Optional[OpaqueTableStorage]:
         # Docstring inherited from OpaqueTableStorageManager.
@@ -179,6 +187,6 @@ class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
         return result
 
     @classmethod
-    def currentVersion(cls) -> Optional[VersionTuple]:
+    def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return _VERSION
+        return [_VERSION]

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -257,7 +257,7 @@ class SqliteMemoryRegistryTests(RegistryTests):
         # dropped (DM-27373).
         config = self.makeRegistryConfig()
         config["db"] = "sqlite://"
-        with self.assertRaises(sqlalchemy.exc.OperationalError):
+        with self.assertRaises(LookupError):
             Registry.fromConfig(config)
 
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,242 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import os.path
+import tempfile
+import unittest
+
+from lsst.daf.butler.registry.attributes import DefaultButlerAttributeManager
+from lsst.daf.butler.registry.databases.sqlite import SqliteDatabase
+from lsst.daf.butler.registry.interfaces import (
+    Database,
+    IncompatibleVersionError,
+    VersionedExtension,
+    VersionTuple,
+)
+from lsst.daf.butler.registry.versions import ButlerVersionsManager
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+# Assorted version numbers used throughout the tests
+V_1_0_0 = VersionTuple(major=1, minor=0, patch=0)
+V_1_0_1 = VersionTuple(major=1, minor=0, patch=1)
+V_1_1_0 = VersionTuple(major=1, minor=1, patch=0)
+V_2_0_0 = VersionTuple(major=2, minor=0, patch=0)
+V_2_0_1 = VersionTuple(major=2, minor=0, patch=1)
+
+
+class Manager0(VersionedExtension):
+    """Versioned extension implementation for tests."""
+
+    @classmethod
+    def currentVersions(cls) -> list[VersionTuple]:
+        return []
+
+
+class Manager1(VersionedExtension):
+    """Versioned extension implementation for tests."""
+
+    @classmethod
+    def currentVersions(cls) -> list[VersionTuple]:
+        return [V_1_0_0]
+
+
+class Manager1_1(VersionedExtension):  # noqa: N801
+    """Versioned extension implementation for tests."""
+
+    @classmethod
+    def currentVersions(cls) -> list[VersionTuple]:
+        return [V_1_1_0]
+
+
+class Manager2(VersionedExtension):
+    """Versioned extension implementation for tests.
+
+    This extension supports two schema versions.
+    """
+
+    @classmethod
+    def currentVersions(cls) -> list[VersionTuple]:
+        return [V_1_0_0, V_2_0_0]
+
+    def newSchemaVersion(self) -> VersionTuple | None:
+        if self._registry_schema_version is None:
+            return V_1_0_0
+        elif self._registry_schema_version.major == 1:
+            return V_1_0_0
+        elif self._registry_schema_version.major == 2:
+            return V_2_0_0
+        else:
+            raise ValueError(f"Unexpected registry_schema_version: {self._registry_schema_version}")
+
+
+class SchemaVersioningTestCase(unittest.TestCase):
+    """Tests for schema versioning classes."""
+
+    def setUp(self):
+        self.root = makeTestTempDir(TESTDIR)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def makeEmptyDatabase(self, origin: int = 0) -> Database:
+        _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
+        engine = SqliteDatabase.makeEngine(filename=filename)
+        return SqliteDatabase.fromEngine(engine=engine, origin=origin)
+
+    def test_new_schema(self) -> None:
+        """Test for creating new database schema."""
+
+        # Check that managers know what schema versions they can make.
+        Manager1.checkNewSchemaVersion(V_1_0_0)
+        Manager2.checkNewSchemaVersion(V_1_0_0)
+        Manager2.checkNewSchemaVersion(V_2_0_0)
+        with self.assertRaises(IncompatibleVersionError):
+            Manager1.checkNewSchemaVersion(V_1_0_1)
+        with self.assertRaises(IncompatibleVersionError):
+            Manager1.checkNewSchemaVersion(V_1_1_0)
+        with self.assertRaises(IncompatibleVersionError):
+            Manager2.checkNewSchemaVersion(V_1_0_1)
+
+        manager_versions = (
+            ((None, V_1_0_0), (None, V_1_0_0)),
+            ((V_1_0_0, V_1_0_0), (V_1_0_0, V_1_0_0)),
+            ((None, V_1_0_0), (V_2_0_0, V_2_0_0)),
+        )
+
+        for (v1, result1), (v2, result2) in manager_versions:
+            # This is roughly what RegistryManagerTypes.makeRepo does.
+            if v1 is not None:
+                Manager1.checkNewSchemaVersion(v1)
+            if v2 is not None:
+                Manager2.checkNewSchemaVersion(v2)
+            manager0 = Manager0()
+            manager1 = Manager1(registry_schema_version=v1)
+            manager2 = Manager2(registry_schema_version=v2)
+            self.assertEqual(manager1.newSchemaVersion(), result1)
+            self.assertEqual(manager2.newSchemaVersion(), result2)
+
+            database = self.makeEmptyDatabase()
+            with database.declareStaticTables(create=True) as context:
+                attributes = DefaultButlerAttributeManager.initialize(database, context)
+
+            vmgr = ButlerVersionsManager(attributes)
+            vmgr.storeManagersConfig({"manager0": manager0, "manager1": manager1, "manager2": manager2})
+
+            attr_dict = {key: value for key, value in attributes.items()}
+            expected = {
+                "config:registry.managers.manager0": Manager0.extensionName(),
+                "config:registry.managers.manager1": Manager1.extensionName(),
+                "config:registry.managers.manager2": Manager2.extensionName(),
+                f"version:{Manager1.extensionName()}": str(result1),
+                f"version:{Manager2.extensionName()}": str(result2),
+            }
+            self.assertEqual(attr_dict, expected)
+
+    def test_existing_schema(self) -> None:
+        """Test for reading manager versions from existing database."""
+
+        manager_versions = (
+            ((None, V_1_0_0), (None, V_1_0_0)),
+            ((V_1_0_0, V_1_0_0), (V_1_0_0, V_1_0_0)),
+        )
+
+        for (v1, result1), (v2, result2) in manager_versions:
+            # This is roughly what RegistryManagerTypes.loadRepo does.
+            if v1 is not None:
+                Manager1.checkNewSchemaVersion(v1)
+            if v2 is not None:
+                Manager2.checkNewSchemaVersion(v2)
+            manager0 = Manager0()
+            manager1 = Manager1(registry_schema_version=v1)
+            manager2 = Manager2(registry_schema_version=v2)
+
+            # Create new schema first.
+            database = self.makeEmptyDatabase()
+            with database.declareStaticTables(create=True) as context:
+                attributes = DefaultButlerAttributeManager.initialize(database, context)
+
+            vmgr = ButlerVersionsManager(attributes)
+            vmgr.storeManagersConfig({"manager0": manager0, "manager1": manager1, "manager2": manager2})
+
+            # Switch to reading existing manager configs/versions.
+            with database.declareStaticTables(create=False) as context:
+                attributes = DefaultButlerAttributeManager.initialize(database, context)
+
+            vmgr = ButlerVersionsManager(attributes)
+            vmgr.checkManagersConfig({"manager0": Manager0, "manager1": Manager1, "manager2": Manager2})
+            versions = vmgr.managerVersions()
+
+            Manager1.checkCompatibility(result1, database.isWriteable())
+            Manager2.checkCompatibility(result2, database.isWriteable())
+
+            # Make manager instances using versions from registry.
+            manager0 = Manager1(registry_schema_version=versions.get("manager0"))
+            manager1 = Manager1(registry_schema_version=versions.get("manager1"))
+            manager2 = Manager2(registry_schema_version=versions.get("manager2"))
+            self.assertIsNone(manager0._registry_schema_version)
+            self.assertEqual(manager1._registry_schema_version, result1)
+            self.assertEqual(manager2._registry_schema_version, result2)
+
+    def test_compatibility(self) -> None:
+        """Test for version compatibility rules."""
+
+        #    Manager,  version, update, compatible
+        compat_matrix = (
+            (Manager0, V_1_0_0, False, True),
+            (Manager0, V_1_0_0, True, True),
+            (Manager1, V_1_0_0, False, True),
+            (Manager1, V_1_0_0, True, True),
+            (Manager1, V_1_0_1, False, True),
+            (Manager1, V_1_0_1, True, True),
+            (Manager1, V_1_1_0, False, False),
+            (Manager1, V_1_1_0, True, False),
+            (Manager1, V_2_0_0, False, False),
+            (Manager1, V_2_0_0, True, False),
+            (Manager1_1, V_1_0_0, False, True),
+            (Manager1_1, V_1_0_0, True, False),
+            (Manager1_1, V_1_0_1, False, True),
+            (Manager1_1, V_1_0_1, True, False),
+            (Manager1_1, V_1_1_0, False, True),
+            (Manager1_1, V_1_1_0, True, True),
+            (Manager2, V_1_0_0, False, True),
+            (Manager2, V_1_0_0, True, True),
+            (Manager2, V_1_0_1, False, True),
+            (Manager2, V_1_0_1, True, True),
+            (Manager2, V_1_1_0, False, False),
+            (Manager2, V_1_1_0, True, False),
+            (Manager2, V_2_0_0, False, True),
+            (Manager2, V_2_0_0, True, True),
+        )
+
+        for Manager, version, update, compatible in compat_matrix:
+            with self.subTest(test=(Manager, version, update, compatible)):
+                if compatible:
+                    Manager.checkCompatibility(version, update)
+                else:
+                    with self.assertRaises(IncompatibleVersionError):
+                        Manager.checkCompatibility(version, update)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit enables support of multiple schema versions by a single manager. Managers now have an access to the exact schema version as defined by the registry. Added unit test to check new functionality.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
