### PR TITLE
DM-38514: Extend obscore query method to return fewer columns

### DIFF
--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -22,13 +22,11 @@ from __future__ import annotations
 
 __all__ = ()
 
-from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
 import click
 
 from ... import script
-from .. import utils as cmd_utils
 from ..opt import (
     collection_argument,
     collection_type_option,
@@ -60,17 +58,12 @@ from ..utils import (
     MWOptionDecorator,
     option_section,
     printAstropyTables,
+    split_commas,
+    to_upper,
     typeStrAcceptsMultiple,
     unwrap,
     where_help,
 )
-
-# Cast the callback signatures to appease mypy since mypy thinks they
-# are too constrained.
-split_commas = cast(
-    Callable[[click.Context, click.Option | click.Parameter, Any], Any], cmd_utils.split_commas
-)
-to_upper = cast(Callable[[click.Context, click.Option | click.Parameter, Any], Any], cmd_utils.to_upper)
 
 willCreateRepoHelp = "REPO is the URI or path to the new repository. Will be created if it does not exist."
 existingRepoHelp = "REPO is the URI or path to an existing data repository root or configuration file."

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -233,11 +233,17 @@ class ObsCoreTableManager(VersionedExtension):
 
     @abstractmethod
     @contextmanager
-    def query(self, **kwargs: Any) -> Iterator[sqlalchemy.engine.CursorResult]:
+    def query(
+        self, columns: Iterable[str | sqlalchemy.sql.expression.ColumnElement] | None = None, /, **kwargs: Any
+    ) -> Iterator[sqlalchemy.engine.CursorResult]:
         """Run a SELECT query against obscore table and return result rows.
 
         Parameters
         ----------
+        columns : `~collections.abc.Iterable` [`str`]
+            Columns to return from query. It is a sequence which can include
+            column names or any other column elements (e.g.
+            `sqlalchemy.sql.functions.count` function).
         **kwargs
             Restriction on values of individual obscore columns. Key is the
             column name, value is the required value of the column. Multiple
@@ -248,10 +254,5 @@ class ObsCoreTableManager(VersionedExtension):
         result_context : `sqlalchemy.engine.CursorResult`
             Context manager that returns the query result object when entered.
             These results are invalidated when the context is exited.
-
-        Notes
-        -----
-        This method is intended mostly for tests that need to check the
-        contents of obscore table.
         """
         raise NotImplementedError()

--- a/tests/test_obscore.py
+++ b/tests/test_obscore.py
@@ -371,6 +371,11 @@ class ObsCoreTests:
                     rows = list(result)
                     self.assertEqual(len(rows), count)
 
+                # Also check `query` method with COUNT(*)
+                with obscore.query([sqlalchemy.sql.func.count()]) as result:
+                    scalar = result.scalar_one()
+                    self.assertEqual(scalar, count)
+
     def test_drop_datasets(self):
         """Test for dropping datasets after obscore insert."""
 
@@ -479,7 +484,7 @@ class ObsCoreTests:
         )
         self.assertEqual(count, 2)
 
-        with obscore.query() as result:
+        with obscore.query(["s_ra", "s_dec", "s_region", "lsst_detector"]) as result:
             rows = list(result)
             self.assertEqual(len(rows), 4)
             for row in rows:


### PR DESCRIPTION
`ObsCoreTableManager.query` method adds new parameter that accepts a list of column elements to return from a query instead of a full set of columns. This is used in re-implementation of dax_obscore CLI command.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
