### PR TITLE
DM-37322: Add support for nanosecond ingest_date to datasets manager

### DIFF
--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -67,7 +67,10 @@ def _doUpdate(d: Mapping[str, Any], u: Mapping[str, Any]) -> Mapping[str, Any]:
         raise RuntimeError("Only call update with Mapping, not {}".format(type(d)))
     for k, v in u.items():
         if isinstance(v, Mapping):
-            d[k] = _doUpdate(d.get(k, {}), v)
+            lhs = d.get(k, {})
+            if not isinstance(lhs, Mapping):
+                lhs = {}
+            d[k] = _doUpdate(lhs, v)
         else:
             d[k] = v
     return d

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -1152,6 +1152,7 @@ class SqlRegistry(Registry):
             # QueryBuilder.
             summary = queries.QuerySummary(
                 requested=DimensionGraph(self.dimensions, names=dimension_names),
+                column_types=self._managers.column_types,
                 data_id=data_id,
                 expression=where,
                 bind=bind,
@@ -1207,6 +1208,7 @@ class SqlRegistry(Registry):
         )
         summary = queries.QuerySummary(
             requested=requestedDimensions,
+            column_types=self._managers.column_types,
             data_id=data_id,
             expression=where,
             bind=bind,
@@ -1250,6 +1252,7 @@ class SqlRegistry(Registry):
         )
         summary = queries.QuerySummary(
             requested=element.graph,
+            column_types=self._managers.column_types,
             data_id=data_id,
             expression=where,
             bind=bind,

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -162,7 +162,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         universe : `DimensionUniverse`
             Universe graph containing all dimensions known to this `Registry`.
         schema_version : `VersionTuple` or `None`
-            Version of the schema that should be crteated, if `None` then
+            Version of the schema that should be created, if `None` then
             default schema should be used.
 
         Returns

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -39,6 +39,10 @@ if TYPE_CHECKING:
 
 # This has to be updated on every schema change
 _VERSION_UUID = VersionTuple(1, 0, 0)
+# Starting with 2.0.0 the `ingest_date` column type uses nanoseconds instead
+# of TIMESTAMP. The code supports both 1.0.0 and 2.0.0 for the duration of
+# client migration period.
+_VERSION_UUID_NS = VersionTuple(2, 0, 0)
 
 _LOG = logging.getLogger(__name__)
 
@@ -115,7 +119,9 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         registry_schema_version: VersionTuple | None = None,
     ) -> DatasetRecordStorageManager:
         # Docstring inherited from DatasetRecordStorageManager.
-        specs = cls.makeStaticTableSpecs(type(collections), universe=dimensions.universe)
+        specs = cls.makeStaticTableSpecs(
+            type(collections), universe=dimensions.universe, schema_version=registry_schema_version
+        )
         static: StaticDatasetTablesTuple = context.addTableTuple(specs)  # type: ignore
         summaries = CollectionSummaryManager.initialize(
             db,
@@ -135,11 +141,14 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
     @classmethod
     def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.
-        return [cls._version]
+        return cls._versions
 
     @classmethod
     def makeStaticTableSpecs(
-        cls, collections: type[CollectionManager], universe: DimensionUniverse
+        cls,
+        collections: type[CollectionManager],
+        universe: DimensionUniverse,
+        schema_version: VersionTuple | None,
     ) -> StaticDatasetTablesTuple:
         """Construct all static tables used by the classes in this package.
 
@@ -152,14 +161,23 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
             Manager object for the collections in this `Registry`.
         universe : `DimensionUniverse`
             Universe graph containing all dimensions known to this `Registry`.
+        schema_version : `VersionTuple` or `None`
+            Version of the schema that should be crteated, if `None` then
+            default schema should be used.
 
         Returns
         -------
         specs : `StaticDatasetTablesTuple`
             A named tuple containing `ddl.TableSpec` instances.
         """
+        schema_version = cls.clsNewSchemaVersion(schema_version)
+        assert schema_version is not None, "New schema version cannot be None"
         return makeStaticTableSpecs(
-            collections, universe=universe, dtype=cls.getIdColumnType(), autoincrement=cls._autoincrement
+            collections,
+            universe=universe,
+            dtype=cls.getIdColumnType(),
+            autoincrement=cls._autoincrement,
+            schema_version=schema_version,
         )
 
     @classmethod
@@ -466,7 +484,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         # Docstring inherited from DatasetRecordStorageManager.
         return self._summaries.get(collection)
 
-    _version: VersionTuple
+    _versions: list[VersionTuple]
     """Schema version for this class."""
 
     _recordStorageType: type[ByDimensionsDatasetRecordStorage]
@@ -484,7 +502,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(ByDimensionsDatasetRecordStora
     UUID for dataset primary key.
     """
 
-    _version: VersionTuple = _VERSION_UUID
+    _versions: list[VersionTuple] = [_VERSION_UUID, _VERSION_UUID_NS]
     _recordStorageType: type[ByDimensionsDatasetRecordStorage] = ByDimensionsDatasetRecordStorageUUID
     _autoincrement: bool = False
     _idColumnType: type = ddl.GUID
@@ -493,3 +511,11 @@ class ByDimensionsDatasetRecordStorageManagerUUID(ByDimensionsDatasetRecordStora
     def supportsIdGenerationMode(cls, mode: DatasetIdGenEnum) -> bool:
         # Docstring inherited from DatasetRecordStorageManager.
         return True
+
+    @classmethod
+    def _newDefaultSchemaVersion(cls) -> VersionTuple:
+        # Docstring inherited from VersionedExtension.
+
+        # By default return 1.0.0 so that older clients can still access new
+        # registries created with a default config.
+        return _VERSION_UUID

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -248,6 +248,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
                 calibs=calibs,
                 dataset_type_id=row["id"],
                 collections=self._collections,
+                use_astropy_ingest_date=self.ingest_date_dtype() is ddl.AstropyTimeNsecTai,
             )
             byName[datasetType.name] = storage
             byId[storage._dataset_type_id] = storage
@@ -337,6 +338,7 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
                 calibs=calibs,
                 dataset_type_id=row["id"],
                 collections=self._collections,
+                use_astropy_ingest_date=self.ingest_date_dtype() is ddl.AstropyTimeNsecTai,
             )
             self._byName[datasetType.name] = storage
             self._byId[storage._dataset_type_id] = storage
@@ -519,3 +521,11 @@ class ByDimensionsDatasetRecordStorageManagerUUID(ByDimensionsDatasetRecordStora
         # By default return 1.0.0 so that older clients can still access new
         # registries created with a default config.
         return _VERSION_UUID
+
+    def ingest_date_dtype(self) -> type:
+        """Return type of the ``ingest_date`` column."""
+        schema_version = self.newSchemaVersion()
+        if schema_version is not None and schema_version.major > 1:
+            return ddl.AstropyTimeNsecTai
+        else:
+            return sqlalchemy.TIMESTAMP

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -76,6 +76,7 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
         static: StaticDatasetTablesTuple,
         summaries: CollectionSummaryManager,
         tags: sqlalchemy.schema.Table,
+        use_astropy_ingest_date: bool,
         calibs: sqlalchemy.schema.Table | None,
     ):
         super().__init__(datasetType=datasetType)
@@ -87,9 +88,7 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
         self._tags = tags
         self._calibs = calibs
         self._runKeyColumn = collections.getRunForeignKeyName()
-        # The ingest_date column can be one of two different types.
-        column: sqlalchemy.schema.Column = self._static.dataset.columns["ingest_date"]
-        self._use_astropy = isinstance(column.type, ddl.AstropyTimeNsecTai)
+        self._use_astropy = use_astropy_ingest_date
 
     def delete(self, datasets: Iterable[DatasetRef]) -> None:
         # Docstring inherited from DatasetRecordStorage.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -26,8 +26,10 @@ __all__ = ("ByDimensionsDatasetRecordStorage",)
 
 import uuid
 from collections.abc import Iterable, Iterator, Sequence, Set
+from datetime import datetime
 from typing import TYPE_CHECKING
 
+import astropy.time
 import sqlalchemy
 from lsst.daf.relation import Relation, sql
 
@@ -85,6 +87,9 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
         self._tags = tags
         self._calibs = calibs
         self._runKeyColumn = collections.getRunForeignKeyName()
+        # The ingest_date column can be one of two different types.
+        column: sqlalchemy.schema.Column = self._static.dataset.columns["ingest_date"]
+        self._use_astropy = isinstance(column.type, ddl.AstropyTimeNsecTai)
 
     def delete(self, datasets: Iterable[DatasetRef]) -> None:
         # Docstring inherited from DatasetRecordStorage.
@@ -565,6 +570,17 @@ class ByDimensionsDatasetRecordStorageUUID(ByDimensionsDatasetRecordStorage):
     ) -> Iterator[DatasetRef]:
         # Docstring inherited from DatasetRecordStorage.
 
+        # Current timestamp, type depends on schema version. Use microsecond
+        # precision for astropy time to keep things consistent with
+        # TIMESTAMP(6) SQL type.
+        timestamp: datetime | astropy.time.Time
+        if self._use_astropy:
+            # Astropy `now()` precision should be the same as `utcnow()` which
+            # should mean microsecond.
+            timestamp = astropy.time.Time.now()
+        else:
+            timestamp = datetime.utcnow()
+
         # Iterate over data IDs, transforming a possibly-single-pass iterable
         # into a list.
         dataIdList = []
@@ -577,6 +593,7 @@ class ByDimensionsDatasetRecordStorageUUID(ByDimensionsDatasetRecordStorage):
                     "id": self.idMaker.makeDatasetId(run.name, self.datasetType, dataId, idMode),
                     "dataset_type_id": self._dataset_type_id,
                     self._runKeyColumn: run.key,
+                    "ingest_date": timestamp,
                 }
             )
 
@@ -616,6 +633,14 @@ class ByDimensionsDatasetRecordStorageUUID(ByDimensionsDatasetRecordStorage):
         reuseIds: bool = False,
     ) -> Iterator[DatasetRef]:
         # Docstring inherited from DatasetRecordStorage.
+
+        # Current timestamp, type depends on schema version.
+        if self._use_astropy:
+            # Astropy `now()` precision should be the same as `utcnow()` which
+            # should mean microsecond.
+            timestamp = sqlalchemy.sql.literal(astropy.time.Time.now(), type_=ddl.AstropyTimeNsecTai)
+        else:
+            timestamp = sqlalchemy.sql.literal(datetime.utcnow())
 
         # Iterate over data IDs, transforming a possibly-single-pass iterable
         # into a list.
@@ -665,6 +690,7 @@ class ByDimensionsDatasetRecordStorageUUID(ByDimensionsDatasetRecordStorage):
                         tmp_tags.columns.dataset_id.label("id"),
                         tmp_tags.columns.dataset_type_id,
                         tmp_tags.columns[collFkName].label(self._runKeyColumn),
+                        timestamp.label("ingest_date"),
                     ),
                 )
 

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -734,3 +734,8 @@ class DatasetRecordStorageManager(VersionedExtension):
             this collection.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def ingest_date_dtype(self) -> type:
+        """Return type of the ``ingest_date`` column."""
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_versioning.py
+++ b/python/lsst/daf/butler/registry/interfaces/_versioning.py
@@ -180,7 +180,7 @@ class VersionedExtension(ABC):
 
         Notes
         -----
-        Extension classes which support multiple schema versions need to
+        Extension classes that support multiple schema versions need to
         override `_newDefaultSchemaVersion` method.
         """
         return self.clsNewSchemaVersion(self._registry_schema_version)
@@ -206,7 +206,7 @@ class VersionedExtension(ABC):
         Notes
         -----
         Default implementation of this method can work in simple cases. If
-        the extension only supports single schema version than that versions is
+        the extension only supports single schema version than that version is
         returned. If the extension supports multiple schema versions and
         ``schema_version`` is not `None` then ``schema_version`` is returned.
         If the extension supports multiple schema versions, but

--- a/python/lsst/daf/butler/registry/interfaces/_versioning.py
+++ b/python/lsst/daf/butler/registry/interfaces/_versioning.py
@@ -180,19 +180,63 @@ class VersionedExtension(ABC):
 
         Notes
         -----
-        Default implementation only forks for extensions that support single
-        schema version and it returns version obtained from `currentVersions`.
-        If `currentVersions` returns multiple version then default
-        implementation will raise an exception and the method has to be
-        reimplemented by a subclass.
+        Extension classes which support multiple schema versions need to
+        override `_newDefaultSchemaVersion` method.
         """
-        my_versions = self.currentVersions()
+        return self.clsNewSchemaVersion(self._registry_schema_version)
+
+    @classmethod
+    def clsNewSchemaVersion(cls, schema_version: VersionTuple | None) -> VersionTuple | None:
+        """Class method which returns schema version to use for newly created
+        registry database.
+
+        Parameters
+        ----------
+        schema_version : `VersionTuple` or `None`
+            Configured schema version or `None` if default schema version
+            should be created. If not `None` then it is guaranteed to be
+            compatible with `currentVersions`.
+
+        Returns
+        -------
+        version : `VersionTuple` or `None`
+            Schema version created by this extension. `None` is returned if an
+            extension does not require its version to be saved or checked.
+
+        Notes
+        -----
+        Default implementation of this method can work in simple cases. If
+        the extension only supports single schema version than that versions is
+        returned. If the extension supports multiple schema versions and
+        ``schema_version`` is not `None` then ``schema_version`` is returned.
+        If the extension supports multiple schema versions, but
+        ``schema_version`` is `None` it calls ``_newDefaultSchemaVersion``
+        method which needs to be reimplemented in a subsclass.
+        """
+        my_versions = cls.currentVersions()
         if not my_versions:
             return None
         elif len(my_versions) == 1:
             return my_versions[0]
+        else:
+            if schema_version is not None:
+                assert schema_version in my_versions, "Schema version must be compatible."
+                return schema_version
+            else:
+                return cls._newDefaultSchemaVersion()
+
+    @classmethod
+    def _newDefaultSchemaVersion(cls) -> VersionTuple:
+        """Return default shema version for new registry for extensions that
+        support multiple schema versions.
+
+        Notes
+        -----
+        Default implementation simply raises an exception. Managers which
+        support multiple schema versions must re-implement this method.
+        """
         raise NotImplementedError(
-            f"Extension {self.extensionName()} supports multiple schema versions, "
+            f"Extension {cls.extensionName()} supports multiple schema versions, "
             "its newSchemaVersion() method needs to be re-implemented."
         )
 

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -375,16 +375,6 @@ class RegistryManagerInstances(
         """
         dummy_table = ddl.TableSpec(fields=())
         kwargs: dict[str, Any] = {}
-        kwargs["column_types"] = ColumnTypeInfo(
-            database.getTimespanRepresentation(),
-            universe,
-            dataset_id_spec=types.datasets.addDatasetForeignKey(
-                dummy_table,
-                primaryKey=False,
-                nullable=False,
-            ),
-            run_key_spec=types.collections.addRunForeignKey(dummy_table, primaryKey=False, nullable=False),
-        )
         schema_versions = types.schema_versions
         kwargs["attributes"] = types.attributes.initialize(
             database, context, registry_schema_version=schema_versions.get("attributes")
@@ -398,13 +388,14 @@ class RegistryManagerInstances(
             dimensions=kwargs["dimensions"],
             registry_schema_version=schema_versions.get("collections"),
         )
-        kwargs["datasets"] = types.datasets.initialize(
+        datasets = types.datasets.initialize(
             database,
             context,
             collections=kwargs["collections"],
             dimensions=kwargs["dimensions"],
             registry_schema_version=schema_versions.get("datasets"),
         )
+        kwargs["datasets"] = datasets
         kwargs["opaque"] = types.opaque.initialize(
             database, context, registry_schema_version=schema_versions.get("opaque")
         )
@@ -428,6 +419,17 @@ class RegistryManagerInstances(
             )
         else:
             kwargs["obscore"] = None
+        kwargs["column_types"] = ColumnTypeInfo(
+            database.getTimespanRepresentation(),
+            universe,
+            dataset_id_spec=types.datasets.addDatasetForeignKey(
+                dummy_table,
+                primaryKey=False,
+                nullable=False,
+            ),
+            run_key_spec=types.collections.addRunForeignKey(dummy_table, primaryKey=False, nullable=False),
+            ingest_date_dtype=datasets.ingest_date_dtype(),
+        )
         return cls(**kwargs)
 
     def as_dict(self) -> Mapping[str, VersionedExtension]:

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -32,6 +32,7 @@ from lsst.sphgeom import IntersectionRegion, Region
 from lsst.utils.classes import cached_getter, immutable
 
 from ...core import (
+    ColumnTypeInfo,
     DataCoordinate,
     DatasetType,
     DimensionElement,
@@ -65,6 +66,7 @@ class QueryWhereClause:
         dimensions: DimensionGraph,
         expression: str = "",
         *,
+        column_types: ColumnTypeInfo,
         bind: Mapping[str, Any] | None = None,
         data_id: DataCoordinate | None = None,
         region: Region | None = None,
@@ -81,6 +83,8 @@ class QueryWhereClause:
             of the WHERE clause.
         expression : `str`, optional
             A user-provided string expression.
+        column_types : `ColumnTypeInfo`
+            Information about column types.
         bind : `Mapping` [ `str`, `object` ], optional
             Mapping containing literal values that should be injected into the
             query expression, keyed by the identifiers they replace.
@@ -112,6 +116,7 @@ class QueryWhereClause:
         expression_predicate, governor_constraints = make_string_expression_predicate(
             expression,
             dimensions,
+            column_types=column_types,
             bind=bind,
             data_id=data_id,
             defaults=defaults,
@@ -324,6 +329,8 @@ class QuerySummary:
     requested : `DimensionGraph`
         The dimensions whose primary keys should be included in the result rows
         of the query.
+    column_types : `ColumnTypeInfo`
+        Information about column types.
     data_id : `DataCoordinate`, optional
         A fully-expanded data ID identifying dimensions known in advance.  If
         not provided, will be set to an empty data ID.
@@ -359,6 +366,7 @@ class QuerySummary:
         self,
         requested: DimensionGraph,
         *,
+        column_types: ColumnTypeInfo,
         data_id: DataCoordinate | None = None,
         expression: str = "",
         region: Region | None = None,
@@ -378,6 +386,7 @@ class QuerySummary:
         self.where = QueryWhereClause.combine(
             self.requested,
             expression=expression,
+            column_types=column_types,
             bind=bind,
             data_id=data_id,
             region=region,

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -89,10 +89,10 @@ class RegistryTests(ABC):
     (`str`).
     """
 
-    datasetsManager: Optional[str] = None
-    """Name of the datasets manager class, if subclass provides value for
-    this member then it overrides name specified in default configuration
-    (`str`).
+    datasetsManager: Optional[str | dict[str, str]] = None
+    """Name or configuration dictionary of the datasets manager class, if
+    subclass provides value for this member then it overrides name specified
+    in default configuration (`str` or `dict`).
     """
 
     @classmethod
@@ -515,8 +515,12 @@ class RegistryTests(ABC):
 
     def testImportDatasetsUUID(self):
         """Test for `Registry._importDatasets` with UUID dataset ID."""
-        if not self.datasetsManager.endswith(".ByDimensionsDatasetRecordStorageManagerUUID"):
-            self.skipTest(f"Unexpected dataset manager {self.datasetsManager}")
+        if isinstance(self.datasetsManager, str):
+            if not self.datasetsManager.endswith(".ByDimensionsDatasetRecordStorageManagerUUID"):
+                self.skipTest(f"Unexpected dataset manager {self.datasetsManager}")
+        elif isinstance(self.datasetsManager, dict):
+            if not self.datasetsManager["cls"].endswith(".ByDimensionsDatasetRecordStorageManagerUUID"):
+                self.skipTest(f"Unexpected dataset manager {self.datasetsManager['cls']}")
 
         registry = self.makeRegistry()
         self.loadData(registry, "base.yaml")

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -287,5 +287,20 @@ class SqliteMemoryRegistrySynthIntKeyCollMgrUUIDTestCase(unittest.TestCase, Sqli
     )
 
 
+class SqliteMemoryRegistryAstropyIngestDateTestCase(unittest.TestCase, SqliteMemoryRegistryTests):
+    """Tests for `Registry` backed by a SQLite in-memory database.
+
+    This test case uses version schema with ingest_date as nanoseconds instead
+    of DATETIME. This tests can be removed when/if we switch to nanoseconds as
+    default.
+    """
+
+    collectionsManager = "lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager"
+    datasetsManager = {
+        "cls": "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
+        "schema_version": "2.0.0",
+    }
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -79,15 +79,9 @@ class Manager2(VersionedExtension):
     def currentVersions(cls) -> list[VersionTuple]:
         return [V_1_0_0, V_2_0_0]
 
-    def newSchemaVersion(self) -> VersionTuple | None:
-        if self._registry_schema_version is None:
-            return V_1_0_0
-        elif self._registry_schema_version.major == 1:
-            return V_1_0_0
-        elif self._registry_schema_version.major == 2:
-            return V_2_0_0
-        else:
-            raise ValueError(f"Unexpected registry_schema_version: {self._registry_schema_version}")
+    @classmethod
+    def _newDefaultSchemaVersion(cls) -> VersionTuple:
+        return V_1_0_0
 
 
 class SchemaVersioningTestCase(unittest.TestCase):
@@ -191,7 +185,7 @@ class SchemaVersioningTestCase(unittest.TestCase):
             Manager2.checkCompatibility(result2, database.isWriteable())
 
             # Make manager instances using versions from registry.
-            manager0 = Manager1(registry_schema_version=versions.get("manager0"))
+            manager0 = Manager0(registry_schema_version=versions.get("manager0"))
             manager1 = Manager1(registry_schema_version=versions.get("manager1"))
             manager2 = Manager2(registry_schema_version=versions.get("manager2"))
             self.assertIsNone(manager0._registry_schema_version)


### PR DESCRIPTION
Schema version management in daf_butler is extended to support multiple versions per manager type.
Datasets manager class now supports both `TIMESTAMP` and nanosecond integer (for `astropy.time.Time`) as `ingest_date` column type.
Default `ingest_date` for new registries is still `TIMESTAMP`, it can be changed by specifying `schema_version` in `butler.yaml` for datasets manager.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
