### PR TITLE
DM-38552: (hotfix) Stop relying on current working directory in repr test

### DIFF
--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1821,11 +1821,10 @@ class DatasetRefURIsTestCase(unittest.TestCase):
 
     def testRepr(self):
         """Verify __repr__ output."""
-        uris = DatasetRefURIs(ResourcePath("1/2/3"), {"comp": ResourcePath("a/b/c")})
+        uris = DatasetRefURIs(ResourcePath("/1/2/3"), {"comp": ResourcePath("/a/b/c")})
         self.assertEqual(
             repr(uris),
-            f'DatasetRefURIs(ResourcePath("file://{os.getcwd()}/1/2/3"), '
-            f"{{'comp': ResourcePath(\"file://{os.getcwd()}/a/b/c\")}})",
+            'DatasetRefURIs(ResourcePath("file:///1/2/3"), {\'comp\': ResourcePath("file:///a/b/c")})',
         )
 
 


### PR DESCRIPTION
The file URIs could urlencode some components of the path.

The test is not a good test. `repr()` tests rarely are.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
