### PR TITLE
DM-38642: Add support for multi-index dataframes with DataFrameDelegate/InMemoryDatastore

### DIFF
--- a/doc/changes/DM-38642.feature.md
+++ b/doc/changes/DM-38642.feature.md
@@ -1,0 +1,1 @@
+Add support for multi-index dataframes with DataFrameDelegate and InMemoryDatastore.

--- a/python/lsst/daf/butler/delegates/dataframe.py
+++ b/python/lsst/daf/butler/delegates/dataframe.py
@@ -59,7 +59,10 @@ class DataFrameDelegate(StorageClassDelegate):
             The component can not be found.
         """
         if componentName == "columns":
-            return pandas.Index(self._getAllColumns(composite))
+            if isinstance(composite.columns, pandas.MultiIndex):
+                return composite.columns
+            else:
+                return pandas.Index(self._getAllColumns(composite))
         elif componentName == "rowcount":
             return len(composite)
         elif componentName == "schema":

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -617,28 +617,6 @@ class InMemoryDataFrameDelegateTestCase(ParquetFormatterDataFrameTestCase):
 
     configFile = os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml")
 
-    def testMultiIndexDataFrame(self):
-        df1 = _makeMultiIndexDataFrame()
-
-        delegate = DataFrameDelegate("DataFrame")
-
-        # Read the whole DataFrame.
-        df2 = delegate.handleParameters(inMemoryDataset=df1)
-        self.assertTrue(df1.equals(df2))
-        # Read just the column descriptions.
-        columns2 = delegate.getComponent(composite=df1, componentName="columns")
-        self.assertTrue(df1.columns.equals(columns2))
-
-        # Read just some columns a few different ways.
-        with self.assertRaises(NotImplementedError) as cm:
-            delegate.handleParameters(inMemoryDataset=df1, parameters={"columns": {"filter": "g"}})
-        self.assertIn("only supports string column names", str(cm.exception))
-        with self.assertRaises(NotImplementedError) as cm:
-            delegate.handleParameters(
-                inMemoryDataset=df1, parameters={"columns": {"filter": ["r"], "column": "a"}}
-            )
-        self.assertIn("only supports string column names", str(cm.exception))
-
     def testWriteMultiIndexDataFrameReadAsAstropyTable(self):
         df1 = _makeMultiIndexDataFrame()
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -317,6 +317,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         # Read just the column descriptions.
         columns2 = self.butler.get(self.datasetType.componentTypeName("columns"), dataId={})
         self.assertTrue(df1.columns.equals(columns2))
+        self.assertEqual(columns2.names, df1.columns.names)
         # Read the rowcount.
         rowcount = self.butler.get(self.datasetType.componentTypeName("rowcount"), dataId={})
         self.assertEqual(rowcount, len(df1))
@@ -333,6 +334,9 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         column_list = [("g", "a"), ("r", "c")]
         df5 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": column_list})
         self.assertTrue(df1.loc[:, column_list].equals(df5))
+        column_dict = {"filter": "r", "column": ["a", "b"]}
+        df6 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": column_dict})
+        self.assertTrue(df1.loc[:, [("r", "a"), ("r", "b")]].equals(df6))
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d"]})


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
