### PR TITLE
DM-38694: Add StorageClassDelegate.copy() method

### DIFF
--- a/doc/changes/DM-38694.api.rst
+++ b/doc/changes/DM-38694.api.rst
@@ -1,0 +1,2 @@
+Added ``StorageClassDelegate.copy()`` method.
+By default this method calls `copy.deepcopy()` but subclasses can override as needed.

--- a/python/lsst/daf/butler/core/storageClassDelegate.py
+++ b/python/lsst/daf/butler/core/storageClassDelegate.py
@@ -26,9 +26,12 @@ from __future__ import annotations
 __all__ = ("DatasetComponent", "StorageClassDelegate")
 
 import collections.abc
+import copy
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional, Set, Tuple, Type
+
+from lsst.utils.introspection import get_full_type_name
 
 if TYPE_CHECKING:
     from .storageClass import StorageClass
@@ -396,3 +399,38 @@ class StorageClassDelegate:
             from the supplied options.
         """
         raise NotImplementedError("This delegate does not support derived components")
+
+    def copy(self, inMemoryDataset: Any) -> Any:
+        """Copy the supplied python type and return the copy.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to copy.
+
+        Returns
+        -------
+        copied : `object`
+            A copy of the supplied object. Can be the same object if the
+            object is known to be read-only.
+
+        Raises
+        ------
+        NotImplementedError
+            Raised if none of the default methods for copying work.
+
+        Notes
+        -----
+        The default implementation uses `copy.deepcopy()`.
+        It is generally expected that this method is the equivalent of a deep
+        copy. Subclasses can override this method if they already know the
+        optimal approach for deep copying.
+        """
+
+        try:
+            return copy.deepcopy(inMemoryDataset)
+        except Exception as e:
+            raise NotImplementedError(
+                f"Unable to deep copy the supplied python type ({get_full_type_name(inMemoryDataset)}) "
+                f"using default methods ({e})"
+            )

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -52,6 +52,11 @@ class PythonType3:
     pass
 
 
+class NotCopyable:
+    def __deepcopy__(self, memo=None):
+        raise RuntimeError("Can not be copied.")
+
+
 class StorageClassFactoryTestCase(unittest.TestCase):
     """Tests of the storage class infrastructure."""
 
@@ -91,6 +96,16 @@ class StorageClassFactoryTestCase(unittest.TestCase):
 
         # Ensure that we have a delegate
         self.assertIsInstance(scc.delegate(), StorageClassDelegate)
+
+        # Check that delegate copy() works.
+        list1 = [1, 2, 3]
+        list2 = scc.delegate().copy(list1)
+        self.assertEqual(list1, list2)
+        list2.append(4)
+        self.assertNotEqual(list1, list2)
+
+        with self.assertRaises(NotImplementedError):
+            scc.delegate().copy(NotCopyable())
 
         # Check we can create a storageClass using the name of an importable
         # type.


### PR DESCRIPTION
This allows for a future where in-memory datastore can decide whether to do copying when returning an object.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
