### PR TITLE
DM-38814: Small fix for Butler.makeRepo method

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -469,11 +469,14 @@ class Butler(LimitedButler):
             configURI = root_uri
         # Strip obscore configuration, if it is present, before writing config
         # to a file, obscore config will be stored in registry.
-        config_to_write = config
         if (obscore_config_key := ("registry", "managers", "obscore", "config")) in config:
             config_to_write = config.copy()
             del config_to_write[obscore_config_key]
-        config_to_write.dumpToUri(configURI, overwrite=overwrite)
+            config_to_write.dumpToUri(configURI, overwrite=overwrite)
+            # configFile attribute is updated, need to copy it to original.
+            config.configFile = config_to_write.configFile
+        else:
+            config.dumpToUri(configURI, overwrite=overwrite)
 
         # Create Registry and populate tables
         registryConfig = RegistryConfig(config.get("registry"))

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 __all__ = ["PostgresqlDatabase"]
 
 from contextlib import closing, contextmanager
-from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, Tuple, Type, Union
 
 import psycopg2
 import sqlalchemy
@@ -428,7 +428,7 @@ class _RangeTimespanRepresentation(TimespanDatabaseRepresentation):
                 sqlalchemy.sql.func.upper(self.column) <= other,
             )
         else:
-            return cast(sqlalchemy.sql.ColumnElement, self.column << other.column)
+            return self.column << other.column
 
     def __gt__(
         self, other: Union[_RangeTimespanRepresentation, sqlalchemy.sql.ColumnElement]
@@ -441,7 +441,7 @@ class _RangeTimespanRepresentation(TimespanDatabaseRepresentation):
                 sqlalchemy.sql.func.lower(self.column) > other,
             )
         else:
-            return cast(sqlalchemy.sql.ColumnElement, self.column >> other.column)
+            return self.column >> other.column
 
     def overlaps(
         self, other: _RangeTimespanRepresentation | sqlalchemy.sql.ColumnElement


### PR DESCRIPTION
In case when we need to drop obscore config key from registry before writing out butler.yaml file, we make a copy of the config, modify it and write that copy. Writing it out modifies its `configFile` attribute and we need to propagate its new value back to the original config. I have added new unit test to `pipe_base` that uses obscore and found that it needs this change.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
