### PR TITLE
DM-38839: Change default verbosity for query-dataset-types command line 

### DIFF
--- a/doc/changes/DM-38839.misc.rst
+++ b/doc/changes/DM-38839.misc.rst
@@ -1,0 +1,2 @@
+Changed the default behavior for ``butler query-dataset-types`` to report the full details of the registered dataset types.
+Previously only the dataset type names were reported.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -443,7 +443,7 @@ def query_collections(*args: Any, **kwargs: Any) -> None:
     help="GLOB is one or more glob-style expressions that fully or partially identify the "
     "dataset types to return."
 )
-@verbose_option(help="Include dataset type name, dimensions, and storage class in output.")
+@verbose_option(help="Include dataset type name, dimensions, and storage class in output.", default=True)
 @components_option()
 @options_file_option()
 def query_dataset_types(*args: Any, **kwargs: Any) -> None:

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -278,7 +278,7 @@ transfer_dimensions_option = MWOptionDecorator(
 )
 
 
-verbose_option = MWOptionDecorator("-v", "--verbose", help="Increase verbosity.", is_flag=True)
+verbose_option = MWOptionDecorator("-v", "--verbose/--no-verbose", help="Increase verbosity.", is_flag=True)
 
 
 where_option = MWOptionDecorator(

--- a/tests/test_cliCmdQueryDatasetTypes.py
+++ b/tests/test_cliCmdQueryDatasetTypes.py
@@ -54,7 +54,7 @@ class QueryDatasetTypesCmdTest(CliCmdTestBase, unittest.TestCase):
 
     def test_minimal(self):
         """Test only required parameters."""
-        self.run_test(["query-dataset-types", "here"], self.makeExpected(repo="here"))
+        self.run_test(["query-dataset-types", "here"], self.makeExpected(repo="here", verbose=True))
 
     def test_requiredMissing(self):
         """Test that if the required parameter is missing it fails"""
@@ -123,11 +123,11 @@ class QueryDatasetTypesScriptTest(ButlerTestHelper, unittest.TestCase):
             )
             self.assertNotEqual(result.exit_code, 0, clickResultMsg(result))
             # check not-verbose output:
-            result = runner.invoke(cli, ["query-dataset-types", "here"])
+            result = runner.invoke(cli, ["query-dataset-types", "here", "--no-verbose"])
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
             self.assertAstropyTablesEqual(readTable(result.output), expectedNotVerbose)
             # check glob output:
-            result = runner.invoke(cli, ["query-dataset-types", "here", "t*"])
+            result = runner.invoke(cli, ["query-dataset-types", "here", "--no-verbose", "t*"])
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
             self.assertAstropyTablesEqual(readTable(result.output), expectedNotVerbose)
             # check verbose output:
@@ -244,7 +244,7 @@ class QueryDatasetTypesScriptTest(ButlerTestHelper, unittest.TestCase):
             self.assertDatasetTypes(runner, "*", ("placeholder",))
 
     def assertDatasetTypes(self, runner: LogCliRunner, query: str, expected: tuple[str, ...]) -> None:
-        result = runner.invoke(cli, ["query-dataset-types", "here", query])
+        result = runner.invoke(cli, ["query-dataset-types", "here", "--no-verbose", query])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
         expected = AstropyTable(
             (expected,),


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
