### PR TITLE
DM-38845: Fix row group computation crash if a list in a DataFrame is serialized to parquet.

### DIFF
--- a/doc/changes/DM-38845.bugfix.md
+++ b/doc/changes/DM-38845.bugfix.md
@@ -1,0 +1,1 @@
+Add check for ListType when pandas converts a list object into parquet.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1311,9 +1311,19 @@ def compute_row_group_size(schema: pa.Schema, target_size: int = TARGET_ROW_GROU
             # Assuming UTF-8 encoding, and very few wide characters.
             t_width = 8 * strlen
         elif isinstance(t, pa.FixedSizeListType):
-            t_width = t.list_size * t.value_type.bit_width
+            if t.value_type == pa.null():
+                t_width = 0
+            else:
+                t_width = t.list_size * t.value_type.bit_width
         elif t == pa.null():
             t_width = 0
+        elif isinstance(t, pa.ListType):
+            if t.value_type == pa.null():
+                t_width = 0
+            else:
+                # This is a variable length list, just choose
+                # something arbitrary.
+                t_width = 10 * t.value_type.bit_width
         else:
             t_width = t.bit_width
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1754,6 +1754,14 @@ class ComputeRowGroupSizeTestCase(unittest.TestCase):
 
         self.assertGreater(row_group_size, 1_000_000)
 
+    @unittest.skipUnless(pd is not None, "Cannot run testRowGroupSizeDataFrameWithLists without pandas.")
+    def testRowGroupSizeDataFrameWithLists(self):
+        df = pd.DataFrame({"a": np.zeros(10), "b": [[0, 0]] * 10, "c": [[0.0, 0.0]] * 10, "d": [[]] * 10})
+        arrowTable = pandas_to_arrow(df)
+        row_group_size = compute_row_group_size(arrowTable.schema)
+
+        self.assertGreater(row_group_size, 1_000_000)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
