### PR TITLE
DM-38870: Change how file datastore transfer_from handles absolute URIs

### DIFF
--- a/doc/DM-38870.misc.rst
+++ b/doc/DM-38870.misc.rst
@@ -1,0 +1,3 @@
+The behavior of ``FileDatastore.transfer_from()`` has been clarified regarding what to do when an absolute URI (from a direct ingest) is found in the source butler.
+If ``transfer="auto"`` (the default) the absolute URI will be stored in the target butler.
+If any other transfer mode is used the absolute URI will be copied/linked into the target butler.

--- a/doc/lsst.daf.butler/datastores.rst
+++ b/doc/lsst.daf.butler/datastores.rst
@@ -78,6 +78,16 @@ The order is:
    For example ``instrument+physical_filter+visit`` would match any `DatasetType` that uses those three dimensions.
 #. The final match is against the `StorageClass` name.
 
+Datastore to Datastore Transfers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When `~lsst.daf.butler.Butler.transfer_from()` is called between two `FileDatastore` datastores, there is an optimized code path that makes it far more efficient than doing a butler export followed by an import or ingest.
+
+If the source datastore uses absolute URIs for some datasets, whether those datasets are copied/linked into the target datastore or left as direct URIs depends on the value of the ``transfer`` parameter.
+If the default transfer mode of ``"auto"`` is used the direct URI will be stored in the target identically to that used in the source datastore.
+This can be useful if you are doing a local transfer and know that the original location will always be available.
+Any other transfer mode, such as ``"copy"`` will be result in the target datastore taking ownership of the file.
+
 .. _daf_butler-datastores-memory:
 
 In-Memory Datastore

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -750,12 +750,12 @@ class TimespanDatabaseRepresentation(ABC):
 
     @classmethod
     @abstractmethod
-    def extract(cls, mapping: Mapping[str, Any], name: Optional[str] = None) -> Timespan | None:
+    def extract(cls, mapping: Mapping[Any, Any], name: Optional[str] = None) -> Timespan | None:
         """Extract a timespan from a dictionary that represents a database row.
 
         Parameters
         ----------
-        mapping : `Mapping` [ `str`, `Any` ]
+        mapping : `Mapping` [ `Any`, `Any` ]
             A dictionary representing a database row containing a `Timespan`
             in this representation.  Should have key(s) equal to the return
             value of `getFieldNames`.

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -237,7 +237,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Run query, transform results into a list of dicts that we can later
         # use to delete.
         with self._db.query(info_in_trash) as sql_result:
-            rows = [dict(**row, datastore_name=self.datastoreName) for row in sql_result.mappings()]
+            rows = [dict(row, datastore_name=self.datastoreName) for row in sql_result.mappings()]
 
         # It is possible for trashed refs to be linked to artifacts that
         # are still associated with refs that are not to be trashed. We

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -68,7 +68,7 @@ class OpaqueTableStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def fetch(self, **where: Any) -> Iterator[Mapping[str, Any]]:
+    def fetch(self, **where: Any) -> Iterator[Mapping[Any, Any]]:
         """Retrieve records from an opaque table.
 
         Parameters

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -27,7 +27,7 @@ opaque tables for `Registry`.
 __all__ = ["ByNameOpaqueTableStorage", "ByNameOpaqueTableStorageManager"]
 
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, Iterator, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, Iterator, List, Optional
 
 import sqlalchemy
 
@@ -77,7 +77,7 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         # the database itself providing any rollback functionality.
         self._db.insert(self._table, *data)
 
-    def fetch(self, **where: Any) -> Iterator[Mapping[str, Any]]:
+    def fetch(self, **where: Any) -> Iterator[sqlalchemy.RowMapping]:
         # Docstring inherited from OpaqueTableStorage.
 
         def _batch_in_clause(

--- a/python/lsst/daf/butler/registry/queries/_sql_query_context.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_context.py
@@ -504,7 +504,7 @@ class _SqlRowTransformer:
 
     __slots__ = ("_scalar_columns", "_timespan_columns", "_has_no_columns")
 
-    def sql_to_relation(self, sql_row: Mapping[str, Any]) -> dict[ColumnTag, Any]:
+    def sql_to_relation(self, sql_row: sqlalchemy.RowMapping) -> dict[ColumnTag, Any]:
         """Convert a result row from a SQLAlchemy result into the form expected
         by `lsst.daf.relation.iteration`.
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1786,15 +1786,17 @@ class PosixDatastoreTransfers(unittest.TestCase):
         config["registry", "managers", "datasets"] = manager
         return Butler(Butler.makeRepo(f"{self.root}/butler{label}", config=config), writeable=True)
 
-    def create_butlers(self, manager1, manager2):
+    def create_butlers(self, manager1=None, manager2=None):
+        default = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID"
+        if manager1 is None:
+            manager1 = default
+        if manager2 is None:
+            manager2 = default
         self.source_butler = self.create_butler(manager1, "1")
         self.target_butler = self.create_butler(manager2, "2")
 
     def testTransferUuidToUuid(self):
-        self.create_butlers(
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-        )
+        self.create_butlers()
         # Setting id_gen_map should have no effect here
         self.assertButlerTransfers(id_gen_map={"random_data_2": DatasetIdGenEnum.DATAID_TYPE})
 
@@ -1811,10 +1813,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
 
         This is how execution butler works.
         """
-        self.create_butlers(
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-        )
+        self.create_butlers()
 
         # Configure the source butler to allow trust.
         self._enable_trust(self.source_butler.datastore)
@@ -1826,10 +1825,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
 
         This is how execution butler works.
         """
-        self.create_butlers(
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-            "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID",
-        )
+        self.create_butlers()
 
         # Configure the source butler to allow trust.
         self._enable_trust(self.source_butler.datastore)


### PR DESCRIPTION
Previously the code stored the absolute URI in the target datastore. Now it only does that in "auto" transfer mode. In other modes it will copy/link etc.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
