### PR TITLE
DM-38954: Fix duplicate join terms in spatial queries involving common skypix.

### DIFF
--- a/doc/changes/DM-38954.bugfix.md
+++ b/doc/changes/DM-38954.bugfix.md
@@ -1,0 +1,1 @@
+Fix a SQL generation bug for queries that involve the common skypix dimension and at least two other spatial dimensions.

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -815,6 +815,7 @@ class DimensionRecordStorageManager(VersionedExtension):
         element2: str,
         context: queries.SqlQueryContext,
         governor_constraints: Mapping[str, Set[str]],
+        existing_relationships: Set[frozenset[str]] = frozenset(),
     ) -> tuple[Relation, bool]:
         """Create a relation that represents the spatial join between two
         dimension elements.
@@ -832,6 +833,13 @@ class DimensionRecordStorageManager(VersionedExtension):
                 optional
             Constraints imposed by other aspects of the query on governor
             dimensions.
+        existing_relationships : `~collections.abc.Set` [ `frozenset` [ `str` \
+                ] ], optional
+            Relationships between dimensions that are already present in the
+            relation the result will be joined to.  Spatial join relations
+            that duplicate these relationships will not be included in the
+            result, which may cause an identity relation to be returned if
+            a spatial relationship has already been established.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -701,7 +701,7 @@ class QueryBackend(Generic[_C]):
         just dimension relations themselves, but anything created from queries
         based on them, including datasets and query results.  It is possible to
         construct `LeafRelation` objects that don't satisfy this criteria (e.g.
-        when accepting in user-provided data IDs(, and in this case
+        when accepting in user-provided data IDs), and in this case
         higher-level guards or warnings must be provided.``
         """
         return {

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -3230,6 +3230,17 @@ class RegistryTests(ABC):
             },
             overlapping_patches,
         )
+        # Test that a three-way join that includes the common skypix system in
+        # the dimensions doesn't generate redundant join terms in the query.
+        full_data_ids = set(
+            registry.queryDataIds(
+                ["tract", "visit", "htm7"], skymap="hsc_rings_v1", instrument="HSC"
+            ).expanded()
+        )
+        self.assertGreater(len(full_data_ids), 0)
+        for data_id in full_data_ids:
+            self.assertFalse(data_id.records["tract"].region.isDisjointFrom(data_id.records["htm7"].region))
+            self.assertFalse(data_id.records["visit"].region.isDisjointFrom(data_id.records["htm7"].region))
 
     def test_spatial_constraint_queries(self) -> None:
         """Test queries in which one spatial dimension in the constraint (data


### PR DESCRIPTION
## Checklist

- [x] ran [Jenkins](https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/38616/pipeline)
- [x] added a release note for user-visible changes to `doc/changes`
