### PR TITLE
DM-38915: Fix handling of empty collection lists

### DIFF
--- a/doc/changes/DM-38915.bugfix.md
+++ b/doc/changes/DM-38915.bugfix.md
@@ -1,0 +1,2 @@
+Few registry methods treated empty collection list in the same way as `None`, meaning that Registry-default run collection was used.
+This has been fixed now to mean that queries always return empty result set, with explicit "doomed by" messages.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -44,7 +44,7 @@ Arguments that specify one or more collections are similar to those for dataset 
  - `str` values (the full collection name);
  - `str` values using glob wildcard syntax which will be converted to `re.Pattern`;
  - `re.Pattern` values (matched to the collection name, via `~re.Pattern.fullmatch`);
- - iterables of any of the above;
+ - iterables of any of the above, empty collection cannot match anything, methods always return an empty result set in this case;
  - the special value "``...``", which matches all collections;
 
 Collection expressions are processed by the `~registry.wildcards.CollectionWildcard` class.

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -25,6 +25,7 @@ __all__ = ("Registry",)
 
 import contextlib
 import logging
+import re
 from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
@@ -44,6 +45,7 @@ from typing import (
 
 from lsst.resources import ResourcePathExpression
 from lsst.utils import doImportType
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
 
 from ..core import (
     Config,
@@ -70,12 +72,16 @@ from ._collectionType import CollectionType
 from ._config import RegistryConfig
 from ._defaults import RegistryDefaults
 from .queries import DataCoordinateQueryResults, DatasetQueryResults, DimensionRecordQueryResults
+from .wildcards import CollectionWildcard
 
 if TYPE_CHECKING:
     from .._butlerConfig import ButlerConfig
     from .interfaces import CollectionRecord, DatastoreRegistryBridgeManager, ObsCoreTableManager
 
 _LOG = logging.getLogger(__name__)
+
+# TYpe alias for `collections` arguments.
+CollectionArgType = str | re.Pattern | Iterable[str | re.Pattern] | EllipsisType | CollectionWildcard
 
 
 class Registry(ABC):
@@ -674,7 +680,7 @@ class Registry(ABC):
         datasetType: Union[DatasetType, str],
         dataId: Optional[DataId] = None,
         *,
-        collections: Any = None,
+        collections: CollectionArgType | None = None,
         timespan: Optional[Timespan] = None,
         **kwargs: Any,
     ) -> Optional[DatasetRef]:
@@ -1316,7 +1322,7 @@ class Registry(ABC):
         self,
         datasetType: Any,
         *,
-        collections: Any = None,
+        collections: CollectionArgType | None = None,
         dimensions: Optional[Iterable[Union[Dimension, str]]] = None,
         dataId: Optional[DataId] = None,
         where: str = "",
@@ -1437,7 +1443,7 @@ class Registry(ABC):
         *,
         dataId: Optional[DataId] = None,
         datasets: Any = None,
-        collections: Any = None,
+        collections: CollectionArgType | None = None,
         where: str = "",
         components: Optional[bool] = None,
         bind: Optional[Mapping[str, Any]] = None,
@@ -1543,7 +1549,7 @@ class Registry(ABC):
         *,
         dataId: Optional[DataId] = None,
         datasets: Any = None,
-        collections: Any = None,
+        collections: CollectionArgType | None = None,
         where: str = "",
         components: Optional[bool] = None,
         bind: Optional[Mapping[str, Any]] = None,
@@ -1624,7 +1630,7 @@ class Registry(ABC):
     def queryDatasetAssociations(
         self,
         datasetType: Union[str, DatasetType],
-        collections: Any = ...,
+        collections: CollectionArgType | None = Ellipsis,
         *,
         collectionTypes: Iterable[CollectionType] = CollectionType.all(),
         flattenChains: bool = False,

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -490,6 +490,11 @@ class CollectionWildcard:
             )
         return self.strings
 
+    def empty(self) -> bool:
+        """Return true if both ``strings`` and ``patterns`` are empty."""
+        # bool(Ellipsis) is True
+        return not self.strings and not self.patterns
+
     def __str__(self) -> str:
         if self.patterns is Ellipsis:
             return "..."

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from astropy.table import Table as AstropyTable
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
 
 from .._butler import Butler, DataCoordinate
 from ..cli.utils import sortAstropyTable
@@ -128,8 +129,11 @@ def queryDataIds(
         dimensions = set(graph.names)
         _LOG.info("Determined dimensions %s from datasets option %s", dimensions, datasets)
 
+    query_collections: Iterable[str] | EllipsisType | None = None
+    if datasets:
+        query_collections = collections if collections else Ellipsis
     results = butler.registry.queryDataIds(
-        dimensions, datasets=datasets, where=where, collections=collections
+        dimensions, datasets=datasets, where=where, collections=query_collections
     )
 
     if order_by:

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from astropy.table import Table as AstropyTable
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
 
 from .._butler import Butler
 from ..cli.utils import sortAstropyTable
@@ -183,7 +184,7 @@ class QueryDatasets:
         self, glob: Iterable[str], collections: Iterable[str], where: str, find_first: bool
     ) -> None:
         datasetTypes = glob if glob else ...
-        query_collections = collections if collections else ...
+        query_collections: Iterable[str] | EllipsisType = collections if collections else Ellipsis
 
         self.datasets = self.butler.registry.queryDatasets(
             datasetType=datasetTypes, collections=query_collections, where=where, findFirst=find_first

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -21,9 +21,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 from astropy.table import Table
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
 
 from .._butler import Butler
 from ..core import Timespan
@@ -46,8 +48,11 @@ def queryDimensionRecords(
 
     butler = Butler(repo)
 
+    query_collections: Iterable[str] | EllipsisType | None = None
+    if datasets:
+        query_collections = collections if collections else Ellipsis
     query_results = butler.registry.queryDimensionRecords(
-        element, datasets=datasets, collections=collections, where=where, check=not no_check
+        element, datasets=datasets, collections=query_collections, where=where, check=not no_check
     )
 
     if order_by:

--- a/python/lsst/daf/butler/script/retrieveArtifacts.py
+++ b/python/lsst/daf/butler/script/retrieveArtifacts.py
@@ -26,6 +26,8 @@ __all__ = ("retrieveArtifacts",)
 import logging
 from typing import TYPE_CHECKING
 
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
+
 from .._butler import Butler
 
 if TYPE_CHECKING:
@@ -77,7 +79,7 @@ def retrieveArtifacts(
         The destination URIs of every transferred artifact.
     """
     query_types = dataset_type if dataset_type else ...
-    query_collections = collections if collections else ...
+    query_collections: tuple[str, ...] | EllipsisType = collections if collections else Ellipsis
 
     butler = Butler(repo, writeable=False)
 

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -24,6 +24,8 @@ __all__ = ("transferDatasets",)
 
 import logging
 
+from lsst.utils.ellipsis import Ellipsis, EllipsisType
+
 from .._butler import Butler
 from ..registry.queries import DatasetQueryResults
 
@@ -71,7 +73,7 @@ def transferDatasets(
     dest_butler = Butler(dest, writeable=True)
 
     dataset_type_expr = ... if not dataset_type else dataset_type
-    collections_expr = ... if not collections else collections
+    collections_expr: tuple[str, ...] | EllipsisType = Ellipsis if not collections else collections
 
     source_refs = source_butler.registry.queryDatasets(
         datasetType=dataset_type_expr, collections=collections_expr, where=where, findFirst=find_first


### PR DESCRIPTION
Empty collection iterable is now handled as it was supposed to be handled -
producing empty result (with "doomed by" messages). I added a proper type
annotation for `collections` parameter in Registry methods to help me
verify that it is used correctly (maybe need to extend that to Butler
methods too). Also needed to update couple of CLI scripts to fix their
handling of the default collection values. Unit tests was added to check
that it works correctly now.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
