### PR TITLE
DM-39429: Enable repository index in QBB and `butler config-dump`

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -233,7 +233,7 @@ class Butler(LimitedButler):
             if isinstance(config, str):
                 # Somehow ButlerConfig fails in some cases if config is a
                 # ResourcePath, force it back to string here.
-                config = str(self.get_repo_uri(config, config))
+                config = str(self.get_repo_uri(config, True))
             try:
                 self._config = ButlerConfig(config, searchPaths=searchPaths)
             except FileNotFoundError as e:
@@ -288,18 +288,19 @@ class Butler(LimitedButler):
             return None
 
     @classmethod
-    def get_repo_uri(cls, label: str, default: ResourcePath | str | None = None) -> ResourcePath:
+    def get_repo_uri(cls, label: str, return_label: bool = False) -> ResourcePath:
         """Look up the label in a butler repository index.
 
         Parameters
         ----------
         label : `str`
             Label of the Butler repository to look up.
-        default : `lsst.resources.ResourcePath` or `str`, optional
+        return_label : `bool`, optional
             If ``label`` cannot be found in the repository index (either
             because index is not defined or ``label`` is not in the index) and
-            ``default`` is not `None` then return its value. If not specified
-            then an exception will be raised instead.
+            ``return_label`` is `True` then return ``ResourcePath(label)``.
+            If ``return_label`` is `False` (default) then an exception will be
+            raised instead.
 
         Returns
         -------
@@ -311,14 +312,14 @@ class Butler(LimitedButler):
         ------
         KeyError
             Raised if the label is not found in the index, or if an index
-            is not defined, and ``default`` is not specified.
+            is not defined, and ``return_label`` is `False`.
 
         Notes
         -----
         See `~lsst.daf.butler.ButlerRepoIndex` for details on how the
         information is discovered.
         """
-        return ButlerRepoIndex.get_repo_uri(label, default)
+        return ButlerRepoIndex.get_repo_uri(label, return_label)
 
     @classmethod
     def get_known_repos(cls) -> Set[str]:

--- a/python/lsst/daf/butler/_butlerRepoIndex.py
+++ b/python/lsst/daf/butler/_butlerRepoIndex.py
@@ -137,18 +137,19 @@ class ButlerRepoIndex:
         return set(repo_index)
 
     @classmethod
-    def get_repo_uri(cls, label: str, default: ResourcePath | str | None = None) -> ResourcePath:
+    def get_repo_uri(cls, label: str, return_label: bool = False) -> ResourcePath:
         """Look up the label in a butler repository index.
 
         Parameters
         ----------
         label : `str`
             Label of the Butler repository to look up.
-        default : `lsst.resources.ResourcePath` or `str`, optional
+        return_label : `bool`, optional
             If ``label`` cannot be found in the repository index (either
             because index is not defined or ``label`` is not in the index) and
-            ``default`` is not `None` then return its value. If not specified
-            then an exception will be raised instead.
+            ``return_label`` is `True` then return ``ResourcePath(label)``.
+            If ``return_label`` is `False` (default) then an exception will be
+            raised instead.
 
         Returns
         -------
@@ -160,7 +161,7 @@ class ButlerRepoIndex:
         ------
         KeyError
             Raised if the label is not found in the index, or if an index
-            is not defined, and ``default`` is not specified.
+            is not defined, and ``return_label`` is `False`.
         FileNotFoundError
             Raised if an index is defined in the environment but it
             can not be found.
@@ -168,14 +169,14 @@ class ButlerRepoIndex:
         try:
             repo_index = cls._read_repository_index_from_environment()
         except KeyError:
-            if default is not None:
-                return ResourcePath(default)
+            if return_label:
+                return ResourcePath(label)
             raise
 
         repo_uri = repo_index.get(label)
         if repo_uri is None:
-            if default is not None:
-                return ResourcePath(default)
+            if return_label:
+                return ResourcePath(label)
             # This should not raise since it worked earlier.
             try:
                 index_uri = str(cls._get_index_uri())

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -30,9 +30,11 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Set, Type, Union
 
 from deprecated.sphinx import deprecated
+from lsst.resources import ResourcePathExpression
 from pydantic import BaseModel
 
 from ._butlerConfig import ButlerConfig
+from ._butlerRepoIndex import ButlerRepoIndex
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._limited_butler import LimitedButler
 from .core import (
@@ -174,7 +176,7 @@ class QuantumBackedButler(LimitedButler):
     @classmethod
     def initialize(
         cls,
-        config: Union[Config, str],
+        config: Union[Config, ResourcePathExpression],
         quantum: Quantum,
         dimensions: DimensionUniverse,
         filename: str = ":memory:",
@@ -188,7 +190,7 @@ class QuantumBackedButler(LimitedButler):
 
         Parameters
         ----------
-        config : `Config` or `str`
+        config : `Config` or `~lsst.resources.ResourcePathExpression`
             A butler repository root, configuration filename, or configuration
             instance.
         quantum : `Quantum`
@@ -230,7 +232,7 @@ class QuantumBackedButler(LimitedButler):
     @classmethod
     def from_predicted(
         cls,
-        config: Union[Config, str],
+        config: Union[Config, ResourcePathExpression],
         predicted_inputs: Iterable[DatasetId],
         predicted_outputs: Iterable[DatasetId],
         dimensions: DimensionUniverse,
@@ -246,7 +248,7 @@ class QuantumBackedButler(LimitedButler):
 
         Parameters
         ----------
-        config : `Config` or `str`
+        config : `Config` or `~lsst.resources.ResourcePathExpression`
             A butler repository root, configuration filename, or configuration
             instance.
         predicted_inputs : `~collections.abc.Iterable` [`DatasetId`]
@@ -289,7 +291,7 @@ class QuantumBackedButler(LimitedButler):
     def _initialize(
         cls,
         *,
-        config: Union[Config, str],
+        config: Union[Config, ResourcePathExpression],
         predicted_inputs: Iterable[DatasetId],
         predicted_outputs: Iterable[DatasetId],
         dimensions: DimensionUniverse,
@@ -305,7 +307,7 @@ class QuantumBackedButler(LimitedButler):
 
         Parameters
         ----------
-        config : `Config` or `str`
+        config : `Config` or `~lsst.resources.ResourcePathExpression`
             A butler repository root, configuration filename, or configuration
             instance.
         predicted_inputs : `~collections.abc.Iterable` [`DatasetId`]
@@ -330,6 +332,8 @@ class QuantumBackedButler(LimitedButler):
         dataset_types: `Mapping` [`str`, `DatasetType`]
             Mapping of the dataset type name to its registry definition.
         """
+        if isinstance(config, str):
+            config = ButlerRepoIndex.get_repo_uri(config, config)
         butler_config = ButlerConfig(config, searchPaths=search_paths)
         if "root" in butler_config:
             butler_root = butler_config["root"]

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -333,7 +333,7 @@ class QuantumBackedButler(LimitedButler):
             Mapping of the dataset type name to its registry definition.
         """
         if isinstance(config, str):
-            config = ButlerRepoIndex.get_repo_uri(config, config)
+            config = ButlerRepoIndex.get_repo_uri(config, True)
         butler_config = ButlerConfig(config, searchPaths=search_paths)
         if "root" in butler_config:
             butler_root = butler_config["root"]

--- a/python/lsst/daf/butler/script/configDump.py
+++ b/python/lsst/daf/butler/script/configDump.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from typing import IO
 
 from .._butlerConfig import ButlerConfig
+from .._butlerRepoIndex import ButlerRepoIndex
 
 
 def configDump(repo: str, subset: str, searchpath: str, outfile: IO) -> None:
@@ -49,7 +50,8 @@ def configDump(repo: str, subset: str, searchpath: str, outfile: IO) -> None:
     AttributeError
         If there is an issue dumping the configuration.
     """
-    config = ButlerConfig(repo, searchPaths=searchpath)
+    repo_path = ButlerRepoIndex.get_repo_uri(repo, repo)
+    config = ButlerConfig(repo_path, searchPaths=searchpath)
     if subset is not None:
         try:
             config = config[subset]

--- a/python/lsst/daf/butler/script/configDump.py
+++ b/python/lsst/daf/butler/script/configDump.py
@@ -50,7 +50,7 @@ def configDump(repo: str, subset: str, searchpath: str, outfile: IO) -> None:
     AttributeError
         If there is an issue dumping the configuration.
     """
-    repo_path = ButlerRepoIndex.get_repo_uri(repo, repo)
+    repo_path = ButlerRepoIndex.get_repo_uri(repo, True)
     config = ButlerConfig(repo_path, searchPaths=searchpath)
     if subset is not None:
         try:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -590,6 +590,7 @@ class ButlerTests(ButlerPutGetTests):
                         Butler("not_there", writeable=False)
                     with self.assertRaises(KeyError) as cm:
                         Butler.get_repo_uri("missing")
+                    self.assertEqual(Butler.get_repo_uri("missing", "missing"), ResourcePath("missing"))
                     self.assertIn("not known to", str(cm.exception))
         with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": "file://not_found/x.yaml"}):
             with self.assertRaises(FileNotFoundError):
@@ -598,6 +599,7 @@ class ButlerTests(ButlerPutGetTests):
         with self.assertRaises(KeyError) as cm:
             # No environment variable set.
             Butler.get_repo_uri("label")
+        self.assertEqual(Butler.get_repo_uri("label", "/path"), ResourcePath("/path"))
         self.assertIn("No repository index defined", str(cm.exception))
         with self.assertRaisesRegex(FileNotFoundError, "no known aliases"):
             # No aliases registered.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -590,7 +590,7 @@ class ButlerTests(ButlerPutGetTests):
                         Butler("not_there", writeable=False)
                     with self.assertRaises(KeyError) as cm:
                         Butler.get_repo_uri("missing")
-                    self.assertEqual(Butler.get_repo_uri("missing", "missing"), ResourcePath("missing"))
+                    self.assertEqual(Butler.get_repo_uri("missing", True), ResourcePath("missing"))
                     self.assertIn("not known to", str(cm.exception))
         with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": "file://not_found/x.yaml"}):
             with self.assertRaises(FileNotFoundError):
@@ -599,7 +599,7 @@ class ButlerTests(ButlerPutGetTests):
         with self.assertRaises(KeyError) as cm:
             # No environment variable set.
             Butler.get_repo_uri("label")
-        self.assertEqual(Butler.get_repo_uri("label", "/path"), ResourcePath("/path"))
+        self.assertEqual(Butler.get_repo_uri("label", True), ResourcePath("label"))
         self.assertIn("No repository index defined", str(cm.exception))
         with self.assertRaisesRegex(FileNotFoundError, "no known aliases"):
             # No aliases registered.

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -138,7 +138,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
     def test_initialize_repo_index(self) -> None:
         """Test for initialize using config file and repo index."""
 
-        # store config to a file
+        # Store config to a file.
         self.config.dumpToUri(self.root)
 
         butler_index = Config()


### PR DESCRIPTION
Extended `ButlerRepoIndex.get_repo_uri` method with a `default` parameter, if label is not found in an index then default is returned. Updated QBB and `configDump` to use that method to try to resolve repo in the index. Added a unit test for QBB, `config-dump` was tested manually. Also changed `Butler` use of that method to pass a default to simplify its logic.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
