### PR TITLE
DM-39434: Avoid defaultdict with lambda in pickled dataclasses

### DIFF
--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -252,3 +252,6 @@ class StoredFileInfo(StoredDatastoreItemInfo):
         if kwargs:
             raise ValueError(f"Unexpected keyword arguments for update: {', '.join(kwargs)}")
         return type(self)(**new_args)
+
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return (self.from_record, (self.to_record(),))

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2934,12 +2934,11 @@ class FileDatastore(GenericBaseDatastore):
         # Docstring inherited from the base class.
         exported_refs = list(self._bridge.check(refs))
         ids = {ref.id for ref in exported_refs}
-        records: defaultdict[DatasetId, defaultdict[str, List[StoredDatastoreItemInfo]]] = defaultdict(
-            lambda: defaultdict(list), {id: defaultdict(list) for id in ids}
-        )
+        records: dict[DatasetId, dict[str, list[StoredDatastoreItemInfo]]] = {id: {} for id in ids}
         for row in self._table.fetch(dataset_id=ids):
             info: StoredDatastoreItemInfo = StoredFileInfo.from_record(row)
-            records[info.dataset_id][self._table.name].append(info)
+            dataset_records = records.setdefault(info.dataset_id, {})
+            dataset_records.setdefault(self._table.name, []).append(info)
 
         record_data = DatastoreRecordData(records=records)
         return {self.name: record_data}


### PR DESCRIPTION
Pickle does not like lambdas or local/nested methods, using a `dataclass.field`
with defaultdict and default_factory as a lambda breaks pickle. Instead of defining
a module-level factory method I decided to use a plain dict and its `setdefault` method.
Also had to add explicit pickle method to StoredFileInfo, being a frozen
dataclass it does not work by default with pickle.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
