### PR TITLE
DM-39484: Fix password auth error creating Postgres registry

### DIFF
--- a/doc/changes/DM-39484.api.md
+++ b/doc/changes/DM-39484.api.md
@@ -1,0 +1,1 @@
+`Database.fromUri` and `Database.makeEngine` methods now accept `sqlalchemy.engine.URL` instances in addition to strings.

--- a/doc/changes/DM-39484.bugfix.md
+++ b/doc/changes/DM-39484.bugfix.md
@@ -1,0 +1,2 @@
+Fixed the bug in initializing PostgreSQL registry which resulted in "password authentication failed" error.
+The bug appeared during sqlalchemy 2.0 transition which changed default rendering of URL to string.

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -169,7 +169,7 @@ class SqlRegistry(Registry):
 
         DatabaseClass = config.getDatabaseClass()
         database = DatabaseClass.fromUri(
-            str(config.connectionString), origin=config.get("origin", 0), namespace=config.get("namespace")
+            config.connectionString, origin=config.get("origin", 0), namespace=config.get("namespace")
         )
         managerTypes = RegistryManagerTypes.fromConfig(config)
         managers = managerTypes.makeRepo(database, dimensionConfig)
@@ -208,7 +208,7 @@ class SqlRegistry(Registry):
         config.replaceRoot(butlerRoot)
         DatabaseClass = config.getDatabaseClass()
         database = DatabaseClass.fromUri(
-            config.connectionString.render_as_string(hide_password=False),
+            config.connectionString,
             origin=config.get("origin", 0),
             namespace=config.get("namespace"),
             writeable=writeable,

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -99,7 +99,9 @@ class PostgresqlDatabase(Database):
         self._shrinker = NameShrinker(self.dialect.max_identifier_length)
 
     @classmethod
-    def makeEngine(cls, uri: str, *, writeable: bool = True) -> sqlalchemy.engine.Engine:
+    def makeEngine(
+        cls, uri: str | sqlalchemy.engine.URL, *, writeable: bool = True
+    ) -> sqlalchemy.engine.Engine:
         return sqlalchemy.engine.create_engine(uri, pool_size=1)
 
     @classmethod

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -110,14 +110,18 @@ class SqliteDatabase(Database):
 
     @classmethod
     def makeEngine(
-        cls, uri: Optional[str] = None, *, filename: Optional[str] = None, writeable: bool = True
+        cls,
+        uri: str | sqlalchemy.engine.URL | None = None,
+        *,
+        filename: Optional[str] = None,
+        writeable: bool = True,
     ) -> sqlalchemy.engine.Engine:
         """Create a `sqlalchemy.engine.Engine` from a SQLAlchemy URI or
         filename.
 
         Parameters
         ----------
-        uri : `str`
+        uri : `str` or `sqlalchemy.engine.URL`, optional
             A SQLAlchemy URI connection string.
         filename : `str`
             Name of the SQLite database file, or `None` to use an in-memory
@@ -147,6 +151,9 @@ class SqliteDatabase(Database):
                 target = f"file:{filename}"
                 uri = f"sqlite:///{filename}"
         else:
+            if isinstance(uri, sqlalchemy.engine.URL):
+                # We have to parse strings anyway, so convert it to string.
+                uri = uri.render_as_string(hide_password=False)
             parsed = urllib.parse.urlparse(uri)
             queries = parsed.query.split("&")
             if "uri=true" in queries:

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -252,13 +252,18 @@ class Database(ABC):
 
     @classmethod
     def fromUri(
-        cls, uri: str, *, origin: int, namespace: Optional[str] = None, writeable: bool = True
+        cls,
+        uri: str | sqlalchemy.engine.URL,
+        *,
+        origin: int,
+        namespace: str | None = None,
+        writeable: bool = True,
     ) -> Database:
         """Construct a database from a SQLAlchemy URI.
 
         Parameters
         ----------
-        uri : `str`
+        uri : `str` or `sqlalchemy.engine.URL`
             A SQLAlchemy URI connection string.
         origin : `int`
             An integer ID that should be used as the default for any datasets,
@@ -283,12 +288,14 @@ class Database(ABC):
 
     @classmethod
     @abstractmethod
-    def makeEngine(cls, uri: str, *, writeable: bool = True) -> sqlalchemy.engine.Engine:
+    def makeEngine(
+        cls, uri: str | sqlalchemy.engine.URL, *, writeable: bool = True
+    ) -> sqlalchemy.engine.Engine:
         """Create a `sqlalchemy.engine.Engine` from a SQLAlchemy URI.
 
         Parameters
         ----------
-        uri : `str`
+        uri : `str` or `sqlalchemy.engine.URL`
             A SQLAlchemy URI connection string.
         writeable : `bool`, optional
             If `True`, allow write operations on the database, including


### PR DESCRIPTION
This commit allows passing `URL` to sqlalchemy methods without rendering it as a string. SQLite database still renders it internally and re-parses it again, just to keep code path intact.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
