### PR TITLE
DM-39563: Make clearer error message when repo alias has failed to find something

### DIFF
--- a/doc/changes/DM-39563.misc.rst
+++ b/doc/changes/DM-39563.misc.rst
@@ -1,0 +1,1 @@
+Moved Butler repository aliasing resolution into `~lsst.daf.butler.ButlerConfig` so that it is available everywhere without having to do the resolving each time.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -231,25 +231,7 @@ class Butler(LimitedButler):
             self.storageClasses = butler.storageClasses
             self._config: ButlerConfig = butler._config
         else:
-            # Can only look for strings in the known repos list.
-            if isinstance(config, str):
-                # Somehow ButlerConfig fails in some cases if config is a
-                # ResourcePath, force it back to string here.
-                try:
-                    config = str(self.get_repo_uri(config, True))
-                except FileNotFoundError:
-                    pass
-            try:
-                self._config = ButlerConfig(config, searchPaths=searchPaths)
-            except FileNotFoundError as e:
-                if known := self.get_known_repos():
-                    aliases = f"(known aliases: {', '.join(known)})"
-                else:
-                    failure_reason = ButlerRepoIndex.get_failure_reason()
-                    if failure_reason:
-                        failure_reason = f": {failure_reason}"
-                    aliases = f"(no known aliases{failure_reason})"
-                raise FileNotFoundError(f"{e} {aliases}") from e
+            self._config = ButlerConfig(config, searchPaths=searchPaths)
             try:
                 if "root" in self._config:
                     butlerRoot = self._config["root"]

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -89,7 +89,7 @@ class ButlerConfig(Config):
                 # might not refer explicitly to a directory and we have
                 # check below to guess that.
                 other = str(ButlerRepoIndex.get_repo_uri(other, True))
-            except FileNotFoundError:
+            except Exception:
                 pass
             if other != original_other:
                 resolved_alias = True

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -32,6 +32,7 @@ from typing import Optional, Sequence, Union
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 
+from ._butlerRepoIndex import ButlerRepoIndex
 from .core import Config, DatastoreConfig, StorageClassConfig
 from .registry import RegistryConfig
 from .transfers import RepoTransferFormatConfig
@@ -78,6 +79,21 @@ class ButlerConfig(Config):
             self.configDir = copy.copy(other.configDir)
             return
 
+        # If a string is given it *could* be an alias that should be
+        # expanded by the repository index system.
+        original_other = other
+        resolved_alias = False
+        if isinstance(other, str):
+            try:
+                # Force back to a string because the resolved URI
+                # might not refer explicitly to a directory and we have
+                # check below to guess that.
+                other = str(ButlerRepoIndex.get_repo_uri(other, True))
+            except FileNotFoundError:
+                pass
+            if other != original_other:
+                resolved_alias = True
+
         # Include ResourcePath here in case it refers to a directory.
         # Creating a ResourcePath from a ResourcePath is a no-op.
         if isinstance(other, (str, os.PathLike, ResourcePath)):
@@ -106,7 +122,29 @@ class ButlerConfig(Config):
 
         # Read the supplied config so that we can work out which other
         # defaults to use.
-        butlerConfig = Config(other)
+        try:
+            butlerConfig = Config(other)
+        except FileNotFoundError as e:
+            # No reason to talk about aliases unless we were given a
+            # string and the alias was not resolved.
+            if isinstance(original_other, str):
+                if not resolved_alias:
+                    # No alias was resolved. List known aliases if we have
+                    # them or else explain a reason why aliasing might not
+                    # have happened.
+                    if known := ButlerRepoIndex.get_known_repos():
+                        aliases = f"(given {original_other!r} and known aliases: {', '.join(known)})"
+                    else:
+                        failure_reason = ButlerRepoIndex.get_failure_reason()
+                        if failure_reason:
+                            failure_reason = f": {failure_reason}"
+                        aliases = f"(no known aliases{failure_reason})"
+                else:
+                    aliases = f"(resolved from alias {original_other!r})"
+                errmsg = f"{e} {aliases}"
+            else:
+                errmsg = str(e)
+            raise FileNotFoundError(errmsg) from e
 
         configFile = butlerConfig.configFile
         if configFile is not None:

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -138,7 +138,7 @@ class ButlerConfig(Config):
                         failure_reason = ButlerRepoIndex.get_failure_reason()
                         if failure_reason:
                             failure_reason = f": {failure_reason}"
-                        aliases = f"(no known aliases{failure_reason})"
+                        aliases = f"(given {original_other!r} and no known aliases{failure_reason})"
                 else:
                     aliases = f"(resolved from alias {original_other!r})"
                 errmsg = f"{e} {aliases}"

--- a/python/lsst/daf/butler/_butlerRepoIndex.py
+++ b/python/lsst/daf/butler/_butlerRepoIndex.py
@@ -191,13 +191,13 @@ class ButlerRepoIndex:
             repo_index = cls._read_repository_index_from_environment()
         except KeyError:
             if return_label:
-                return ResourcePath(label)
+                return ResourcePath(label, forceAbsolute=False)
             raise
 
         repo_uri = repo_index.get(label)
         if repo_uri is None:
             if return_label:
-                return ResourcePath(label)
+                return ResourcePath(label, forceAbsolute=False)
             # This should not raise since it worked earlier.
             try:
                 index_uri = str(cls._get_index_uri())

--- a/python/lsst/daf/butler/_butlerRepoIndex.py
+++ b/python/lsst/daf/butler/_butlerRepoIndex.py
@@ -85,7 +85,11 @@ class ButlerRepoIndex:
         if index_uri in cls._cache:
             return cls._cache[uri]
 
-        repo_index = Config(uri)
+        try:
+            repo_index = Config(uri)
+        except FileNotFoundError as e:
+            # More explicit error message.
+            raise FileNotFoundError(f"Butler repository index file not found at {uri}.") from e
         cls._cache[uri] = repo_index
 
         return repo_index
@@ -135,6 +139,23 @@ class ButlerRepoIndex:
         except (FileNotFoundError, KeyError):
             return set()
         return set(repo_index)
+
+    @classmethod
+    def get_failure_reason(cls) -> str:
+        """Return possible reason for failure to return repository index.
+
+        Returns
+        -------
+        reason : `str`
+            If there is a problem reading the repository index, this will
+            contain a string with an explanation. Empty string if everything
+            worked.
+        """
+        try:
+            cls._read_repository_index_from_environment()
+        except (FileNotFoundError, KeyError) as e:
+            return str(e)
+        return ""
 
     @classmethod
     def get_repo_uri(cls, label: str, return_label: bool = False) -> ResourcePath:

--- a/python/lsst/daf/butler/_butlerRepoIndex.py
+++ b/python/lsst/daf/butler/_butlerRepoIndex.py
@@ -90,6 +90,10 @@ class ButlerRepoIndex:
         except FileNotFoundError as e:
             # More explicit error message.
             raise FileNotFoundError(f"Butler repository index file not found at {uri}.") from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Butler repository index file at {uri} could not be read: {type(e).__qualname__} {e}"
+            ) from e
         cls._cache[uri] = repo_index
 
         return repo_index
@@ -136,7 +140,7 @@ class ButlerRepoIndex:
         """
         try:
             repo_index = cls._read_repository_index_from_environment()
-        except (FileNotFoundError, KeyError):
+        except Exception:
             return set()
         return set(repo_index)
 
@@ -153,7 +157,7 @@ class ButlerRepoIndex:
         """
         try:
             cls._read_repository_index_from_environment()
-        except (FileNotFoundError, KeyError) as e:
+        except Exception as e:
             return str(e)
         return ""
 
@@ -189,7 +193,7 @@ class ButlerRepoIndex:
         """
         try:
             repo_index = cls._read_repository_index_from_environment()
-        except KeyError:
+        except Exception:
             if return_label:
                 return ResourcePath(label, forceAbsolute=False)
             raise

--- a/python/lsst/daf/butler/_butlerRepoIndex.py
+++ b/python/lsst/daf/butler/_butlerRepoIndex.py
@@ -26,7 +26,7 @@ __all__ = ("ButlerRepoIndex",)
 import os
 from typing import ClassVar, Dict, Set
 
-from lsst.resources import ResourcePath, ResourcePathExpression
+from lsst.resources import ResourcePath
 
 from .core import Config
 
@@ -55,13 +55,17 @@ class ButlerRepoIndex:
     """Cache of indexes. In most scenarios only one index will be found
     and the environment will not change. In tests this may not be true."""
 
+    _most_recent_failure: ClassVar[str] = ""
+    """Cache of the most recent failure when reading an index. Reset on
+    every read."""
+
     @classmethod
-    def _read_repository_index(cls, index_uri: ResourcePathExpression) -> Config:
+    def _read_repository_index(cls, index_uri: ResourcePath) -> Config:
         """Read the repository index from the supplied URI.
 
         Parameters
         ----------
-        index_uri : `lsst.resources.ResourcePathExpression`
+        index_uri : `lsst.resources.ResourcePath`
             URI of the repository index.
 
         Returns
@@ -78,23 +82,19 @@ class ButlerRepoIndex:
         -----
         Does check the cache before reading the file.
         """
-        # Force the given value to a ResourcePath so that it can be used
-        # as an index into the cache consistently.
-        uri = ResourcePath(index_uri)
-
         if index_uri in cls._cache:
-            return cls._cache[uri]
+            return cls._cache[index_uri]
 
         try:
-            repo_index = Config(uri)
+            repo_index = Config(index_uri)
         except FileNotFoundError as e:
             # More explicit error message.
-            raise FileNotFoundError(f"Butler repository index file not found at {uri}.") from e
+            raise FileNotFoundError(f"Butler repository index file not found at {index_uri}.") from e
         except Exception as e:
             raise RuntimeError(
-                f"Butler repository index file at {uri} could not be read: {type(e).__qualname__} {e}"
+                f"Butler repository index file at {index_uri} could not be read: {type(e).__qualname__} {e}"
             ) from e
-        cls._cache[uri] = repo_index
+        cls._cache[index_uri] = repo_index
 
         return repo_index
 
@@ -126,8 +126,18 @@ class ButlerRepoIndex:
         repo_index : `Config`
             The index found in the environment.
         """
-        index_uri = cls._get_index_uri()
-        return cls._read_repository_index(index_uri)
+        cls._most_recent_failure = ""
+        try:
+            index_uri = cls._get_index_uri()
+        except KeyError as e:
+            cls._most_recent_failure = str(e)
+            raise
+        try:
+            repo_index = cls._read_repository_index(index_uri)
+        except Exception as e:
+            cls._most_recent_failure = str(e)
+            raise
+        return repo_index
 
     @classmethod
     def get_known_repos(cls) -> Set[str]:
@@ -154,12 +164,14 @@ class ButlerRepoIndex:
             If there is a problem reading the repository index, this will
             contain a string with an explanation. Empty string if everything
             worked.
+
+        Notes
+        -----
+        The value returned is only reliable if called immediately after a
+        failure. The most recent failure reason is reset every time an attempt
+        is made to request a label and so the reason can be out of date.
         """
-        try:
-            cls._read_repository_index_from_environment()
-        except Exception as e:
-            return str(e)
-        return ""
+        return cls._most_recent_failure
 
     @classmethod
     def get_repo_uri(cls, label: str, return_label: bool = False) -> ResourcePath:

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -34,7 +34,6 @@ from lsst.resources import ResourcePathExpression
 from pydantic import BaseModel
 
 from ._butlerConfig import ButlerConfig
-from ._butlerRepoIndex import ButlerRepoIndex
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._limited_butler import LimitedButler
 from .core import (
@@ -332,8 +331,6 @@ class QuantumBackedButler(LimitedButler):
         dataset_types: `Mapping` [`str`, `DatasetType`]
             Mapping of the dataset type name to its registry definition.
         """
-        if isinstance(config, str):
-            config = ButlerRepoIndex.get_repo_uri(config, True)
         butler_config = ButlerConfig(config, searchPaths=search_paths)
         if "root" in butler_config:
             butler_root = butler_config["root"]

--- a/python/lsst/daf/butler/script/configDump.py
+++ b/python/lsst/daf/butler/script/configDump.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 from typing import IO
 
 from .._butlerConfig import ButlerConfig
-from .._butlerRepoIndex import ButlerRepoIndex
 
 
 def configDump(repo: str, subset: str, searchpath: str, outfile: IO) -> None:
@@ -50,8 +49,7 @@ def configDump(repo: str, subset: str, searchpath: str, outfile: IO) -> None:
     AttributeError
         If there is an issue dumping the configuration.
     """
-    repo_path = ButlerRepoIndex.get_repo_uri(repo, True)
-    config = ButlerConfig(repo_path, searchPaths=searchpath)
+    config = ButlerConfig(repo, searchPaths=searchpath)
     if subset is not None:
         try:
             config = config[subset]

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -588,7 +588,9 @@ class ButlerTests(ButlerPutGetTests):
                         Butler("not_there", writeable=False)
                     with self.assertRaises(KeyError) as cm:
                         Butler.get_repo_uri("missing")
-                    self.assertEqual(Butler.get_repo_uri("missing", True), ResourcePath("missing"))
+                    self.assertEqual(
+                        Butler.get_repo_uri("missing", True), ResourcePath("missing", forceAbsolute=False)
+                    )
                     self.assertIn("not known to", str(cm.exception))
         with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": "file://not_found/x.yaml"}):
             with self.assertRaises(FileNotFoundError):
@@ -604,7 +606,7 @@ class ButlerTests(ButlerPutGetTests):
         with self.assertRaises(KeyError) as cm:
             # No environment variable set.
             Butler.get_repo_uri("label")
-        self.assertEqual(Butler.get_repo_uri("label", True), ResourcePath("label"))
+        self.assertEqual(Butler.get_repo_uri("label", True), ResourcePath("label", forceAbsolute=False))
         self.assertIn("No repository index defined", str(cm.exception))
         with self.assertRaisesRegex(FileNotFoundError, "no known aliases.*No repository index"):
             # No aliases registered.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -102,6 +102,18 @@ if TYPE_CHECKING:
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
+def clean_environment() -> None:
+    """Remove external environment variables that affect the tests."""
+    for k in (
+        "DAF_BUTLER_REPOSITORY_INDEX",
+        "S3_ENDPOINT_URL",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SHARED_CREDENTIALS_FILE",
+    ):
+        os.environ.pop(k, None)
+
+
 def makeExampleMetrics():
     return MetricsExample(
         {"AM1": 5.2, "AM2": 30.6},
@@ -2280,5 +2292,10 @@ class ChainedDatastoreTransfers(PosixDatastoreTransfers):
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
 
 
+def setup_module(module) -> None:
+    clean_environment()
+
+
 if __name__ == "__main__":
+    clean_environment()
     unittest.main()

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -619,6 +619,13 @@ class ButlerTests(ButlerPutGetTests):
             with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": str(temp_file)}):
                 with self.assertRaisesRegex(FileNotFoundError, "(no known aliases)"):
                     Butler("label")
+        with ResourcePath.temporary_uri(suffix=suffix) as temp_file:
+            # Now with bad contents.
+            with open(temp_file.ospath, "w") as fh:
+                print("'", file=fh)
+            with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": str(temp_file)}):
+                with self.assertRaisesRegex(FileNotFoundError, "(no known aliases:.*could not be read)"):
+                    Butler("label")
         with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": "file://not_found/x.yaml"}):
             with self.assertRaises(FileNotFoundError):
                 Butler.get_repo_uri("label")

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -594,12 +594,19 @@ class ButlerTests(ButlerPutGetTests):
             with self.assertRaises(FileNotFoundError):
                 Butler.get_repo_uri("label")
             self.assertEqual(Butler.get_known_repos(), set())
+
+            with self.assertRaisesRegex(FileNotFoundError, "index file not found"):
+                Butler("label")
+
+            # Check that we can create Butler when the alias file is not found.
+            butler = Butler(self.tmpConfigFile, writeable=False)
+            self.assertIsInstance(butler, Butler)
         with self.assertRaises(KeyError) as cm:
             # No environment variable set.
             Butler.get_repo_uri("label")
         self.assertEqual(Butler.get_repo_uri("label", True), ResourcePath("label"))
         self.assertIn("No repository index defined", str(cm.exception))
-        with self.assertRaisesRegex(FileNotFoundError, "no known aliases"):
+        with self.assertRaisesRegex(FileNotFoundError, "no known aliases.*No repository index"):
             # No aliases registered.
             Butler("not_there")
         self.assertEqual(Butler.get_known_repos(), set())


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
