### PR TITLE
DM-39605: Use butler.dimensions rather than butler.registry.dimensions

### DIFF
--- a/doc/changes/DM-39605.misc.rst
+++ b/doc/changes/DM-39605.misc.rst
@@ -1,0 +1,4 @@
+* Replace usage of ``Butler.registry.dimensions`` with ``Butler.dimensions``.
+* Modernize type annotations.
+* Fix some documentation problems.
+* Minor modernizations to use set notation and f-strings.

--- a/doc/lsst.daf.butler/organizing.rst
+++ b/doc/lsst.daf.butler/organizing.rst
@@ -14,7 +14,6 @@ We call a `DatasetRef` whose `~DatasetRef.id` attribute is not `None` a *resolve
 
     In most data repositories, dataset IDs are 128-bit UUIDs that are guaranteed to be unique across all data repositories, not just within one; if two datasets share the same UUID in different data repositories, they must be identical (this is possible because of the extraordinarily low probability of a collision between two random 128-bit numbers, and our reservation of deterministic UUIDs for very special datasets).
     As a result, we also frequently refer to the dataset ID as the UUID, especially in contexts where UUIDs are actually needed or can be safely assumed.
-    But 64-bit autoincrement integers are also supported (albeit mostly for legacy reasons), and we continue to use "dataset ID" in most code and documentation to refer to either form.
 
 Most of the time, however, users identify a dataset using a combination of three other attributes:
 

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -16,5 +16,5 @@ from .core import *
 
 # Import the registry subpackage directly for other symbols.
 from .registry import CollectionSearch, CollectionType, Registry, RegistryConfig
-from .transfers import YamlRepoExportBackend, YamlRepoImportBackend
+from .transfers import RepoExportContext, YamlRepoExportBackend, YamlRepoImportBackend
 from .version import *

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -118,7 +118,7 @@ class Butler(LimitedButler):
         datastore as the given one, but with the given collection and run.
         Incompatible with the ``config``, ``searchPaths``, and ``writeable``
         arguments.
-    collections : `str` or `Iterable` [ `str` ], optional
+    collections : `str` or `~collections.abc.Iterable` [ `str` ], optional
         An expression specifying the collections to be searched (in order) when
         reading datasets.
         This may be a `str` collection name or an iterable thereof.
@@ -1785,7 +1785,7 @@ class Butler(LimitedButler):
 
         Parameters
         ----------
-        names : `Iterable` [ `str` ]
+        names : `~collections.abc.Iterable` [ `str` ]
             The names of the collections to remove.
         unstore : `bool`, optional
             If `True` (default), delete datasets from all datastores in which
@@ -2596,7 +2596,7 @@ class Butler(LimitedButler):
     @property
     def collections(self) -> Sequence[str]:
         """The collections to search by default, in order
-        (`Sequence` [ `str` ]).
+        (`~collections.abc.Sequence` [ `str` ]).
 
         This is an alias for ``self.registry.defaults.collections``.  It cannot
         be set directly in isolation, but all defaults may be changed together

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -729,7 +729,7 @@ class Butler(LimitedButler):
             for dimensionName in list(dataIdDict):
                 value = dataIdDict[dimensionName]
                 try:
-                    dimension = self.registry.dimensions.getStaticDimensions()[dimensionName]
+                    dimension = self.dimensions.getStaticDimensions()[dimensionName]
                 except KeyError:
                     # This is not a real dimension
                     not_dimensions[dimensionName] = value
@@ -801,7 +801,7 @@ class Butler(LimitedButler):
             # fail but they are going to fail anyway because of the
             # ambiguousness of the dataId...
             if datasetType.isCalibration():
-                for dim in self.registry.dimensions.getStaticDimensions():
+                for dim in self.dimensions.getStaticDimensions():
                     if dim.temporal:
                         candidateDimensions.add(str(dim))
 
@@ -817,7 +817,7 @@ class Butler(LimitedButler):
             # given names with records within those dimensions
             matched_dims = set()
             for dimensionName in candidateDimensions:
-                dimension = self.registry.dimensions.getStaticDimensions()[dimensionName]
+                dimension = self.dimensions.getStaticDimensions()[dimensionName]
                 fields = dimension.metadata.names | dimension.uniqueKeys.names
                 for field in not_dimensions:
                     if field in fields:
@@ -940,8 +940,8 @@ class Butler(LimitedButler):
                         # by the instrument.
                         if (
                             dimensionName == "visit"
-                            and "visit_system_membership" in self.registry.dimensions
-                            and "visit_system" in self.registry.dimensions["instrument"].metadata
+                            and "visit_system_membership" in self.dimensions
+                            and "visit_system" in self.dimensions["instrument"].metadata
                         ):
                             instrument_records = list(
                                 self.registry.queryDimensionRecords(
@@ -992,7 +992,7 @@ class Butler(LimitedButler):
                         )
 
                 # Get the primary key from the real dimension object
-                dimension = self.registry.dimensions.getStaticDimensions()[dimensionName]
+                dimension = self.dimensions.getStaticDimensions()[dimensionName]
                 if not isinstance(dimension, Dimension):
                     raise RuntimeError(
                         f"{dimension.name} is not a true dimension, and cannot be used in data IDs."
@@ -1072,7 +1072,7 @@ class Butler(LimitedButler):
             # dimensions that provide temporal information for a validity-range
             # lookup.
             dataId = DataCoordinate.standardize(
-                dataId, universe=self.registry.dimensions, defaults=self.registry.defaults.dataId, **kwargs
+                dataId, universe=self.dimensions, defaults=self.registry.defaults.dataId, **kwargs
             )
             if dataId.graph.temporal:
                 dataId = self.registry.expandDataId(dataId)
@@ -2150,7 +2150,7 @@ class Butler(LimitedButler):
             raise ValueError(f"Unknown export format {format!r}, allowed: {','.join(formats.keys())}")
         BackendClass = get_class_of(formats[format, "export"])
         with open(filename, "w") as stream:
-            backend = BackendClass(stream, universe=self.registry.dimensions)
+            backend = BackendClass(stream, universe=self.dimensions)
             try:
                 helper = RepoExportContext(
                     self.registry, self.datastore, backend=backend, directory=directory, transfer=transfer
@@ -2392,7 +2392,7 @@ class Butler(LimitedButler):
             # come from this butler's universe.
             elements = frozenset(
                 element
-                for element in self.registry.dimensions.getStaticElements()
+                for element in self.dimensions.getStaticElements()
                 if element.hasTable() and element.viewOf is None
             )
             dataIds = set(ref.dataId for ref in source_refs)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -956,7 +956,7 @@ class Butler(LimitedButler):
                                     )
                                     if membership:
                                         # This record is the right answer.
-                                        records = set([rec])
+                                        records = {rec}
                                         break
 
                         # The ambiguity may have been resolved so check again.
@@ -2379,7 +2379,7 @@ class Butler(LimitedButler):
                 for element in self.dimensions.getStaticElements()
                 if element.hasTable() and element.viewOf is None
             )
-            dataIds = set(ref.dataId for ref in source_refs)
+            dataIds = {ref.dataId for ref in source_refs}
             # This logic comes from saveDataIds.
             for dataId in dataIds:
                 # Need an expanded record, if not expanded that we need a full
@@ -2506,7 +2506,7 @@ class Butler(LimitedButler):
             ignore = set()
 
         # Find all the registered instruments
-        instruments = set(record.name for record in self.registry.queryDimensionRecords("instrument"))
+        instruments = {record.name for record in self.registry.queryDimensionRecords("instrument")}
 
         # For each datasetType that has an instrument dimension, create
         # a DatasetRef for each defined instrument
@@ -2568,7 +2568,7 @@ class Butler(LimitedButler):
             # Currently only support instrument so check for that
             if key.dataId:
                 dataIdKeys = set(key.dataId)
-                if set(["instrument"]) != dataIdKeys:
+                if {"instrument"} != dataIdKeys:
                     if logFailures:
                         log.critical("Key '%s' has unsupported DataId override", key)
                     failedDataId.add(key)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -36,25 +36,9 @@ import logging
 import numbers
 import os
 import warnings
-from collections import defaultdict
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Counter,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    MutableMapping,
-    Optional,
-    Sequence,
-    Set,
-    TextIO,
-    Tuple,
-    Type,
-    Union,
-)
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Iterator, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, TextIO
 
 from deprecated.sphinx import deprecated
 from lsst.resources import ResourcePath, ResourcePathExpression
@@ -209,13 +193,13 @@ class Butler(LimitedButler):
 
     def __init__(
         self,
-        config: Union[Config, ResourcePathExpression, None] = None,
+        config: Config | ResourcePathExpression | None = None,
         *,
-        butler: Optional[Butler] = None,
+        butler: Butler | None = None,
         collections: Any = None,
-        run: Optional[str] = None,
-        searchPaths: Optional[Sequence[ResourcePathExpression]] = None,
-        writeable: Optional[bool] = None,
+        run: str | None = None,
+        searchPaths: Sequence[ResourcePathExpression] | None = None,
+        writeable: bool | None = None,
         inferDefaults: bool = True,
         **kwargs: str,
     ):
@@ -312,7 +296,7 @@ class Butler(LimitedButler):
         return ButlerRepoIndex.get_repo_uri(label, return_label)
 
     @classmethod
-    def get_known_repos(cls) -> Set[str]:
+    def get_known_repos(cls) -> set[str]:
         """Retrieve the list of known repository labels.
 
         Returns
@@ -330,12 +314,12 @@ class Butler(LimitedButler):
     @staticmethod
     def makeRepo(
         root: ResourcePathExpression,
-        config: Union[Config, str, None] = None,
-        dimensionConfig: Union[Config, str, None] = None,
+        config: Config | str | None = None,
+        dimensionConfig: Config | str | None = None,
         standalone: bool = False,
-        searchPaths: Optional[List[str]] = None,
+        searchPaths: list[str] | None = None,
         forceConfigRoot: bool = True,
-        outfile: Optional[ResourcePathExpression] = None,
+        outfile: ResourcePathExpression | None = None,
         overwrite: bool = False,
     ) -> Config:
         """Create an empty data repository by adding a butler.yaml config
@@ -426,7 +410,7 @@ class Butler(LimitedButler):
         imported_class = doImportType(full["datastore", "cls"])
         if not issubclass(imported_class, Datastore):
             raise TypeError(f"Imported datastore class {full['datastore', 'cls']} is not a Datastore")
-        datastoreClass: Type[Datastore] = imported_class
+        datastoreClass: type[Datastore] = imported_class
         datastoreClass.setConfigRoot(BUTLER_ROOT_TAG, config, full, overwrite=forceConfigRoot)
 
         # if key exists in given config, parse it, otherwise parse the defaults
@@ -485,9 +469,9 @@ class Butler(LimitedButler):
     def _unpickle(
         cls,
         config: ButlerConfig,
-        collections: Optional[tuple[str, ...]],
-        run: Optional[str],
-        defaultDataId: Dict[str, str],
+        collections: tuple[str, ...] | None,
+        run: str | None,
+        defaultDataId: dict[str, str],
         writeable: bool,
     ) -> Butler:
         """Callable used to unpickle a Butler.
@@ -560,11 +544,11 @@ class Butler(LimitedButler):
 
     def _standardizeArgs(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
-        dataId: Optional[DataId] = None,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        dataId: DataId | None = None,
         for_put: bool = True,
         **kwargs: Any,
-    ) -> Tuple[DatasetType, Optional[DataId]]:
+    ) -> tuple[DatasetType, DataId | None]:
         """Standardize the arguments passed to several Butler APIs.
 
         Parameters
@@ -606,8 +590,8 @@ class Butler(LimitedButler):
         returned ``dataId`` (and ``kwargs``) to `Registry` APIs, which are
         generally similarly flexible.
         """
-        externalDatasetType: Optional[DatasetType] = None
-        internalDatasetType: Optional[DatasetType] = None
+        externalDatasetType: DatasetType | None = None
+        internalDatasetType: DatasetType | None = None
         if isinstance(datasetRefOrType, DatasetRef):
             if dataId is not None or kwargs:
                 raise ValueError("DatasetRef given, cannot use dataId as well")
@@ -649,8 +633,8 @@ class Butler(LimitedButler):
         return internalDatasetType, dataId
 
     def _rewrite_data_id(
-        self, dataId: Optional[DataId], datasetType: DatasetType, **kwargs: Any
-    ) -> Tuple[Optional[DataId], Dict[str, Any]]:
+        self, dataId: DataId | None, datasetType: DatasetType, **kwargs: Any
+    ) -> tuple[DataId | None, dict[str, Any]]:
         """Rewrite a data ID taking into account dimension records.
 
         Take a Data ID and keyword args and rewrite it if necessary to
@@ -698,8 +682,8 @@ class Butler(LimitedButler):
 
         # Process dimension records that are using record information
         # rather than ids
-        newDataId: Dict[str, DataIdValue] = {}
-        byRecord: Dict[str, Dict[str, Any]] = defaultdict(dict)
+        newDataId: dict[str, DataIdValue] = {}
+        byRecord: dict[str, dict[str, Any]] = defaultdict(dict)
 
         # if all the dataId comes from keyword parameters we do not need
         # to do anything here because they can't be of the form
@@ -790,7 +774,7 @@ class Butler(LimitedButler):
             # match.
             mandatoryDimensions = datasetType.dimensions.names  # - provided
 
-            candidateDimensions: Set[str] = set()
+            candidateDimensions: set[str] = set()
             candidateDimensions.update(mandatoryDimensions)
 
             # For calibrations we may well be needing temporal dimensions
@@ -806,12 +790,12 @@ class Butler(LimitedButler):
                         candidateDimensions.add(str(dim))
 
             # Look up table for the first association with a dimension
-            guessedAssociation: Dict[str, Dict[str, Any]] = defaultdict(dict)
+            guessedAssociation: dict[str, dict[str, Any]] = defaultdict(dict)
 
             # Keep track of whether an item is associated with multiple
             # dimensions.
             counter: Counter[str] = Counter()
-            assigned: Dict[str, Set[str]] = defaultdict(set)
+            assigned: dict[str, set[str]] = defaultdict(set)
 
             # Go through the missing dimensions and associate the
             # given names with records within those dimensions
@@ -907,7 +891,7 @@ class Butler(LimitedButler):
                             f" record values {byRecord[dimensionName]}"
                         ) from None
                     if len(recs) == 1:
-                        errmsg: List[str] = []
+                        errmsg: list[str] = []
                         for k, v in values.items():
                             if (recval := getattr(recs[0], k)) != v:
                                 errmsg.append(f"{k}({recval} != {v})")
@@ -1003,8 +987,8 @@ class Butler(LimitedButler):
 
     def _findDatasetRef(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
-        dataId: Optional[DataId] = None,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        dataId: DataId | None = None,
         *,
         collections: Any = None,
         predict: bool = False,
@@ -1061,7 +1045,7 @@ class Butler(LimitedButler):
             if collections is not None:
                 warnings.warn("Collections should not be specified with DatasetRef", stacklevel=3)
             return datasetRefOrType
-        timespan: Optional[Timespan] = None
+        timespan: Timespan | None = None
 
         dataId, kwargs = self._rewrite_data_id(dataId, datasetType, **kwargs)
 
@@ -1128,11 +1112,11 @@ class Butler(LimitedButler):
     def put(
         self,
         obj: Any,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        datasetRefOrType: DatasetRef | DatasetType | str,
         /,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
-        run: Optional[str] = None,
+        run: str | None = None,
         **kwargs: Any,
     ) -> DatasetRef:
         """Store and register a dataset.
@@ -1216,8 +1200,8 @@ class Butler(LimitedButler):
         self,
         ref: DatasetRef,
         *,
-        parameters: Optional[Dict[str, Any]] = None,
-        storageClass: Optional[Union[StorageClass, str]] = None,
+        parameters: dict[str, Any] | None = None,
+        storageClass: StorageClass | str | None = None,
     ) -> Any:
         """Retrieve a stored dataset.
 
@@ -1252,7 +1236,7 @@ class Butler(LimitedButler):
         self,
         ref: DatasetRef,
         *,
-        parameters: Union[dict, None] = None,
+        parameters: dict | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
@@ -1289,11 +1273,11 @@ class Butler(LimitedButler):
 
     def getDeferred(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        datasetRefOrType: DatasetRef | DatasetType | str,
         /,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
-        parameters: Union[dict, None] = None,
+        parameters: dict | None = None,
         collections: Any = None,
         storageClass: str | StorageClass | None = None,
         **kwargs: Any,
@@ -1349,13 +1333,13 @@ class Butler(LimitedButler):
 
     def get(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        datasetRefOrType: DatasetRef | DatasetType | str,
         /,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
-        parameters: Optional[Dict[str, Any]] = None,
+        parameters: dict[str, Any] | None = None,
         collections: Any = None,
-        storageClass: Optional[Union[StorageClass, str]] = None,
+        storageClass: StorageClass | str | None = None,
         **kwargs: Any,
     ) -> Any:
         """Retrieve a stored dataset.
@@ -1417,13 +1401,13 @@ class Butler(LimitedButler):
 
     def getURIs(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        datasetRefOrType: DatasetRef | DatasetType | str,
         /,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
         predict: bool = False,
         collections: Any = None,
-        run: Optional[str] = None,
+        run: str | None = None,
         **kwargs: Any,
     ) -> DatasetRefURIs:
         """Returns the URIs associated with the dataset.
@@ -1466,13 +1450,13 @@ class Butler(LimitedButler):
 
     def getURI(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
+        datasetRefOrType: DatasetRef | DatasetType | str,
         /,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
         predict: bool = False,
         collections: Any = None,
-        run: Optional[str] = None,
+        run: str | None = None,
         **kwargs: Any,
     ) -> ResourcePath:
         """Return the URI to the Dataset.
@@ -1543,7 +1527,7 @@ class Butler(LimitedButler):
         transfer: str = "auto",
         preserve_path: bool = True,
         overwrite: bool = False,
-    ) -> List[ResourcePath]:
+    ) -> list[ResourcePath]:
         """Retrieve the artifacts associated with the supplied refs.
 
         Parameters
@@ -1748,8 +1732,8 @@ class Butler(LimitedButler):
     )
     def datasetExists(
         self,
-        datasetRefOrType: Union[DatasetRef, DatasetType, str],
-        dataId: Optional[DataId] = None,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        dataId: DataId | None = None,
         *,
         collections: Any = None,
         **kwargs: Any,
@@ -1819,7 +1803,7 @@ class Butler(LimitedButler):
         if not self.isWriteable():
             raise TypeError("Butler is read-only.")
         names = list(names)
-        refs: List[DatasetRef] = []
+        refs: list[DatasetRef] = []
         for name in names:
             collectionType = self.registry.getCollectionType(name)
             if collectionType is not CollectionType.RUN:
@@ -1907,8 +1891,8 @@ class Butler(LimitedButler):
     def ingest(
         self,
         *datasets: FileDataset,
-        transfer: Optional[str] = "auto",
-        run: Optional[str] = None,
+        transfer: str | None = "auto",
+        run: str | None = None,
         idGenerationMode: DatasetIdGenEnum = DatasetIdGenEnum.UNIQUE,
         record_validation_info: bool = True,
     ) -> None:
@@ -1999,7 +1983,7 @@ class Butler(LimitedButler):
         for dataset in progress.wrap(datasets, desc="Grouping by dataset type"):
             # Somewhere to store pre-existing refs if we have an
             # execution butler.
-            existingRefs: List[DatasetRef] = []
+            existingRefs: list[DatasetRef] = []
 
             for ref in dataset.refs:
                 assert ref.run is not None  # For mypy
@@ -2081,10 +2065,10 @@ class Butler(LimitedButler):
     def export(
         self,
         *,
-        directory: Optional[str] = None,
-        filename: Optional[str] = None,
-        format: Optional[str] = None,
-        transfer: Optional[str] = None,
+        directory: str | None = None,
+        filename: str | None = None,
+        format: str | None = None,
+        transfer: str | None = None,
     ) -> Iterator[RepoExportContext]:
         """Export datasets from the repository represented by this `Butler`.
 
@@ -2164,11 +2148,11 @@ class Butler(LimitedButler):
     def import_(
         self,
         *,
-        directory: Optional[ResourcePathExpression] = None,
-        filename: Union[ResourcePathExpression, TextIO, None] = None,
-        format: Optional[str] = None,
-        transfer: Optional[str] = None,
-        skip_dimensions: Optional[Set] = None,
+        directory: ResourcePathExpression | None = None,
+        filename: ResourcePathExpression | TextIO | None = None,
+        format: str | None = None,
+        transfer: str | None = None,
+        skip_dimensions: set | None = None,
     ) -> None:
         """Import datasets into this repository that were exported from a
         different butler repository via `~lsst.daf.butler.Butler.export`.
@@ -2330,7 +2314,7 @@ class Butler(LimitedButler):
         # purged, we have to ask for the (predicted) URI and check
         # existence explicitly. Execution butler is set up exactly like
         # this with no datastore records.
-        artifact_existence: Dict[ResourcePath, bool] = {}
+        artifact_existence: dict[ResourcePath, bool] = {}
         if skip_missing:
             dataset_existence = source_butler.datastore.mexists(
                 source_refs, artifact_existence=artifact_existence
@@ -2385,7 +2369,7 @@ class Butler(LimitedButler):
         else:
             log.log(VERBOSE, "All required dataset types are known to the target Butler")
 
-        dimension_records: Dict[DimensionElement, Dict[DataCoordinate, DimensionRecord]] = defaultdict(dict)
+        dimension_records: dict[DimensionElement, dict[DataCoordinate, DimensionRecord]] = defaultdict(dict)
         if transfer_dimensions:
             # Collect all the dimension records for these refs.
             # All dimensions are to be copied but the list of valid dimensions
@@ -2411,7 +2395,7 @@ class Butler(LimitedButler):
                     if record is not None and record.definition in elements:
                         dimension_records[record.definition].setdefault(record.dataId, record)
 
-        handled_collections: Set[str] = set()
+        handled_collections: set[str] = set()
 
         # Do all the importing in a single transaction.
         with self.transaction():
@@ -2480,7 +2464,7 @@ class Butler(LimitedButler):
     def validateConfiguration(
         self,
         logFailures: bool = False,
-        datasetTypeNames: Optional[Iterable[str]] = None,
+        datasetTypeNames: Iterable[str] | None = None,
         ignore: Iterable[str] | None = None,
     ) -> None:
         """Validate butler configuration.
@@ -2539,7 +2523,7 @@ class Butler(LimitedButler):
                     )
                     datasetRefs.append(datasetRef)
 
-        entities: List[Union[DatasetType, DatasetRef]] = []
+        entities: list[DatasetType | DatasetRef] = []
         entities.extend(datasetTypes)
         entities.extend(datasetRefs)
 
@@ -2622,7 +2606,7 @@ class Butler(LimitedButler):
         return self.registry.defaults.collections
 
     @property
-    def run(self) -> Optional[str]:
+    def run(self) -> str | None:
         """Name of the run this butler writes outputs to by default (`str` or
         `None`).
 

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -28,7 +28,7 @@ __all__ = ("ButlerConfig",)
 
 import copy
 import os
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 
@@ -66,10 +66,10 @@ class ButlerConfig(Config):
 
     def __init__(
         self,
-        other: Optional[Union[ResourcePathExpression, Config]] = None,
+        other: ResourcePathExpression | Config | None = None,
         searchPaths: Sequence[ResourcePathExpression] | None = None,
     ):
-        self.configDir: Optional[ResourcePath] = None
+        self.configDir: ResourcePath | None = None
 
         # If this is already a ButlerConfig we assume that defaults
         # have already been loaded.

--- a/python/lsst/daf/butler/_butlerRepoIndex.py
+++ b/python/lsst/daf/butler/_butlerRepoIndex.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ("ButlerRepoIndex",)
 
 import os
-from typing import ClassVar, Dict, Set
+from typing import ClassVar
 
 from lsst.resources import ResourcePath
 
@@ -51,7 +51,7 @@ class ButlerRepoIndex:
     index_env_var: ClassVar[str] = "DAF_BUTLER_REPOSITORY_INDEX"
     """The name of the environment variable to read to locate the index."""
 
-    _cache: ClassVar[Dict[ResourcePath, Config]] = {}
+    _cache: ClassVar[dict[ResourcePath, Config]] = {}
     """Cache of indexes. In most scenarios only one index will be found
     and the environment will not change. In tests this may not be true."""
 
@@ -140,7 +140,7 @@ class ButlerRepoIndex:
         return repo_index
 
     @classmethod
-    def get_known_repos(cls) -> Set[str]:
+    def get_known_repos(cls) -> set[str]:
         """Retrieve the list of known repository labels.
 
         Returns

--- a/python/lsst/daf/butler/_deferredDatasetHandle.py
+++ b/python/lsst/daf/butler/_deferredDatasetHandle.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 __all__ = ("DeferredDatasetHandle",)
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ._limited_butler import LimitedButler
@@ -41,8 +41,8 @@ class DeferredDatasetHandle:
     def get(
         self,
         *,
-        component: Optional[str] = None,
-        parameters: Optional[dict] = None,
+        component: str | None = None,
+        parameters: dict | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> Any:
         """Retrieves the dataset pointed to by this handle
@@ -104,10 +104,10 @@ class DeferredDatasetHandle:
     """Reference to the dataset (`DatasetRef`).
     """
 
-    parameters: Optional[dict]
+    parameters: dict | None
     """Optional parameters that may be used to specify a subset of the dataset
     to be loaded (`dict` or `None`).
     """
 
-    storageClass: Optional[Union[str, StorageClass]] = None
+    storageClass: str | StorageClass | None = None
     """Optional storage class override that can be applied on ``get()``."""

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -379,7 +379,7 @@ class LimitedButler(ABC):
             datastores known to this butler.  Note that this will make it
             impossible to retrieve these datasets even via other collections.
             Datasets that are already not stored are ignored by this option.
-        tags : `Iterable` [ `str` ], optional
+        tags : `~collections.abc.Iterable` [ `str` ], optional
             `~CollectionType.TAGGED` collections to disassociate the datasets
             from.  Ignored if ``disassociate`` is `False` or ``purge`` is
             `True`.

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -25,7 +25,8 @@ __all__ = ("LimitedButler",)
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Any, ClassVar
 
 from deprecated.sphinx import deprecated
 
@@ -172,7 +173,7 @@ class LimitedButler(ABC):
         self,
         ref: DatasetRef,
         *,
-        parameters: Optional[Dict[str, Any]] = None,
+        parameters: dict[str, Any] | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> Any:
         """Retrieve a stored dataset.
@@ -208,7 +209,7 @@ class LimitedButler(ABC):
         self,
         ref: DatasetRef,
         *,
-        parameters: Union[dict, None] = None,
+        parameters: dict | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -209,7 +209,7 @@ class LimitedButler(ABC):
         self,
         ref: DatasetRef,
         *,
-        parameters: dict | None = None,
+        parameters: dict[str, Any] | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -426,7 +426,7 @@ class QuantumBackedButler(LimitedButler):
         self,
         ref: DatasetRef,
         *,
-        parameters: dict | None = None,
+        parameters: dict[str, Any] | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         # Docstring inherited.

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -739,7 +739,7 @@ class QuantumProvenanceData(BaseModel):
             """Convert input UUIDs, which could be in string representation to
             a set of `UUID` instances.
             """
-            return set(uuid.UUID(id) if isinstance(id, str) else id for id in uuids)
+            return {uuid.UUID(id) if isinstance(id, str) else id for id in uuids}
 
         data = QuantumProvenanceData.__new__(cls)
         setter = object.__setattr__

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -27,7 +27,8 @@ import itertools
 import logging
 import uuid
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Set, Type, Union
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 from deprecated.sphinx import deprecated
 from lsst.resources import ResourcePathExpression
@@ -86,7 +87,7 @@ class _DatasetRecordStorageManagerDatastoreConstructionMimic:
         *,
         name: str = "dataset",
         constraint: bool = True,
-        onDelete: Optional[str] = None,
+        onDelete: str | None = None,
         **kwargs: Any,
     ) -> ddl.FieldSpec:
         # Docstring inherited.
@@ -161,10 +162,10 @@ class QuantumBackedButler(LimitedButler):
         self._dimensions = dimensions
         self._predicted_inputs = set(predicted_inputs)
         self._predicted_outputs = set(predicted_outputs)
-        self._available_inputs: Set[DatasetId] = set()
-        self._unavailable_inputs: Set[DatasetId] = set()
-        self._actual_inputs: Set[DatasetId] = set()
-        self._actual_output_refs: Set[DatasetRef] = set()
+        self._available_inputs: set[DatasetId] = set()
+        self._unavailable_inputs: set[DatasetId] = set()
+        self._actual_inputs: set[DatasetId] = set()
+        self._actual_output_refs: set[DatasetRef] = set()
         self.datastore = datastore
         self.storageClasses = storageClasses
         self._dataset_types: Mapping[str, DatasetType] = {}
@@ -175,13 +176,13 @@ class QuantumBackedButler(LimitedButler):
     @classmethod
     def initialize(
         cls,
-        config: Union[Config, ResourcePathExpression],
+        config: Config | ResourcePathExpression,
         quantum: Quantum,
         dimensions: DimensionUniverse,
         filename: str = ":memory:",
-        OpaqueManagerClass: Type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
-        BridgeManagerClass: Type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
-        search_paths: Optional[List[str]] = None,
+        OpaqueManagerClass: type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
+        BridgeManagerClass: type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
+        search_paths: list[str] | None = None,
         dataset_types: Mapping[str, DatasetType] | None = None,
     ) -> QuantumBackedButler:
         """Construct a new `QuantumBackedButler` from repository configuration
@@ -231,15 +232,15 @@ class QuantumBackedButler(LimitedButler):
     @classmethod
     def from_predicted(
         cls,
-        config: Union[Config, ResourcePathExpression],
+        config: Config | ResourcePathExpression,
         predicted_inputs: Iterable[DatasetId],
         predicted_outputs: Iterable[DatasetId],
         dimensions: DimensionUniverse,
         datastore_records: Mapping[str, DatastoreRecordData],
         filename: str = ":memory:",
-        OpaqueManagerClass: Type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
-        BridgeManagerClass: Type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
-        search_paths: Optional[List[str]] = None,
+        OpaqueManagerClass: type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
+        BridgeManagerClass: type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
+        search_paths: list[str] | None = None,
         dataset_types: Mapping[str, DatasetType] | None = None,
     ) -> QuantumBackedButler:
         """Construct a new `QuantumBackedButler` from sets of input and output
@@ -290,15 +291,15 @@ class QuantumBackedButler(LimitedButler):
     def _initialize(
         cls,
         *,
-        config: Union[Config, ResourcePathExpression],
+        config: Config | ResourcePathExpression,
         predicted_inputs: Iterable[DatasetId],
         predicted_outputs: Iterable[DatasetId],
         dimensions: DimensionUniverse,
         filename: str = ":memory:",
         datastore_records: Mapping[str, DatastoreRecordData] | None = None,
-        OpaqueManagerClass: Type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
-        BridgeManagerClass: Type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
-        search_paths: Optional[List[str]] = None,
+        OpaqueManagerClass: type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
+        BridgeManagerClass: type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
+        search_paths: list[str] | None = None,
         dataset_types: Mapping[str, DatasetType] | None = None,
     ) -> QuantumBackedButler:
         """Internal method with common implementation used by `initialize` and
@@ -384,7 +385,7 @@ class QuantumBackedButler(LimitedButler):
         self,
         ref: DatasetRef,
         *,
-        parameters: Optional[Dict[str, Any]] = None,
+        parameters: dict[str, Any] | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> Any:
         # Docstring inherited.
@@ -423,7 +424,7 @@ class QuantumBackedButler(LimitedButler):
         self,
         ref: DatasetRef,
         *,
-        parameters: Union[dict, None] = None,
+        parameters: dict | None = None,
         storageClass: str | StorageClass | None = None,
     ) -> DeferredDatasetHandle:
         # Docstring inherited.
@@ -610,12 +611,12 @@ class QuantumProvenanceData(BaseModel):
     # `~CollectionType.RUN` level, such as the compute node ID). but adding it
     # now is out of scope for this prototype.
 
-    predicted_inputs: Set[uuid.UUID]
+    predicted_inputs: set[uuid.UUID]
     """Unique IDs of datasets that were predicted as inputs to this quantum
     when the QuantumGraph was built.
     """
 
-    available_inputs: Set[uuid.UUID]
+    available_inputs: set[uuid.UUID]
     """Unique IDs of input datasets that were actually present in the datastore
     when this quantum was executed.
 
@@ -624,7 +625,7 @@ class QuantumProvenanceData(BaseModel):
     task.
     """
 
-    actual_inputs: Set[uuid.UUID]
+    actual_inputs: set[uuid.UUID]
     """Unique IDs of datasets that were actually used as inputs by this task.
 
     This is a subset of `available_inputs`.
@@ -638,17 +639,17 @@ class QuantumProvenanceData(BaseModel):
     that input as actually used.
     """
 
-    predicted_outputs: Set[uuid.UUID]
+    predicted_outputs: set[uuid.UUID]
     """Unique IDs of datasets that were predicted as outputs of this quantum
     when the QuantumGraph was built.
     """
 
-    actual_outputs: Set[uuid.UUID]
+    actual_outputs: set[uuid.UUID]
     """Unique IDs of datasets that were actually written when this quantum
     was executed.
     """
 
-    datastore_records: Dict[str, SerializedDatastoreRecordData]
+    datastore_records: dict[str, SerializedDatastoreRecordData]
     """Datastore records indexed by datastore name."""
 
     @staticmethod
@@ -687,7 +688,7 @@ class QuantumProvenanceData(BaseModel):
         ignored.
         """
         grouped_refs = defaultdict(list)
-        summary_records: Dict[str, DatastoreRecordData] = {}
+        summary_records: dict[str, DatastoreRecordData] = {}
         for quantum, provenance_for_quantum in zip(quanta, provenance):
             quantum_refs_by_id = {
                 ref.id: ref
@@ -717,11 +718,11 @@ class QuantumProvenanceData(BaseModel):
     def direct(
         cls,
         *,
-        predicted_inputs: Iterable[Union[str, uuid.UUID]],
-        available_inputs: Iterable[Union[str, uuid.UUID]],
-        actual_inputs: Iterable[Union[str, uuid.UUID]],
-        predicted_outputs: Iterable[Union[str, uuid.UUID]],
-        actual_outputs: Iterable[Union[str, uuid.UUID]],
+        predicted_inputs: Iterable[str | uuid.UUID],
+        available_inputs: Iterable[str | uuid.UUID],
+        actual_inputs: Iterable[str | uuid.UUID],
+        predicted_outputs: Iterable[str | uuid.UUID],
+        actual_outputs: Iterable[str | uuid.UUID],
         datastore_records: Mapping[str, Mapping],
     ) -> QuantumProvenanceData:
         """Construct an instance directly without validators.
@@ -734,7 +735,7 @@ class QuantumProvenanceData(BaseModel):
         This method should only be called when the inputs are trusted.
         """
 
-        def _to_uuid_set(uuids: Iterable[Union[str, uuid.UUID]]) -> Set[uuid.UUID]:
+        def _to_uuid_set(uuids: Iterable[str | uuid.UUID]) -> set[uuid.UUID]:
             """Convert input UUIDs, which could be in string representation to
             a set of `UUID` instances.
             """

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -210,7 +210,8 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
-        dataset_types: `Mapping` [`str`, `DatasetType`], optional
+        dataset_types: `~collections.abc.Mapping` [`str`, `DatasetType`], \
+                optional
             Mapping of the dataset type name to its registry definition.
         """
         predicted_inputs = [ref.id for ref in itertools.chain.from_iterable(quantum.inputs.values())]
@@ -271,7 +272,8 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
-        dataset_types: `Mapping` [`str`, `DatasetType`], optional
+        dataset_types: `~collections.abc.Mapping` [`str`, `DatasetType`], \
+                optional
             Mapping of the dataset type name to its registry definition.
         """
         return cls._initialize(
@@ -329,7 +331,7 @@ class QuantumBackedButler(LimitedButler):
             location records.  Default is a SQL-backed implementation.
         search_paths : `list` of `str`, optional
             Additional search paths for butler configuration.
-        dataset_types: `Mapping` [`str`, `DatasetType`]
+        dataset_types: `~collections.abc.Mapping` [`str`, `DatasetType`]
             Mapping of the dataset type name to its registry definition.
         """
         butler_config = ButlerConfig(config, searchPaths=search_paths)
@@ -664,10 +666,10 @@ class QuantumProvenanceData(BaseModel):
         butler : `Butler`
             Full butler representing the data repository to transfer datasets
             to.
-        quanta : `Iterable` [ `Quantum` ]
+        quanta : `~collections.abc.Iterable` [ `Quantum` ]
             Iterable of `Quantum` objects that carry information about
             predicted outputs.  May be a single-pass iterator.
-        provenance : `Iterable` [ `QuantumProvenanceData` ]
+        provenance : `~collections.abc.Iterable` [ `QuantumProvenanceData` ]
             Provenance and datastore data for each of the given quanta, in the
             same order.  May be a single-pass iterator.
 

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -407,7 +407,7 @@ class QuantumBackedButler(LimitedButler):
                 parameters=parameters,
                 storageClass=storageClass,
             )
-        except (LookupError, FileNotFoundError, IOError):
+        except (LookupError, FileNotFoundError, OSError):
             self._unavailable_inputs.add(ref.id)
             raise
         if ref.id in self._predicted_inputs:

--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -268,7 +268,7 @@ class LoaderCLI(click.MultiCommand, abc.ABC):
         commands: defaultdict[str, list[str]] = defaultdict(list)
         for pluginName in cls.getPluginList():
             try:
-                with open(pluginName, "r") as resourceFile:
+                with open(pluginName) as resourceFile:
                     resources = defaultdict(list, yaml.safe_load(resourceFile))
             except Exception as err:
                 log.warning("Error loading commands from %s, skipping. %s", pluginName, err)

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -110,7 +110,7 @@ class CliLog:
         variable ``DAF_BUTLER_ROOT_LOGGER``. This variable can contain
         multiple default loggers separated by a ``:``.
         """
-        log_names = set(["lsst"])
+        log_names = {"lsst"}
         envvar = "DAF_BUTLER_ROOT_LOGGER"
         if envvar in os.environ:
             log_names |= set(os.environ[envvar].split(":"))

--- a/python/lsst/daf/butler/core/_column_categorization.py
+++ b/python/lsst/daf/butler/core/_column_categorization.py
@@ -34,6 +34,8 @@ from .dimensions import DimensionUniverse, GovernorDimension, SkyPixDimension
 
 @dataclasses.dataclass
 class ColumnCategorization:
+    """Split an iterable of ColumnTag objects by type."""
+
     dimension_keys: set[str] = dataclasses.field(default_factory=set)
     dimension_records: defaultdict[str, set[str]] = dataclasses.field(
         default_factory=lambda: defaultdict(set)

--- a/python/lsst/daf/butler/core/_column_tags.py
+++ b/python/lsst/daf/butler/core/_column_tags.py
@@ -74,7 +74,7 @@ class DimensionKeyColumnTag(_BaseColumnTag):
 
         Parameters
         ----------
-        dimensions : `Iterable` [ `str` ]
+        dimensions : `~collections.abc.Iterable` [ `str` ]
             Dimension names.
 
         Returns
@@ -119,7 +119,7 @@ class DimensionRecordColumnTag(_BaseColumnTag):
         ----------
         element : `str`
             Name of the dimension element.
-        columns : `Iterable` [ `str` ]
+        columns : `~collections.abc.Iterable` [ `str` ]
             Column names.
 
         Returns
@@ -172,7 +172,7 @@ class DatasetColumnTag(_BaseColumnTag):
         ----------
         dataset_type : `str`
             Name of the dataset type.
-        columns : `Iterable` [ `str` ]
+        columns : `~collections.abc.Iterable` [ `str` ]
             Column names.
 
         Returns

--- a/python/lsst/daf/butler/core/_column_type_info.py
+++ b/python/lsst/daf/butler/core/_column_type_info.py
@@ -26,7 +26,7 @@ __all__ = ("ColumnTypeInfo", "LogicalColumn")
 import dataclasses
 import datetime
 from collections.abc import Iterable
-from typing import Union, cast
+from typing import cast
 
 import astropy.time
 import sqlalchemy
@@ -37,7 +37,7 @@ from ._column_tags import DatasetColumnTag, DimensionKeyColumnTag, DimensionReco
 from .dimensions import Dimension, DimensionUniverse
 from .timespan import TimespanDatabaseRepresentation
 
-LogicalColumn = Union[sqlalchemy.sql.ColumnElement, TimespanDatabaseRepresentation]
+LogicalColumn = sqlalchemy.sql.ColumnElement | TimespanDatabaseRepresentation
 """A type alias for the types used to represent columns in SQL relations.
 
 This is the butler specialization of the `lsst.daf.relation.sql.LogicalColumn`

--- a/python/lsst/daf/butler/core/_column_type_info.py
+++ b/python/lsst/daf/butler/core/_column_type_info.py
@@ -95,9 +95,10 @@ class ColumnTypeInfo:
 
         Parameters
         ----------
-        columns : `Iterable` [ `ColumnTag` ]
+        columns : `~collections.abc.Iterable` [ `ColumnTag` ]
             Iterable of column identifiers.
-        unique_keys : `Iterable` [ `Iterable` [ `ColumnTag` ] ]
+        unique_keys : `~collections.abc.Iterable` \
+                [ `~collections.abc.Iterable` [ `ColumnTag` ] ]
             Unique constraints to add the table, as a nested iterable of
             (first) constraint and (second) the columns within that constraint.
 

--- a/python/lsst/daf/butler/core/_topology.py
+++ b/python/lsst/daf/butler/core/_topology.py
@@ -29,7 +29,8 @@ __all__ = (
 
 import enum
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any
 
 from lsst.utils.classes import immutable
 
@@ -156,11 +157,11 @@ class TopologicalRelationshipEndpoint(ABC):
         raise NotImplementedError()
 
     @property
-    def spatial(self) -> Optional[TopologicalFamily]:
+    def spatial(self) -> TopologicalFamily | None:
         """Return this endpoint's `~TopologicalSpace.SPATIAL` family."""
         return self.topology.get(TopologicalSpace.SPATIAL)
 
     @property
-    def temporal(self) -> Optional[TopologicalFamily]:
+    def temporal(self) -> TopologicalFamily | None:
         """Return this endpoint's `~TopologicalSpace.TEMPORAL` family."""
         return self.topology.get(TopologicalSpace.TEMPORAL)

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -34,6 +34,8 @@ from .config import ConfigSubset
 from .configSupport import processLookupConfigs
 
 if TYPE_CHECKING:
+    from lsst.resources import ResourcePathExpression
+
     from .._butlerConfig import ButlerConfig
     from .configSupport import LookupKey
     from .datasets import DatasetRef, DatasetType
@@ -77,7 +79,9 @@ class CompositesMap:
         in lookup keys.
     """
 
-    def __init__(self, config: ResourcePathExpression | ButlerConfig | CompositesConfig, *, universe: DimensionUniverse):
+    def __init__(
+        self, config: ResourcePathExpression | ButlerConfig | CompositesConfig, *, universe: DimensionUniverse
+    ):
         if not isinstance(config, CompositesConfig):
             config = CompositesConfig(config)
         assert isinstance(config, CompositesConfig)

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -126,7 +126,7 @@ class CompositesMap:
             log.debug("%s will not be disassembled (not a composite)", entity)
             return False
 
-        matchName: LookupKey | str = "{} (via default)".format(entity)
+        matchName: LookupKey | str = f"{entity} (via default)"
         disassemble = self.config["default"]
 
         for key in entity._lookupNames():

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -77,7 +77,7 @@ class CompositesMap:
         in lookup keys.
     """
 
-    def __init__(self, config: str | ButlerConfig | CompositesConfig, *, universe: DimensionUniverse):
+    def __init__(self, config: ResourcePathExpression | ButlerConfig | CompositesConfig, *, universe: DimensionUniverse):
         if not isinstance(config, CompositesConfig):
             config = CompositesConfig(config)
         assert isinstance(config, CompositesConfig)

--- a/python/lsst/daf/butler/core/composites.py
+++ b/python/lsst/daf/butler/core/composites.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 __all__ = ("CompositesConfig", "CompositesMap")
 
 import logging
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import yaml
 
@@ -77,7 +77,7 @@ class CompositesMap:
         in lookup keys.
     """
 
-    def __init__(self, config: Union[str, ButlerConfig, CompositesConfig], *, universe: DimensionUniverse):
+    def __init__(self, config: str | ButlerConfig | CompositesConfig, *, universe: DimensionUniverse):
         if not isinstance(config, CompositesConfig):
             config = CompositesConfig(config)
         assert isinstance(config, CompositesConfig)
@@ -96,7 +96,7 @@ class CompositesMap:
         # the values
         self._lut = processLookupConfigs(disassemblyMap, universe=universe)
 
-    def shouldBeDisassembled(self, entity: Union[DatasetRef, DatasetType, StorageClass]) -> bool:
+    def shouldBeDisassembled(self, entity: DatasetRef | DatasetType | StorageClass) -> bool:
         """Indicate whether the entity should be disassembled.
 
         Parameters
@@ -126,7 +126,7 @@ class CompositesMap:
             log.debug("%s will not be disassembled (not a composite)", entity)
             return False
 
-        matchName: Union[LookupKey, str] = "{} (via default)".format(entity)
+        matchName: LookupKey | str = "{} (via default)".format(entity)
         disassemble = self.config["default"]
 
         for key in entity._lookupNames():

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -1113,7 +1113,7 @@ class ConfigSubset(Config):
 
     Parameters
     ----------
-    other : `Config` or `str` or `dict`
+    other : `Config` or `~lsst.resources.ResourcePathExpression` or `dict`
         Argument specifying the configuration information as understood
         by `Config`
     validate : `bool`, optional

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -33,9 +33,9 @@ import os
 import pprint
 import sys
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, ClassVar, Iterator, cast
+from typing import IO, TYPE_CHECKING, Any, ClassVar, cast
 
 import yaml
 from lsst.resources import ResourcePath, ResourcePathExpression

--- a/python/lsst/daf/butler/core/config.py
+++ b/python/lsst/daf/butler/core/config.py
@@ -64,7 +64,7 @@ else:
 
 def _doUpdate(d: Mapping[str, Any], u: Mapping[str, Any]) -> Mapping[str, Any]:
     if not isinstance(u, Mapping) or not isinstance(d, MutableMapping):
-        raise RuntimeError("Only call update with Mapping, not {}".format(type(d)))
+        raise RuntimeError(f"Only call update with Mapping, not {type(d)}")
     for k, v in u.items():
         if isinstance(v, Mapping):
             lhs = d.get(k, {})

--- a/python/lsst/daf/butler/core/configSupport.py
+++ b/python/lsst/daf/butler/core/configSupport.py
@@ -27,8 +27,8 @@ __all__ = ("LookupKey", "processLookupConfigs", "processLookupConfigList")
 
 import logging
 import re
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Set, Union
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 from .dimensions import DimensionGraph
 
@@ -67,11 +67,11 @@ class LookupKey:
 
     def __init__(
         self,
-        name: Optional[str] = None,
-        dimensions: Optional[Iterable[Union[str, Dimension]]] = None,
-        dataId: Optional[Dict[str, Any]] = None,
+        name: str | None = None,
+        dimensions: Iterable[str | Dimension] | None = None,
+        dataId: dict[str, Any] | None = None,
         *,
-        universe: Optional[DimensionUniverse] = None,
+        universe: DimensionUniverse | None = None,
     ):
         if name is None and dimensions is None:
             raise ValueError("At least one of name or dimensions must be given")
@@ -170,17 +170,17 @@ class LookupKey:
         return False
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """Primary name string to use as lookup (`str`)."""
         return self._name
 
     @property
-    def dimensions(self) -> Optional[DimensionGraph]:
+    def dimensions(self) -> DimensionGraph | None:
         """Dimensions associated with lookup (`DimensionGraph`)."""
         return self._dimensions
 
     @property
-    def dataId(self) -> Optional[Dict[str, Any]]:
+    def dataId(self) -> dict[str, Any] | None:
         """Return dict of keys/values that are important for dataId lookup.
 
         (`dict` or `None`)
@@ -196,9 +196,9 @@ class LookupKey:
 
     def clone(
         self,
-        name: Optional[str] = None,
-        dimensions: Optional[DimensionGraph] = None,
-        dataId: Optional[Dict[str, Any]] = None,
+        name: str | None = None,
+        dimensions: DimensionGraph | None = None,
+        dataId: dict[str, Any] | None = None,
     ) -> LookupKey:
         """Clone the object, overriding some options.
 
@@ -238,8 +238,8 @@ class LookupKey:
 
 
 def processLookupConfigs(
-    config: Config, *, allow_hierarchy: bool = False, universe: Optional[DimensionUniverse] = None
-) -> Dict[LookupKey, Union[str, Dict[str, Any]]]:
+    config: Config, *, allow_hierarchy: bool = False, universe: DimensionUniverse | None = None
+) -> dict[LookupKey, str | dict[str, Any]]:
     """Process sections of configuration relating to lookups.
 
     Can be by dataset type name, storage class name, dimensions, or values
@@ -322,8 +322,8 @@ def processLookupConfigs(
 
 
 def processLookupConfigList(
-    config: Iterable[Union[str, Mapping]], *, universe: Optional[DimensionUniverse] = None
-) -> Set[LookupKey]:
+    config: Iterable[str | Mapping], *, universe: DimensionUniverse | None = None
+) -> set[LookupKey]:
     """Process sections of configuration relating to lookups.
 
     Can be by dataset type name, storage class name, dimensions, or values

--- a/python/lsst/daf/butler/core/constraints.py
+++ b/python/lsst/daf/butler/core/constraints.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 __all__ = ("Constraints", "ConstraintsValidationError", "ConstraintsConfig")
 
 import logging
-from typing import TYPE_CHECKING, Optional, Set, Union
+from typing import TYPE_CHECKING
 
 from .config import Config
 from .configSupport import LookupKey, processLookupConfigList
@@ -71,7 +71,7 @@ class Constraints:
     matchAllKey = LookupKey("all")
     """Configuration key associated with matching everything."""
 
-    def __init__(self, config: Optional[Union[ConstraintsConfig, str]], *, universe: DimensionUniverse):
+    def __init__(self, config: ConstraintsConfig | str | None, *, universe: DimensionUniverse):
         # Default is to accept all and reject nothing
         self._accept = set()
         self._reject = set()
@@ -98,7 +98,7 @@ class Constraints:
         rejects = ", ".join(str(k) for k in self._reject)
         return f"Accepts: {accepts}; Rejects: {rejects}"
 
-    def isAcceptable(self, entity: Union[DatasetRef, DatasetType, StorageClass]) -> bool:
+    def isAcceptable(self, entity: DatasetRef | DatasetType | StorageClass) -> bool:
         """Check whether the supplied entity will be acceptable.
 
         Parameters
@@ -147,7 +147,7 @@ class Constraints:
 
         return False
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         """Retrieve the look up keys for all the constraints entries.
 
         Returns

--- a/python/lsst/daf/butler/core/constraints.py
+++ b/python/lsst/daf/butler/core/constraints.py
@@ -157,4 +157,4 @@ class Constraints:
             the special "all" lookup key.
         """
         all = self._accept | self._accept
-        return set(a for a in all if a.name != self.matchAllKey.name)
+        return {a for a in all if a.name != self.matchAllKey.name}

--- a/python/lsst/daf/butler/core/datasets/association.py
+++ b/python/lsst/daf/butler/core/datasets/association.py
@@ -22,7 +22,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from ..timespan import Timespan
 from .ref import DatasetRef
@@ -46,7 +46,7 @@ class DatasetAssociation:
     """Name of a collection (`str`).
     """
 
-    timespan: Optional[Timespan]
+    timespan: Timespan | None
     """Validity range of the dataset if this is a `~CollectionType.CALIBRATION`
     collection (`Timespan` or `None`).
     """

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -252,12 +252,6 @@ class DatasetRef:
         deterministic UUID5-type ID based on a dataset type name, run
         collection name, and ``dataId``.
 
-    Raises
-    ------
-    ValueError
-        Raised if ``run`` is provided but ``id`` is not, or if ``id`` is
-        provided but ``run`` is not.
-
     See Also
     --------
     :ref:`daf_butler_organizing_datasets`

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -62,7 +62,7 @@ class PositiveInt(ConstrainedInt):
 
 
 class DatasetIdGenEnum(enum.Enum):
-    """This enum is used to specify dataset ID generation options."""
+    """Enum used to specify dataset ID generation options."""
 
     UNIQUE = 0
     """Unique mode generates unique ID for each inserted dataset, e.g.

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -550,7 +550,7 @@ class DatasetRef:
 
         Parameters
         ----------
-        refs : `Iterable` [ `DatasetRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
             `DatasetRef` instances to group.
 
         Returns

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -325,7 +325,7 @@ class Datastore(metaclass=ABCMeta):
 
         Parameters
         ----------
-        config : `Config`
+        config : `Config` or `~lsst.resources.ResourcePathExpression`
             Configuration instance.
         bridgeManager : `DatastoreRegistryBridgeManager`
             Object that manages the interface between `Registry` and
@@ -340,7 +340,7 @@ class Datastore(metaclass=ABCMeta):
 
     def __init__(
         self,
-        config: Config | str,
+        config: Config | ResourcePathExpression,
         bridgeManager: DatastoreRegistryBridgeManager,
         butlerRoot: ResourcePathExpression | None = None,
     ):

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -936,7 +936,7 @@ class Datastore(metaclass=ABCMeta):
 
         Parameters
         ----------
-        refs : `Iterable` [ `DatasetRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
             References to the datasets being forgotten.
 
         Notes
@@ -1136,7 +1136,7 @@ class Datastore(metaclass=ABCMeta):
 
         Parameters
         ----------
-        data : `Mapping` [ `str`, `DatastoreRecordData` ]
+        data : `~collections.abc.Mapping` [ `str`, `DatastoreRecordData` ]
             Datastore records indexed by datastore name.  May contain data for
             other `Datastore` instances (generally because they are chained to
             this one), which should be ignored.
@@ -1164,13 +1164,13 @@ class Datastore(metaclass=ABCMeta):
 
         Parameters
         ----------
-        refs : `Iterable` [ `DatasetIdRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetIdRef` ]
             Datasets to save.  This may include datasets not known to this
             datastore, which should be ignored.
 
         Returns
         -------
-        data : `Mapping` [ `str`, `DatastoreRecordData` ]
+        data : `~collections.abc.Mapping` [ `str`, `DatastoreRecordData` ]
             Exported datastore records indexed by datastore name.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -565,7 +565,7 @@ class DatastoreCacheManager(AbstractDatastoreCacheManager):
 
     @classmethod
     def set_fallback_cache_directory_if_unset(cls) -> tuple[bool, str]:
-        """Defines a fallback cache directory if a fallback not set already.
+        """Define a fallback cache directory if a fallback not set already.
 
         Returns
         -------

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -611,7 +611,7 @@ class DatastoreCacheManager(AbstractDatastoreCacheManager):
 
     def should_be_cached(self, entity: DatasetRef | DatasetType | StorageClass) -> bool:
         # Docstring inherited
-        matchName: LookupKey | str = "{} (via default)".format(entity)
+        matchName: LookupKey | str = f"{entity} (via default)"
         should_cache = self._caching_default
 
         for key in entity._lookupNames():

--- a/python/lsst/daf/butler/core/datastoreRecordData.py
+++ b/python/lsst/daf/butler/core/datastoreRecordData.py
@@ -165,7 +165,7 @@ class DatastoreRecordData:
             """
             if not records:
                 return ""
-            classes = set(record.__class__ for record in records)
+            classes = {record.__class__ for record in records}
             assert len(classes) == 1, f"Records have to be of the same class: {classes}"
             return get_full_type_name(classes.pop())
 

--- a/python/lsst/daf/butler/core/ddl.py
+++ b/python/lsst/daf/butler/core/ddl.py
@@ -534,15 +534,15 @@ class TableSpec:
 
     Parameters
     ----------
-    fields : `Iterable` [ `FieldSpec` ]
+    fields : `~collections.abc.Iterable` [ `FieldSpec` ]
         Specifications for the columns in this table.
-    unique : `Iterable` [ `tuple` [ `str` ] ], optional
+    unique : `~collections.abc.Iterable` [ `tuple` [ `str` ] ], optional
         Non-primary-key unique constraints for the table.
-    indexes: `Iterable` [ `IndexSpec` ], optional
+    indexes: `~collections.abc.Iterable` [ `IndexSpec` ], optional
         Indexes for the table.
-    foreignKeys : `Iterable` [ `ForeignKeySpec` ], optional
+    foreignKeys : `~collections.abc.Iterable` [ `ForeignKeySpec` ], optional
         Foreign key constraints for the table.
-    exclusion : `Iterable` [ `tuple` [ `str` or `type` ] ]
+    exclusion : `~collections.abc.Iterable` [ `tuple` [ `str` or `type` ] ]
         Special constraints that prohibit overlaps between timespans over rows
         where other columns are equal.  These take the same form as unique
         constraints, but each tuple may contain a single

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -30,8 +30,8 @@ __all__ = ("DataCoordinate", "DataId", "DataIdKey", "DataIdValue", "SerializedDa
 
 import numbers
 from abc import abstractmethod
-from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, AbstractSet, Any, ClassVar, Literal, overload
+from collections.abc import Iterator, Mapping, Set
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 from deprecated.sphinx import deprecated
 from lsst.sphgeom import IntersectionRegion, Region
@@ -374,7 +374,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         return self.graph.required
 
     @property
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         """Names of the required dimensions identified by this data ID.
 
         They are returned in the same order as `keys`
@@ -788,7 +788,7 @@ class _DataCoordinateFullView(NamedKeyMapping[Dimension, DataIdValue]):
         return self._target.graph.dimensions
 
     @property
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         # Docstring inherited from `NamedKeyMapping`.
         return self.keys().names
 
@@ -832,7 +832,7 @@ class _DataCoordinateRecordsView(NamedKeyMapping[DimensionElement, DimensionReco
         return self._target.graph.elements
 
     @property
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         # Docstring inherited from `NamedKeyMapping`.
         return self.keys().names
 

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -459,10 +459,11 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
 
         Parameters
         ----------
-        records : `Mapping` [ `str`, `DimensionRecord` or `None` ]
+        records : `~collections.abc.Mapping` [ `str`, `DimensionRecord` or \
+                `None` ]
             A `NamedKeyMapping` with `DimensionElement` keys or a regular
-            `Mapping` with `str` (`DimensionElement` name) keys and
-            `DimensionRecord` values.  Keys must cover all elements in
+            `~collections.abc.Mapping` with `str` (`DimensionElement` name)
+            keys and `DimensionRecord` values.  Keys must cover all elements in
             ``self.graph.elements``.  Values may be `None`, but only to reflect
             actual NULL values in the database, not just records that have not
             been fetched.
@@ -972,10 +973,10 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
         Data ID values, ordered to match ``graph._dataCoordinateIndices``.
         May include values for just required dimensions (which always come
         first) or all dimensions.
-    records : `Mapping` [ `str`, `DimensionRecord` or `None` ]
+    records : `~collections.abc.Mapping` [ `str`, `DimensionRecord` or `None` ]
         A `NamedKeyMapping` with `DimensionElement` keys or a regular
-        `Mapping` with `str` (`DimensionElement` name) keys and
-        `DimensionRecord` values.  Keys must cover all elements in
+        `~collections.abc.Mapping` with `str` (`DimensionElement` name) keys
+        and `DimensionRecord` values.  Keys must cover all elements in
         ``self.graph.elements``.  Values may be `None`, but only to reflect
         actual NULL values in the database, not just records that have not
         been fetched.

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -147,7 +147,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
        instance for at least one operand in any data ID comparison is strongly
        recommended.
 
-    See also
+    See Also
     --------
     :ref:`lsst.daf.butler-dimensions_data_ids`
     """

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -30,20 +30,8 @@ __all__ = ("DataCoordinate", "DataId", "DataIdKey", "DataIdValue", "SerializedDa
 
 import numbers
 from abc import abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    ClassVar,
-    Dict,
-    Iterator,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Union,
-    overload,
-)
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, AbstractSet, Any, ClassVar, Literal, overload
 
 from deprecated.sphinx import deprecated
 from lsst.sphgeom import IntersectionRegion, Region
@@ -60,13 +48,13 @@ if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
     from ...registry import Registry
     from ._universe import DimensionUniverse
 
-DataIdKey = Union[str, Dimension]
+DataIdKey = str | Dimension
 """Type annotation alias for the keys that can be used to index a
 DataCoordinate.
 """
 
 # Pydantic will cast int to str if str is first in the Union.
-DataIdValue = Union[int, str, None]
+DataIdValue = int | str | None
 """Type annotation alias for the values that can be present in a
 DataCoordinate or other data ID.
 """
@@ -75,11 +63,11 @@ DataCoordinate or other data ID.
 class SerializedDataCoordinate(BaseModel):
     """Simplified model for serializing a `DataCoordinate`."""
 
-    dataId: Dict[str, DataIdValue]
-    records: Optional[Dict[str, SerializedDimensionRecord]] = None
+    dataId: dict[str, DataIdValue]
+    records: dict[str, SerializedDimensionRecord] | None = None
 
     @classmethod
-    def direct(cls, *, dataId: Dict[str, DataIdValue], records: Dict[str, Dict]) -> SerializedDataCoordinate:
+    def direct(cls, *, dataId: dict[str, DataIdValue], records: dict[str, dict]) -> SerializedDataCoordinate:
         """Construct a `SerializedDataCoordinate` directly without validators.
 
         This differs from the pydantic "construct" method in that the arguments
@@ -102,7 +90,7 @@ class SerializedDataCoordinate(BaseModel):
         return node
 
 
-def _intersectRegions(*args: Region) -> Optional[Region]:
+def _intersectRegions(*args: Region) -> Region | None:
     """Return the intersection of several regions.
 
     For internal use by `ExpandedDataCoordinate` only.
@@ -170,11 +158,11 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
 
     @staticmethod
     def standardize(
-        mapping: Optional[NameLookupMapping[Dimension, DataIdValue]] = None,
+        mapping: NameLookupMapping[Dimension, DataIdValue] | None = None,
         *,
-        graph: Optional[DimensionGraph] = None,
-        universe: Optional[DimensionUniverse] = None,
-        defaults: Optional[DataCoordinate] = None,
+        graph: DimensionGraph | None = None,
+        universe: DimensionUniverse | None = None,
+        defaults: DataCoordinate | None = None,
         **kwargs: Any,
     ) -> DataCoordinate:
         """Standardize the supplied dataId.
@@ -215,7 +203,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         KeyError
             Raised if a key-value pair for a required dimension is missing.
         """
-        d: Dict[str, DataIdValue] = {}
+        d: dict[str, DataIdValue] = {}
         if isinstance(mapping, DataCoordinate):
             if graph is None:
                 if not kwargs:
@@ -288,7 +276,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         return _ExpandedTupleDataCoordinate(universe.empty, (), {})
 
     @staticmethod
-    def fromRequiredValues(graph: DimensionGraph, values: Tuple[DataIdValue, ...]) -> DataCoordinate:
+    def fromRequiredValues(graph: DimensionGraph, values: tuple[DataIdValue, ...]) -> DataCoordinate:
         """Construct a `DataCoordinate` from required dimension values.
 
         This is a low-level interface with at most assertion-level checking of
@@ -316,7 +304,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         return _BasicTupleDataCoordinate(graph, values)
 
     @staticmethod
-    def fromFullValues(graph: DimensionGraph, values: Tuple[DataIdValue, ...]) -> DataCoordinate:
+    def fromFullValues(graph: DimensionGraph, values: tuple[DataIdValue, ...]) -> DataCoordinate:
         """Construct a `DataCoordinate` from all dimension values.
 
         This is a low-level interface with at most assertion-level checking of
@@ -460,7 +448,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
 
     @abstractmethod
     def expanded(
-        self, records: NameLookupMapping[DimensionElement, Optional[DimensionRecord]]
+        self, records: NameLookupMapping[DimensionElement, DimensionRecord | None]
     ) -> DataCoordinate:
         """Return a `DataCoordinate` that holds the given records.
 
@@ -553,7 +541,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         raise NotImplementedError()
 
     @property
-    def records(self) -> NamedKeyMapping[DimensionElement, Optional[DimensionRecord]]:
+    def records(self) -> NamedKeyMapping[DimensionElement, DimensionRecord | None]:
         """Return the records.
 
         Returns a  mapping that contains `DimensionRecord` objects for all
@@ -572,7 +560,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         return _DataCoordinateRecordsView(self)
 
     @abstractmethod
-    def _record(self, name: str) -> Optional[DimensionRecord]:
+    def _record(self, name: str) -> DimensionRecord | None:
         """Protected implementation hook that backs the ``records`` attribute.
 
         Parameters
@@ -590,7 +578,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         raise NotImplementedError()
 
     @property
-    def region(self) -> Optional[Region]:
+    def region(self) -> Region | None:
         """Spatial region associated with this data ID.
 
         (`lsst.sphgeom.Region` or `None`).
@@ -613,7 +601,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         return _intersectRegions(*regions)
 
     @property
-    def timespan(self) -> Optional[Timespan]:
+    def timespan(self) -> Timespan | None:
         """Temporal interval associated with this data ID.
 
         (`Timespan` or `None`).
@@ -643,7 +631,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
             return Timespan.intersection(*timespans)
 
     @overload
-    def pack(self, name: str, *, returnMaxBits: Literal[True]) -> Tuple[int, int]:
+    def pack(self, name: str, *, returnMaxBits: Literal[True]) -> tuple[int, int]:
         ...
 
     @overload
@@ -656,7 +644,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
         version="v26",
         category=FutureWarning,
     )
-    def pack(self, name: str, *, returnMaxBits: bool = False) -> Union[Tuple[int, int], int]:
+    def pack(self, name: str, *, returnMaxBits: bool = False) -> tuple[int, int] | int:
         """Pack this data ID into an integer.
 
         Parameters
@@ -706,7 +694,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
             dataId = self.full.byName()
         else:
             dataId = self.byName()
-        records: Optional[Dict[str, SerializedDimensionRecord]]
+        records: dict[str, SerializedDimensionRecord] | None
         if not minimal and self.hasRecords():
             records = {k: v.to_simple() for k, v in self.records.byName().items() if v is not None}
         else:
@@ -718,8 +706,8 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
     def from_simple(
         cls,
         simple: SerializedDataCoordinate,
-        universe: Optional[DimensionUniverse] = None,
-        registry: Optional[Registry] = None,
+        universe: DimensionUniverse | None = None,
+        registry: Registry | None = None,
     ) -> DataCoordinate:
         """Construct a new object from the simplified form.
 
@@ -760,7 +748,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
     from_json: ClassVar = classmethod(from_json_pydantic)
 
 
-DataId = Union[DataCoordinate, Mapping[str, Any]]
+DataId = DataCoordinate | Mapping[str, Any]
 """A type-annotation alias for signatures that accept both informal data ID
 dictionaries and validated `DataCoordinate` instances.
 """
@@ -805,7 +793,7 @@ class _DataCoordinateFullView(NamedKeyMapping[Dimension, DataIdValue]):
         return self.keys().names
 
 
-class _DataCoordinateRecordsView(NamedKeyMapping[DimensionElement, Optional[DimensionRecord]]):
+class _DataCoordinateRecordsView(NamedKeyMapping[DimensionElement, DimensionRecord | None]):
     """View class for `DataCoordinate.records`.
 
     Provides the default implementation for
@@ -829,7 +817,7 @@ class _DataCoordinateRecordsView(NamedKeyMapping[DimensionElement, Optional[Dime
     def __str__(self) -> str:
         return "\n".join(str(v) for v in self.values())
 
-    def __getitem__(self, key: Union[DimensionElement, str]) -> Optional[DimensionRecord]:
+    def __getitem__(self, key: DimensionElement | str) -> DimensionRecord | None:
         if isinstance(key, DimensionElement):
             key = key.name
         return self._target._record(key)
@@ -868,7 +856,7 @@ class _BasicTupleDataCoordinate(DataCoordinate):
         or all dimensions.
     """
 
-    def __init__(self, graph: DimensionGraph, values: Tuple[DataIdValue, ...]):
+    def __init__(self, graph: DimensionGraph, values: tuple[DataIdValue, ...]):
         self._graph = graph
         self._values = values
 
@@ -934,7 +922,7 @@ class _BasicTupleDataCoordinate(DataCoordinate):
         return DataCoordinate.standardize(values, graph=graph)
 
     def expanded(
-        self, records: NameLookupMapping[DimensionElement, Optional[DimensionRecord]]
+        self, records: NameLookupMapping[DimensionElement, DimensionRecord | None]
     ) -> DataCoordinate:
         # Docstring inherited from DataCoordinate
         values = self._values
@@ -954,7 +942,7 @@ class _BasicTupleDataCoordinate(DataCoordinate):
         # Docstring inherited from DataCoordinate.
         return False
 
-    def _record(self, name: str) -> Optional[DimensionRecord]:
+    def _record(self, name: str) -> DimensionRecord | None:
         # Docstring inherited from DataCoordinate.
         assert False
 
@@ -996,8 +984,8 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
     def __init__(
         self,
         graph: DimensionGraph,
-        values: Tuple[DataIdValue, ...],
-        records: NameLookupMapping[DimensionElement, Optional[DimensionRecord]],
+        values: tuple[DataIdValue, ...],
+        records: NameLookupMapping[DimensionElement, DimensionRecord | None],
     ):
         super().__init__(graph, values)
         assert super().hasFull(), "This implementation requires full dimension records."
@@ -1014,7 +1002,7 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
         )
 
     def expanded(
-        self, records: NameLookupMapping[DimensionElement, Optional[DimensionRecord]]
+        self, records: NameLookupMapping[DimensionElement, DimensionRecord | None]
     ) -> DataCoordinate:
         # Docstring inherited from DataCoordinate.
         return self
@@ -1051,7 +1039,7 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
             elements -= self.graph.elements.names
             elements -= other.graph.elements.names
             if not elements:
-                records = NamedKeyDict[DimensionElement, Optional[DimensionRecord]](self.records)
+                records = NamedKeyDict[DimensionElement, DimensionRecord | None](self.records)
                 records.update(other.records)
                 return basic.expanded(records.freeze())
         return basic
@@ -1064,7 +1052,7 @@ class _ExpandedTupleDataCoordinate(_BasicTupleDataCoordinate):
         # Docstring inherited from DataCoordinate.
         return True
 
-    def _record(self, name: str) -> Optional[DimensionRecord]:
+    def _record(self, name: str) -> DimensionRecord | None:
         # Docstring inherited from DataCoordinate.
         return self._records[name]
 

--- a/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
+++ b/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
@@ -28,8 +28,8 @@ __all__ = (
 )
 
 from abc import abstractmethod
-from collections.abc import Collection, Iterable, Iterator, Sequence
-from typing import AbstractSet, Any, overload
+from collections.abc import Collection, Iterable, Iterator, Sequence, Set
+from typing import Any, overload
 
 from ._coordinate import DataCoordinate
 from ._graph import DimensionGraph
@@ -428,7 +428,7 @@ class DataCoordinateSet(_DataCoordinateCollectionBase):
 
     def __init__(
         self,
-        dataIds: AbstractSet[DataCoordinate],
+        dataIds: Set[DataCoordinate],
         graph: DimensionGraph,
         *,
         hasFull: bool | None = None,
@@ -437,7 +437,7 @@ class DataCoordinateSet(_DataCoordinateCollectionBase):
     ):
         super().__init__(dataIds, graph, hasFull=hasFull, hasRecords=hasRecords, check=check)
 
-    _dataIds: AbstractSet[DataCoordinate]
+    _dataIds: Set[DataCoordinate]
 
     __slots__ = ()
 

--- a/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
+++ b/python/lsst/daf/butler/core/dimensions/_dataCoordinateIterable.py
@@ -28,7 +28,8 @@ __all__ = (
 )
 
 from abc import abstractmethod
-from typing import AbstractSet, Any, Collection, Dict, Iterable, Iterator, Optional, Sequence, overload
+from collections.abc import Collection, Iterable, Iterator, Sequence
+from typing import AbstractSet, Any, overload
 
 from ._coordinate import DataCoordinate
 from ._graph import DimensionGraph
@@ -256,8 +257,8 @@ class _DataCoordinateCollectionBase(DataCoordinateIterable):
         dataIds: Collection[DataCoordinate],
         graph: DimensionGraph,
         *,
-        hasFull: Optional[bool] = None,
-        hasRecords: Optional[bool] = None,
+        hasFull: bool | None = None,
+        hasRecords: bool | None = None,
         check: bool = True,
     ):
         self._dataIds = dataIds
@@ -332,7 +333,7 @@ class _DataCoordinateCollectionBase(DataCoordinateIterable):
         key = DataCoordinate.standardize(key, universe=self.universe)
         return key in self._dataIds
 
-    def _subsetKwargs(self, graph: DimensionGraph) -> Dict[str, Any]:
+    def _subsetKwargs(self, graph: DimensionGraph) -> dict[str, Any]:
         """Return constructor kwargs useful for subclasses implementing subset.
 
         Parameters
@@ -347,7 +348,7 @@ class _DataCoordinateCollectionBase(DataCoordinateIterable):
             with the appropriate values for a `subset` operation with the given
             dimensions.
         """
-        hasFull: Optional[bool]
+        hasFull: bool | None
         if graph.dimensions <= self.graph.required:
             hasFull = True
         else:
@@ -430,8 +431,8 @@ class DataCoordinateSet(_DataCoordinateCollectionBase):
         dataIds: AbstractSet[DataCoordinate],
         graph: DimensionGraph,
         *,
-        hasFull: Optional[bool] = None,
-        hasRecords: Optional[bool] = None,
+        hasFull: bool | None = None,
+        hasRecords: bool | None = None,
         check: bool = True,
     ):
         super().__init__(dataIds, graph, hasFull=hasFull, hasRecords=hasRecords, check=check)
@@ -683,8 +684,8 @@ class DataCoordinateSequence(_DataCoordinateCollectionBase, Sequence[DataCoordin
         dataIds: Sequence[DataCoordinate],
         graph: DimensionGraph,
         *,
-        hasFull: Optional[bool] = None,
-        hasRecords: Optional[bool] = None,
+        hasFull: bool | None = None,
+        hasRecords: bool | None = None,
         check: bool = True,
     ):
         super().__init__(tuple(dataIds), graph, hasFull=hasFull, hasRecords=hasRecords, check=check)

--- a/python/lsst/daf/butler/core/dimensions/_database.py
+++ b/python/lsst/daf/butler/core/dimensions/_database.py
@@ -123,7 +123,7 @@ class DatabaseTopologicalFamilyConstructionVisitor(DimensionConstructionVisitor)
     ----------
     name : `str`
         Name of the family.
-    members : `Iterable` [ `str` ]
+    members : `~collections.abc.Iterable` [ `str` ]
         The names of the members of this family, ordered according to the
         priority used in `choose` (first-choice member first).
     """
@@ -418,16 +418,16 @@ class DatabaseDimensionElementConstructionVisitor(DimensionConstructionVisitor):
         Fully qualified name of the `DatabaseDimensionRecordStorage` subclass
         that will back this element in the registry (in a "cls" key) along
         with any other construction keyword arguments (in other keys).
-    required : `Set` [ `Dimension` ]
+    required : `~collections.abc.Set` [ `Dimension` ]
         Names of dimensions whose keys define the compound primary key for this
         element's (logical) table, as well as references to their own
         tables.
-    implied : `Set` [ `Dimension` ]
+    implied : `~collections.abc.Set` [ `Dimension` ]
         Names of dimension whose keys are included in this elements's
         (logical) table as foreign keys.
-    metadata : `Iterable` [ `ddl.FieldSpec` ]
+    metadata : `~collections.abc.Iterable` [ `ddl.FieldSpec` ]
         Field specifications for all non-key fields in this element's table.
-    uniqueKeys : `Iterable` [ `ddl.FieldSpec` ]
+    uniqueKeys : `~collections.abc.Iterable` [ `ddl.FieldSpec` ]
         Fields that can each be used to uniquely identify this dimension (given
         values for all required dimensions).  The first of these is used as
         (part of) this dimension's table's primary key, while others are used

--- a/python/lsst/daf/butler/core/dimensions/_database.py
+++ b/python/lsst/daf/butler/core/dimensions/_database.py
@@ -28,9 +28,9 @@ __all__ = (
     "DatabaseTopologicalFamily",
 )
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Set
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet
+from typing import TYPE_CHECKING
 
 from lsst.utils import doImportType
 from lsst.utils.classes import cached_getter
@@ -133,7 +133,7 @@ class DatabaseTopologicalFamilyConstructionVisitor(DimensionConstructionVisitor)
         self._space = space
         self._members = tuple(members)
 
-    def hasDependenciesIn(self, others: AbstractSet[str]) -> bool:
+    def hasDependenciesIn(self, others: Set[str]) -> bool:
         # Docstring inherited from DimensionConstructionVisitor.
         return not others.isdisjoint(self._members)
 
@@ -459,7 +459,7 @@ class DatabaseDimensionElementConstructionVisitor(DimensionConstructionVisitor):
         self._uniqueKeys = NamedValueSet(uniqueKeys).freeze()
         self._alwaysJoin = alwaysJoin
 
-    def hasDependenciesIn(self, others: AbstractSet[str]) -> bool:
+    def hasDependenciesIn(self, others: Set[str]) -> bool:
         # Docstring inherited from DimensionConstructionVisitor.
         return not (self._required.isdisjoint(others) and self._implied.isdisjoint(others))
 

--- a/python/lsst/daf/butler/core/dimensions/_database.py
+++ b/python/lsst/daf/butler/core/dimensions/_database.py
@@ -28,8 +28,9 @@ __all__ = (
     "DatabaseTopologicalFamily",
 )
 
+from collections.abc import Iterable, Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Mapping, Optional, Set
+from typing import TYPE_CHECKING, AbstractSet
 
 from lsst.utils import doImportType
 from lsst.utils.classes import cached_getter
@@ -184,7 +185,7 @@ class DatabaseDimensionElement(DimensionElement):
         self._storage = storage
         self._implied = implied
         self._metadata = metadata
-        self._topology: Dict[TopologicalSpace, DatabaseTopologicalFamily] = {}
+        self._topology: dict[TopologicalSpace, DatabaseTopologicalFamily] = {}
 
     @property
     def name(self) -> str:
@@ -202,7 +203,7 @@ class DatabaseDimensionElement(DimensionElement):
         return self._metadata
 
     @property
-    def viewOf(self) -> Optional[str]:
+    def viewOf(self) -> str | None:
         # Docstring inherited from DimensionElement.
         # This is a bit encapsulation-breaking; these storage config values
         # are supposed to be opaque here, and just forwarded on to some
@@ -220,12 +221,12 @@ class DatabaseDimensionElement(DimensionElement):
         return MappingProxyType(self._topology)
 
     @property
-    def spatial(self) -> Optional[DatabaseTopologicalFamily]:
+    def spatial(self) -> DatabaseTopologicalFamily | None:
         # Docstring inherited from TopologicalRelationshipEndpoint
         return self.topology.get(TopologicalSpace.SPATIAL)
 
     @property
-    def temporal(self) -> Optional[DatabaseTopologicalFamily]:
+    def temporal(self) -> DatabaseTopologicalFamily | None:
         # Docstring inherited from TopologicalRelationshipEndpoint
         return self.topology.get(TopologicalSpace.TEMPORAL)
 
@@ -233,7 +234,7 @@ class DatabaseDimensionElement(DimensionElement):
         self,
         db: Database,
         *,
-        context: Optional[StaticTablesContext] = None,
+        context: StaticTablesContext | None = None,
         governors: NamedKeyMapping[GovernorDimension, GovernorDimensionRecordStorage],
         view_target: DatabaseDimensionRecordStorage | None = None,
     ) -> DatabaseDimensionRecordStorage:
@@ -444,8 +445,8 @@ class DatabaseDimensionElementConstructionVisitor(DimensionConstructionVisitor):
         self,
         name: str,
         storage: dict,
-        required: Set[str],
-        implied: Set[str],
+        required: set[str],
+        implied: set[str],
         metadata: Iterable[ddl.FieldSpec] = (),
         uniqueKeys: Iterable[ddl.FieldSpec] = (),
         alwaysJoin: bool = False,

--- a/python/lsst/daf/butler/core/dimensions/_database.py
+++ b/python/lsst/daf/butler/core/dimensions/_database.py
@@ -93,7 +93,7 @@ class DatabaseTopologicalFamily(TopologicalFamily):
 
         (`GovernorDimension`).
         """
-        governors = set(m.governor for m in self.members)
+        governors = {m.governor for m in self.members}
         if None in governors:
             raise RuntimeError(
                 f"Bad {self.space.name} family definition {self.name}: at least one member "

--- a/python/lsst/daf/butler/core/dimensions/_elements.py
+++ b/python/lsst/daf/butler/core/dimensions/_elements.py
@@ -28,7 +28,7 @@ __all__ = (
 )
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Type
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.utils.classes import cached_getter
 
@@ -150,7 +150,7 @@ class DimensionElement(TopologicalRelationshipEndpoint):
 
     @classmethod
     def from_simple(
-        cls, simple: str, universe: Optional[DimensionUniverse] = None, registry: Optional[Registry] = None
+        cls, simple: str, universe: DimensionUniverse | None = None, registry: Registry | None = None
     ) -> DimensionElement:
         """Construct a new object from the simplified form.
 
@@ -199,7 +199,7 @@ class DimensionElement(TopologicalRelationshipEndpoint):
 
     @property
     @cached_getter
-    def governor(self) -> Optional[GovernorDimension]:
+    def governor(self) -> GovernorDimension | None:
         """Return the governor dimension.
 
         This is the `GovernorDimension` that is a required dependency of this
@@ -289,7 +289,7 @@ class DimensionElement(TopologicalRelationshipEndpoint):
 
     @property
     @cached_getter
-    def RecordClass(self) -> Type[DimensionRecord]:
+    def RecordClass(self) -> type[DimensionRecord]:
         """Return the record subclass for this element.
 
         The `DimensionRecord` subclass used to hold records for this element
@@ -313,7 +313,7 @@ class DimensionElement(TopologicalRelationshipEndpoint):
         raise NotImplementedError()
 
     @property
-    def viewOf(self) -> Optional[str]:
+    def viewOf(self) -> str | None:
         """Name of another table this element's records are drawn from.
 
         (`str` or `None`).

--- a/python/lsst/daf/butler/core/dimensions/_governor.py
+++ b/python/lsst/daf/butler/core/dimensions/_governor.py
@@ -183,9 +183,9 @@ class GovernorDimensionConstructionVisitor(DimensionConstructionVisitor):
         Fully qualified name of the `GovernorDimensionRecordStorage` subclass
         that will back this element in the registry (in a "cls" key) along
         with any other construction keyword arguments (in other keys).
-    metadata : `Iterable` [ `ddl.FieldSpec` ]
+    metadata : `~collections.abc.Iterable` [ `ddl.FieldSpec` ]
         Field specifications for all non-key fields in this element's table.
-    uniqueKeys : `Iterable` [ `ddl.FieldSpec` ]
+    uniqueKeys : `~collections.abc.Iterable` [ `ddl.FieldSpec` ]
         Fields that can each be used to uniquely identify this dimension (given
         values for all required dimensions).  The first of these is used as
         (part of) this dimension's table's primary key, while others are used

--- a/python/lsst/daf/butler/core/dimensions/_governor.py
+++ b/python/lsst/daf/butler/core/dimensions/_governor.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 
 __all__ = ("GovernorDimension",)
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Set
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet
+from typing import TYPE_CHECKING
 
 from lsst.utils import doImportType
 
@@ -205,7 +205,7 @@ class GovernorDimensionConstructionVisitor(DimensionConstructionVisitor):
         self._metadata = NamedValueSet(metadata).freeze()
         self._uniqueKeys = NamedValueSet(uniqueKeys).freeze()
 
-    def hasDependenciesIn(self, others: AbstractSet[str]) -> bool:
+    def hasDependenciesIn(self, others: Set[str]) -> bool:
         # Docstring inherited from DimensionConstructionVisitor.
         return False
 

--- a/python/lsst/daf/butler/core/dimensions/_governor.py
+++ b/python/lsst/daf/butler/core/dimensions/_governor.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 __all__ = ("GovernorDimension",)
 
+from collections.abc import Iterable, Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet, Iterable, Mapping, Optional
+from typing import TYPE_CHECKING, AbstractSet
 
 from lsst.utils import doImportType
 
@@ -144,7 +145,7 @@ class GovernorDimension(Dimension):
         self,
         db: Database,
         *,
-        context: Optional[StaticTablesContext] = None,
+        context: StaticTablesContext | None = None,
     ) -> GovernorDimensionRecordStorage:
         """Make storage record.
 

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -24,22 +24,9 @@ from __future__ import annotations
 __all__ = ["DimensionGraph", "SerializedDimensionGraph"]
 
 import itertools
+from collections.abc import Iterable, Iterator, Mapping
 from types import MappingProxyType
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, AbstractSet, Any, ClassVar
 
 from lsst.utils.classes import cached_getter, immutable
 from pydantic import BaseModel
@@ -58,10 +45,10 @@ if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
 class SerializedDimensionGraph(BaseModel):
     """Simplified model of a `DimensionGraph` suitable for serialization."""
 
-    names: List[str]
+    names: list[str]
 
     @classmethod
-    def direct(cls, *, names: List[str]) -> SerializedDimensionGraph:
+    def direct(cls, *, names: list[str]) -> SerializedDimensionGraph:
         """Construct a `SerializedDimensionGraph` directly without validators.
 
         This differs from the pydantic "construct" method in that the arguments
@@ -124,11 +111,11 @@ class DimensionGraph:
     def __new__(
         cls,
         universe: DimensionUniverse,
-        dimensions: Optional[Iterable[Dimension]] = None,
-        names: Optional[Iterable[str]] = None,
+        dimensions: Iterable[Dimension] | None = None,
+        names: Iterable[str] | None = None,
         conform: bool = True,
     ) -> DimensionGraph:
-        conformedNames: Set[str]
+        conformedNames: set[str]
         if names is None:
             if dimensions is None:
                 conformedNames = set()
@@ -202,7 +189,7 @@ class DimensionGraph:
         # we want them to be lightweight.  The order here is what's convenient
         # for DataCoordinate: all required dimensions before all implied
         # dimensions.
-        self._dataCoordinateIndices: Dict[str, int] = {
+        self._dataCoordinateIndices: dict[str, int] = {
             name: i for i, name in enumerate(itertools.chain(self.required.names, self.implied.names))
         }
 
@@ -241,8 +228,8 @@ class DimensionGraph:
     def from_simple(
         cls,
         names: SerializedDimensionGraph,
-        universe: Optional[DimensionUniverse] = None,
-        registry: Optional[Registry] = None,
+        universe: DimensionUniverse | None = None,
+        registry: Registry | None = None,
     ) -> DimensionGraph:
         """Construct a new object from the simplified form.
 
@@ -292,7 +279,7 @@ class DimensionGraph:
         """
         return len(self.dimensions)
 
-    def __contains__(self, element: Union[str, DimensionElement]) -> bool:
+    def __contains__(self, element: str | DimensionElement) -> bool:
         """Return `True` if the given element or element name is in the graph.
 
         This test covers all `DimensionElement` instances in ``self.elements``,
@@ -404,7 +391,7 @@ class DimensionGraph:
 
     @property
     @cached_getter
-    def primaryKeyTraversalOrder(self) -> Tuple[DimensionElement, ...]:
+    def primaryKeyTraversalOrder(self) -> tuple[DimensionElement, ...]:
         """Return a tuple of all elements in specific order.
 
         The order allows records to be
@@ -415,7 +402,7 @@ class DimensionGraph:
         DimensionUniverse.sorted gives you), when dimension A implies
         dimension B, dimension A appears first.
         """
-        done: Set[str] = set()
+        done: set[str] = set()
         order = []
 
         def addToOrder(element: DimensionElement) -> None:

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -478,6 +478,6 @@ class DimensionGraph:
 
     topology: Mapping[TopologicalSpace, NamedValueAbstractSet[TopologicalFamily]]
     """Families of elements in this graph that can participate in topological
-    relationships (`Mapping` from `TopologicalSpace` to
+    relationships (`~collections.abc.Mapping` from `TopologicalSpace` to
     `NamedValueAbstractSet` of `TopologicalFamily`).
     """

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -125,7 +125,7 @@ class DimensionGraph:
                     # not required.
                     conformedNames = set(dimensions.names)  # type: ignore
                 except AttributeError:
-                    conformedNames = set(d.name for d in dimensions)
+                    conformedNames = {d.name for d in dimensions}
         else:
             if dimensions is not None:
                 raise TypeError("Only one of 'dimensions' and 'names' may be provided.")

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -24,9 +24,9 @@ from __future__ import annotations
 __all__ = ["DimensionGraph", "SerializedDimensionGraph"]
 
 import itertools
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Set
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.utils.classes import cached_getter, immutable
 from pydantic import BaseModel
@@ -202,7 +202,7 @@ class DimensionGraph:
         return self
 
     @property
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         """Set of the names of all dimensions in the graph (`KeysView`)."""
         return self.dimensions.names
 

--- a/python/lsst/daf/butler/core/dimensions/_packer.py
+++ b/python/lsst/daf/butler/core/dimensions/_packer.py
@@ -25,8 +25,8 @@ __all__ = ("DimensionPacker",)
 
 import warnings
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, AbstractSet, Any
+from collections.abc import Iterable, Set
+from typing import TYPE_CHECKING, Any
 
 from deprecated.sphinx import deprecated
 from lsst.utils import doImportType
@@ -192,11 +192,11 @@ class DimensionPackerFactory:
     ----------
     clsName : `str`
         Fully-qualified name of the packer class this factory constructs.
-    fixed : `AbstractSet` [ `str` ]
+    fixed : `~collections.abc.Set` [ `str` ]
         Names of dimensions whose values must be provided to the packer when it
         is constructed.  This will be expanded lazily into a `DimensionGraph`
         prior to `DimensionPacker` construction.
-    dimensions : `AbstractSet` [ `str` ]
+    dimensions : `~collections.abc.Set` [ `str` ]
         Names of dimensions whose values are passed to `DimensionPacker.pack`.
         This will be expanded lazily into a `DimensionGraph` prior to
         `DimensionPacker` construction.
@@ -205,14 +205,14 @@ class DimensionPackerFactory:
     def __init__(
         self,
         clsName: str,
-        fixed: AbstractSet[str],
-        dimensions: AbstractSet[str],
+        fixed: Set[str],
+        dimensions: Set[str],
     ):
         # We defer turning these into DimensionGraph objects until first use
         # because __init__ is called before a DimensionUniverse exists, and
         # DimensionGraph instances can only be constructed afterwards.
-        self._fixed: AbstractSet[str] | DimensionGraph = fixed
-        self._dimensions: AbstractSet[str] | DimensionGraph = dimensions
+        self._fixed: Set[str] | DimensionGraph = fixed
+        self._dimensions: Set[str] | DimensionGraph = dimensions
         self._clsName = clsName
         self._cls: type[DimensionPacker] | None = None
 
@@ -278,7 +278,7 @@ class DimensionPackerConstructionVisitor(DimensionConstructionVisitor):
         self._dimensions = set(dimensions)
         self._clsName = clsName
 
-    def hasDependenciesIn(self, others: AbstractSet[str]) -> bool:
+    def hasDependenciesIn(self, others: Set[str]) -> bool:
         # Docstring inherited from DimensionConstructionVisitor.
         return False
 

--- a/python/lsst/daf/butler/core/dimensions/_packer.py
+++ b/python/lsst/daf/butler/core/dimensions/_packer.py
@@ -25,7 +25,8 @@ __all__ = ("DimensionPacker",)
 
 import warnings
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Any, Iterable, Optional, Tuple, Type, Union
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, AbstractSet, Any
 
 from deprecated.sphinx import deprecated
 from lsst.utils import doImportType
@@ -99,7 +100,7 @@ class DimensionPacker(metaclass=ABCMeta):
 
     def pack(
         self, dataId: DataId | None = None, *, returnMaxBits: bool = False, **kwargs: Any
-    ) -> Union[Tuple[int, int], int]:
+    ) -> tuple[int, int] | int:
         """Pack the given data ID into a single integer.
 
         Parameters
@@ -210,10 +211,10 @@ class DimensionPackerFactory:
         # We defer turning these into DimensionGraph objects until first use
         # because __init__ is called before a DimensionUniverse exists, and
         # DimensionGraph instances can only be constructed afterwards.
-        self._fixed: Union[AbstractSet[str], DimensionGraph] = fixed
-        self._dimensions: Union[AbstractSet[str], DimensionGraph] = dimensions
+        self._fixed: AbstractSet[str] | DimensionGraph = fixed
+        self._dimensions: AbstractSet[str] | DimensionGraph = dimensions
         self._clsName = clsName
-        self._cls: Optional[Type[DimensionPacker]] = None
+        self._cls: type[DimensionPacker] | None = None
 
     def __call__(self, universe: DimensionUniverse, fixed: DataCoordinate) -> DimensionPacker:
         """Construct a `DimensionPacker` instance for the given fixed data ID.

--- a/python/lsst/daf/butler/core/dimensions/_packer.py
+++ b/python/lsst/daf/butler/core/dimensions/_packer.py
@@ -262,11 +262,11 @@ class DimensionPackerConstructionVisitor(DimensionConstructionVisitor):
         `DimensionUniverse`.
     clsName : `str`
         Fully-qualified name of a `DimensionPacker` subclass.
-    fixed : `Iterable` [ `str` ]
+    fixed : `~collections.abc.Iterable` [ `str` ]
         Names of dimensions whose values must be provided to the packer when it
         is constructed.  This will be expanded lazily into a `DimensionGraph`
         prior to `DimensionPacker` construction.
-    dimensions : `Iterable` [ `str` ]
+    dimensions : `~collections.abc.Iterable` [ `str` ]
         Names of dimensions whose values are passed to `DimensionPacker.pack`.
         This will be expanded lazily into a `DimensionGraph` prior to
         `DimensionPacker` construction.

--- a/python/lsst/daf/butler/core/dimensions/_records.py
+++ b/python/lsst/daf/butler/core/dimensions/_records.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 __all__ = ("DimensionRecord", "SerializedDimensionRecord")
 
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple
 
 import lsst.sphgeom
 from lsst.utils.classes import immutable
@@ -40,7 +40,7 @@ if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
     from ._schema import DimensionElementFields
 
 
-def _reconstructDimensionRecord(definition: DimensionElement, mapping: Dict[str, Any]) -> DimensionRecord:
+def _reconstructDimensionRecord(definition: DimensionElement, mapping: dict[str, Any]) -> DimensionRecord:
     """Unpickle implementation for `DimensionRecord` subclasses.
 
     For internal use by `DimensionRecord`.
@@ -48,7 +48,7 @@ def _reconstructDimensionRecord(definition: DimensionElement, mapping: Dict[str,
     return definition.RecordClass(**mapping)
 
 
-def _subclassDimensionRecord(definition: DimensionElement) -> Type[DimensionRecord]:
+def _subclassDimensionRecord(definition: DimensionElement) -> type[DimensionRecord]:
     """Create a dynamic subclass of `DimensionRecord` for the given element.
 
     For internal use by `DimensionRecord`.
@@ -69,12 +69,12 @@ class SpecificSerializedDimensionRecord(BaseModel, extra="forbid"):
     """Base model for a specific serialized record content."""
 
 
-_SIMPLE_RECORD_CLASS_CACHE: Dict[
-    Tuple[DimensionElement, DimensionUniverse], Type[SpecificSerializedDimensionRecord]
+_SIMPLE_RECORD_CLASS_CACHE: dict[
+    tuple[DimensionElement, DimensionUniverse], type[SpecificSerializedDimensionRecord]
 ] = {}
 
 
-def _createSimpleRecordSubclass(definition: DimensionElement) -> Type[SpecificSerializedDimensionRecord]:
+def _createSimpleRecordSubclass(definition: DimensionElement) -> type[SpecificSerializedDimensionRecord]:
     from ._schema import DimensionElementFields
 
     # Cache on the definition (which hashes as the name) and the
@@ -125,7 +125,7 @@ class SerializedDimensionRecord(BaseModel):
     )
 
     # Use strict types to prevent casting
-    record: Dict[str, Union[None, StrictFloat, StrictStr, StrictBool, StrictInt, Tuple[int, int]]] = Field(
+    record: dict[str, None | StrictFloat | StrictStr | StrictBool | StrictInt | tuple[int, int]] = Field(
         ...,
         title="Dimension record keys and values.",
         example={
@@ -156,7 +156,7 @@ class SerializedDimensionRecord(BaseModel):
         cls,
         *,
         definition: str,
-        record: Dict[str, Union[None, StrictFloat, StrictStr, StrictBool, StrictInt, Tuple[int, int]]],
+        record: dict[str, None | StrictFloat | StrictStr | StrictBool | StrictInt | tuple[int, int]],
     ) -> SerializedDimensionRecord:
         """Construct a `SerializedDimensionRecord` directly without validators.
 
@@ -336,8 +336,8 @@ class DimensionRecord:
     def from_simple(
         cls,
         simple: SerializedDimensionRecord,
-        universe: Optional[DimensionUniverse] = None,
-        registry: Optional[Registry] = None,
+        universe: DimensionUniverse | None = None,
+        registry: Registry | None = None,
     ) -> DimensionRecord:
         """Construct a new object from the simplified form.
 
@@ -394,7 +394,7 @@ class DimensionRecord:
     to_json = to_json_pydantic
     from_json: ClassVar = classmethod(from_json_pydantic)
 
-    def toDict(self, splitTimespan: bool = False) -> Dict[str, Any]:
+    def toDict(self, splitTimespan: bool = False) -> dict[str, Any]:
         """Return a vanilla `dict` representation of this record.
 
         Parameters

--- a/python/lsst/daf/butler/core/dimensions/_schema.py
+++ b/python/lsst/daf/butler/core/dimensions/_schema.py
@@ -245,7 +245,7 @@ class DimensionElementFields:
     @cached_getter
     def columns(self) -> Mapping[ColumnTag, str]:
         """A mapping from `ColumnTag` to field name for all fields in this
-        element's records (`Mapping`).
+        element's records (`~collections.abc.Mapping`).
         """
         result: dict[ColumnTag, str] = {}
         for dimension_name, field_name in zip(self.element.dimensions.names, self.dimensions.names):

--- a/python/lsst/daf/butler/core/dimensions/_schema.py
+++ b/python/lsst/daf/butler/core/dimensions/_schema.py
@@ -24,7 +24,7 @@ __all__ = ("addDimensionForeignKey",)
 
 import copy
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 from lsst.utils.classes import cached_getter
 
@@ -305,7 +305,7 @@ class DimensionElementFields:
     and/or timespan (`NamedValueSet` [ `ddl.FieldSpec` ]).
     """
 
-    names: Tuple[str, ...]
+    names: tuple[str, ...]
     """The names of all fields in the specification (`tuple` [ `str` ]).
 
     This includes "region" and/or "timespan" if `element` is spatial and/or

--- a/python/lsst/daf/butler/core/dimensions/_skypix.py
+++ b/python/lsst/daf/butler/core/dimensions/_skypix.py
@@ -26,8 +26,9 @@ __all__ = (
     "SkyPixSystem",
 )
 
+from collections.abc import Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet, Dict, Mapping, Optional, Type
+from typing import TYPE_CHECKING, AbstractSet
 
 import sqlalchemy
 from lsst.sphgeom import PixelizationABC
@@ -65,18 +66,18 @@ class SkyPixSystem(TopologicalFamily):
         name: str,
         *,
         maxLevel: int,
-        PixelizationClass: Type[PixelizationABC],
+        PixelizationClass: type[PixelizationABC],
     ):
         super().__init__(name, TopologicalSpace.SPATIAL)
         self.maxLevel = maxLevel
         self.PixelizationClass = PixelizationClass
-        self._members: Dict[int, SkyPixDimension] = {}
+        self._members: dict[int, SkyPixDimension] = {}
         for level in range(maxLevel + 1):
             self._members[level] = SkyPixDimension(self, level)
 
     def choose(self, endpoints: NamedValueAbstractSet[TopologicalRelationshipEndpoint]) -> SkyPixDimension:
         # Docstring inherited from TopologicalFamily.
-        best: Optional[SkyPixDimension] = None
+        best: SkyPixDimension | None = None
         for endpoint in endpoints:
             if endpoint not in self:
                 continue
@@ -214,7 +215,7 @@ class SkyPixConstructionVisitor(DimensionConstructionVisitor):
     universe being static.
     """
 
-    def __init__(self, name: str, pixelizationClassName: str, maxLevel: Optional[int] = None):
+    def __init__(self, name: str, pixelizationClassName: str, maxLevel: int | None = None):
         super().__init__(name)
         self._pixelizationClassName = pixelizationClassName
         self._maxLevel = maxLevel

--- a/python/lsst/daf/butler/core/dimensions/_skypix.py
+++ b/python/lsst/daf/butler/core/dimensions/_skypix.py
@@ -26,9 +26,9 @@ __all__ = (
     "SkyPixSystem",
 )
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Set
 from types import MappingProxyType
-from typing import TYPE_CHECKING, AbstractSet
+from typing import TYPE_CHECKING
 
 import sqlalchemy
 from lsst.sphgeom import PixelizationABC
@@ -220,7 +220,7 @@ class SkyPixConstructionVisitor(DimensionConstructionVisitor):
         self._pixelizationClassName = pixelizationClassName
         self._maxLevel = maxLevel
 
-    def hasDependenciesIn(self, others: AbstractSet[str]) -> bool:
+    def hasDependenciesIn(self, others: Set[str]) -> bool:
         # Docstring inherited from DimensionConstructionVisitor.
         return False
 

--- a/python/lsst/daf/butler/core/dimensions/_universe.py
+++ b/python/lsst/daf/butler/core/dimensions/_universe.py
@@ -26,21 +26,8 @@ __all__ = ["DimensionUniverse"]
 import logging
 import math
 import pickle
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    FrozenSet,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
 from deprecated.sphinx import deprecated
 from lsst.utils.classes import cached_getter, immutable
@@ -98,7 +85,7 @@ class DimensionUniverse:
         called; this will be called if needed by `DimensionUniverse`.
     """
 
-    _instances: ClassVar[Dict[Tuple[int, str], DimensionUniverse]] = {}
+    _instances: ClassVar[dict[tuple[int, str], DimensionUniverse]] = {}
     """Singleton dictionary of all instances, keyed by version.
 
     For internal use only.
@@ -106,11 +93,11 @@ class DimensionUniverse:
 
     def __new__(
         cls,
-        config: Optional[Config] = None,
+        config: Config | None = None,
         *,
-        version: Optional[int] = None,
-        namespace: Optional[str] = None,
-        builder: Optional[DimensionConstructionBuilder] = None,
+        version: int | None = None,
+        namespace: str | None = None,
+        builder: DimensionConstructionBuilder | None = None,
     ) -> DimensionUniverse:
         # Try to get a version first, to look for existing instances; try to
         # do as little work as possible at this stage.
@@ -133,7 +120,7 @@ class DimensionUniverse:
             namespace = _DEFAULT_NAMESPACE
 
         # See if an equivalent instance already exists.
-        self: Optional[DimensionUniverse] = cls._instances.get((version, namespace))
+        self: DimensionUniverse | None = cls._instances.get((version, namespace))
         if self is not None:
             return self
 
@@ -247,7 +234,7 @@ class DimensionUniverse:
     def __contains__(self, name: Any) -> bool:
         return name in self._elements
 
-    def get(self, name: str, default: Optional[DimensionElement] = None) -> Optional[DimensionElement]:
+    def get(self, name: str, default: DimensionElement | None = None) -> DimensionElement | None:
         """Return the `DimensionElement` with the given name or a default.
 
         Parameters
@@ -375,7 +362,7 @@ class DimensionUniverse:
         """
         return self._dimensionIndices[name]
 
-    def expandDimensionNameSet(self, names: Set[str]) -> None:
+    def expandDimensionNameSet(self, names: set[str]) -> None:
         """Expand a set of dimension names in-place.
 
         Includes recursive dependencies.
@@ -404,7 +391,7 @@ class DimensionUniverse:
             else:
                 oldSize = len(names)
 
-    def extract(self, iterable: Iterable[Union[Dimension, str]]) -> DimensionGraph:
+    def extract(self, iterable: Iterable[Dimension | str]) -> DimensionGraph:
         """Construct graph from iterable.
 
         Constructs a `DimensionGraph` from a possibly-heterogenous iterable
@@ -433,7 +420,7 @@ class DimensionUniverse:
                 names.add(item)
         return DimensionGraph(universe=self, names=names)
 
-    def sorted(self, elements: Iterable[Union[E, str]], *, reverse: bool = False) -> List[E]:
+    def sorted(self, elements: Iterable[E | str], *, reverse: bool = False) -> list[E]:
         """Return a sorted version of the given iterable of dimension elements.
 
         The universe's sort order is topological (an element's dependencies
@@ -497,7 +484,7 @@ class DimensionUniverse:
         return math.ceil(len(self._dimensions) / 8)
 
     @classmethod
-    def _unpickle(cls, version: int, namespace: Optional[str] = None) -> DimensionUniverse:
+    def _unpickle(cls, version: int, namespace: str | None = None) -> DimensionUniverse:
         """Return an unpickled dimension universe.
 
         Callable used for unpickling.
@@ -541,7 +528,7 @@ class DimensionUniverse:
     dimensionConfig: DimensionConfig
     """The configuration used to create this Universe (`DimensionConfig`)."""
 
-    _cache: Dict[FrozenSet[str], DimensionGraph]
+    _cache: dict[frozenset[str], DimensionGraph]
 
     _dimensions: NamedValueAbstractSet[Dimension]
 
@@ -549,11 +536,11 @@ class DimensionUniverse:
 
     _topology: Mapping[TopologicalSpace, NamedValueAbstractSet[TopologicalFamily]]
 
-    _dimensionIndices: Dict[str, int]
+    _dimensionIndices: dict[str, int]
 
-    _elementIndices: Dict[str, int]
+    _elementIndices: dict[str, int]
 
-    _packers: Dict[str, DimensionPackerFactory]
+    _packers: dict[str, DimensionPackerFactory]
 
     _version: int
 

--- a/python/lsst/daf/butler/core/dimensions/construction.py
+++ b/python/lsst/daf/butler/core/dimensions/construction.py
@@ -22,7 +22,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, AbstractSet, Dict, Iterable, Optional
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, AbstractSet
 
 from .._topology import TopologicalFamily, TopologicalSpace
 from ..named import NamedValueSet
@@ -122,7 +123,7 @@ class DimensionConstructionBuilder:
         commonSkyPixName: str,
         config: DimensionConfig,
         *,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         visitors: Iterable[DimensionConstructionVisitor] = (),
     ) -> None:
         self.dimensions = NamedValueSet()
@@ -133,7 +134,7 @@ class DimensionConstructionBuilder:
         self.namespace = namespace
         self.config = config
         self.commonSkyPixName = commonSkyPixName
-        self._todo: Dict[str, DimensionConstructionVisitor] = {v.name: v for v in visitors}
+        self._todo: dict[str, DimensionConstructionVisitor] = {v.name: v for v in visitors}
 
     def add(self, visitor: DimensionConstructionVisitor) -> None:
         """Add a single visitor to the builder.
@@ -180,7 +181,7 @@ class DimensionConstructionBuilder:
     Populated at builder construction.
     """
 
-    namespace: Optional[str]
+    namespace: str | None
     """Namespace for the `DimensionUniverse` (`str`)
 
     Populated at builder construction.
@@ -208,12 +209,12 @@ class DimensionConstructionBuilder:
     set as well as `dimensions`.
     """
 
-    topology: Dict[TopologicalSpace, NamedValueSet[TopologicalFamily]]
+    topology: dict[TopologicalSpace, NamedValueSet[TopologicalFamily]]
     """Dictionary containing all `TopologicalFamily` objects
     (`dict` [ `TopologicalSpace`, `NamedValueSet` [ `TopologicalFamily` ] ] ).
     """
 
-    packers: Dict[str, DimensionPackerFactory]
+    packers: dict[str, DimensionPackerFactory]
     """Dictionary containing all `DimensionPackerFactory` objects
     (`dict` [ `str`, `DimensionPackerFactory` ] ).
     """

--- a/python/lsst/daf/butler/core/dimensions/construction.py
+++ b/python/lsst/daf/butler/core/dimensions/construction.py
@@ -65,7 +65,7 @@ class DimensionConstructionVisitor(ABC):
 
         Parameters
         ----------
-        others : `Set` [ `str` ]
+        others : `~collections.abc.Set` [ `str` ]
             The names of other visitors that have not yet been invoked.
 
         Returns
@@ -113,7 +113,7 @@ class DimensionConstructionBuilder:
         spatial `TopologicalRelationshipEndpoint` objects.
     namespace : `str`, optional
         The namespace to assign to this universe.
-    visitors : `Iterable` [ `DimensionConstructionVisitor` ]
+    visitors : `~collections.abc.Iterable` [ `DimensionConstructionVisitor` ]
         Visitor instances to include from the start.
     """
 
@@ -151,7 +151,8 @@ class DimensionConstructionBuilder:
 
         Parameters
         ----------
-        visitors : `Iterable` [ `DimensionConstructionVisitor` ]
+        visitors : `~collections.abc.Iterable` \
+                [ `DimensionConstructionVisitor` ]
             Visitor instances to add.
         """
         self._todo.update((v.name, v) for v in visitors)

--- a/python/lsst/daf/butler/core/dimensions/construction.py
+++ b/python/lsst/daf/butler/core/dimensions/construction.py
@@ -22,8 +22,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, AbstractSet
+from collections.abc import Iterable, Set
+from typing import TYPE_CHECKING
 
 from .._topology import TopologicalFamily, TopologicalSpace
 from ..named import NamedValueSet
@@ -57,7 +57,7 @@ class DimensionConstructionVisitor(ABC):
         return self.name
 
     @abstractmethod
-    def hasDependenciesIn(self, others: AbstractSet[str]) -> bool:
+    def hasDependenciesIn(self, others: Set[str]) -> bool:
         """Test if dependencies have already been constructed.
 
         Tests whether other entities this visitor depends on have already
@@ -65,7 +65,7 @@ class DimensionConstructionVisitor(ABC):
 
         Parameters
         ----------
-        others : `AbstractSet` [ `str` ]
+        others : `Set` [ `str` ]
             The names of other visitors that have not yet been invoked.
 
         Returns

--- a/python/lsst/daf/butler/core/fileDataset.py
+++ b/python/lsst/daf/butler/core/fileDataset.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ["FileDataset"]
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Union
+from typing import Any
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 
@@ -38,11 +38,11 @@ class FileDataset:
 
     __slots__ = ("refs", "path", "formatter")
 
-    refs: List[DatasetRef]
+    refs: list[DatasetRef]
     """Registry information about the dataset. (`list` of `DatasetRef`).
     """
 
-    path: Union[str, ResourcePath]
+    path: str | ResourcePath
     """Path to the dataset (`lsst.resources.ResourcePath` or `str`).
 
     If the dataset was exported with ``transfer=None`` (i.e. in-place),
@@ -52,16 +52,16 @@ class FileDataset:
     to `Datastore.export`.
     """
 
-    formatter: Optional[FormatterParameter]
+    formatter: FormatterParameter | None
     """A `Formatter` class or fully-qualified name.
     """
 
     def __init__(
         self,
         path: ResourcePathExpression,
-        refs: Union[DatasetRef, List[DatasetRef]],
+        refs: DatasetRef | list[DatasetRef],
         *,
-        formatter: Optional[FormatterParameter] = None,
+        formatter: FormatterParameter | None = None,
     ):
         # Do not want to store all possible options supported by ResourcePath
         # so force a conversion for the non-str parameters.

--- a/python/lsst/daf/butler/core/fileDescriptor.py
+++ b/python/lsst/daf/butler/core/fileDescriptor.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 __all__ = ("FileDescriptor",)
 
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .location import Location
@@ -52,8 +53,8 @@ class FileDescriptor:
         self,
         location: Location,
         storageClass: StorageClass,
-        readStorageClass: Optional[StorageClass] = None,
-        parameters: Optional[Mapping[str, Any]] = None,
+        readStorageClass: StorageClass | None = None,
+        parameters: Mapping[str, Any] | None = None,
     ):
         self.location = location
         self._readStorageClass = readStorageClass
@@ -61,7 +62,7 @@ class FileDescriptor:
         self.parameters = dict(parameters) if parameters is not None else None
 
     def __repr__(self) -> str:
-        optionals: Dict[str, Any] = {}
+        optionals: dict[str, Any] = {}
         if self._readStorageClass is not None:
             optionals["readStorageClass"] = self._readStorageClass
         if self.parameters:

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -28,8 +28,9 @@ __all__ = ("FileTemplates", "FileTemplate", "FileTemplatesConfig", "FileTemplate
 import logging
 import os.path
 import string
+from collections.abc import Iterable, Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 from .config import Config
 from .configSupport import LookupKey, processLookupConfigs
@@ -93,8 +94,8 @@ class FileTemplates:
 
     def __init__(
         self,
-        config: Union[FileTemplatesConfig, str],
-        default: Optional[str] = None,
+        config: FileTemplatesConfig | str,
+        default: str | None = None,
         *,
         universe: DimensionUniverse,
     ):
@@ -145,7 +146,7 @@ class FileTemplates:
         return self.templates[key]
 
     def validateTemplates(
-        self, entities: Iterable[Union[DatasetType, DatasetRef, StorageClass]], logFailures: bool = False
+        self, entities: Iterable[DatasetType | DatasetRef | StorageClass], logFailures: bool = False
     ) -> None:
         """Validate the templates.
 
@@ -204,7 +205,7 @@ class FileTemplates:
                 msg = f"{len(failed)} template validation failures: {failMsg}"
             raise FileTemplateValidationError(msg)
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         """Retrieve the look up keys for all the template entries.
 
         Returns
@@ -215,8 +216,8 @@ class FileTemplates:
         return set(self.templates)
 
     def getTemplateWithMatch(
-        self, entity: Union[DatasetRef, DatasetType, StorageClass]
-    ) -> Tuple[LookupKey, FileTemplate]:
+        self, entity: DatasetRef | DatasetType | StorageClass
+    ) -> tuple[LookupKey, FileTemplate]:
         """Retrieve the `FileTemplate` associated with the dataset type.
 
         Also retrieves the lookup key that was a match for this template.
@@ -266,7 +267,7 @@ class FileTemplates:
 
         return source, template
 
-    def getTemplate(self, entity: Union[DatasetType, DatasetRef, StorageClass]) -> FileTemplate:
+    def getTemplate(self, entity: DatasetType | DatasetRef | StorageClass) -> FileTemplate:
         """Retrieve the `FileTemplate` associated with the dataset type.
 
         If the lookup name corresponds to a component the base name for
@@ -370,7 +371,7 @@ class FileTemplate:
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}("{self.template}")'
 
-    def fields(self, optionals: bool = False, specials: bool = False, subfields: bool = False) -> Set[str]:
+    def fields(self, optionals: bool = False, specials: bool = False, subfields: bool = False) -> set[str]:
         """Return the field names used in this template.
 
         Parameters
@@ -576,7 +577,7 @@ class FileTemplate:
 
         return path
 
-    def validateTemplate(self, entity: Union[DatasetRef, DatasetType, StorageClass, None]) -> None:
+    def validateTemplate(self, entity: DatasetRef | DatasetType | StorageClass | None) -> None:
         """Compare the template against supplied entity that wants to use it.
 
         Parameters
@@ -701,7 +702,7 @@ class FileTemplate:
 
         return
 
-    def _determine_skypix_alias(self, entity: Union[DatasetRef, DatasetType]) -> Optional[str]:
+    def _determine_skypix_alias(self, entity: DatasetRef | DatasetType) -> str | None:
         """Return the dimension name that refers to a sky pixel.
 
         Parameters

--- a/python/lsst/daf/butler/core/fileTemplates.py
+++ b/python/lsst/daf/butler/core/fileTemplates.py
@@ -563,9 +563,7 @@ class FileTemplate:
 
         # Complain if we were meant to use a component
         if component is not None and not usedComponent:
-            raise KeyError(
-                "Component '{}' specified but template {} did not use it".format(component, self.template)
-            )
+            raise KeyError(f"Component '{component}' specified but template {self.template} did not use it")
 
         # Since this is known to be a path, normalize it in case some double
         # slashes have crept in

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -27,8 +27,8 @@ import contextlib
 import copy
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, AbstractSet, Any, ClassVar
+from collections.abc import Iterator, Mapping, Set
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.utils.introspection import get_full_type_name
 
@@ -76,18 +76,18 @@ class Formatter(metaclass=ABCMeta):
     signature.
     """
 
-    unsupportedParameters: ClassVar[AbstractSet[str] | None] = frozenset()
+    unsupportedParameters: ClassVar[Set[str] | None] = frozenset()
     """Set of read parameters not understood by this `Formatter`. An empty set
     means all parameters are supported.  `None` indicates that no parameters
     are supported. These param (`frozenset`).
     """
 
-    supportedWriteParameters: ClassVar[AbstractSet[str] | None] = None
+    supportedWriteParameters: ClassVar[Set[str] | None] = None
     """Parameters understood by this formatter that can be used to control
     how a dataset is serialized. `None` indicates that no parameters are
     supported."""
 
-    supportedExtensions: ClassVar[AbstractSet[str]] = frozenset()
+    supportedExtensions: ClassVar[Set[str]] = frozenset()
     """Set of all extensions supported by this formatter.
 
     Only expected to be populated by Formatters that write files. Any extension

--- a/python/lsst/daf/butler/core/formatter.py
+++ b/python/lsst/daf/butler/core/formatter.py
@@ -27,20 +27,8 @@ import contextlib
 import copy
 import logging
 from abc import ABCMeta, abstractmethod
-from collections.abc import Mapping
-from typing import (
-    TYPE_CHECKING,
-    AbstractSet,
-    Any,
-    ClassVar,
-    Dict,
-    Iterator,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, AbstractSet, Any, ClassVar
 
 from lsst.utils.introspection import get_full_type_name
 
@@ -56,7 +44,7 @@ from .storageClass import StorageClass
 log = logging.getLogger(__name__)
 
 # Define a new special type for functions that take "entity"
-Entity = Union[DatasetType, DatasetRef, StorageClass, str]
+Entity = DatasetType | DatasetRef | StorageClass | str
 
 
 if TYPE_CHECKING:
@@ -88,13 +76,13 @@ class Formatter(metaclass=ABCMeta):
     signature.
     """
 
-    unsupportedParameters: ClassVar[Optional[AbstractSet[str]]] = frozenset()
+    unsupportedParameters: ClassVar[AbstractSet[str] | None] = frozenset()
     """Set of read parameters not understood by this `Formatter`. An empty set
     means all parameters are supported.  `None` indicates that no parameters
     are supported. These param (`frozenset`).
     """
 
-    supportedWriteParameters: ClassVar[Optional[AbstractSet[str]]] = None
+    supportedWriteParameters: ClassVar[AbstractSet[str] | None] = None
     """Parameters understood by this formatter that can be used to control
     how a dataset is serialized. `None` indicates that no parameters are
     supported."""
@@ -110,8 +98,8 @@ class Formatter(metaclass=ABCMeta):
         self,
         fileDescriptor: FileDescriptor,
         dataId: DataCoordinate,
-        writeParameters: Optional[Dict[str, Any]] = None,
-        writeRecipes: Optional[Dict[str, Any]] = None,
+        writeParameters: dict[str, Any] | None = None,
+        writeRecipes: dict[str, Any] | None = None,
     ):
         if not isinstance(fileDescriptor, FileDescriptor):
             raise TypeError("File descriptor must be a FileDescriptor")
@@ -170,7 +158,7 @@ class Formatter(metaclass=ABCMeta):
         return {}
 
     @classmethod
-    def validateWriteRecipes(cls, recipes: Optional[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
+    def validateWriteRecipes(cls, recipes: Mapping[str, Any] | None) -> Mapping[str, Any] | None:
         """Validate supplied recipes for this formatter.
 
         The recipes are supplemented with default values where appropriate.
@@ -207,7 +195,7 @@ class Formatter(metaclass=ABCMeta):
         return get_full_type_name(cls)
 
     @abstractmethod
-    def read(self, component: Optional[str] = None) -> Any:
+    def read(self, component: str | None = None) -> Any:
         """Read a Dataset.
 
         Parameters
@@ -256,7 +244,7 @@ class Formatter(metaclass=ABCMeta):
             pass
         return True
 
-    def fromBytes(self, serializedDataset: bytes, component: Optional[str] = None) -> object:
+    def fromBytes(self, serializedDataset: bytes, component: str | None = None) -> object:
         """Read serialized data into a Dataset or its component.
 
         Parameters
@@ -292,7 +280,7 @@ class Formatter(metaclass=ABCMeta):
         raise NotImplementedError("Type does not support writing to bytes.")
 
     @contextlib.contextmanager
-    def _updateLocation(self, location: Optional[Location]) -> Iterator[Location]:
+    def _updateLocation(self, location: Location | None) -> Iterator[Location]:
         """Temporarily replace the location associated with this formatter.
 
         Parameters
@@ -433,7 +421,7 @@ class Formatter(metaclass=ABCMeta):
         updated = self.makeUpdatedLocation(self.fileDescriptor.location)
         return updated.pathInStore.path
 
-    def segregateParameters(self, parameters: Optional[Dict[str, Any]] = None) -> Tuple[Dict, Dict]:
+    def segregateParameters(self, parameters: dict[str, Any] | None = None) -> tuple[dict, dict]:
         """Segregate the supplied parameters.
 
         This splits the parameters into those understood by the
@@ -490,7 +478,7 @@ class FormatterFactory:
     def __init__(self) -> None:
         self._mappingFactory = MappingFactory(Formatter)
 
-    def __contains__(self, key: Union[LookupKey, str]) -> bool:
+    def __contains__(self, key: LookupKey | str) -> bool:
         """Indicate whether the supplied key is present in the factory.
 
         Parameters
@@ -639,7 +627,7 @@ class FormatterFactory:
             writeParameters = copy.deepcopy(defaultParameters.get(formatter, {}))
             writeParameters.update(specificWriteParameters)
 
-            kwargs: Dict[str, Any] = {}
+            kwargs: dict[str, Any] = {}
             if writeParameters:
                 kwargs["writeParameters"] = writeParameters
 
@@ -648,7 +636,7 @@ class FormatterFactory:
 
             self.registerFormatter(key, formatter, **kwargs)
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         """Retrieve the look up keys for all the registry entries.
 
         Returns
@@ -658,7 +646,7 @@ class FormatterFactory:
         """
         return self._mappingFactory.getLookupKeys()
 
-    def getFormatterClassWithMatch(self, entity: Entity) -> Tuple[LookupKey, Type[Formatter], Dict[str, Any]]:
+    def getFormatterClassWithMatch(self, entity: Entity) -> tuple[LookupKey, type[Formatter], dict[str, Any]]:
         """Get the matching formatter class along with the registry key.
 
         Parameters
@@ -690,7 +678,7 @@ class FormatterFactory:
 
         return matchKey, formatter, formatter_kwargs
 
-    def getFormatterClass(self, entity: Entity) -> Type:
+    def getFormatterClass(self, entity: Entity) -> type:
         """Get the matching formatter class.
 
         Parameters
@@ -710,7 +698,7 @@ class FormatterFactory:
         _, formatter, _ = self.getFormatterClassWithMatch(entity)
         return formatter
 
-    def getFormatterWithMatch(self, entity: Entity, *args: Any, **kwargs: Any) -> Tuple[LookupKey, Formatter]:
+    def getFormatterWithMatch(self, entity: Entity, *args: Any, **kwargs: Any) -> tuple[LookupKey, Formatter]:
         """Get a new formatter instance along with the matching registry key.
 
         Parameters
@@ -770,7 +758,7 @@ class FormatterFactory:
 
     def registerFormatter(
         self,
-        type_: Union[LookupKey, str, StorageClass, DatasetType],
+        type_: LookupKey | str | StorageClass | DatasetType,
         formatter: str,
         *,
         overwrite: bool = False,
@@ -804,4 +792,4 @@ class FormatterFactory:
 
 
 # Type to use when allowing a Formatter or its class name
-FormatterParameter = Union[str, Type[Formatter], Formatter]
+FormatterParameter = str | type[Formatter] | Formatter

--- a/python/lsst/daf/butler/core/json.py
+++ b/python/lsst/daf/butler/core/json.py
@@ -27,12 +27,14 @@ import json
 from typing import TYPE_CHECKING, Any, Optional, Protocol, Type
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from ..registry import Registry
     from .dimensions import DimensionUniverse
 
 
 class SupportsSimple(Protocol):
-    _serializedType: Type
+    _serializedType: Type[BaseModel]
 
     def to_simple(self, minimal: bool) -> Any:
         ...

--- a/python/lsst/daf/butler/core/json.py
+++ b/python/lsst/daf/butler/core/json.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ("to_json_generic", "from_json_generic", "to_json_pydantic", "from_json_pydantic")
 
 import json
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Type
+from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -34,14 +34,14 @@ if TYPE_CHECKING:
 
 
 class SupportsSimple(Protocol):
-    _serializedType: Type[BaseModel]
+    _serializedType: type[BaseModel]
 
     def to_simple(self, minimal: bool) -> Any:
         ...
 
     @classmethod
     def from_simple(
-        cls, simple: Any, universe: Optional[DimensionUniverse] = None, registry: Optional[Registry] = None
+        cls, simple: Any, universe: DimensionUniverse | None = None, registry: Registry | None = None
     ) -> SupportsSimple:
         ...
 
@@ -55,10 +55,10 @@ def to_json_pydantic(self: SupportsSimple, minimal: bool = False) -> str:
 
 
 def from_json_pydantic(
-    cls: Type[SupportsSimple],
+    cls: type[SupportsSimple],
     json_str: str,
-    universe: Optional[DimensionUniverse] = None,
-    registry: Optional[Registry] = None,
+    universe: DimensionUniverse | None = None,
+    registry: Registry | None = None,
 ) -> SupportsSimple:
     """Convert from JSON to a pydantic model."""
     simple = cls._serializedType.parse_raw(json_str)
@@ -91,10 +91,10 @@ def to_json_generic(self: SupportsSimple, minimal: bool = False) -> str:
 
 
 def from_json_generic(
-    cls: Type[SupportsSimple],
+    cls: type[SupportsSimple],
     json_str: str,
-    universe: Optional[DimensionUniverse] = None,
-    registry: Optional[Registry] = None,
+    universe: DimensionUniverse | None = None,
+    registry: Registry | None = None,
 ) -> SupportsSimple:
     """Return new class from JSON string.
 

--- a/python/lsst/daf/butler/core/location.py
+++ b/python/lsst/daf/butler/core/location.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 __all__ = ("Location", "LocationFactory")
 
-from typing import Optional, Union
-
 from lsst.resources import ResourcePath, ResourcePathExpression
 
 
@@ -45,7 +43,7 @@ class Location:
 
     __slots__ = ("_datastoreRootUri", "_path", "_uri")
 
-    def __init__(self, datastoreRootUri: Union[None, ResourcePathExpression], path: ResourcePathExpression):
+    def __init__(self, datastoreRootUri: None | ResourcePathExpression, path: ResourcePathExpression):
         # Be careful not to force a relative local path to absolute path
         path_uri = ResourcePath(path, forceAbsolute=False)
 
@@ -71,7 +69,7 @@ class Location:
         self._path = path_uri
 
         # Internal cache of the full location as a ResourcePath
-        self._uri: Optional[ResourcePath] = None
+        self._uri: ResourcePath | None = None
 
         # Check that the resulting URI is inside the datastore
         # This can go wrong if we were given ../dir as path
@@ -144,7 +142,7 @@ class Location:
         """
         return self.uri.relativeToPathRoot
 
-    def updateExtension(self, ext: Optional[str]) -> None:
+    def updateExtension(self, ext: str | None) -> None:
         """Update the file extension associated with this `Location`.
 
         All file extensions are replaced.

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -300,7 +300,7 @@ class ButlerLogRecords(BaseModel):
         Works with one-record-per-line format JSON files and a direct
         serialization of the Pydantic model.
         """
-        with open(filename, "r") as fd:
+        with open(filename) as fd:
             return cls.from_stream(fd)
 
     @staticmethod

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -24,22 +24,10 @@ __all__ = ("ButlerMDC", "ButlerLogRecords", "ButlerLogRecordHandler", "ButlerLog
 import datetime
 import logging
 import traceback
+from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
 from logging import Formatter, LogRecord, StreamHandler
-from typing import (
-    IO,
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Generator,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Union,
-    overload,
-)
+from typing import IO, Any, ClassVar, Union, overload
 
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import isplit
@@ -84,7 +72,7 @@ class ButlerMDC:
 
     _MDC = MDCDict()
 
-    _old_factory: Optional[Callable[..., logging.LogRecord]] = None
+    _old_factory: Callable[..., logging.LogRecord] | None = None
     """Old log record factory."""
 
     @classmethod
@@ -117,7 +105,7 @@ class ButlerMDC:
 
     @classmethod
     @contextmanager
-    def set_mdc(cls, mdc: Dict[str, str]) -> Generator[None, None, None]:
+    def set_mdc(cls, mdc: dict[str, str]) -> Generator[None, None, None]:
         """Set the MDC key for this context.
 
         Parameters
@@ -187,11 +175,11 @@ class ButlerLogRecord(BaseModel):
     filename: str
     pathname: str
     lineno: int
-    funcName: Optional[str]
+    funcName: str | None
     process: int
     processName: str
-    exc_info: Optional[str]
-    MDC: Dict[str, str]
+    exc_info: str | None
+    MDC: dict[str, str]
 
     class Config:
         """Pydantic model configuration."""
@@ -243,7 +231,7 @@ class ButlerLogRecord(BaseModel):
 
         return cls(**record_dict)
 
-    def format(self, log_format: Optional[str] = None) -> str:
+    def format(self, log_format: str | None = None) -> str:
         """Format this record.
 
         Parameters
@@ -276,7 +264,7 @@ class ButlerLogRecord(BaseModel):
 
 
 # The class below can convert LogRecord to ButlerLogRecord if needed.
-Record = Union[LogRecord, ButlerLogRecord]
+Record = LogRecord | ButlerLogRecord
 
 
 # Do not inherit from MutableSequence since mypy insists on the values
@@ -284,8 +272,8 @@ Record = Union[LogRecord, ButlerLogRecord]
 class ButlerLogRecords(BaseModel):
     """Class representing a collection of `ButlerLogRecord`."""
 
-    __root__: List[ButlerLogRecord]
-    _log_format: Optional[str] = PrivateAttr(None)
+    __root__: list[ButlerLogRecord]
+    _log_format: str | None = PrivateAttr(None)
 
     @classmethod
     def from_records(cls, records: Iterable[ButlerLogRecord]) -> "ButlerLogRecords":
@@ -316,7 +304,7 @@ class ButlerLogRecords(BaseModel):
             return cls.from_stream(fd)
 
     @staticmethod
-    def _detect_model(startdata: Union[str, bytes]) -> bool:
+    def _detect_model(startdata: str | bytes) -> bool:
         """Given some representative data, determine if this is a serialized
         model or a streaming format.
 
@@ -407,7 +395,7 @@ class ButlerLogRecords(BaseModel):
         return cls.from_records(records)
 
     @classmethod
-    def from_raw(cls, serialized: Union[str, bytes]) -> "ButlerLogRecords":
+    def from_raw(cls, serialized: str | bytes) -> "ButlerLogRecords":
         """Parse raw serialized form and return records.
 
         Parameters
@@ -430,7 +418,7 @@ class ButlerLogRecords(BaseModel):
         # Filter out blank lines -- mypy is confused by the newline
         # argument to isplit() [which can't have two different types
         # simultaneously] so we have to duplicate some logic.
-        substrings: Iterator[Union[str, bytes]]
+        substrings: Iterator[str | bytes]
         if isinstance(serialized, str):
             substrings = isplit(serialized, "\n")
         elif isinstance(serialized, bytes):
@@ -449,7 +437,7 @@ class ButlerLogRecords(BaseModel):
 
     # Pydantic does not allow a property setter to be given for
     # public properties of a model that is not based on a dict.
-    def set_log_format(self, format: Optional[str]) -> Optional[str]:
+    def set_log_format(self, format: str | None) -> str | None:
         """Set the log format string for these records.
 
         Parameters
@@ -488,7 +476,7 @@ class ButlerLogRecords(BaseModel):
     def __getitem__(self, index: slice) -> "ButlerLogRecords":
         ...
 
-    def __getitem__(self, index: Union[slice, int]) -> "Union[ButlerLogRecords, ButlerLogRecord]":
+    def __getitem__(self, index: slice | int) -> "Union[ButlerLogRecords, ButlerLogRecord]":
         # Handles slices and returns a new collection in that
         # case.
         item = self.__root__[index]
@@ -500,7 +488,7 @@ class ButlerLogRecords(BaseModel):
     def __reversed__(self) -> Iterator[ButlerLogRecord]:
         return self.__root__.__reversed__()
 
-    def __delitem__(self, index: Union[slice, int]) -> None:
+    def __delitem__(self, index: slice | int) -> None:
         del self.__root__[index]
 
     def __str__(self) -> str:

--- a/python/lsst/daf/butler/core/mappingFactory.py
+++ b/python/lsst/daf/butler/core/mappingFactory.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 __all__ = ("MappingFactory",)
 
-from typing import Any, Dict, Iterable, List, Set, Tuple, Type, Union
+from collections.abc import Iterable
+from typing import Any
 
 from lsst.utils.introspection import get_class_of
 
@@ -49,8 +50,8 @@ class MappingFactory:
 
     """
 
-    def __init__(self, refType: Type):
-        self._registry: Dict[LookupKey, Dict[str, Any]] = {}
+    def __init__(self, refType: type):
+        self._registry: dict[LookupKey, dict[str, Any]] = {}
         self.refType = refType
 
     def __contains__(self, key: Any) -> bool:
@@ -70,7 +71,7 @@ class MappingFactory:
         key = self._getNameKey(key)
         return key in self._registry
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         """Retrieve the look up keys for all the registry entries.
 
         Returns
@@ -82,7 +83,7 @@ class MappingFactory:
 
     def getClassFromRegistryWithMatch(
         self, targetClasses: Iterable[Any]
-    ) -> Tuple[LookupKey, Type, Dict[Any, Any]]:
+    ) -> tuple[LookupKey, type, dict[Any, Any]]:
         """Get the class stored in the registry along with the matching key.
 
         Parameters
@@ -107,7 +108,7 @@ class MappingFactory:
             Raised if none of the supplied target classes match an item in the
             registry.
         """
-        attempts: List[Any] = []
+        attempts: list[Any] = []
         for t in targetClasses:
             if t is None:
                 attempts.append(t)
@@ -126,7 +127,7 @@ class MappingFactory:
         plural = "" if len(attempts) == 1 else "s"
         raise KeyError(f"Unable to find item in registry with key{plural}: {msg}")
 
-    def getClassFromRegistry(self, targetClasses: Iterable[Any]) -> Type:
+    def getClassFromRegistry(self, targetClasses: Iterable[Any]) -> type:
         """Get the matching class stored in the registry.
 
         Parameters
@@ -152,7 +153,7 @@ class MappingFactory:
 
     def getFromRegistryWithMatch(
         self, targetClasses: Iterable[Any], *args: Any, **kwargs: Any
-    ) -> Tuple[LookupKey, Any]:
+    ) -> tuple[LookupKey, Any]:
         """Get a new instance of the registry object along with matching key.
 
         Parameters
@@ -220,7 +221,7 @@ class MappingFactory:
         return instance
 
     def placeInRegistry(
-        self, registryKey: Any, typeName: Union[str, Type], overwrite: bool = False, **kwargs: Any
+        self, registryKey: Any, typeName: str | type, overwrite: bool = False, **kwargs: Any
     ) -> None:
         """Register a class name with the associated type.
 

--- a/python/lsst/daf/butler/core/named.py
+++ b/python/lsst/daf/butler/core/named.py
@@ -39,10 +39,11 @@ from collections.abc import (
     Mapping,
     MutableMapping,
     MutableSet,
+    Set,
     ValuesView,
 )
 from types import MappingProxyType
-from typing import AbstractSet, Any, Protocol, TypeVar
+from typing import Any, Protocol, TypeVar
 
 
 class Named(Protocol):
@@ -82,10 +83,10 @@ class NamedKeyMapping(Mapping[K, V_co]):
 
     @property
     @abstractmethod
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         """Return the set of names associated with the keys, in the same order.
 
-        (`AbstractSet` [ `str` ]).
+        (`Set` [ `str` ]).
         """
         raise NotImplementedError()
 
@@ -261,7 +262,7 @@ class NamedKeyDict(NamedKeyMutableMapping[K, V]):
         return self
 
 
-class NamedValueAbstractSet(AbstractSet[K_co]):
+class NamedValueAbstractSet(Set[K_co]):
     """Custom sets with named elements.
 
     An abstract base class for custom sets whose elements are objects with
@@ -273,7 +274,7 @@ class NamedValueAbstractSet(AbstractSet[K_co]):
 
     @property
     @abstractmethod
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         """Return set of names associated with the keys, in the same order.
 
         (`AbstractSet` [ `str` ]).
@@ -336,7 +337,7 @@ class NameMappingSetView(NamedValueAbstractSet[K_co]):
     __slots__ = ("_mapping",)
 
     @property
-    def names(self) -> AbstractSet[str]:
+    def names(self) -> Set[str]:
         # Docstring inherited from NamedValueAbstractSet.
         return self._mapping.keys()
 
@@ -365,13 +366,13 @@ class NameMappingSetView(NamedValueAbstractSet[K_co]):
         else:
             return set(self._mapping.values()) == other
 
-    def __le__(self, other: AbstractSet[K]) -> bool:
+    def __le__(self, other: Set[K]) -> bool:
         if isinstance(other, NamedValueAbstractSet):
             return self.names <= other.names
         else:
             return set(self._mapping.values()) <= other
 
-    def __ge__(self, other: AbstractSet[K]) -> bool:
+    def __ge__(self, other: Set[K]) -> bool:
         if isinstance(other, NamedValueAbstractSet):
             return self.names >= other.names
         else:
@@ -489,10 +490,10 @@ class NamedValueSet(NameMappingSetView[K], NamedValueMutableSet[K]):
     def __repr__(self) -> str:
         return "NamedValueSet({{{}}})".format(", ".join(repr(element) for element in self))
 
-    def issubset(self, other: AbstractSet[K]) -> bool:
+    def issubset(self, other: Set[K]) -> bool:
         return self <= other
 
-    def issuperset(self, other: AbstractSet[K]) -> bool:
+    def issuperset(self, other: Set[K]) -> bool:
         return self >= other
 
     def __delitem__(self, name: str) -> None:

--- a/python/lsst/daf/butler/core/named.py
+++ b/python/lsst/daf/butler/core/named.py
@@ -75,8 +75,9 @@ class NamedKeyMapping(Mapping[K, V_co]):
     -----
     In addition to the new `names` property and `byName` method, this class
     simply redefines the type signature for `__getitem__` and `get` that would
-    otherwise be inherited from `Mapping`. That is only relevant for static
-    type checking; the actual Python runtime doesn't care about types at all.
+    otherwise be inherited from `~collections.abc.Mapping`. That is only
+    relevant for static type checking; the actual Python runtime doesn't
+    care about types at all.
     """
 
     __slots__ = ()
@@ -86,12 +87,13 @@ class NamedKeyMapping(Mapping[K, V_co]):
     def names(self) -> Set[str]:
         """Return the set of names associated with the keys, in the same order.
 
-        (`Set` [ `str` ]).
+        (`~collections.abc.Set` [ `str` ]).
         """
         raise NotImplementedError()
 
     def byName(self) -> dict[str, V_co]:
-        """Return a `Mapping` with names as keys and the ``self`` values.
+        """Return a `~collections.abc.Mapping` with names as keys and the
+        ``self`` values.
 
         Returns
         -------
@@ -277,7 +279,7 @@ class NamedValueAbstractSet(Set[K_co]):
     def names(self) -> Set[str]:
         """Return set of names associated with the keys, in the same order.
 
-        (`AbstractSet` [ `str` ]).
+        (`~collections.abc.Set` [ `str` ]).
         """
         raise NotImplementedError()
 
@@ -287,7 +289,7 @@ class NamedValueAbstractSet(Set[K_co]):
 
         Returns
         -------
-        dict : `Mapping`
+        dict : `~collections.abc.Mapping`
             A dictionary-like view with ``values() == self``.
         """
         raise NotImplementedError()
@@ -327,7 +329,7 @@ class NameMappingSetView(NamedValueAbstractSet[K_co]):
 
     Parameters
     ----------
-    mapping : `Mapping` [ `str`, `object` ]
+    mapping : `~collections.abc.Mapping` [ `str`, `object` ]
         Mapping this object will provide a view of.
     """
 
@@ -389,11 +391,12 @@ class NamedValueMutableSet(NamedValueAbstractSet[K], MutableSet[K]):
     """Mutable variant of `NamedValueAbstractSet`.
 
     Methods that can add new elements to the set are unchanged from their
-    `MutableSet` definitions, while those that only remove them can generally
-    accept names or element instances.  `pop` can be used in either its
-    `MutableSet` form (no arguments; an arbitrary element is returned) or its
-    `MutableMapping` form (one or two arguments for the name and optional
-    default value, respectively).  A `MutableMapping`-like `__delitem__`
+    `~collections.abc.MutableSet` definitions, while those that only remove
+    them can generally accept names or element instances.  `pop` can be used
+    in either its `~collections.abc.MutableSet` form (no arguments; an
+    arbitrary element is returned) or its `~collections.abc.MutableMapping`
+    form (one or two arguments for the name and optional default value,
+    respectively).  A `~collections.abc.MutableMapping`-like `__delitem__`
     interface is also included, which takes only names (like
     `NamedValueAbstractSet.__getitem__`).
     """
@@ -545,7 +548,7 @@ class NamedValueSet(NameMappingSetView[K], NamedValueMutableSet[K]):
 
         Parameters
         ----------
-        elements : `Iterable`
+        elements : `~collections.abc.Iterable`
             Elements to add.
         """
         for element in elements:

--- a/python/lsst/daf/butler/core/progress.py
+++ b/python/lsst/daf/butler/core/progress.py
@@ -160,7 +160,7 @@ class Progress:
 
         Parameters
         ----------
-        iterable : `Iterable`, optional
+        iterable : `~collections.abc.Iterable`, optional
             An arbitrary Python iterable that will be iterated over when the
             returned `ProgressBar` is.  If not provided, whether the progress
             bar is iterable is handler-defined, but it may be updated manually.
@@ -212,7 +212,7 @@ class Progress:
 
         Parameters
         ----------
-        iterable : `Iterable`
+        iterable : `~collections.abc.Iterable`
             An arbitrary Python iterable to iterate over.
         desc: `str`, optional
             A user-friendly description for this progress bar; usually appears
@@ -246,7 +246,7 @@ class Progress:
 
         Parameters
         ----------
-        chunks : `Collection`
+        chunks : `~collections.abc.Collection`
             A sized iterable whose elements are themselves both iterable and
             sized (i.e. ``len(item)`` works).  If ``total`` is not provided,
             this may not be a single-pass iteration, because an initial pass to
@@ -288,7 +288,7 @@ class Progress:
 
         Parameters
         ----------
-        items : `Iterable`
+        items : `~collections.abc.Iterable`
             A sized iterable whose elements are (key, value) tuples, where the
             values are themselves both iterable and sized (i.e. ``len(item)``
             works).  If ``total`` is not provided, this may not be a
@@ -332,7 +332,7 @@ class ProgressHandler(ABC):
 
         Parameters
         ----------
-        iterable : `Iterable` or `None`
+        iterable : `~collections.abc.Iterable` or `None`
             An arbitrary Python iterable that will be iterated over when the
             returned `ProgressBar` is.  If `None`, whether the progress bar is
             iterable is handler-defined, but it may be updated manually.
@@ -358,7 +358,7 @@ class _NullProgressBar(Iterable[_T]):
 
     Parameters
     ----------
-    iterable : `Iterable` or `None`
+    iterable : `~collections.abc.Iterable` or `None`
         An arbitrary Python iterable that will be iterated over when ``self``
         is.
     """
@@ -377,7 +377,7 @@ class _NullProgressBar(Iterable[_T]):
 
         Parameters
         ----------
-        iterable : `Iterable` or `None`
+        iterable : `~collections.abc.Iterable` or `None`
             An arbitrary Python iterable that will be iterated over when the
             returned object is.
         """

--- a/python/lsst/daf/butler/core/progress.py
+++ b/python/lsst/daf/butler/core/progress.py
@@ -25,19 +25,9 @@ __all__ = ("Progress", "ProgressBar", "ProgressHandler")
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Collection, Generator, Iterable, Iterator
 from contextlib import contextmanager
-from typing import (
-    ClassVar,
-    Collection,
-    ContextManager,
-    Generator,
-    Iterable,
-    Iterator,
-    Optional,
-    Protocol,
-    Tuple,
-    TypeVar,
-)
+from typing import ClassVar, ContextManager, Protocol, TypeVar
 
 _T = TypeVar("_T", covariant=True)
 _K = TypeVar("_K")
@@ -108,10 +98,10 @@ class Progress:
     # by pytest-xdist.  If butler codes is ever used in a real multithreaded
     # or asyncio application _and_ we want progress bars, we'll have to set
     # up per-thread handlers or similar.
-    _active_handler: ClassVar[Optional[ProgressHandler]] = None
+    _active_handler: ClassVar[ProgressHandler | None] = None
 
     @classmethod
-    def set_handler(cls, handler: Optional[ProgressHandler]) -> None:
+    def set_handler(cls, handler: ProgressHandler | None) -> None:
         """Set the (global) progress handler to the given instance.
 
         This should only be called in very high-level code that can be
@@ -161,9 +151,9 @@ class Progress:
 
     def bar(
         self,
-        iterable: Optional[Iterable[_T]] = None,
-        desc: Optional[str] = None,
-        total: Optional[int] = None,
+        iterable: Iterable[_T] | None = None,
+        desc: str | None = None,
+        total: int | None = None,
         skip_scalar: bool = True,
     ) -> ContextManager[ProgressBar[_T]]:
         """Return a new progress bar context manager.
@@ -214,8 +204,8 @@ class Progress:
     def wrap(
         self,
         iterable: Iterable[_T],
-        desc: Optional[str] = None,
-        total: Optional[int] = None,
+        desc: str | None = None,
+        total: int | None = None,
         skip_scalar: bool = True,
     ) -> Generator[_T, None, None]:
         """Iterate over an object while reporting progress.
@@ -248,8 +238,8 @@ class Progress:
     def iter_chunks(
         self,
         chunks: Collection[_V],
-        desc: Optional[str] = None,
-        total: Optional[int] = None,
+        desc: str | None = None,
+        total: int | None = None,
         skip_scalar: bool = True,
     ) -> Generator[_V, None, None]:
         """Wrap iteration over chunks of elements in a progress bar.
@@ -289,11 +279,11 @@ class Progress:
 
     def iter_item_chunks(
         self,
-        items: Collection[Tuple[_K, _V]],
-        desc: Optional[str] = None,
-        total: Optional[int] = None,
+        items: Collection[tuple[_K, _V]],
+        desc: str | None = None,
+        total: int | None = None,
         skip_scalar: bool = True,
-    ) -> Generator[Tuple[_K, _V], None, None]:
+    ) -> Generator[tuple[_K, _V], None, None]:
         """Wrap iteration over chunks of items in a progress bar.
 
         Parameters
@@ -336,7 +326,7 @@ class ProgressHandler(ABC):
 
     @abstractmethod
     def get_progress_bar(
-        self, iterable: Optional[Iterable[_T]], desc: str, total: Optional[int], level: int
+        self, iterable: Iterable[_T] | None, desc: str, total: int | None, level: int
     ) -> ContextManager[ProgressBar[_T]]:
         """Create a new progress bar.
 
@@ -373,12 +363,12 @@ class _NullProgressBar(Iterable[_T]):
         is.
     """
 
-    def __init__(self, iterable: Optional[Iterable[_T]]):
+    def __init__(self, iterable: Iterable[_T] | None):
         self._iterable = iterable
 
     @classmethod
     @contextmanager
-    def context(cls, iterable: Optional[Iterable[_T]]) -> Generator[_NullProgressBar[_T], None, None]:
+    def context(cls, iterable: Iterable[_T] | None) -> Generator[_NullProgressBar[_T], None, None]:
         """Return a trivial context manager that wraps an instance of this
         class.
 

--- a/python/lsst/daf/butler/core/repoRelocation.py
+++ b/python/lsst/daf/butler/core/repoRelocation.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 __all__ = ("BUTLER_ROOT_TAG", "replaceRoot")
 
 import os.path
-from typing import Optional
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 
@@ -35,7 +34,7 @@ BUTLER_ROOT_TAG = "<butlerRoot>"
 the butler root location should be used."""
 
 
-def replaceRoot(configRoot: str, butlerRoot: Optional[ResourcePathExpression]) -> str:
+def replaceRoot(configRoot: str, butlerRoot: ResourcePathExpression | None) -> str:
     """Update a configuration root with the butler root location.
 
     No changes are made if the special root string is not found in the

--- a/python/lsst/daf/butler/core/serverModels.py
+++ b/python/lsst/daf/butler/core/serverModels.py
@@ -30,7 +30,8 @@ __all__ = (
 """Models used for client/server communication."""
 
 import re
-from typing import Any, ClassVar, Dict, List, Mapping, Optional, Union
+from collections.abc import Mapping
+from typing import Any, ClassVar
 
 from lsst.utils.iteration import ensure_iterable
 from pydantic import BaseModel, Field, validator
@@ -39,10 +40,10 @@ from .dimensions import DataIdValue, SerializedDataCoordinate
 from .utils import globToRegex
 
 # Simple scalar python types.
-ScalarType = Union[int, bool, float, str]
+ScalarType = int | bool | float | str
 
 # Bind parameters can have any scalar type.
-BindType = Dict[str, ScalarType]
+BindType = dict[str, ScalarType]
 
 # For serialization purposes a data ID key must be a str.
 SimpleDataId = Mapping[str, DataIdValue]
@@ -58,13 +59,13 @@ class ExpressionQueryParameter(BaseModel):
     _allow_ellipsis: ClassVar[bool] = True
     """Control whether expression can match everything."""
 
-    regex: Optional[List[str]] = Field(
+    regex: list[str] | None = Field(
         None,
         title="List of regular expression strings.",
         example="^cal.*",
     )
 
-    glob: Optional[List[str]] = Field(
+    glob: list[str] | None = Field(
         None,
         title="List of globs or explicit strings to use in expression.",
         example="cal*",
@@ -89,7 +90,7 @@ class ExpressionQueryParameter(BaseModel):
             # at all.
             return None
 
-        expression: List[Union[str, re.Pattern]] = []
+        expression: list[str | re.Pattern] = []
         if self.regex is not None:
             for r in self.regex:
                 expression.append(re.compile(r))
@@ -110,7 +111,7 @@ class ExpressionQueryParameter(BaseModel):
             return cls()
 
         expressions = ensure_iterable(expression)
-        params: Dict[str, List[str]] = {"glob": [], "regex": []}
+        params: dict[str, list[str]] = {"glob": [], "regex": []}
         for expression in expressions:
             if expression is ...:
                 # This matches everything
@@ -197,7 +198,7 @@ class QueryBaseModel(BaseModel):
     """Base model for all query models."""
 
     @validator("keyword_args", check_fields=False)
-    def _check_keyword_args(cls, v, values) -> Optional[SimpleDataId]:  # type: ignore # noqa: N805
+    def _check_keyword_args(cls, v, values) -> SimpleDataId | None:  # type: ignore # noqa: N805
         """Convert kwargs into None if empty.
 
         This retains the property at its default value and can therefore
@@ -234,39 +235,39 @@ class QueryDatasetsModel(QueryBaseModel):
     """Information needed for a registry dataset query."""
 
     datasetType: ExpressionQueryParameter = Field(..., title="Dataset types to query. Can match all.")
-    collections: Optional[ExpressionQueryParameter] = Collections
-    dimensions: Optional[List[str]] = OptionalDimensions
-    dataId: Optional[SerializedDataCoordinate] = DataId
+    collections: ExpressionQueryParameter | None = Collections
+    dimensions: list[str] | None = OptionalDimensions
+    dataId: SerializedDataCoordinate | None = DataId
     where: str = Where
     findFirst: bool = FindFirst
-    components: Optional[bool] = Components
-    bind: Optional[BindType] = Bind
+    components: bool | None = Components
+    bind: BindType | None = Bind
     check: bool = Check
-    keyword_args: Optional[SimpleDataId] = KeywordArgs  # mypy refuses to allow kwargs in model
+    keyword_args: SimpleDataId | None = KeywordArgs  # mypy refuses to allow kwargs in model
 
 
 class QueryDataIdsModel(QueryBaseModel):
     """Information needed to query data IDs."""
 
-    dimensions: List[str] = Dimensions
-    dataId: Optional[SerializedDataCoordinate] = DataId
-    datasets: Optional[DatasetsQueryParameter] = Datasets
-    collections: Optional[ExpressionQueryParameter] = Collections
+    dimensions: list[str] = Dimensions
+    dataId: SerializedDataCoordinate | None = DataId
+    datasets: DatasetsQueryParameter | None = Datasets
+    collections: ExpressionQueryParameter | None = Collections
     where: str = Where
-    components: Optional[bool] = Components
-    bind: Optional[BindType] = Bind
+    components: bool | None = Components
+    bind: BindType | None = Bind
     check: bool = Check
-    keyword_args: Optional[SimpleDataId] = KeywordArgs  # mypy refuses to allow kwargs in model
+    keyword_args: SimpleDataId | None = KeywordArgs  # mypy refuses to allow kwargs in model
 
 
 class QueryDimensionRecordsModel(QueryBaseModel):
     """Information needed to query the dimension records."""
 
-    dataId: Optional[SerializedDataCoordinate] = DataId
-    datasets: Optional[DatasetsQueryParameter] = Datasets
-    collections: Optional[ExpressionQueryParameter] = Collections
+    dataId: SerializedDataCoordinate | None = DataId
+    datasets: DatasetsQueryParameter | None = Datasets
+    collections: ExpressionQueryParameter | None = Collections
     where: str = Where
-    components: Optional[bool] = Components
-    bind: Optional[SimpleDataId] = Bind
+    components: bool | None = Components
+    bind: SimpleDataId | None = Bind
     check: bool = Check
-    keyword_args: Optional[SimpleDataId] = KeywordArgs  # mypy refuses to allow kwargs in model
+    keyword_args: SimpleDataId | None = KeywordArgs  # mypy refuses to allow kwargs in model

--- a/python/lsst/daf/butler/core/storageClass.py
+++ b/python/lsst/daf/butler/core/storageClass.py
@@ -380,7 +380,7 @@ class StorageClass:
 
         Parameters
         ----------
-        parameters : `Mapping`, optional
+        parameters : `~collections.abc.Mapping`, optional
             Candidate parameters. Can be `None` if no parameters have
             been provided.
         subset : `~collections.abc.Collection`, optional
@@ -391,7 +391,7 @@ class StorageClass:
 
         Returns
         -------
-        filtered : `Mapping`
+        filtered : `~collections.abc.Mapping`
             Valid parameters. Empty `dict` if none are suitable.
 
         Raises
@@ -439,7 +439,7 @@ class StorageClass:
 
         Parameters
         ----------
-        other : `Type`
+        other : `type`
             The type to be checked.
         compare_types : `bool`, optional
             If `True` the python type will be used in the comparison

--- a/python/lsst/daf/butler/core/storageClassDelegate.py
+++ b/python/lsst/daf/butler/core/storageClassDelegate.py
@@ -396,7 +396,6 @@ class StorageClassDelegate:
         copy. Subclasses can override this method if they already know the
         optimal approach for deep copying.
         """
-
         try:
             return copy.deepcopy(inMemoryDataset)
         except Exception as e:

--- a/python/lsst/daf/butler/core/storageClassDelegate.py
+++ b/python/lsst/daf/butler/core/storageClassDelegate.py
@@ -27,8 +27,9 @@ __all__ = ("DatasetComponent", "StorageClassDelegate")
 
 import copy
 import logging
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional, Set, Tuple, Type
+from typing import TYPE_CHECKING, Any
 
 from lsst.utils.introspection import get_full_type_name
 
@@ -80,7 +81,7 @@ class StorageClassDelegate:
         self.storageClass = storageClass
 
     @staticmethod
-    def _attrNames(componentName: str, getter: bool = True) -> Tuple[str, ...]:
+    def _attrNames(componentName: str, getter: bool = True) -> tuple[str, ...]:
         """Return list of suitable attribute names to attempt to use.
 
         Parameters
@@ -107,7 +108,7 @@ class StorageClassDelegate:
         capitalized = f"{root}{first}{tail}"
         return (componentName, f"{root}_{componentName}", capitalized)
 
-    def assemble(self, components: Dict[str, Any], pytype: Optional[Type] = None) -> Any:
+    def assemble(self, components: dict[str, Any], pytype: type | None = None) -> Any:
         """Construct an object from components based on storageClass.
 
         This generic implementation assumes that instances of objects
@@ -218,8 +219,8 @@ class StorageClassDelegate:
         return component
 
     def disassemble(
-        self, composite: Any, subset: Optional[Iterable] = None, override: Optional[Any] = None
-    ) -> Dict[str, DatasetComponent]:
+        self, composite: Any, subset: Iterable | None = None, override: Any | None = None
+    ) -> dict[str, DatasetComponent]:
         """Disassembler a composite.
 
         This is a generic implementation of a disassembler.
@@ -301,7 +302,7 @@ class StorageClassDelegate:
 
         return components
 
-    def handleParameters(self, inMemoryDataset: Any, parameters: Optional[Mapping[str, Any]] = None) -> Any:
+    def handleParameters(self, inMemoryDataset: Any, parameters: Mapping[str, Any] | None = None) -> Any:
         """Modify the in-memory dataset using the supplied parameters.
 
         Can return a possibly new object.
@@ -338,7 +339,7 @@ class StorageClassDelegate:
         return inMemoryDataset
 
     @classmethod
-    def selectResponsibleComponent(cls, derivedComponent: str, fromComponents: Set[Optional[str]]) -> str:
+    def selectResponsibleComponent(cls, derivedComponent: str, fromComponents: set[str | None]) -> str:
         """Select the best component for calculating a derived component.
 
         Given a possible set of components to choose from, return the

--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -92,7 +92,8 @@ class StoredDatastoreItemInfo:
 
     def update(self, **kwargs: Any) -> StoredDatastoreItemInfo:
         """Create a new class with everything retained apart from the
-        specified values."""
+        specified values.
+        """
         raise NotImplementedError()
 
 

--- a/python/lsst/daf/butler/core/storedFileInfo.py
+++ b/python/lsst/daf/butler/core/storedFileInfo.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 __all__ = ("StoredDatastoreItemInfo", "StoredFileInfo")
 
 import inspect
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Any
 
 from lsst.resources import ResourcePath
 
@@ -65,7 +66,7 @@ class StoredDatastoreItemInfo:
         raise NotImplementedError("The base class does not know how to locate an item in a datastore.")
 
     @classmethod
-    def from_record(cls: Type[StoredDatastoreItemInfo], record: Mapping[str, Any]) -> StoredDatastoreItemInfo:
+    def from_record(cls: type[StoredDatastoreItemInfo], record: Mapping[str, Any]) -> StoredDatastoreItemInfo:
         """Create instance from database record.
 
         Parameters
@@ -80,7 +81,7 @@ class StoredDatastoreItemInfo:
         """
         raise NotImplementedError()
 
-    def to_record(self) -> Dict[str, Any]:
+    def to_record(self) -> dict[str, Any]:
         """Convert record contents to a dictionary."""
         raise NotImplementedError()
 
@@ -108,8 +109,8 @@ class StoredFileInfo(StoredDatastoreItemInfo):
         formatter: FormatterParameter,
         path: str,
         storageClass: StorageClass,
-        component: Optional[str],
-        checksum: Optional[str],
+        component: str | None,
+        checksum: str | None,
         file_size: int,
         dataset_id: DatasetId,
     ):
@@ -142,11 +143,11 @@ class StoredFileInfo(StoredDatastoreItemInfo):
     storageClass: StorageClass
     """StorageClass associated with Dataset."""
 
-    component: Optional[str]
+    component: str | None
     """Component associated with this file. Can be None if the file does
     not refer to a component of a composite."""
 
-    checksum: Optional[str]
+    checksum: str | None
     """Checksum of the serialized dataset."""
 
     file_size: int
@@ -176,7 +177,7 @@ class StoredFileInfo(StoredDatastoreItemInfo):
         dataset_id = ref.id
         return self.update(dataset_id=dataset_id, component=component)
 
-    def to_record(self) -> Dict[str, Any]:
+    def to_record(self) -> dict[str, Any]:
         """Convert the supplied ref to a database record."""
         component = self.component
         if component is None:
@@ -214,7 +215,7 @@ class StoredFileInfo(StoredDatastoreItemInfo):
         return location
 
     @classmethod
-    def from_record(cls: Type[StoredFileInfo], record: Mapping[str, Any]) -> StoredFileInfo:
+    def from_record(cls: type[StoredFileInfo], record: Mapping[str, Any]) -> StoredFileInfo:
         """Create instance from database record.
 
         Parameters

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -28,20 +28,8 @@ __all__ = (
 import enum
 import warnings
 from abc import ABC, abstractmethod
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Generator,
-    List,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from collections.abc import Generator, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, Union
 
 import astropy.time
 import astropy.utils.exceptions
@@ -148,7 +136,7 @@ class Timespan:
         begin: TimespanBound,
         end: TimespanBound,
         padInstantaneous: bool = True,
-        _nsec: Optional[Tuple[int, int]] = None,
+        _nsec: tuple[int, int] | None = None,
     ):
         converter = TimeConverter()
         if _nsec is None:
@@ -328,7 +316,7 @@ class Timespan:
     def __reduce__(self) -> tuple:
         return (Timespan, (None, None, False, self._nsec))
 
-    def __lt__(self, other: Union[astropy.time.Time, Timespan]) -> bool:
+    def __lt__(self, other: astropy.time.Time | Timespan) -> bool:
         """Test if a Timespan's bounds are strictly less than the given time.
 
         Parameters
@@ -355,7 +343,7 @@ class Timespan:
         else:
             return self._nsec[1] <= other._nsec[0] and self._nsec[0] < other._nsec[1]
 
-    def __gt__(self, other: Union[astropy.time.Time, Timespan]) -> bool:
+    def __gt__(self, other: astropy.time.Time | Timespan) -> bool:
         """Test if a Timespan's bounds are strictly greater than given time.
 
         Parameters
@@ -406,7 +394,7 @@ class Timespan:
             return self.contains(other)
         return self._nsec[1] > other._nsec[0] and other._nsec[1] > self._nsec[0]
 
-    def contains(self, other: Union[astropy.time.Time, Timespan]) -> bool:
+    def contains(self, other: astropy.time.Time | Timespan) -> bool:
         """Test if the supplied timespan is within this one.
 
         Tests whether the intersection of this timespan with another timespan
@@ -494,7 +482,7 @@ class Timespan:
             if intersection._nsec[1] < self._nsec[1]:
                 yield Timespan(None, None, _nsec=(intersection._nsec[1], self._nsec[1]))
 
-    def to_simple(self, minimal: bool = False) -> List[int]:
+    def to_simple(self, minimal: bool = False) -> list[int]:
         """Return simple python type form suitable for serialization.
 
         Parameters
@@ -513,9 +501,9 @@ class Timespan:
     @classmethod
     def from_simple(
         cls,
-        simple: List[int],
-        universe: Optional[DimensionUniverse] = None,
-        registry: Optional[Registry] = None,
+        simple: list[int],
+        universe: DimensionUniverse | None = None,
+        registry: Registry | None = None,
     ) -> Timespan:
         """Construct a new object from simplified form.
 
@@ -564,7 +552,7 @@ class Timespan:
             )
 
     @classmethod
-    def from_yaml(cls, loader: yaml.SafeLoader, node: yaml.MappingNode) -> Optional[Timespan]:
+    def from_yaml(cls, loader: yaml.SafeLoader, node: yaml.MappingNode) -> Timespan | None:
         """Convert YAML node into _SpecialTimespanBound.
 
         Parameters
@@ -615,7 +603,7 @@ class TimespanDatabaseRepresentation(ABC):
 
     NAME: ClassVar[str] = "timespan"
 
-    Compound: ClassVar[Type[TimespanDatabaseRepresentation]]
+    Compound: ClassVar[type[TimespanDatabaseRepresentation]]
     """A concrete subclass of `TimespanDatabaseRepresentation` that simply
     uses two separate fields for the begin (inclusive) and end (exclusive)
     endpoints.
@@ -629,7 +617,7 @@ class TimespanDatabaseRepresentation(ABC):
     @classmethod
     @abstractmethod
     def makeFieldSpecs(
-        cls, nullable: bool, name: Optional[str] = None, **kwargs: Any
+        cls, nullable: bool, name: str | None = None, **kwargs: Any
     ) -> tuple[ddl.FieldSpec, ...]:
         """Make objects that reflect the fields that must be added to table.
 
@@ -662,7 +650,7 @@ class TimespanDatabaseRepresentation(ABC):
 
     @classmethod
     @abstractmethod
-    def getFieldNames(cls, name: Optional[str] = None) -> tuple[str, ...]:
+    def getFieldNames(cls, name: str | None = None) -> tuple[str, ...]:
         """Return the actual field names used by this representation.
 
         Parameters
@@ -681,7 +669,7 @@ class TimespanDatabaseRepresentation(ABC):
 
     @classmethod
     @abstractmethod
-    def fromLiteral(cls: Type[_S], timespan: Optional[Timespan]) -> _S:
+    def fromLiteral(cls: type[_S], timespan: Timespan | None) -> _S:
         """Construct a database timespan from a literal `Timespan` instance.
 
         Parameters
@@ -700,9 +688,7 @@ class TimespanDatabaseRepresentation(ABC):
 
     @classmethod
     @abstractmethod
-    def from_columns(
-        cls: Type[_S], columns: sqlalchemy.sql.ColumnCollection, name: Optional[str] = None
-    ) -> _S:
+    def from_columns(cls: type[_S], columns: sqlalchemy.sql.ColumnCollection, name: str | None = None) -> _S:
         """Construct a database timespan from the columns of a table or
         subquery.
 
@@ -725,8 +711,8 @@ class TimespanDatabaseRepresentation(ABC):
     @classmethod
     @abstractmethod
     def update(
-        cls, timespan: Optional[Timespan], name: Optional[str] = None, result: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        cls, timespan: Timespan | None, name: str | None = None, result: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Add a timespan value to a dictionary that represents a database row.
 
         Parameters
@@ -750,7 +736,7 @@ class TimespanDatabaseRepresentation(ABC):
 
     @classmethod
     @abstractmethod
-    def extract(cls, mapping: Mapping[Any, Any], name: Optional[str] = None) -> Timespan | None:
+    def extract(cls, mapping: Mapping[Any, Any], name: str | None = None) -> Timespan | None:
         """Extract a timespan from a dictionary that represents a database row.
 
         Parameters
@@ -809,7 +795,7 @@ class TimespanDatabaseRepresentation(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def flatten(self, name: Optional[str] = None) -> Tuple[sqlalchemy.sql.ColumnElement, ...]:
+    def flatten(self, name: str | None = None) -> tuple[sqlalchemy.sql.ColumnElement, ...]:
         """Return the actual column(s) that comprise this logical column.
 
         Parameters
@@ -838,7 +824,7 @@ class TimespanDatabaseRepresentation(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def __lt__(self: _S, other: Union[_S, sqlalchemy.sql.ColumnElement]) -> sqlalchemy.sql.ColumnElement:
+    def __lt__(self: _S, other: _S | sqlalchemy.sql.ColumnElement) -> sqlalchemy.sql.ColumnElement:
         """Return SQLAlchemy expression for testing less than.
 
         Returns a SQLAlchemy expression representing a test for whether an
@@ -864,7 +850,7 @@ class TimespanDatabaseRepresentation(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def __gt__(self: _S, other: Union[_S, sqlalchemy.sql.ColumnElement]) -> sqlalchemy.sql.ColumnElement:
+    def __gt__(self: _S, other: _S | sqlalchemy.sql.ColumnElement) -> sqlalchemy.sql.ColumnElement:
         """Return a SQLAlchemy expression for testing greater than.
 
         Returns a SQLAlchemy expression representing a test for whether an
@@ -911,7 +897,7 @@ class TimespanDatabaseRepresentation(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def contains(self: _S, other: Union[_S, sqlalchemy.sql.ColumnElement]) -> sqlalchemy.sql.ColumnElement:
+    def contains(self: _S, other: _S | sqlalchemy.sql.ColumnElement) -> sqlalchemy.sql.ColumnElement:
         """Return a SQLAlchemy expression representing containment.
 
         Returns a test for whether an in-database timespan contains another
@@ -1012,7 +998,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
 
     @classmethod
     def makeFieldSpecs(
-        cls, nullable: bool, name: Optional[str] = None, **kwargs: Any
+        cls, nullable: bool, name: str | None = None, **kwargs: Any
     ) -> tuple[ddl.FieldSpec, ...]:
         # Docstring inherited.
         if name is None:
@@ -1035,7 +1021,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         )
 
     @classmethod
-    def getFieldNames(cls, name: Optional[str] = None) -> tuple[str, ...]:
+    def getFieldNames(cls, name: str | None = None) -> tuple[str, ...]:
         # Docstring inherited.
         if name is None:
             name = cls.NAME
@@ -1043,8 +1029,8 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
 
     @classmethod
     def update(
-        cls, extent: Optional[Timespan], name: Optional[str] = None, result: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        cls, extent: Timespan | None, name: str | None = None, result: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         # Docstring inherited.
         if name is None:
             name = cls.NAME
@@ -1061,7 +1047,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         return result
 
     @classmethod
-    def extract(cls, mapping: Mapping[str, Any], name: Optional[str] = None) -> Optional[Timespan]:
+    def extract(cls, mapping: Mapping[str, Any], name: str | None = None) -> Timespan | None:
         # Docstring inherited.
         if name is None:
             name = cls.NAME
@@ -1083,7 +1069,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
 
     @classmethod
     def from_columns(
-        cls, columns: sqlalchemy.sql.ColumnCollection, name: Optional[str] = None
+        cls, columns: sqlalchemy.sql.ColumnCollection, name: str | None = None
     ) -> _CompoundTimespanDatabaseRepresentation:
         # Docstring inherited.
         if name is None:
@@ -1091,7 +1077,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         return cls(nsec=(columns[f"{name}_begin"], columns[f"{name}_end"]), name=name)
 
     @classmethod
-    def fromLiteral(cls, timespan: Optional[Timespan]) -> _CompoundTimespanDatabaseRepresentation:
+    def fromLiteral(cls, timespan: Timespan | None) -> _CompoundTimespanDatabaseRepresentation:
         # Docstring inherited.
         if timespan is None:
             return cls(nsec=(sqlalchemy.sql.null(), sqlalchemy.sql.null()), name=cls.NAME)
@@ -1114,7 +1100,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         return self._nsec[0] >= self._nsec[1]
 
     def __lt__(
-        self, other: Union[_CompoundTimespanDatabaseRepresentation, sqlalchemy.sql.ColumnElement]
+        self, other: _CompoundTimespanDatabaseRepresentation | sqlalchemy.sql.ColumnElement
     ) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
         # See comments in Timespan.__lt__ for why we use these exact
@@ -1125,7 +1111,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
             return sqlalchemy.sql.and_(self._nsec[1] <= other._nsec[0], self._nsec[0] < other._nsec[1])
 
     def __gt__(
-        self, other: Union[_CompoundTimespanDatabaseRepresentation, sqlalchemy.sql.ColumnElement]
+        self, other: _CompoundTimespanDatabaseRepresentation | sqlalchemy.sql.ColumnElement
     ) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
         # See comments in Timespan.__gt__ for why we use these exact
@@ -1144,7 +1130,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         return sqlalchemy.sql.and_(self._nsec[1] > other._nsec[0], other._nsec[1] > self._nsec[0])
 
     def contains(
-        self, other: Union[_CompoundTimespanDatabaseRepresentation, sqlalchemy.sql.ColumnElement]
+        self, other: _CompoundTimespanDatabaseRepresentation | sqlalchemy.sql.ColumnElement
     ) -> sqlalchemy.sql.ColumnElement:
         # Docstring inherited.
         if isinstance(other, sqlalchemy.sql.ColumnElement):
@@ -1160,7 +1146,7 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         # Docstring inherited.
         return sqlalchemy.sql.functions.coalesce(self._nsec[1], sqlalchemy.sql.literal(0))
 
-    def flatten(self, name: Optional[str] = None) -> Tuple[sqlalchemy.sql.ColumnElement, ...]:
+    def flatten(self, name: str | None = None) -> tuple[sqlalchemy.sql.ColumnElement, ...]:
         # Docstring inherited.
         if name is None:
             return self._nsec

--- a/python/lsst/daf/butler/core/timespan.py
+++ b/python/lsst/daf/butler/core/timespan.py
@@ -741,7 +741,7 @@ class TimespanDatabaseRepresentation(ABC):
 
         Parameters
         ----------
-        mapping : `Mapping` [ `Any`, `Any` ]
+        mapping : `~collections.abc.Mapping` [ `Any`, `Any` ]
             A dictionary representing a database row containing a `Timespan`
             in this representation.  Should have key(s) equal to the return
             value of `getFieldNames`.

--- a/python/lsst/daf/butler/core/utils.py
+++ b/python/lsst/daf/butler/core/utils.py
@@ -29,8 +29,10 @@ import fnmatch
 import functools
 import logging
 import re
+from collections.abc import Callable
+from re import Pattern
 from types import EllipsisType
-from typing import Any, Callable, List, Optional, Pattern, TypeVar, Union
+from typing import Any, TypeVar
 
 from lsst.utils.iteration import ensure_iterable
 
@@ -55,7 +57,7 @@ def transactional(func: F) -> F:
     return inner  # type: ignore
 
 
-def stripIfNotNone(s: Optional[str]) -> Optional[str]:
+def stripIfNotNone(s: str | None) -> str | None:
     """Strip leading and trailing whitespace if the given object is not None.
 
     Parameters
@@ -74,9 +76,7 @@ def stripIfNotNone(s: Optional[str]) -> Optional[str]:
     return s
 
 
-def globToRegex(
-    expressions: Union[str, EllipsisType, None, List[str]]
-) -> Union[List[Union[str, Pattern]], EllipsisType]:
+def globToRegex(expressions: str | EllipsisType | None | list[str]) -> list[str | Pattern] | EllipsisType:
     """Translate glob-style search terms to regex.
 
     If a stand-alone '``*``' is found in ``expressions``, or expressions is
@@ -107,9 +107,9 @@ def globToRegex(
     magic = re.compile(r"[\*\?]|\[.*\]|\[!.*\]")
 
     # Try not to convert simple string to a regex.
-    results: List[Union[str, Pattern]] = []
+    results: list[str | Pattern] = []
     for e in expressions:
-        res: Union[str, Pattern]
+        res: str | Pattern
         if magic.search(e):
             res = re.compile(fnmatch.translate(e))
         else:

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -29,7 +29,8 @@ import itertools
 import logging
 import time
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import (
     Constraints,
@@ -62,7 +63,7 @@ class _IngestPrepData(Datastore.IngestPrepData):
         Pairs of `Datastore`, `IngestPrepData` for all child datastores.
     """
 
-    def __init__(self, children: List[Tuple[Datastore, Datastore.IngestPrepData, set[ResourcePath]]]):
+    def __init__(self, children: list[tuple[Datastore, Datastore.IngestPrepData, set[ResourcePath]]]):
         super().__init__(itertools.chain.from_iterable(data.refs.values() for _, data, _ in children))
         self.children = children
 
@@ -102,10 +103,10 @@ class ChainedDatastore(Datastore):
     containerKey = "datastores"
     """Key to specify where child datastores are configured."""
 
-    datastores: List[Datastore]
+    datastores: list[Datastore]
     """All the child datastores known to this datastore."""
 
-    datastoreConstraints: Sequence[Optional[Constraints]]
+    datastoreConstraints: Sequence[Constraints | None]
     """Constraints to be applied to each of the child datastores."""
 
     @classmethod
@@ -178,7 +179,7 @@ class ChainedDatastore(Datastore):
 
     def __init__(
         self,
-        config: Union[Config, str],
+        config: Config | str,
         bridgeManager: DatastoreRegistryBridgeManager,
         butlerRoot: str | None = None,
     ):
@@ -235,7 +236,7 @@ class ChainedDatastore(Datastore):
         log.debug("Created %s (%s)", self.name, ("ephemeral" if self.isEphemeral else "permanent"))
 
     @property
-    def names(self) -> Tuple[str, ...]:
+    def names(self) -> tuple[str, ...]:
         return tuple(self._names)
 
     def __str__(self) -> str:
@@ -276,8 +277,8 @@ class ChainedDatastore(Datastore):
         return refs_known
 
     def mexists(
-        self, refs: Iterable[DatasetRef], artifact_existence: Optional[Dict[ResourcePath, bool]] = None
-    ) -> Dict[DatasetRef, bool]:
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool] | None = None
+    ) -> dict[DatasetRef, bool]:
         """Check the existence of multiple datasets at once.
 
         Parameters
@@ -295,7 +296,7 @@ class ChainedDatastore(Datastore):
             Mapping from dataset to boolean indicating existence in any
             of the child datastores.
         """
-        dataset_existence: Dict[DatasetRef, bool] = {}
+        dataset_existence: dict[DatasetRef, bool] = {}
         for datastore in self.datastores:
             dataset_existence.update(datastore.mexists(refs, artifact_existence=artifact_existence))
 
@@ -327,8 +328,8 @@ class ChainedDatastore(Datastore):
     def get(
         self,
         ref: DatasetRef,
-        parameters: Optional[Mapping[str, Any]] = None,
-        storageClass: Optional[Union[StorageClass, str]] = None,
+        parameters: Mapping[str, Any] | None = None,
+        storageClass: StorageClass | str | None = None,
     ) -> Any:
         """Load an InMemoryDataset from the store.
 
@@ -438,7 +439,7 @@ class ChainedDatastore(Datastore):
         if self._transaction is not None:
             self._transaction.registerUndo("put", self.remove, ref)
 
-    def _overrideTransferMode(self, *datasets: Any, transfer: Optional[str] = None) -> Optional[str]:
+    def _overrideTransferMode(self, *datasets: Any, transfer: str | None = None) -> str | None:
         # Docstring inherited from base class.
         if transfer != "auto":
             return transfer
@@ -459,7 +460,7 @@ class ChainedDatastore(Datastore):
             f" from 'auto' in each child datastore (wanted {transfers})"
         )
 
-    def _prepIngest(self, *datasets: FileDataset, transfer: Optional[str] = None) -> _IngestPrepData:
+    def _prepIngest(self, *datasets: FileDataset, transfer: str | None = None) -> _IngestPrepData:
         # Docstring inherited from Datastore._prepIngest.
         if transfer is None:
             raise NotImplementedError("ChainedDatastore does not support transfer=None.")
@@ -478,7 +479,7 @@ class ChainedDatastore(Datastore):
 
         # Filter down to just datasets the chained datastore's own
         # configuration accepts.
-        okForParent: List[FileDataset] = [
+        okForParent: list[FileDataset] = [
             dataset
             for dataset in datasets
             if isDatasetAcceptable(dataset, name=self.name, constraints=self.constraints)
@@ -486,12 +487,12 @@ class ChainedDatastore(Datastore):
 
         # Iterate over nested datastores and call _prepIngest on each.
         # Save the results to a list:
-        children: List[Tuple[Datastore, Datastore.IngestPrepData, set[ResourcePath]]] = []
+        children: list[tuple[Datastore, Datastore.IngestPrepData, set[ResourcePath]]] = []
         # ...and remember whether all of the failures are due to
         # NotImplementedError being raised.
         allFailuresAreNotImplementedError = True
         for datastore, constraints in zip(self.datastores, self.datastoreConstraints):
-            okForChild: List[FileDataset]
+            okForChild: list[FileDataset]
             if constraints is not None:
                 okForChild = [
                     dataset
@@ -528,7 +529,7 @@ class ChainedDatastore(Datastore):
         self,
         prepData: _IngestPrepData,
         *,
-        transfer: Optional[str] = None,
+        transfer: str | None = None,
         record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited from Datastore._finishIngest.
@@ -558,10 +559,10 @@ class ChainedDatastore(Datastore):
         refs: Iterable[DatasetRef],
         predict: bool = False,
         allow_missing: bool = False,
-    ) -> Dict[DatasetRef, DatasetRefURIs]:
+    ) -> dict[DatasetRef, DatasetRefURIs]:
         # Docstring inherited
 
-        uris: Dict[DatasetRef, DatasetRefURIs] = {}
+        uris: dict[DatasetRef, DatasetRefURIs] = {}
         missing_refs = set(refs)
 
         # If predict is True we don't want to predict a dataset in the first
@@ -615,9 +616,9 @@ class ChainedDatastore(Datastore):
         be returned.
         """
         log.debug("Requesting URIs for %s", ref)
-        predictedUri: Optional[DatasetRefURIs] = None
-        predictedEphemeralUri: Optional[DatasetRefURIs] = None
-        firstEphemeralUri: Optional[DatasetRefURIs] = None
+        predictedUri: DatasetRefURIs | None = None
+        predictedEphemeralUri: DatasetRefURIs | None = None
+        firstEphemeralUri: DatasetRefURIs | None = None
         for datastore in self.datastores:
             if datastore.exists(ref):
                 if not datastore.isEphemeral:
@@ -701,7 +702,7 @@ class ChainedDatastore(Datastore):
         transfer: str = "auto",
         preserve_path: bool = True,
         overwrite: bool = False,
-    ) -> List[ResourcePath]:
+    ) -> list[ResourcePath]:
         """Retrieve the file artifacts associated with the supplied refs.
 
         Parameters
@@ -743,7 +744,7 @@ class ChainedDatastore(Datastore):
         # early if some of the refs are missing, or whether files should be
         # transferred until a problem is hit. Prefer to complain up front.
         # Use the datastore integer as primary key.
-        grouped_by_datastore: Dict[int, Set[DatasetRef]] = {}
+        grouped_by_datastore: dict[int, set[DatasetRef]] = {}
 
         for number, datastore in enumerate(self.datastores):
             if datastore.isEphemeral:
@@ -768,7 +769,7 @@ class ChainedDatastore(Datastore):
             raise RuntimeError(f"Some datasets were not found in any datastores: {pending}")
 
         # Now do the transfer.
-        targets: List[ResourcePath] = []
+        targets: list[ResourcePath] = []
         for number, datastore_refs in grouped_by_datastore.items():
             targets.extend(
                 self.datastores[number].retrieveArtifacts(
@@ -807,7 +808,7 @@ class ChainedDatastore(Datastore):
         for datastore in tuple(self.datastores):
             datastore.forget(refs)
 
-    def trash(self, ref: Union[DatasetRef, Iterable[DatasetRef]], ignore_errors: bool = True) -> None:
+    def trash(self, ref: DatasetRef | Iterable[DatasetRef], ignore_errors: bool = True) -> None:
         if isinstance(ref, DatasetRef):
             ref_label = str(ref)
         else:
@@ -856,7 +857,7 @@ class ChainedDatastore(Datastore):
         self.put(inMemoryDataset, ref)
 
     def validateConfiguration(
-        self, entities: Iterable[Union[DatasetRef, DatasetType, StorageClass]], logFailures: bool = False
+        self, entities: Iterable[DatasetRef | DatasetType | StorageClass], logFailures: bool = False
     ) -> None:
         """Validate some of the configuration for this datastore.
 
@@ -895,7 +896,7 @@ class ChainedDatastore(Datastore):
             msg = ";\n".join(failures)
             raise DatastoreValidationError(msg)
 
-    def validateKey(self, lookupKey: LookupKey, entity: Union[DatasetRef, DatasetType, StorageClass]) -> None:
+    def validateKey(self, lookupKey: LookupKey, entity: DatasetRef | DatasetType | StorageClass) -> None:
         # Docstring is inherited from base class
         failures = []
         for datastore in self.datastores:
@@ -908,7 +909,7 @@ class ChainedDatastore(Datastore):
             msg = ";\n".join(failures)
             raise DatastoreValidationError(msg)
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         # Docstring is inherited from base class
         keys = set()
         for datastore in self.datastores:
@@ -923,8 +924,8 @@ class ChainedDatastore(Datastore):
 
     def needs_expanded_data_ids(
         self,
-        transfer: Optional[str],
-        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+        transfer: str | None,
+        entity: DatasetRef | DatasetType | StorageClass | None = None,
     ) -> bool:
         # Docstring inherited.
         # We can't safely use `self.datastoreConstraints` with `entity` to
@@ -945,7 +946,7 @@ class ChainedDatastore(Datastore):
     def export_records(self, refs: Iterable[DatasetIdRef]) -> Mapping[str, DatastoreRecordData]:
         # Docstring inherited from the base class.
 
-        all_records: Dict[str, DatastoreRecordData] = {}
+        all_records: dict[str, DatastoreRecordData] = {}
 
         # Merge all sub-datastore records into one structure
         for datastore in self.datastores:
@@ -962,8 +963,8 @@ class ChainedDatastore(Datastore):
         self,
         refs: Iterable[DatasetRef],
         *,
-        directory: Optional[ResourcePathExpression] = None,
-        transfer: Optional[str] = "auto",
+        directory: ResourcePathExpression | None = None,
+        transfer: str | None = "auto",
     ) -> Iterable[FileDataset]:
         # Docstring inherited from Datastore.export.
         if transfer == "auto" and directory is None:
@@ -1034,7 +1035,7 @@ class ChainedDatastore(Datastore):
         source_datastore: Datastore,
         refs: Iterable[DatasetRef],
         transfer: str = "auto",
-        artifact_existence: Optional[Dict[ResourcePath, bool]] = None,
+        artifact_existence: dict[ResourcePath, bool] | None = None,
     ) -> tuple[set[DatasetRef], set[DatasetRef]]:
         # Docstring inherited
         # mypy does not understand "type(self) is not type(source)"

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -179,7 +179,7 @@ class ChainedDatastore(Datastore):
 
     def __init__(
         self,
-        config: Config | str,
+        config: Config | ResourcePathExpression,
         bridgeManager: DatastoreRegistryBridgeManager,
         butlerRoot: str | None = None,
     ):

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -161,7 +161,7 @@ class ChainedDatastore(Datastore):
             datastoreClass = doImportType(fullChildConfig["cls"])
             if not issubclass(datastoreClass, Datastore):
                 raise TypeError(f"Imported child class {fullChildConfig['cls']} is not a Datastore")
-            newroot = "{}/{}_{}".format(root, datastoreClass.__qualname__, idx)
+            newroot = f"{root}/{datastoreClass.__qualname__}_{idx}"
             datastoreClass.setConfigRoot(newroot, childConfig, fullChildConfig, overwrite=overwrite)
 
             # Reattach to parent
@@ -202,9 +202,9 @@ class ChainedDatastore(Datastore):
             self._names = [d.name for d in self.datastores]
             childNames = ",".join(self.names)
         else:
-            childNames = "(empty@{})".format(time.time())
+            childNames = f"(empty@{time.time()})"
             self._names = [childNames]
-        self.name = "{}[{}]".format(type(self).__qualname__, childNames)
+        self.name = f"{type(self).__qualname__}[{childNames}]"
 
         # We declare we are ephemeral if all our child datastores declare
         # they are ephemeral
@@ -373,7 +373,7 @@ class ChainedDatastore(Datastore):
             except FileNotFoundError:
                 pass
 
-        raise FileNotFoundError("Dataset {} could not be found in any of the datastores".format(ref))
+        raise FileNotFoundError(f"Dataset {ref} could not be found in any of the datastores")
 
     def put(self, inMemoryDataset: Any, ref: DatasetRef) -> None:
         """Write a InMemoryDataset with a given `DatasetRef` to each
@@ -645,7 +645,7 @@ class ChainedDatastore(Datastore):
             log.debug("Retrieved predicted ephemeral URI: %s", predictedEphemeralUri)
             return predictedEphemeralUri
 
-        raise FileNotFoundError("Dataset {} not in any datastore".format(ref))
+        raise FileNotFoundError(f"Dataset {ref} not in any datastore")
 
     def getURI(self, ref: DatasetRef, predict: bool = False) -> ResourcePath:
         """URI to the Dataset.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2571,7 +2571,7 @@ class FileDatastore(GenericBaseDatastore):
         source_ids = set(source_records)
         log.debug("Number of datastore records found in source: %d", len(source_ids))
 
-        requested_ids = set(ref.id for ref in refs)
+        requested_ids = {ref.id for ref in refs}
         missing_ids = requested_ids - source_ids
 
         # Missing IDs can be okay if that datastore has allowed

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -86,11 +86,11 @@ class _IngestPrepData(Datastore.IngestPrepData):
 
     Parameters
     ----------
-    datasets : `list` of `FileDataset`
+    datasets : `~collections.abc.Iterable` of `FileDataset`
         Files to be ingested by this datastore.
     """
 
-    def __init__(self, datasets: list[FileDataset]):
+    def __init__(self, datasets: Iterable[FileDataset]):
         super().__init__(ref for dataset in datasets for ref in dataset.refs)
         self.datasets = datasets
 

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -234,7 +234,7 @@ class FileDatastore(GenericBaseDatastore):
 
     def __init__(
         self,
-        config: DatastoreConfig | str,
+        config: DatastoreConfig | ResourcePathExpression,
         bridgeManager: DatastoreRegistryBridgeManager,
         butlerRoot: str | None = None,
     ):

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -27,23 +27,9 @@ __all__ = ("FileDatastore",)
 import hashlib
 import logging
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.daf.butler import (
     CompositesMap,
@@ -104,7 +90,7 @@ class _IngestPrepData(Datastore.IngestPrepData):
         Files to be ingested by this datastore.
     """
 
-    def __init__(self, datasets: List[FileDataset]):
+    def __init__(self, datasets: list[FileDataset]):
         super().__init__(ref for dataset in datasets for ref in dataset.refs)
         self.datasets = datasets
 
@@ -130,7 +116,7 @@ class DatastoreFileGetInformation:
     formatterParams: Mapping[str, Any]
     """Parameters that were understood by the associated formatter."""
 
-    component: Optional[str]
+    component: str | None
     """The component to be retrieved (can be `None`)."""
 
     readStorageClass: StorageClass
@@ -158,7 +144,7 @@ class FileDatastore(GenericBaseDatastore):
         configuration.
     """
 
-    defaultConfigFile: ClassVar[Optional[str]] = None
+    defaultConfigFile: ClassVar[str | None] = None
     """Path to configuration defaults. Accessed within the ``config`` resource
     or relative to a search path. Can be None if no defaults specified.
     """
@@ -248,7 +234,7 @@ class FileDatastore(GenericBaseDatastore):
 
     def __init__(
         self,
-        config: Union[DatastoreConfig, str],
+        config: DatastoreConfig | str,
         bridgeManager: DatastoreRegistryBridgeManager,
         butlerRoot: str | None = None,
     ):
@@ -377,7 +363,7 @@ class FileDatastore(GenericBaseDatastore):
         records = [info.rebase(ref).to_record() for ref, info in zip(refs, infos)]
         self._table.insert(*records, transaction=self._transaction)
 
-    def getStoredItemsInfo(self, ref: DatasetIdRef) -> List[StoredFileInfo]:
+    def getStoredItemsInfo(self, ref: DatasetIdRef) -> list[StoredFileInfo]:
         # Docstring inherited from GenericBaseDatastore
 
         # Look for the dataset_id -- there might be multiple matches
@@ -387,7 +373,7 @@ class FileDatastore(GenericBaseDatastore):
 
     def _get_stored_records_associated_with_refs(
         self, refs: Iterable[DatasetIdRef]
-    ) -> Dict[DatasetId, List[StoredFileInfo]]:
+    ) -> dict[DatasetId, list[StoredFileInfo]]:
         """Retrieve all records associated with the provided refs.
 
         Parameters
@@ -410,9 +396,7 @@ class FileDatastore(GenericBaseDatastore):
             records_by_ref[record["dataset_id"]].append(StoredFileInfo.from_record(record))
         return records_by_ref
 
-    def _refs_associated_with_artifacts(
-        self, paths: List[Union[str, ResourcePath]]
-    ) -> Dict[str, Set[DatasetId]]:
+    def _refs_associated_with_artifacts(self, paths: list[str | ResourcePath]) -> dict[str, set[DatasetId]]:
         """Return paths and associated dataset refs.
 
         Parameters
@@ -431,7 +415,7 @@ class FileDatastore(GenericBaseDatastore):
             result[row["path"]].add(row["dataset_id"])
         return result
 
-    def _registered_refs_per_artifact(self, pathInStore: ResourcePath) -> Set[DatasetId]:
+    def _registered_refs_per_artifact(self, pathInStore: ResourcePath) -> set[DatasetId]:
         """Return all dataset refs associated with the supplied path.
 
         Parameters
@@ -452,7 +436,7 @@ class FileDatastore(GenericBaseDatastore):
         # Docstring inherited from GenericBaseDatastore
         self._table.delete(["dataset_id"], {"dataset_id": ref.id})
 
-    def _get_dataset_locations_info(self, ref: DatasetIdRef) -> List[Tuple[Location, StoredFileInfo]]:
+    def _get_dataset_locations_info(self, ref: DatasetIdRef) -> list[tuple[Location, StoredFileInfo]]:
         r"""Find all the `Location`\ s  of the requested dataset in the
         `Datastore` and the associated stored file information.
 
@@ -507,7 +491,7 @@ class FileDatastore(GenericBaseDatastore):
             return False
         return True
 
-    def _get_expected_dataset_locations_info(self, ref: DatasetRef) -> List[Tuple[Location, StoredFileInfo]]:
+    def _get_expected_dataset_locations_info(self, ref: DatasetRef) -> list[tuple[Location, StoredFileInfo]]:
         """Predict the location and related file information of the requested
         dataset in this datastore.
 
@@ -547,7 +531,7 @@ class FileDatastore(GenericBaseDatastore):
         # See if the ref is a composite that should be disassembled
         doDisassembly = self.composites.shouldBeDisassembled(ref)
 
-        all_info: List[Tuple[Location, Formatter, StorageClass, Optional[str]]] = []
+        all_info: list[tuple[Location, Formatter, StorageClass, str | None]] = []
 
         if doDisassembly:
             for component, componentStorage in ref.datasetType.storageClass.components.items():
@@ -578,8 +562,8 @@ class FileDatastore(GenericBaseDatastore):
         ]
 
     def _prepare_for_get(
-        self, ref: DatasetRef, parameters: Optional[Mapping[str, Any]] = None
-    ) -> List[DatastoreFileGetInformation]:
+        self, ref: DatasetRef, parameters: Mapping[str, Any] | None = None
+    ) -> list[DatastoreFileGetInformation]:
         """Check parameters for ``get`` and obtain formatter and
         location.
 
@@ -681,7 +665,7 @@ class FileDatastore(GenericBaseDatastore):
 
         return fileGetInfo
 
-    def _prepare_for_put(self, inMemoryDataset: Any, ref: DatasetRef) -> Tuple[Location, Formatter]:
+    def _prepare_for_put(self, inMemoryDataset: Any, ref: DatasetRef) -> tuple[Location, Formatter]:
         """Check the arguments for ``put`` and obtain formatter and
         location.
 
@@ -709,7 +693,7 @@ class FileDatastore(GenericBaseDatastore):
         self._validate_put_parameters(inMemoryDataset, ref)
         return self._determine_put_formatter_location(ref)
 
-    def _determine_put_formatter_location(self, ref: DatasetRef) -> Tuple[Location, Formatter]:
+    def _determine_put_formatter_location(self, ref: DatasetRef) -> tuple[Location, Formatter]:
         """Calculate the formatter and output location to use for put.
 
         Parameters
@@ -752,7 +736,7 @@ class FileDatastore(GenericBaseDatastore):
 
         return location, formatter
 
-    def _overrideTransferMode(self, *datasets: FileDataset, transfer: Optional[str] = None) -> Optional[str]:
+    def _overrideTransferMode(self, *datasets: FileDataset, transfer: str | None = None) -> str | None:
         # Docstring inherited from base class
         if transfer != "auto":
             return transfer
@@ -781,7 +765,7 @@ class FileDatastore(GenericBaseDatastore):
 
         return transfer
 
-    def _pathInStore(self, path: ResourcePathExpression) -> Optional[str]:
+    def _pathInStore(self, path: ResourcePathExpression) -> str | None:
         """Return path relative to datastore root
 
         Parameters
@@ -802,8 +786,8 @@ class FileDatastore(GenericBaseDatastore):
         return pathUri.relative_to(self.root)
 
     def _standardizeIngestPath(
-        self, path: Union[str, ResourcePath], *, transfer: Optional[str] = None
-    ) -> Union[str, ResourcePath]:
+        self, path: str | ResourcePath, *, transfer: str | None = None
+    ) -> str | ResourcePath:
         """Standardize the path of a to-be-ingested file.
 
         Parameters
@@ -871,8 +855,8 @@ class FileDatastore(GenericBaseDatastore):
         path: ResourcePathExpression,
         ref: DatasetRef,
         *,
-        formatter: Union[Formatter, Type[Formatter]],
-        transfer: Optional[str] = None,
+        formatter: Formatter | type[Formatter],
+        transfer: str | None = None,
         record_validation_info: bool = True,
     ) -> StoredFileInfo:
         """Relocate (if necessary) and extract `StoredFileInfo` from a
@@ -923,7 +907,7 @@ class FileDatastore(GenericBaseDatastore):
         # Track whether we have read the size of the source yet
         have_sized = False
 
-        tgtLocation: Optional[Location]
+        tgtLocation: Location | None
         if transfer is None or transfer == "split":
             # A relative path is assumed to be relative to the datastore
             # in this context
@@ -1004,7 +988,7 @@ class FileDatastore(GenericBaseDatastore):
             dataset_id=ref.id,
         )
 
-    def _prepIngest(self, *datasets: FileDataset, transfer: Optional[str] = None) -> _IngestPrepData:
+    def _prepIngest(self, *datasets: FileDataset, transfer: str | None = None) -> _IngestPrepData:
         # Docstring inherited from Datastore._prepIngest.
         filtered = []
         for dataset in datasets:
@@ -1030,7 +1014,7 @@ class FileDatastore(GenericBaseDatastore):
         self,
         prepData: Datastore.IngestPrepData,
         *,
-        transfer: Optional[str] = None,
+        transfer: str | None = None,
         record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited from Datastore._finishIngest.
@@ -1052,7 +1036,7 @@ class FileDatastore(GenericBaseDatastore):
         self,
         srcUri: ResourcePath,
         ref: DatasetRef,
-        formatter: Formatter | Type[Formatter] | None = None,
+        formatter: Formatter | type[Formatter] | None = None,
     ) -> Location:
         """Given a source URI and a DatasetRef, determine the name the
         dataset will have inside datastore.
@@ -1205,7 +1189,7 @@ class FileDatastore(GenericBaseDatastore):
         getInfo: DatastoreFileGetInformation,
         ref: DatasetRef,
         isComponent: bool = False,
-        cache_ref: Optional[DatasetRef] = None,
+        cache_ref: DatasetRef | None = None,
     ) -> Any:
         """Read the artifact from datastore into in memory object.
 
@@ -1399,11 +1383,11 @@ class FileDatastore(GenericBaseDatastore):
 
     def _process_mexists_records(
         self,
-        id_to_ref: Dict[DatasetId, DatasetRef],
-        records: Dict[DatasetId, List[StoredFileInfo]],
+        id_to_ref: dict[DatasetId, DatasetRef],
+        records: dict[DatasetId, list[StoredFileInfo]],
         all_required: bool,
-        artifact_existence: Optional[Dict[ResourcePath, bool]] = None,
-    ) -> Dict[DatasetRef, bool]:
+        artifact_existence: dict[ResourcePath, bool] | None = None,
+    ) -> dict[DatasetRef, bool]:
         """Helper function for mexists that checks the given records.
 
         Parameters
@@ -1428,12 +1412,12 @@ class FileDatastore(GenericBaseDatastore):
         """
         # The URIs to be checked and a mapping of those URIs to
         # the dataset ID.
-        uris_to_check: List[ResourcePath] = []
-        location_map: Dict[ResourcePath, DatasetId] = {}
+        uris_to_check: list[ResourcePath] = []
+        location_map: dict[ResourcePath, DatasetId] = {}
 
         location_factory = self.locationFactory
 
-        uri_existence: Dict[ResourcePath, bool] = {}
+        uri_existence: dict[ResourcePath, bool] = {}
         for ref_id, infos in records.items():
             # Key is the dataset Id, value is list of StoredItemInfo
             uris = [info.file_location(location_factory).uri for info in infos]
@@ -1468,7 +1452,7 @@ class FileDatastore(GenericBaseDatastore):
             uris_to_check = filtered_uris_to_check
 
         # Results.
-        dataset_existence: Dict[DatasetRef, bool] = {}
+        dataset_existence: dict[DatasetRef, bool] = {}
 
         uri_existence.update(ResourcePath.mexists(uris_to_check))
         for uri, exists in uri_existence.items():
@@ -1490,8 +1474,8 @@ class FileDatastore(GenericBaseDatastore):
         return dataset_existence
 
     def mexists(
-        self, refs: Iterable[DatasetRef], artifact_existence: Optional[Dict[ResourcePath, bool]] = None
-    ) -> Dict[DatasetRef, bool]:
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool] | None = None
+    ) -> dict[DatasetRef, bool]:
         """Check the existence of multiple datasets at once.
 
         Parameters
@@ -1518,7 +1502,7 @@ class FileDatastore(GenericBaseDatastore):
         still in the cache.
         """
         chunk_size = 10_000
-        dataset_existence: Dict[DatasetRef, bool] = {}
+        dataset_existence: dict[DatasetRef, bool] = {}
         log.debug("Checking for the existence of multiple artifacts in datastore in chunks of %d", chunk_size)
         n_found_total = 0
         n_checked = 0
@@ -1585,8 +1569,8 @@ class FileDatastore(GenericBaseDatastore):
         return dataset_existence
 
     def _mexists(
-        self, refs: Sequence[DatasetRef], artifact_existence: Optional[Dict[ResourcePath, bool]] = None
-    ) -> Dict[DatasetRef, bool]:
+        self, refs: Sequence[DatasetRef], artifact_existence: dict[ResourcePath, bool] | None = None
+    ) -> dict[DatasetRef, bool]:
         """Check the existence of multiple datasets at once.
 
         Parameters
@@ -1639,8 +1623,8 @@ class FileDatastore(GenericBaseDatastore):
         }
 
     def _mexists_check_expected(
-        self, refs: Sequence[DatasetRef], artifact_existence: Optional[Dict[ResourcePath, bool]] = None
-    ) -> Dict[DatasetRef, bool]:
+        self, refs: Sequence[DatasetRef], artifact_existence: dict[ResourcePath, bool] | None = None
+    ) -> dict[DatasetRef, bool]:
         """Check existence of refs that are not known to datastore.
 
         Parameters
@@ -1658,7 +1642,7 @@ class FileDatastore(GenericBaseDatastore):
         existence : `dict` of [`DatasetRef`, `bool`]
             Mapping from dataset to boolean indicating existence.
         """
-        dataset_existence: Dict[DatasetRef, bool] = {}
+        dataset_existence: dict[DatasetRef, bool] = {}
         if not self.trustGetRequest:
             # Must assume these do not exist
             for ref in refs:
@@ -1855,10 +1839,10 @@ class FileDatastore(GenericBaseDatastore):
         refs: Iterable[DatasetRef],
         predict: bool = False,
         allow_missing: bool = False,
-    ) -> Dict[DatasetRef, DatasetRefURIs]:
+    ) -> dict[DatasetRef, DatasetRefURIs]:
         # Docstring inherited
 
-        uris: Dict[DatasetRef, DatasetRefURIs] = {}
+        uris: dict[DatasetRef, DatasetRefURIs] = {}
 
         records = self._get_stored_records_associated_with_refs(refs)
         records_keys = records.keys()
@@ -1901,7 +1885,7 @@ class FileDatastore(GenericBaseDatastore):
     def _locations_to_URI(
         self,
         ref: DatasetRef,
-        file_locations: Sequence[Tuple[Location, StoredFileInfo]],
+        file_locations: Sequence[tuple[Location, StoredFileInfo]],
     ) -> DatasetRefURIs:
         """Convert one or more file locations associated with a DatasetRef
         to a DatasetRefURIs.
@@ -1973,7 +1957,7 @@ class FileDatastore(GenericBaseDatastore):
         transfer: str = "auto",
         preserve_path: bool = True,
         overwrite: bool = False,
-    ) -> List[ResourcePath]:
+    ) -> list[ResourcePath]:
         """Retrieve the file artifacts associated with the supplied refs.
 
         Parameters
@@ -2011,7 +1995,7 @@ class FileDatastore(GenericBaseDatastore):
         # Source -> Destination
         # This also helps filter out duplicate DatasetRef in the request
         # that will map to the same underlying file transfer.
-        to_transfer: Dict[ResourcePath, ResourcePath] = {}
+        to_transfer: dict[ResourcePath, ResourcePath] = {}
 
         for ref in refs:
             locations = self._get_dataset_locations_info(ref)
@@ -2039,8 +2023,8 @@ class FileDatastore(GenericBaseDatastore):
     def get(
         self,
         ref: DatasetRef,
-        parameters: Optional[Mapping[str, Any]] = None,
-        storageClass: Optional[Union[StorageClass, str]] = None,
+        parameters: Mapping[str, Any] | None = None,
+        storageClass: StorageClass | str | None = None,
     ) -> Any:
         """Load an InMemoryDataset from the store.
 
@@ -2122,7 +2106,7 @@ class FileDatastore(GenericBaseDatastore):
             # assembler.
             usedParams = set()
 
-            components: Dict[str, Any] = {}
+            components: dict[str, Any] = {}
             for getInfo in allGetInfo:
                 # assemblerParams are parameters not understood by the
                 # associated formatter.
@@ -2211,7 +2195,7 @@ class FileDatastore(GenericBaseDatastore):
             # see the storage class of the derived component and those
             # parameters will have to be handled by the formatter on the
             # forwarded storage class.
-            assemblerParams: Dict[str, Any] = {}
+            assemblerParams: dict[str, Any] = {}
 
             # Need to created a new info that specifies the derived
             # component and associated storage class
@@ -2317,7 +2301,7 @@ class FileDatastore(GenericBaseDatastore):
         self._register_datasets(artifacts)
 
     @transactional
-    def trash(self, ref: Union[DatasetRef, Iterable[DatasetRef]], ignore_errors: bool = True) -> None:
+    def trash(self, ref: DatasetRef | Iterable[DatasetRef], ignore_errors: bool = True) -> None:
         # At this point can safely remove these datasets from the cache
         # to avoid confusion later on. If they are not trashed later
         # the cache will simply be refilled.
@@ -2344,7 +2328,7 @@ class FileDatastore(GenericBaseDatastore):
                 # Do an explicit existence check on these refs.
                 # We only care about the artifacts at this point and not
                 # the dataset existence.
-                artifact_existence: Dict[ResourcePath, bool] = {}
+                artifact_existence: dict[ResourcePath, bool] = {}
                 _ = self.mexists(missing, artifact_existence)
                 uris = [uri for uri, exists in artifact_existence.items() if exists]
 
@@ -2531,7 +2515,7 @@ class FileDatastore(GenericBaseDatastore):
         source_datastore: Datastore,
         refs: Iterable[DatasetRef],
         transfer: str = "auto",
-        artifact_existence: Optional[Dict[ResourcePath, bool]] = None,
+        artifact_existence: dict[ResourcePath, bool] | None = None,
     ) -> tuple[set[DatasetRef], set[DatasetRef]]:
         # Docstring inherited
         if type(self) is not type(source_datastore):
@@ -2758,7 +2742,7 @@ class FileDatastore(GenericBaseDatastore):
         self._table.delete(["dataset_id"], *[{"dataset_id": ref.id} for ref in refs])
 
     def validateConfiguration(
-        self, entities: Iterable[Union[DatasetRef, DatasetType, StorageClass]], logFailures: bool = False
+        self, entities: Iterable[DatasetRef | DatasetType | StorageClass], logFailures: bool = False
     ) -> None:
         """Validate some of the configuration for this datastore.
 
@@ -2807,7 +2791,7 @@ class FileDatastore(GenericBaseDatastore):
             msg = ";\n".join(messages)
             raise DatastoreValidationError(msg)
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         # Docstring is inherited from base class
         return (
             self.templates.getLookupKeys()
@@ -2815,7 +2799,7 @@ class FileDatastore(GenericBaseDatastore):
             | self.constraints.getLookupKeys()
         )
 
-    def validateKey(self, lookupKey: LookupKey, entity: Union[DatasetRef, DatasetType, StorageClass]) -> None:
+    def validateKey(self, lookupKey: LookupKey, entity: DatasetRef | DatasetType | StorageClass) -> None:
         # Docstring is inherited from base class
         # The key can be valid in either formatters or templates so we can
         # only check the template if it exists
@@ -2829,8 +2813,8 @@ class FileDatastore(GenericBaseDatastore):
         self,
         refs: Iterable[DatasetRef],
         *,
-        directory: Optional[ResourcePathExpression] = None,
-        transfer: Optional[str] = "auto",
+        directory: ResourcePathExpression | None = None,
+        transfer: str | None = "auto",
     ) -> Iterable[FileDataset]:
         # Docstring inherited from Datastore.export.
         if transfer == "auto" and directory is None:
@@ -2849,7 +2833,7 @@ class FileDatastore(GenericBaseDatastore):
             transfer = None
 
         # Force the directory to be a URI object
-        directoryUri: Optional[ResourcePath] = None
+        directoryUri: ResourcePath | None = None
         if directory is not None:
             directoryUri = ResourcePath(directory, forceDirectory=True)
 
@@ -2900,9 +2884,7 @@ class FileDatastore(GenericBaseDatastore):
             yield FileDataset(refs=[ref], path=pathInStore, formatter=storedFileInfo.formatter)
 
     @staticmethod
-    def computeChecksum(
-        uri: ResourcePath, algorithm: str = "blake2b", block_size: int = 8192
-    ) -> Optional[str]:
+    def computeChecksum(uri: ResourcePath, algorithm: str = "blake2b", block_size: int = 8192) -> str | None:
         """Compute the checksum of the supplied file.
 
         Parameters
@@ -2941,8 +2923,8 @@ class FileDatastore(GenericBaseDatastore):
 
     def needs_expanded_data_ids(
         self,
-        transfer: Optional[str],
-        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+        transfer: str | None,
+        entity: DatasetRef | DatasetType | StorageClass | None = None,
     ) -> bool:
         # Docstring inherited.
         # This _could_ also use entity to inspect whether the filename template

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1871,7 +1871,7 @@ class FileDatastore(GenericBaseDatastore):
             # if this has never been written then we have to guess
             if not predict:
                 if not allow_missing:
-                    raise FileNotFoundError("Dataset {} not in this datastore.".format(ref))
+                    raise FileNotFoundError(f"Dataset {ref} not in this datastore.")
             else:
                 uris[ref] = self._predict_URIs(ref)
 
@@ -2907,7 +2907,7 @@ class FileDatastore(GenericBaseDatastore):
         Currently returns None if the URI is for a remote resource.
         """
         if algorithm not in hashlib.algorithms_guaranteed:
-            raise NameError("The specified algorithm '{}' is not supported by hashlib".format(algorithm))
+            raise NameError(f"The specified algorithm '{algorithm}' is not supported by hashlib")
 
         if not uri.isLocal:
             return None

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -27,7 +27,8 @@ __all__ = ("GenericBaseDatastore",)
 
 import logging
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Sequence, Tuple
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import DatasetTypeNotSupportedError, Datastore
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
@@ -97,7 +98,7 @@ class GenericBaseDatastore(Datastore):
         """
         raise NotImplementedError()
 
-    def _register_datasets(self, refsAndInfos: Iterable[Tuple[DatasetRef, StoredDatastoreItemInfo]]) -> None:
+    def _register_datasets(self, refsAndInfos: Iterable[tuple[DatasetRef, StoredDatastoreItemInfo]]) -> None:
         """Update registry to indicate that one or more datasets have been
         stored.
 
@@ -108,7 +109,7 @@ class GenericBaseDatastore(Datastore):
             Datasets to register and the internal datastore metadata associated
             with them.
         """
-        expandedRefs: List[DatasetRef] = []
+        expandedRefs: list[DatasetRef] = []
         expandedItemInfos = []
 
         for ref, itemInfo in refsAndInfos:
@@ -126,7 +127,7 @@ class GenericBaseDatastore(Datastore):
         self,
         inMemoryDataset: Any,
         readStorageClass: StorageClass,
-        assemblerParams: Optional[Mapping[str, Any]] = None,
+        assemblerParams: Mapping[str, Any] | None = None,
         isComponent: bool = False,
     ) -> Any:
         """Given the Python object read from the datastore, manipulate

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -123,7 +123,7 @@ class InMemoryDatastore(GenericBaseDatastore):
 
         # Name ourselves with the timestamp the datastore
         # was created.
-        self.name = "{}@{}".format(type(self).__name__, time.time())
+        self.name = f"{type(self).__name__}@{time.time()}"
         log.debug("Creating datastore %s", self.name)
 
         # Storage of datasets, keyed by dataset_id
@@ -441,7 +441,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         # if this has never been written then we have to guess
         if not self.exists(ref):
             if not predict:
-                raise FileNotFoundError("Dataset {} not in this datastore".format(ref))
+                raise FileNotFoundError(f"Dataset {ref} not in this datastore")
             name = f"{ref.datasetType.name}"
             fragment = "#predicted"
         else:

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -27,8 +27,9 @@ __all__ = ("StoredMemoryItemInfo", "InMemoryDatastore")
 
 import logging
 import time
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 from lsst.daf.butler import (
@@ -106,17 +107,17 @@ class InMemoryDatastore(GenericBaseDatastore):
     """A new datastore is created every time and datasets disappear when
     the process shuts down."""
 
-    datasets: Dict[DatasetId, Any]
+    datasets: dict[DatasetId, Any]
     """Internal storage of datasets indexed by dataset ID."""
 
-    records: Dict[DatasetId, StoredMemoryItemInfo]
+    records: dict[DatasetId, StoredMemoryItemInfo]
     """Internal records about stored datasets."""
 
     def __init__(
         self,
-        config: Union[Config, str],
+        config: Config | str,
         bridgeManager: DatastoreRegistryBridgeManager,
-        butlerRoot: Optional[str] = None,
+        butlerRoot: str | None = None,
     ):
         super().__init__(config, bridgeManager)
 
@@ -126,14 +127,14 @@ class InMemoryDatastore(GenericBaseDatastore):
         log.debug("Creating datastore %s", self.name)
 
         # Storage of datasets, keyed by dataset_id
-        self.datasets: Dict[DatasetId, Any] = {}
+        self.datasets: dict[DatasetId, Any] = {}
 
         # Records is distinct in order to track concrete composite components
         # where we register multiple components for a single dataset.
-        self.records: Dict[DatasetId, StoredMemoryItemInfo] = {}
+        self.records: dict[DatasetId, StoredMemoryItemInfo] = {}
 
         # Related records that share the same parent
-        self.related: Dict[DatasetId, Set[DatasetId]] = {}
+        self.related: dict[DatasetId, set[DatasetId]] = {}
 
         self._bridge = bridgeManager.register(self.name, ephemeral=True)
 
@@ -187,7 +188,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         # Docstring inherited from GenericBaseDatastore.
         return self.records[ref.id]
 
-    def getStoredItemsInfo(self, ref: DatasetIdRef) -> List[StoredMemoryItemInfo]:
+    def getStoredItemsInfo(self, ref: DatasetIdRef) -> list[StoredMemoryItemInfo]:
         # Docstring inherited from GenericBaseDatastore.
         return [self.getStoredItemInfo(ref)]
 
@@ -202,7 +203,7 @@ class InMemoryDatastore(GenericBaseDatastore):
         del self.records[ref.id]
         self.related[record.parentID].remove(ref.id)
 
-    def _get_dataset_info(self, ref: DatasetIdRef) -> Tuple[DatasetId, StoredMemoryItemInfo]:
+    def _get_dataset_info(self, ref: DatasetIdRef) -> tuple[DatasetId, StoredMemoryItemInfo]:
         """Check that the dataset is present and return the real ID and
         associated information.
 
@@ -277,8 +278,8 @@ class InMemoryDatastore(GenericBaseDatastore):
     def get(
         self,
         ref: DatasetRef,
-        parameters: Optional[Mapping[str, Any]] = None,
-        storageClass: Optional[Union[StorageClass, str]] = None,
+        parameters: Mapping[str, Any] | None = None,
+        storageClass: StorageClass | str | None = None,
     ) -> Any:
         """Load an InMemoryDataset from the store.
 
@@ -495,8 +496,8 @@ class InMemoryDatastore(GenericBaseDatastore):
         destination: ResourcePath,
         transfer: str = "auto",
         preserve_path: bool = True,
-        overwrite: Optional[bool] = False,
-    ) -> List[ResourcePath]:
+        overwrite: bool | None = False,
+    ) -> list[ResourcePath]:
         """Retrieve the file artifacts associated with the supplied refs.
 
         Notes
@@ -515,7 +516,7 @@ class InMemoryDatastore(GenericBaseDatastore):
             self.removeStoredItemInfo(ref)
 
     @transactional
-    def trash(self, ref: Union[DatasetRef, Iterable[DatasetRef]], ignore_errors: bool = False) -> None:
+    def trash(self, ref: DatasetRef | Iterable[DatasetRef], ignore_errors: bool = False) -> None:
         """Indicate to the Datastore that a dataset can be removed.
 
         Parameters
@@ -609,7 +610,7 @@ class InMemoryDatastore(GenericBaseDatastore):
                 self.removeStoredItemInfo(ref)
 
     def validateConfiguration(
-        self, entities: Iterable[Union[DatasetRef, DatasetType, StorageClass]], logFailures: bool = False
+        self, entities: Iterable[DatasetRef | DatasetType | StorageClass], logFailures: bool = False
     ) -> None:
         """Validate some of the configuration for this datastore.
 
@@ -634,22 +635,22 @@ class InMemoryDatastore(GenericBaseDatastore):
         """
         return
 
-    def _overrideTransferMode(self, *datasets: Any, transfer: Optional[str] = None) -> Optional[str]:
+    def _overrideTransferMode(self, *datasets: Any, transfer: str | None = None) -> str | None:
         # Docstring is inherited from base class
         return transfer
 
-    def validateKey(self, lookupKey: LookupKey, entity: Union[DatasetRef, DatasetType, StorageClass]) -> None:
+    def validateKey(self, lookupKey: LookupKey, entity: DatasetRef | DatasetType | StorageClass) -> None:
         # Docstring is inherited from base class
         return
 
-    def getLookupKeys(self) -> Set[LookupKey]:
+    def getLookupKeys(self) -> set[LookupKey]:
         # Docstring is inherited from base class
         return self.constraints.getLookupKeys()
 
     def needs_expanded_data_ids(
         self,
-        transfer: Optional[str],
-        entity: Optional[Union[DatasetRef, DatasetType, StorageClass]] = None,
+        transfer: str | None,
+        entity: DatasetRef | DatasetType | StorageClass | None = None,
     ) -> bool:
         # Docstring inherited.
         return False

--- a/python/lsst/daf/butler/delegates/arrowtable.py
+++ b/python/lsst/daf/butler/delegates/arrowtable.py
@@ -22,7 +22,8 @@
 """Support for reading Arrow tables."""
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any
 
 import pyarrow as pa
 from lsst.daf.butler import StorageClassDelegate
@@ -66,7 +67,7 @@ class ArrowTableDelegate(StorageClassDelegate):
             f"Do not know how to retrieve component {componentName} from {get_full_type_name(composite)}"
         )
 
-    def handleParameters(self, inMemoryDataset: Any, parameters: Optional[Mapping[str, Any]] = None) -> Any:
+    def handleParameters(self, inMemoryDataset: Any, parameters: Mapping[str, Any] | None = None) -> Any:
         if not isinstance(inMemoryDataset, self._datasetType):
             raise ValueError(
                 f"inMemoryDataset must be a {get_full_type_name(self._datasetType)} and "

--- a/python/lsst/daf/butler/delegates/dataframe.py
+++ b/python/lsst/daf/butler/delegates/dataframe.py
@@ -23,7 +23,8 @@
 from __future__ import annotations
 
 import collections.abc
-from typing import Any, Mapping, Optional
+from collections.abc import Mapping
+from typing import Any
 
 import pandas
 from lsst.daf.butler import StorageClassDelegate
@@ -72,7 +73,7 @@ class DataFrameDelegate(StorageClassDelegate):
             )
 
     def handleParameters(
-        self, inMemoryDataset: pandas.DataFrame, parameters: Optional[Mapping[str, Any]] = None
+        self, inMemoryDataset: pandas.DataFrame, parameters: Mapping[str, Any] | None = None
     ) -> Any:
         """Return possibly new in-memory dataset using the supplied parameters.
 

--- a/python/lsst/daf/butler/formatters/astropyTable.py
+++ b/python/lsst/daf/butler/formatters/astropyTable.py
@@ -22,7 +22,7 @@
 __all__ = ("AstropyTableFormatter",)
 
 import os.path
-from typing import Any, Optional, Type
+from typing import Any
 
 from .file import FileFormatter
 
@@ -54,7 +54,7 @@ class AstropyTableFormatter(FileFormatter):
         # Other supported formats can be added here
         raise RuntimeError(f"Requested file format '{format}' is not supported for Table")
 
-    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         """Read a file from the path in a supported format format.
 
         Parameters

--- a/python/lsst/daf/butler/formatters/file.py
+++ b/python/lsst/daf/butler/formatters/file.py
@@ -27,7 +27,7 @@ __all__ = ("FileFormatter",)
 
 import dataclasses
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import Formatter
 
@@ -38,12 +38,12 @@ if TYPE_CHECKING:
 class FileFormatter(Formatter):
     """Interface for reading and writing files on a POSIX file system."""
 
-    extension: Optional[str] = None
+    extension: str | None = None
     """Default file extension to use for writing files. None means that no
     modifications will be made to the supplied file extension. (`str`)"""
 
     @abstractmethod
-    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         """Read a file from the path in the correct format.
 
         Parameters
@@ -82,7 +82,7 @@ class FileFormatter(Formatter):
         """
         pass
 
-    def _assembleDataset(self, data: Any, component: Optional[str] = None) -> Any:
+    def _assembleDataset(self, data: Any, component: str | None = None) -> Any:
         """Assembles and coerces the dataset, or one of its components,
         into an appropriate python type and returns it.
 
@@ -219,7 +219,7 @@ class FileFormatter(Formatter):
         inMemoryDataset = self._coerceBuiltinType(inMemoryDataset, writeStorageClass)
         return readStorageClass.coerce_type(inMemoryDataset)
 
-    def read(self, component: Optional[str] = None) -> Any:
+    def read(self, component: str | None = None) -> Any:
         """Read data from a file.
 
         Parameters
@@ -262,7 +262,7 @@ class FileFormatter(Formatter):
 
         return data
 
-    def fromBytes(self, serializedDataset: bytes, component: Optional[str] = None) -> Any:
+    def fromBytes(self, serializedDataset: bytes, component: str | None = None) -> Any:
         """Reads serialized data into a Dataset or its component.
 
         Parameters

--- a/python/lsst/daf/butler/formatters/json.py
+++ b/python/lsst/daf/butler/formatters/json.py
@@ -25,7 +25,7 @@ __all__ = ("JsonFormatter",)
 
 import dataclasses
 import json
-from typing import Any, Optional, Type
+from typing import Any
 
 from .file import FileFormatter
 
@@ -38,7 +38,7 @@ class JsonFormatter(FileFormatter):
     unsupportedParameters = None
     """This formatter does not support any parameters (`frozenset`)"""
 
-    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         """Read a file from the path in JSON format.
 
         Parameters
@@ -76,7 +76,7 @@ class JsonFormatter(FileFormatter):
         """
         self.fileDescriptor.location.uri.write(self._toBytes(inMemoryDataset))
 
-    def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
+    def _fromBytes(self, serializedDataset: bytes, pytype: type[Any] | None = None) -> Any:
         """Read the bytes object as a python object.
 
         Parameters

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -21,7 +21,7 @@
 
 __all__ = ("ButlerLogRecordsFormatter",)
 
-from typing import Any, Optional, Type
+from typing import Any
 
 from lsst.daf.butler.core.logging import ButlerLogRecords
 
@@ -37,7 +37,7 @@ class ButlerLogRecordsFormatter(JsonFormatter):
     of records given some filtering parameters.
     """
 
-    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         """Read a file from the path in JSON format.
 
         Parameters
@@ -66,7 +66,7 @@ class ButlerLogRecordsFormatter(JsonFormatter):
 
         return pytype.from_file(path)
 
-    def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
+    def _fromBytes(self, serializedDataset: bytes, pytype: type[Any] | None = None) -> Any:
         """Read the bytes object as a python object.
 
         Parameters

--- a/python/lsst/daf/butler/formatters/matplotlib.py
+++ b/python/lsst/daf/butler/formatters/matplotlib.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 __all__ = ("MatplotlibFormatter",)
 
-from typing import Any, Optional, Type
+from typing import Any
 
 from .file import FileFormatter
 
@@ -36,7 +36,7 @@ class MatplotlibFormatter(FileFormatter):
     extension = ".png"
     """Matplotlib figures are always written in PNG format."""
 
-    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         # docstring inherited from FileFormatter._readFile
         raise NotImplementedError(f"matplotlib figures cannot be read by the butler; path is {path}")
 

--- a/python/lsst/daf/butler/formatters/packages.py
+++ b/python/lsst/daf/butler/formatters/packages.py
@@ -22,7 +22,7 @@
 __all__ = ("PackagesFormatter",)
 
 import os.path
-from typing import Any, Optional, Type
+from typing import Any
 
 from lsst.daf.butler.formatters.file import FileFormatter
 from lsst.utils.packages import Packages
@@ -51,7 +51,7 @@ class PackagesFormatter(FileFormatter):
             raise RuntimeError(f"Requested file format '{format}' is not supported for Packages")
         return ext
 
-    def _readFile(self, path: str, pytype: Optional[Type] = None) -> Any:
+    def _readFile(self, path: str, pytype: type | None = None) -> Any:
         """Read a file from the path.
 
         Parameters
@@ -74,7 +74,7 @@ class PackagesFormatter(FileFormatter):
         assert issubclass(pytype, Packages)
         return pytype.read(path)
 
-    def _fromBytes(self, serializedDataset: Any, pytype: Optional[Type] = None) -> Any:
+    def _fromBytes(self, serializedDataset: Any, pytype: type | None = None) -> Any:
         """Read the bytes object as a python object.
 
         Parameters

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -506,7 +506,7 @@ def pandas_to_arrow(dataframe: pd.DataFrame, default_length: int = 10) -> pa.Tab
                     strlen = max(len(row.as_py()) for row in arrow_table[name] if row.is_valid)
                 else:
                     strlen = default_length
-                md[f"lsst::arrow::len::{name}".encode("UTF-8")] = str(strlen)
+                md[f"lsst::arrow::len::{name}".encode()] = str(strlen)
 
     arrow_table = arrow_table.replace_schema_metadata(md)
 
@@ -1051,9 +1051,9 @@ def _append_numpy_string_metadata(metadata: dict[bytes, str], name: str, dtype: 
     import numpy as np
 
     if dtype.type is np.str_:
-        metadata[f"lsst::arrow::len::{name}".encode("UTF-8")] = str(dtype.itemsize // 4)
+        metadata[f"lsst::arrow::len::{name}".encode()] = str(dtype.itemsize // 4)
     elif dtype.type is np.bytes_:
-        metadata[f"lsst::arrow::len::{name}".encode("UTF-8")] = str(dtype.itemsize)
+        metadata[f"lsst::arrow::len::{name}".encode()] = str(dtype.itemsize)
 
 
 def _append_numpy_multidim_metadata(metadata: dict[bytes, str], name: str, dtype: np.dtype) -> None:
@@ -1072,7 +1072,7 @@ def _append_numpy_multidim_metadata(metadata: dict[bytes, str], name: str, dtype
         Numpy dtype.
     """
     if len(dtype.shape) > 1:
-        metadata[f"lsst::arrow::shape::{name}".encode("UTF-8")] = str(dtype.shape)
+        metadata[f"lsst::arrow::shape::{name}".encode()] = str(dtype.shape)
 
 
 def _multidim_shape_from_metadata(metadata: dict[bytes, bytes], list_size: int, name: str) -> tuple[int, ...]:

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -44,7 +44,8 @@ import collections.abc
 import itertools
 import json
 import re
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Sequence, cast
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, cast
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -67,7 +68,7 @@ class ParquetFormatter(Formatter):
 
     extension = ".parq"
 
-    def read(self, component: Optional[str] = None) -> Any:
+    def read(self, component: str | None = None) -> Any:
         # Docstring inherited from Formatter.read.
         schema = pq.read_schema(self.fileDescriptor.location.path)
 
@@ -871,7 +872,7 @@ class ArrowNumpySchema:
         return True
 
 
-def _split_multi_index_column_names(n: int, names: Iterable[str]) -> List[Sequence[str]]:
+def _split_multi_index_column_names(n: int, names: Iterable[str]) -> list[Sequence[str]]:
     """Split a string that represents a multi-index column.
 
     PyArrow maps Pandas' multi-index column names (which are tuples in Python)
@@ -891,7 +892,7 @@ def _split_multi_index_column_names(n: int, names: Iterable[str]) -> List[Sequen
     column_names : `list` [`tuple` [`str`]]
         A list of multi-index column name tuples.
     """
-    column_names: List[Sequence[str]] = []
+    column_names: list[Sequence[str]] = []
 
     pattern = re.compile(r"\({}\)".format(", ".join(["'(.*)'"] * n)))
     for name in names:

--- a/python/lsst/daf/butler/formatters/pickle.py
+++ b/python/lsst/daf/butler/formatters/pickle.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 __all__ = ("PickleFormatter",)
 
 import pickle
-from typing import Any, Optional, Type
+from typing import Any
 
 from .file import FileFormatter
 
@@ -41,7 +41,7 @@ class PickleFormatter(FileFormatter):
     unsupportedParameters = None
     """This formatter does not support any parameters"""
 
-    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         """Read a file from the path in pickle format.
 
         Parameters
@@ -81,7 +81,7 @@ class PickleFormatter(FileFormatter):
         with open(self.fileDescriptor.location.path, "wb") as fd:
             pickle.dump(inMemoryDataset, fd, protocol=-1)
 
-    def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
+    def _fromBytes(self, serializedDataset: bytes, pytype: type[Any] | None = None) -> Any:
         """Read the bytes object as a python object.
 
         Parameters

--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ("YamlFormatter",)
 
 import dataclasses
-from typing import Any, Optional, Type
+from typing import Any
 
 import yaml
 
@@ -43,7 +43,7 @@ class YamlFormatter(FileFormatter):
     """Allow the normal yaml.dump to be used to write the YAML. Use this
     if you know that your class has registered representers."""
 
-    def _readFile(self, path: str, pytype: Type[Any] | None = None) -> Any:
+    def _readFile(self, path: str, pytype: type[Any] | None = None) -> Any:
         """Read a file from the path in YAML format.
 
         Parameters
@@ -71,7 +71,7 @@ class YamlFormatter(FileFormatter):
 
         return data
 
-    def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
+    def _fromBytes(self, serializedDataset: bytes, pytype: type[Any] | None = None) -> Any:
         """Read the bytes object as a python object.
 
         Parameters

--- a/python/lsst/daf/butler/instrument.py
+++ b/python/lsst/daf/butler/instrument.py
@@ -42,10 +42,10 @@ class ObservationDimensionPacker(DimensionPacker):
         self._instrumentName = fixed["instrument"]
         record = fixed.records["instrument"]
         assert record is not None
-        if self.dimensions.required.names == set(["instrument", "visit", "detector"]):
+        if self.dimensions.required.names == {"instrument", "visit", "detector"}:
             self._observationName = "visit"
             obsMax = record.visit_max
-        elif dimensions.required.names == set(["instrument", "exposure", "detector"]):
+        elif dimensions.required.names == {"instrument", "exposure", "detector"}:
             self._observationName = "exposure"
             obsMax = record.exposure_max
         else:

--- a/python/lsst/daf/butler/registries/remote.py
+++ b/python/lsst/daf/butler/registries/remote.py
@@ -25,7 +25,8 @@ __all__ = ("RemoteRegistry",)
 
 import contextlib
 import functools
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Sequence, Set
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 import httpx
 from lsst.daf.butler import __version__
@@ -276,7 +277,7 @@ class RemoteRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError()
 
-    def getCollectionParentChains(self, collection: str) -> Set[str]:
+    def getCollectionParentChains(self, collection: str) -> set[str]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -969,7 +969,7 @@ class SqlRegistry(Registry):
         summary : `queries.QuerySummary`
             Object describing and categorizing the full set of dimensions that
             will be included in the query.
-        doomed_by : `Iterable` of `str`, optional
+        doomed_by : `~collections.abc.Iterable` of `str`, optional
             A list of diagnostic messages that indicate why the query is going
             to yield no results and should not even be executed.  If an empty
             container (default) the query will be executed unless other code

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -26,21 +26,8 @@ __all__ = ("SqlRegistry",)
 import contextlib
 import logging
 import warnings
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-    cast,
-)
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import sqlalchemy
 from lsst.daf.relation import LeafRelation, Relation
@@ -123,7 +110,7 @@ class SqlRegistry(Registry):
         All the managers required for this registry.
     """
 
-    defaultConfigFile: Optional[str] = None
+    defaultConfigFile: str | None = None
     """Path to configuration defaults. Accessed within the ``configs`` resource
     or relative to a search path. Can be None if no defaults specified.
     """
@@ -131,9 +118,9 @@ class SqlRegistry(Registry):
     @classmethod
     def createFromConfig(
         cls,
-        config: Optional[Union[RegistryConfig, str]] = None,
-        dimensionConfig: Optional[Union[DimensionConfig, str]] = None,
-        butlerRoot: Optional[ResourcePathExpression] = None,
+        config: RegistryConfig | str | None = None,
+        dimensionConfig: DimensionConfig | str | None = None,
+        butlerRoot: ResourcePathExpression | None = None,
     ) -> Registry:
         """Create registry database and return `SqlRegistry` instance.
 
@@ -177,10 +164,10 @@ class SqlRegistry(Registry):
     @classmethod
     def fromConfig(
         cls,
-        config: Union[ButlerConfig, RegistryConfig, Config, str],
-        butlerRoot: Optional[ResourcePathExpression] = None,
+        config: ButlerConfig | RegistryConfig | Config | str,
+        butlerRoot: ResourcePathExpression | None = None,
         writeable: bool = True,
-        defaults: Optional[RegistryDefaults] = None,
+        defaults: RegistryDefaults | None = None,
     ) -> Registry:
         """Create `Registry` subclass instance from `config`.
 
@@ -241,7 +228,7 @@ class SqlRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return self._db.isWriteable()
 
-    def copy(self, defaults: Optional[RegistryDefaults] = None) -> Registry:
+    def copy(self, defaults: RegistryDefaults | None = None) -> Registry:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         if defaults is None:
             # No need to copy, because `RegistryDefaults` is immutable; we
@@ -354,7 +341,7 @@ class SqlRegistry(Registry):
         self._managers.opaque[tableName].delete(where.keys(), where)
 
     def registerCollection(
-        self, name: str, type: CollectionType = CollectionType.TAGGED, doc: Optional[str] = None
+        self, name: str, type: CollectionType = CollectionType.TAGGED, doc: str | None = None
     ) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         _, registered = self._managers.collections.register(name, type, doc=doc)
@@ -368,7 +355,7 @@ class SqlRegistry(Registry):
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return self._managers.collections.find(name)
 
-    def registerRun(self, name: str, doc: Optional[str] = None) -> bool:
+    def registerRun(self, name: str, doc: str | None = None) -> bool:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         _, registered = self._managers.collections.register(name, CollectionType.RUN, doc=doc)
         return registered
@@ -397,7 +384,7 @@ class SqlRegistry(Registry):
         if children != record.children or flatten:
             record.update(self._managers.collections, children, flatten=flatten)
 
-    def getCollectionParentChains(self, collection: str) -> Set[str]:
+    def getCollectionParentChains(self, collection: str) -> set[str]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return {
             record.name
@@ -406,11 +393,11 @@ class SqlRegistry(Registry):
             )
         }
 
-    def getCollectionDocumentation(self, collection: str) -> Optional[str]:
+    def getCollectionDocumentation(self, collection: str) -> str | None:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return self._managers.collections.getDocumentation(self._managers.collections.find(collection).key)
 
-    def setCollectionDocumentation(self, collection: str, doc: Optional[str]) -> None:
+    def setCollectionDocumentation(self, collection: str, doc: str | None) -> None:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         self._managers.collections.setDocumentation(self._managers.collections.find(collection).key, doc)
 
@@ -451,13 +438,13 @@ class SqlRegistry(Registry):
 
     def findDataset(
         self,
-        datasetType: Union[DatasetType, str],
-        dataId: Optional[DataId] = None,
+        datasetType: DatasetType | str,
+        dataId: DataId | None = None,
         *,
         collections: CollectionArgType | None = None,
-        timespan: Optional[Timespan] = None,
+        timespan: Timespan | None = None,
         **kwargs: Any,
-    ) -> Optional[DatasetRef]:
+    ) -> DatasetRef | None:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         if collections is None:
             if not self.defaults.collections:
@@ -555,12 +542,12 @@ class SqlRegistry(Registry):
     @transactional
     def insertDatasets(
         self,
-        datasetType: Union[DatasetType, str],
+        datasetType: DatasetType | str,
         dataIds: Iterable[DataId],
-        run: Optional[str] = None,
+        run: str | None = None,
         expand: bool = True,
         idGenerationMode: DatasetIdGenEnum = DatasetIdGenEnum.UNIQUE,
-    ) -> List[DatasetRef]:
+    ) -> list[DatasetRef]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         if isinstance(datasetType, DatasetType):
             storage = self._managers.datasets.find(datasetType.name)
@@ -613,7 +600,7 @@ class SqlRegistry(Registry):
         self,
         datasets: Iterable[DatasetRef],
         expand: bool = True,
-    ) -> List[DatasetRef]:
+    ) -> list[DatasetRef]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         datasets = list(datasets)
         if not datasets:
@@ -680,7 +667,7 @@ class SqlRegistry(Registry):
                 )
         return refs
 
-    def getDataset(self, id: DatasetId) -> Optional[DatasetRef]:
+    def getDataset(self, id: DatasetId) -> DatasetRef | None:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         return self._managers.datasets.getDatasetRef(id)
 
@@ -764,10 +751,10 @@ class SqlRegistry(Registry):
     def decertify(
         self,
         collection: str,
-        datasetType: Union[str, DatasetType],
+        datasetType: str | DatasetType,
         timespan: Timespan,
         *,
-        dataIds: Optional[Iterable[DataId]] = None,
+        dataIds: Iterable[DataId] | None = None,
     ) -> None:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         collectionRecord = self._managers.collections.find(collection)
@@ -805,10 +792,10 @@ class SqlRegistry(Registry):
 
     def expandDataId(
         self,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
-        graph: Optional[DimensionGraph] = None,
-        records: Optional[NameLookupMapping[DimensionElement, Optional[DimensionRecord]]] = None,
+        graph: DimensionGraph | None = None,
+        records: NameLookupMapping[DimensionElement, DimensionRecord | None] | None = None,
         withDefaults: bool = True,
         **kwargs: Any,
     ) -> DataCoordinate:
@@ -877,8 +864,8 @@ class SqlRegistry(Registry):
 
     def insertDimensionData(
         self,
-        element: Union[DimensionElement, str],
-        *data: Union[Mapping[str, Any], DimensionRecord],
+        element: DimensionElement | str,
+        *data: Mapping[str, Any] | DimensionRecord,
         conform: bool = True,
         replace: bool = False,
         skip_existing: bool = False,
@@ -898,11 +885,11 @@ class SqlRegistry(Registry):
 
     def syncDimensionData(
         self,
-        element: Union[DimensionElement, str],
-        row: Union[Mapping[str, Any], DimensionRecord],
+        element: DimensionElement | str,
+        row: Mapping[str, Any] | DimensionRecord,
         conform: bool = True,
         update: bool = False,
-    ) -> Union[bool, Dict[str, Any]]:
+    ) -> bool | dict[str, Any]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         if conform:
             if isinstance(element, str):
@@ -918,8 +905,8 @@ class SqlRegistry(Registry):
         self,
         expression: Any = ...,
         *,
-        components: Optional[bool] = None,
-        missing: Optional[List[str]] = None,
+        components: bool | None = None,
+        missing: list[str] | None = None,
     ) -> Iterable[DatasetType]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
         wildcard = DatasetTypeWildcard.from_expression(expression)
@@ -939,10 +926,10 @@ class SqlRegistry(Registry):
     def queryCollections(
         self,
         expression: Any = ...,
-        datasetType: Optional[DatasetType] = None,
-        collectionTypes: Union[Iterable[CollectionType], CollectionType] = CollectionType.all(),
+        datasetType: DatasetType | None = None,
+        collectionTypes: Iterable[CollectionType] | CollectionType = CollectionType.all(),
         flattenChains: bool = False,
-        includeChains: Optional[bool] = None,
+        includeChains: bool | None = None,
     ) -> Sequence[str]:
         # Docstring inherited from lsst.daf.butler.registry.Registry
 
@@ -1129,12 +1116,12 @@ class SqlRegistry(Registry):
         datasetType: Any,
         *,
         collections: CollectionArgType | None = None,
-        dimensions: Optional[Iterable[Union[Dimension, str]]] = None,
-        dataId: Optional[DataId] = None,
+        dimensions: Iterable[Dimension | str] | None = None,
+        dataId: DataId | None = None,
         where: str = "",
         findFirst: bool = False,
-        components: Optional[bool] = None,
-        bind: Optional[Mapping[str, Any]] = None,
+        components: bool | None = None,
+        bind: Mapping[str, Any] | None = None,
         check: bool = True,
         **kwargs: Any,
     ) -> queries.DatasetQueryResults:
@@ -1198,14 +1185,14 @@ class SqlRegistry(Registry):
 
     def queryDataIds(
         self,
-        dimensions: Union[Iterable[Union[Dimension, str]], Dimension, str],
+        dimensions: Iterable[Dimension | str] | Dimension | str,
         *,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         datasets: Any = None,
         collections: CollectionArgType | None = None,
         where: str = "",
-        components: Optional[bool] = None,
-        bind: Optional[Mapping[str, Any]] = None,
+        components: bool | None = None,
+        bind: Mapping[str, Any] | None = None,
         check: bool = True,
         **kwargs: Any,
     ) -> queries.DataCoordinateQueryResults:
@@ -1238,14 +1225,14 @@ class SqlRegistry(Registry):
 
     def queryDimensionRecords(
         self,
-        element: Union[DimensionElement, str],
+        element: DimensionElement | str,
         *,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         datasets: Any = None,
         collections: CollectionArgType | None = None,
         where: str = "",
-        components: Optional[bool] = None,
-        bind: Optional[Mapping[str, Any]] = None,
+        components: bool | None = None,
+        bind: Mapping[str, Any] | None = None,
         check: bool = True,
         **kwargs: Any,
     ) -> queries.DimensionRecordQueryResults:
@@ -1283,7 +1270,7 @@ class SqlRegistry(Registry):
 
     def queryDatasetAssociations(
         self,
-        datasetType: Union[str, DatasetType],
+        datasetType: str | DatasetType,
         collections: CollectionArgType | None = ...,
         *,
         collectionTypes: Iterable[CollectionType] = CollectionType.all(),

--- a/python/lsst/daf/butler/registries/sql.py
+++ b/python/lsst/daf/butler/registries/sql.py
@@ -608,7 +608,7 @@ class SqlRegistry(Registry):
             return []
 
         # find dataset type
-        datasetTypes = set(dataset.datasetType for dataset in datasets)
+        datasetTypes = {dataset.datasetType for dataset in datasets}
         if len(datasetTypes) != 1:
             raise DatasetTypeError(f"Multiple dataset types in input datasets: {datasetTypes}")
         datasetType = datasetTypes.pop()
@@ -619,7 +619,7 @@ class SqlRegistry(Registry):
             raise DatasetTypeError(f"DatasetType '{datasetType}' has not been registered.")
 
         # find run name
-        runs = set(dataset.run for dataset in datasets)
+        runs = {dataset.run for dataset in datasets}
         if len(runs) != 1:
             raise ValueError(f"Multiple run names in input datasets: {runs}")
         run = runs.pop()

--- a/python/lsst/daf/butler/registry/_collectionType.py
+++ b/python/lsst/daf/butler/registry/_collectionType.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 import enum
-from typing import FrozenSet, Iterable, Optional
+from collections.abc import Iterable
 
 
 class CollectionType(enum.IntEnum):
@@ -66,7 +66,7 @@ class CollectionType(enum.IntEnum):
     """
 
     @classmethod
-    def all(cls) -> FrozenSet[CollectionType]:
+    def all(cls) -> frozenset[CollectionType]:
         """Return a `frozenset` containing all members."""
         return frozenset(cls.__members__.values())
 
@@ -96,7 +96,7 @@ class CollectionType(enum.IntEnum):
             raise KeyError(f"Collection type of '{name}' not known to Butler.") from None
 
     @classmethod
-    def from_names(cls, names: Optional[Iterable[str]]) -> FrozenSet[CollectionType]:
+    def from_names(cls, names: Iterable[str] | None) -> frozenset[CollectionType]:
         """Return a `frozenset` containing the `CollectionType` instances
         corresponding to the names.
 

--- a/python/lsst/daf/butler/registry/_collection_summary.py
+++ b/python/lsst/daf/butler/registry/_collection_summary.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 __all__ = ("CollectionSummary",)
 
 import dataclasses
-from collections.abc import Generator, Iterable, Mapping
-from typing import AbstractSet, cast
+from collections.abc import Generator, Iterable, Mapping, Set
+from typing import cast
 
 from ..core import DataCoordinate, DatasetRef, DatasetType
 from ..core.named import NamedValueSet
@@ -167,7 +167,7 @@ class CollectionSummary:
     def is_compatible_with(
         self,
         dataset_type: DatasetType,
-        dimensions: Mapping[str, AbstractSet[str]],
+        dimensions: Mapping[str, Set[str]],
         rejections: list[str] | None = None,
         name: str | None = None,
     ) -> bool:

--- a/python/lsst/daf/butler/registry/_collection_summary.py
+++ b/python/lsst/daf/butler/registry/_collection_summary.py
@@ -54,7 +54,7 @@ class CollectionSummary:
 
         Parameters
         ----------
-        refs : `Iterable` [ `DatasetRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to include.
 
         Yields
@@ -81,7 +81,7 @@ class CollectionSummary:
 
         Parameters
         ----------
-        refs : `Iterable` [ `DatasetRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to include.
         """
         for _ in self.add_datasets_generator(refs):
@@ -97,7 +97,7 @@ class CollectionSummary:
         ----------
         dataset_type : `DatasetType`
             Dataset type to include.
-        data_ids : `Iterable` [ `DataCoordinate` ]
+        data_ids : `~collections.abc.Iterable` [ `DataCoordinate` ]
             Data IDs to include.
 
         Yields
@@ -126,7 +126,7 @@ class CollectionSummary:
         ----------
         dataset_type : `DatasetType`
             Dataset type to include.
-        data_ids : `Iterable` [ `DataCoordinate` ]
+        data_ids : `~collections.abc.Iterable` [ `DataCoordinate` ]
             Data IDs to include.
         """
         for _ in self.add_data_ids_generator(dataset_type, data_ids):
@@ -180,7 +180,7 @@ class CollectionSummary:
             Dataset type being queried.  If this collection has no instances of
             this dataset type (or its parent dataset type, if it is a
             component), `False` will always be returned.
-        dimensions : `Mapping`
+        dimensions : `~collections.abc.Mapping`
             Bounds on the values governor dimensions can take in the query,
             usually from a WHERE expression, as a mapping from dimension name
             to a set of `str` governor dimension values.

--- a/python/lsst/daf/butler/registry/_collection_summary.py
+++ b/python/lsst/daf/butler/registry/_collection_summary.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 __all__ = ("CollectionSummary",)
 
 import dataclasses
-from typing import AbstractSet, Generator, Iterable, List, Mapping, Optional, cast
+from collections.abc import Generator, Iterable, Mapping
+from typing import AbstractSet, cast
 
 from ..core import DataCoordinate, DatasetRef, DatasetType
 from ..core.named import NamedValueSet
@@ -167,8 +168,8 @@ class CollectionSummary:
         self,
         dataset_type: DatasetType,
         dimensions: Mapping[str, AbstractSet[str]],
-        rejections: Optional[List[str]] = None,
-        name: Optional[str] = None,
+        rejections: list[str] | None = None,
+        name: str | None = None,
     ) -> bool:
         """Test whether the collection summarized by this object should be
         queried for a given dataset type and governor dimension values.

--- a/python/lsst/daf/butler/registry/_config.py
+++ b/python/lsst/daf/butler/registry/_config.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 __all__ = ("RegistryConfig",)
 
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING
 
 from lsst.utils import doImportType
 
@@ -53,7 +53,7 @@ class RegistryConfig(ConfigSubset):
         conStr = ConnectionStringFactory.fromConfig(self)
         return conStr.get_backend_name()
 
-    def getDatabaseClass(self) -> Type[Database]:
+    def getDatabaseClass(self) -> type[Database]:
         """Returns the `Database` class targeted by configuration values.
 
         The appropriate class is determined by parsing the `db` key to extract
@@ -69,7 +69,7 @@ class RegistryConfig(ConfigSubset):
             raise TypeError(f"Imported database class {databaseClassName} is not a Database")
         return databaseClass
 
-    def makeDefaultDatabaseUri(self, root: str) -> Optional[str]:
+    def makeDefaultDatabaseUri(self, root: str) -> str | None:
         """Return a default 'db' URI for the registry configured here that is
         appropriate for a new empty repository with the given root.
 
@@ -86,7 +86,7 @@ class RegistryConfig(ConfigSubset):
         DatabaseClass = self.getDatabaseClass()
         return DatabaseClass.makeDefaultUri(root)
 
-    def replaceRoot(self, root: Optional[ResourcePathExpression]) -> None:
+    def replaceRoot(self, root: ResourcePathExpression | None) -> None:
         """Replace any occurrences of `BUTLER_ROOT_TAG` in the connection
         with the given root directory.
 

--- a/python/lsst/daf/butler/registry/_dbAuth.py
+++ b/python/lsst/daf/butler/registry/_dbAuth.py
@@ -89,7 +89,7 @@ class DbAuth:
         mode = os.stat(secretPath).st_mode
         if mode & (stat.S_IRWXG | stat.S_IRWXO) != 0:
             raise DbAuthPermissionsError(
-                "DbAuth configuration file {} has incorrect permissions: {:o}".format(secretPath, mode)
+                f"DbAuth configuration file {secretPath} has incorrect permissions: {mode:o}"
             )
 
         try:

--- a/python/lsst/daf/butler/registry/_dbAuth.py
+++ b/python/lsst/daf/butler/registry/_dbAuth.py
@@ -25,7 +25,6 @@ import fnmatch
 import os
 import stat
 import urllib.parse
-from typing import Dict, List, Optional, Tuple, Union
 
 import yaml
 
@@ -72,9 +71,9 @@ class DbAuth:
 
     def __init__(
         self,
-        path: Optional[str] = None,
-        envVar: Optional[str] = None,
-        authList: Optional[List[Dict[str, str]]] = None,
+        path: str | None = None,
+        envVar: str | None = None,
+        authList: list[dict[str, str]] | None = None,
     ):
         if authList is not None:
             self.authList = authList
@@ -104,12 +103,12 @@ class DbAuth:
     # for that condition.
     def getAuth(
         self,
-        dialectname: Optional[str],
-        username: Optional[str],
-        host: Optional[str],
-        port: Optional[Union[int, str]],
-        database: Optional[str],
-    ) -> Tuple[Optional[str], str]:
+        dialectname: str | None,
+        username: str | None,
+        host: str | None,
+        port: int | str | None,
+        database: str | None,
+    ) -> tuple[str | None, str]:
         """Retrieve a username and password for a database connection.
 
         This function matches elements from the database connection URL with

--- a/python/lsst/daf/butler/registry/_defaults.py
+++ b/python/lsst/daf/butler/registry/_defaults.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ("RegistryDefaults",)
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, AbstractSet, Any, Optional
+from typing import TYPE_CHECKING, AbstractSet, Any
 
 from lsst.utils.classes import immutable
 
@@ -75,7 +75,7 @@ class RegistryDefaults:
         checked when the defaults struct is actually attached to a `Registry`.
     """
 
-    def __init__(self, collections: Any = None, run: Optional[str] = None, infer: bool = True, **kwargs: str):
+    def __init__(self, collections: Any = None, run: str | None = None, infer: bool = True, **kwargs: str):
         if collections is None:
             if run is not None:
                 collections = (run,)
@@ -141,7 +141,7 @@ class RegistryDefaults:
     """The collections to search by default, in order (`Sequence` [ `str` ]).
     """
 
-    run: Optional[str]
+    run: str | None
     """Name of the run this butler writes outputs to by default (`str` or
     `None`).
     """

--- a/python/lsst/daf/butler/registry/_defaults.py
+++ b/python/lsst/daf/butler/registry/_defaults.py
@@ -44,7 +44,7 @@ class RegistryDefaults:
 
     Parameters
     ----------
-    collections : `str` or `Iterable` [ `str` ], optional
+    collections : `str` or `~collections.abc.Iterable` [ `str` ], optional
         An expression specifying the collections to be searched (in order) when
         reading datasets.  If a default value for a governor dimension is not
         given via ``**kwargs``, and exactly one value for that dimension
@@ -138,7 +138,8 @@ class RegistryDefaults:
         self.dataId = registry.expandDataId(self._kwargs, withDefaults=False)
 
     collections: Sequence[str]
-    """The collections to search by default, in order (`Sequence` [ `str` ]).
+    """The collections to search by default, in order
+    (`~collections.abc.Sequence` [ `str` ]).
     """
 
     run: str | None

--- a/python/lsst/daf/butler/registry/_defaults.py
+++ b/python/lsst/daf/butler/registry/_defaults.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 __all__ = ("RegistryDefaults",)
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, AbstractSet, Any
+from collections.abc import Sequence, Set
+from typing import TYPE_CHECKING, Any
 
 from lsst.utils.classes import immutable
 
@@ -131,7 +131,7 @@ class RegistryDefaults:
             if summaries:
                 summary = CollectionSummary.union(*summaries)
                 for dimensionName in allGovernorDimensions.names - self._kwargs.keys():
-                    values: AbstractSet[str] = summary.governors.get(dimensionName, frozenset())
+                    values: Set[str] = summary.governors.get(dimensionName, frozenset())
                     if len(values) == 1:
                         (value,) = values
                         self._kwargs[dimensionName] = value

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -27,22 +27,9 @@ import contextlib
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from types import EllipsisType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any
 
 from lsst.resources import ResourcePathExpression
 from lsst.utils import doImportType
@@ -98,14 +85,14 @@ class Registry(ABC):
     implementations.
     """
 
-    defaultConfigFile: Optional[str] = None
+    defaultConfigFile: str | None = None
     """Path to configuration defaults. Accessed within the ``configs`` resource
     or relative to a search path. Can be None if no defaults specified.
     """
 
     @classmethod
     def forceRegistryConfig(
-        cls, config: Optional[Union[ButlerConfig, RegistryConfig, Config, str]]
+        cls, config: ButlerConfig | RegistryConfig | Config | str | None
     ) -> RegistryConfig:
         """Force the supplied config to a `RegistryConfig`.
 
@@ -129,8 +116,8 @@ class Registry(ABC):
 
     @classmethod
     def determineTrampoline(
-        cls, config: Optional[Union[ButlerConfig, RegistryConfig, Config, str]]
-    ) -> Tuple[Type[Registry], RegistryConfig]:
+        cls, config: ButlerConfig | RegistryConfig | Config | str | None
+    ) -> tuple[type[Registry], RegistryConfig]:
         """Return class to use to instantiate real registry.
 
         Parameters
@@ -162,9 +149,9 @@ class Registry(ABC):
     @classmethod
     def createFromConfig(
         cls,
-        config: Optional[Union[RegistryConfig, str]] = None,
-        dimensionConfig: Optional[Union[DimensionConfig, str]] = None,
-        butlerRoot: Optional[ResourcePathExpression] = None,
+        config: RegistryConfig | str | None = None,
+        dimensionConfig: DimensionConfig | str | None = None,
+        butlerRoot: ResourcePathExpression | None = None,
     ) -> Registry:
         """Create registry database and return `Registry` instance.
 
@@ -199,10 +186,10 @@ class Registry(ABC):
     @classmethod
     def fromConfig(
         cls,
-        config: Union[ButlerConfig, RegistryConfig, Config, str],
-        butlerRoot: Optional[ResourcePathExpression] = None,
+        config: ButlerConfig | RegistryConfig | Config | str,
+        butlerRoot: ResourcePathExpression | None = None,
         writeable: bool = True,
-        defaults: Optional[RegistryDefaults] = None,
+        defaults: RegistryDefaults | None = None,
     ) -> Registry:
         """Create `Registry` subclass instance from ``config``.
 
@@ -245,7 +232,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def copy(self, defaults: Optional[RegistryDefaults] = None) -> Registry:
+    def copy(self, defaults: RegistryDefaults | None = None) -> Registry:
         """Create a new `Registry` backed by the same data repository and
         connection as this one, but independent defaults.
 
@@ -325,7 +312,7 @@ class Registry(ABC):
 
     @abstractmethod
     def registerCollection(
-        self, name: str, type: CollectionType = CollectionType.TAGGED, doc: Optional[str] = None
+        self, name: str, type: CollectionType = CollectionType.TAGGED, doc: str | None = None
     ) -> bool:
         """Add a new collection if one with the given name does not exist.
 
@@ -390,7 +377,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def registerRun(self, name: str, doc: Optional[str] = None) -> bool:
+    def registerRun(self, name: str, doc: str | None = None) -> bool:
         """Add a new run if one with the given name does not exist.
 
         Parameters
@@ -504,7 +491,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def getCollectionParentChains(self, collection: str) -> Set[str]:
+    def getCollectionParentChains(self, collection: str) -> set[str]:
         """Return the CHAINED collections that directly contain the given one.
 
         Parameters
@@ -520,7 +507,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def getCollectionDocumentation(self, collection: str) -> Optional[str]:
+    def getCollectionDocumentation(self, collection: str) -> str | None:
         """Retrieve the documentation string for a collection.
 
         Parameters
@@ -536,7 +523,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def setCollectionDocumentation(self, collection: str, doc: Optional[str]) -> None:
+    def setCollectionDocumentation(self, collection: str, doc: str | None) -> None:
         """Set the documentation string for a collection.
 
         Parameters
@@ -677,13 +664,13 @@ class Registry(ABC):
     @abstractmethod
     def findDataset(
         self,
-        datasetType: Union[DatasetType, str],
-        dataId: Optional[DataId] = None,
+        datasetType: DatasetType | str,
+        dataId: DataId | None = None,
         *,
         collections: CollectionArgType | None = None,
-        timespan: Optional[Timespan] = None,
+        timespan: Timespan | None = None,
         **kwargs: Any,
-    ) -> Optional[DatasetRef]:
+    ) -> DatasetRef | None:
         """Find a dataset given its `DatasetType` and data ID.
 
         This can be used to obtain a `DatasetRef` that permits the dataset to
@@ -753,12 +740,12 @@ class Registry(ABC):
     @abstractmethod
     def insertDatasets(
         self,
-        datasetType: Union[DatasetType, str],
+        datasetType: DatasetType | str,
         dataIds: Iterable[DataId],
-        run: Optional[str] = None,
+        run: str | None = None,
         expand: bool = True,
         idGenerationMode: DatasetIdGenEnum = DatasetIdGenEnum.UNIQUE,
-    ) -> List[DatasetRef]:
+    ) -> list[DatasetRef]:
         """Insert one or more datasets into the `Registry`
 
         This always adds new datasets; to associate existing datasets with
@@ -809,7 +796,7 @@ class Registry(ABC):
         self,
         datasets: Iterable[DatasetRef],
         expand: bool = True,
-    ) -> List[DatasetRef]:
+    ) -> list[DatasetRef]:
         """Import one or more datasets into the `Registry`.
 
         Difference from `insertDatasets` method is that this method accepts
@@ -865,7 +852,7 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def getDataset(self, id: DatasetId) -> Optional[DatasetRef]:
+    def getDataset(self, id: DatasetId) -> DatasetRef | None:
         """Retrieve a Dataset entry.
 
         Parameters
@@ -997,10 +984,10 @@ class Registry(ABC):
     def decertify(
         self,
         collection: str,
-        datasetType: Union[str, DatasetType],
+        datasetType: str | DatasetType,
         timespan: Timespan,
         *,
-        dataIds: Optional[Iterable[DataId]] = None,
+        dataIds: Iterable[DataId] | None = None,
     ) -> None:
         """Remove or adjust datasets to clear a validity range within a
         calibration collection.
@@ -1068,10 +1055,10 @@ class Registry(ABC):
     @abstractmethod
     def expandDataId(
         self,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         *,
-        graph: Optional[DimensionGraph] = None,
-        records: Optional[NameLookupMapping[DimensionElement, Optional[DimensionRecord]]] = None,
+        graph: DimensionGraph | None = None,
+        records: NameLookupMapping[DimensionElement, DimensionRecord | None] | None = None,
         withDefaults: bool = True,
         **kwargs: Any,
     ) -> DataCoordinate:
@@ -1126,8 +1113,8 @@ class Registry(ABC):
     @abstractmethod
     def insertDimensionData(
         self,
-        element: Union[DimensionElement, str],
-        *data: Union[Mapping[str, Any], DimensionRecord],
+        element: DimensionElement | str,
+        *data: Mapping[str, Any] | DimensionRecord,
         conform: bool = True,
         replace: bool = False,
         skip_existing: bool = False,
@@ -1161,11 +1148,11 @@ class Registry(ABC):
     @abstractmethod
     def syncDimensionData(
         self,
-        element: Union[DimensionElement, str],
-        row: Union[Mapping[str, Any], DimensionRecord],
+        element: DimensionElement | str,
+        row: Mapping[str, Any] | DimensionRecord,
         conform: bool = True,
         update: bool = False,
-    ) -> Union[bool, Dict[str, Any]]:
+    ) -> bool | dict[str, Any]:
         """Synchronize the given dimension record with the database, inserting
         if it does not already exist and comparing values if it does.
 
@@ -1206,8 +1193,8 @@ class Registry(ABC):
         self,
         expression: Any = ...,
         *,
-        components: Optional[bool] = None,
-        missing: Optional[List[str]] = None,
+        components: bool | None = None,
+        missing: list[str] | None = None,
     ) -> Iterable[DatasetType]:
         """Iterate over the dataset types whose names match an expression.
 
@@ -1252,10 +1239,10 @@ class Registry(ABC):
     def queryCollections(
         self,
         expression: Any = ...,
-        datasetType: Optional[DatasetType] = None,
-        collectionTypes: Union[Iterable[CollectionType], CollectionType] = CollectionType.all(),
+        datasetType: DatasetType | None = None,
+        collectionTypes: Iterable[CollectionType] | CollectionType = CollectionType.all(),
         flattenChains: bool = False,
-        includeChains: Optional[bool] = None,
+        includeChains: bool | None = None,
     ) -> Sequence[str]:
         """Iterate over the collections whose names match an expression.
 
@@ -1309,12 +1296,12 @@ class Registry(ABC):
         datasetType: Any,
         *,
         collections: CollectionArgType | None = None,
-        dimensions: Optional[Iterable[Union[Dimension, str]]] = None,
-        dataId: Optional[DataId] = None,
+        dimensions: Iterable[Dimension | str] | None = None,
+        dataId: DataId | None = None,
         where: str = "",
         findFirst: bool = False,
-        components: Optional[bool] = None,
-        bind: Optional[Mapping[str, Any]] = None,
+        components: bool | None = None,
+        bind: Mapping[str, Any] | None = None,
         check: bool = True,
         **kwargs: Any,
     ) -> DatasetQueryResults:
@@ -1428,14 +1415,14 @@ class Registry(ABC):
     @abstractmethod
     def queryDataIds(
         self,
-        dimensions: Union[Iterable[Union[Dimension, str]], Dimension, str],
+        dimensions: Iterable[Dimension | str] | Dimension | str,
         *,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         datasets: Any = None,
         collections: CollectionArgType | None = None,
         where: str = "",
-        components: Optional[bool] = None,
-        bind: Optional[Mapping[str, Any]] = None,
+        components: bool | None = None,
+        bind: Mapping[str, Any] | None = None,
         check: bool = True,
         **kwargs: Any,
     ) -> DataCoordinateQueryResults:
@@ -1538,14 +1525,14 @@ class Registry(ABC):
     @abstractmethod
     def queryDimensionRecords(
         self,
-        element: Union[DimensionElement, str],
+        element: DimensionElement | str,
         *,
-        dataId: Optional[DataId] = None,
+        dataId: DataId | None = None,
         datasets: Any = None,
         collections: CollectionArgType | None = None,
         where: str = "",
-        components: Optional[bool] = None,
-        bind: Optional[Mapping[str, Any]] = None,
+        components: bool | None = None,
+        bind: Mapping[str, Any] | None = None,
         check: bool = True,
         **kwargs: Any,
     ) -> DimensionRecordQueryResults:
@@ -1625,7 +1612,7 @@ class Registry(ABC):
     @abstractmethod
     def queryDatasetAssociations(
         self,
-        datasetType: Union[str, DatasetType],
+        datasetType: str | DatasetType,
         collections: CollectionArgType | None = ...,
         *,
         collectionTypes: Iterable[CollectionType] = CollectionType.all(),

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -960,7 +960,7 @@ class Registry(ABC):
         collection : `str`
             The name of an already-registered `~CollectionType.CALIBRATION`
             collection.
-        refs : `Iterable` [ `DatasetRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to be associated.
         timespan : `Timespan`
             The validity range for these datasets within the collection.
@@ -1074,7 +1074,8 @@ class Registry(ABC):
             Dimensions that are in ``dataId`` or ``kwargs`` but not in
             ``graph`` are silently ignored, providing a way to extract and
             ``graph`` expand a subset of a data ID.
-        records : `Mapping` [`str`, `DimensionRecord`], optional
+        records : `~collections.abc.Mapping` [`str`, `DimensionRecord`], \
+                optional
             Dimension record data to use before querying the database for that
             data, keyed by element name.
         withDefaults : `bool`, optional

--- a/python/lsst/daf/butler/registry/attributes.py
+++ b/python/lsst/daf/butler/registry/attributes.py
@@ -26,7 +26,8 @@ attributes for `Registry`.
 
 __all__ = ["DefaultButlerAttributeManager"]
 
-from typing import ClassVar, Iterable, Optional, Tuple
+from collections.abc import Iterable
+from typing import ClassVar
 
 import sqlalchemy
 
@@ -83,7 +84,7 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
         table = context.addTable(cls._TABLE_NAME, cls._TABLE_SPEC)
         return cls(db=db, table=table, registry_schema_version=registry_schema_version)
 
-    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, name: str, default: str | None = None) -> str | None:
         # Docstring inherited from ButlerAttributeManager.
         sql = sqlalchemy.sql.select(self._table.columns.value).where(self._table.columns.name == name)
         with self._db.query(sql) as sql_result:
@@ -121,7 +122,7 @@ class DefaultButlerAttributeManager(ButlerAttributeManager):
         numRows = self._db.delete(self._table, ["name"], {"name": name})
         return numRows > 0
 
-    def items(self) -> Iterable[Tuple[str, str]]:
+    def items(self) -> Iterable[tuple[str, str]]:
         # Docstring inherited from ButlerAttributeManager.
         sql = sqlalchemy.sql.select(
             self._table.columns.name,

--- a/python/lsst/daf/butler/registry/bridge/ephemeral.py
+++ b/python/lsst/daf/butler/registry/bridge/ephemeral.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 
 __all__ = ("EphemeralDatastoreRegistryBridge",)
 
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterable, Iterator, Optional, Set, Tuple, Type
+from typing import TYPE_CHECKING
 
 from ...core import DatasetId
 from ..interfaces import DatasetIdRef, DatastoreRegistryBridge, FakeDatasetRef, OpaqueTableStorage
@@ -53,8 +54,8 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
 
     def __init__(self, datastoreName: str):
         super().__init__(datastoreName)
-        self._datasetIds: Set[DatasetId] = set()
-        self._trashedIds: Set[DatasetId] = set()
+        self._datasetIds: set[DatasetId] = set()
+        self._trashedIds: set[DatasetId] = set()
 
     def insert(self, refs: Iterable[DatasetIdRef]) -> None:
         # Docstring inherited from DatastoreRegistryBridge
@@ -68,7 +69,7 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         for ref in refs:
             self._trashedIds.remove(ref.id)
 
-    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: Optional[DatastoreTransaction]) -> None:
+    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: DatastoreTransaction | None) -> None:
         # Docstring inherited from DatastoreRegistryBridge
         if transaction is None:
             raise RuntimeError("Must be called with a defined transaction.")
@@ -86,14 +87,12 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
     @contextmanager
     def emptyTrash(
         self,
-        records_table: Optional[OpaqueTableStorage] = None,
-        record_class: Optional[Type[StoredDatastoreItemInfo]] = None,
-        record_column: Optional[str] = None,
-    ) -> Iterator[
-        Tuple[Iterable[Tuple[DatasetIdRef, Optional[StoredDatastoreItemInfo]]], Optional[Set[str]]]
-    ]:
+        records_table: OpaqueTableStorage | None = None,
+        record_class: type[StoredDatastoreItemInfo] | None = None,
+        record_column: str | None = None,
+    ) -> Iterator[tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]]:
         # Docstring inherited from DatastoreRegistryBridge
-        matches: Iterable[Tuple[FakeDatasetRef, Optional[StoredDatastoreItemInfo]]] = ()
+        matches: Iterable[tuple[FakeDatasetRef, StoredDatastoreItemInfo | None]] = ()
         if isinstance(records_table, OpaqueTableStorage):
             if record_class is None:
                 raise ValueError("Record class must be provided if records table is given.")

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -24,8 +24,9 @@ __all__ = ("MonolithicDatastoreRegistryBridgeManager", "MonolithicDatastoreRegis
 
 import copy
 from collections import namedtuple
+from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Type, cast
+from typing import TYPE_CHECKING, cast
 
 import sqlalchemy
 
@@ -63,7 +64,7 @@ _TablesTuple = namedtuple(
 _VERSION = VersionTuple(0, 2, 0)
 
 
-def _makeTableSpecs(datasets: Type[DatasetRecordStorageManager]) -> _TablesTuple:
+def _makeTableSpecs(datasets: type[DatasetRecordStorageManager]) -> _TablesTuple:
     """Construct specifications for tables used by the monolithic datastore
     bridge classes.
 
@@ -132,7 +133,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         self._db = db
         self._tables = tables
 
-    def _refsToRows(self, refs: Iterable[DatasetIdRef]) -> List[dict]:
+    def _refsToRows(self, refs: Iterable[DatasetIdRef]) -> list[dict]:
         """Transform an iterable of `DatasetRef` or `FakeDatasetRef` objects to
         a list of dictionaries that match the schema of the tables used by this
         class.
@@ -158,7 +159,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         rows = self._refsToRows(self.check(refs))
         self._db.delete(self._tables.dataset_location, ["datastore_name", "dataset_id"], *rows)
 
-    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: Optional[DatastoreTransaction]) -> None:
+    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: DatastoreTransaction | None) -> None:
         # Docstring inherited from DatastoreRegistryBridge
         # TODO: avoid self.check() call via queries like
         #     INSERT INTO dataset_location_trash
@@ -194,12 +195,10 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
     @contextmanager
     def emptyTrash(
         self,
-        records_table: Optional[OpaqueTableStorage] = None,
-        record_class: Optional[Type[StoredDatastoreItemInfo]] = None,
-        record_column: Optional[str] = None,
-    ) -> Iterator[
-        Tuple[Iterable[Tuple[DatasetIdRef, Optional[StoredDatastoreItemInfo]]], Optional[Set[str]]]
-    ]:
+        records_table: OpaqueTableStorage | None = None,
+        record_class: type[StoredDatastoreItemInfo] | None = None,
+        record_column: str | None = None,
+    ) -> Iterator[tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]]:
         # Docstring inherited from DatastoreRegistryBridge
 
         if records_table is None:
@@ -245,7 +244,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         # that those artifacts should be retained. Can only do this check
         # if the caller provides a column name that can map to multiple
         # refs.
-        preserved: Optional[Set[str]] = None
+        preserved: set[str] | None = None
         if record_column is not None:
             # Some helper subqueries
             items_not_in_trash = join_records(
@@ -328,7 +327,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
         )
         self._db = db
         self._tables = tables
-        self._ephemeral: Dict[str, EphemeralDatastoreRegistryBridge] = {}
+        self._ephemeral: dict[str, EphemeralDatastoreRegistryBridge] = {}
 
     @classmethod
     def initialize(
@@ -337,7 +336,7 @@ class MonolithicDatastoreRegistryBridgeManager(DatastoreRegistryBridgeManager):
         context: StaticTablesContext,
         *,
         opaque: OpaqueTableStorageManager,
-        datasets: Type[DatasetRecordStorageManager],
+        datasets: type[DatasetRecordStorageManager],
         universe: DimensionUniverse,
         registry_schema_version: VersionTuple | None = None,
     ) -> DatastoreRegistryBridgeManager:

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -140,7 +140,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
 
         Parameters
         ----------
-        refs : `Iterable` [ `DatasetRef` or `FakeDatasetRef` ]
+        refs : `~collections.abc.Iterable` [ `DatasetRef` or `FakeDatasetRef` ]
             Datasets to transform.
 
         Returns

--- a/python/lsst/daf/butler/registry/connectionString.py
+++ b/python/lsst/daf/butler/registry/connectionString.py
@@ -68,7 +68,7 @@ class ConnectionStringFactory:
 
         Parameters
         ----------
-        config : `ButlerConfig`, `RegistryConfig`, `Config` or `str`
+        config : `RegistryConfig`
             Registry configuration
 
         Returns

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -26,8 +26,9 @@ import copy
 import os
 import sqlite3
 import urllib.parse
+from collections.abc import Iterable
 from contextlib import closing
-from typing import Any, ContextManager, Iterable, List, Optional
+from typing import Any, ContextManager
 
 import sqlalchemy
 import sqlalchemy.dialects.sqlite
@@ -81,7 +82,7 @@ class SqliteDatabase(Database):
         *,
         engine: sqlalchemy.engine.Engine,
         origin: int,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         writeable: bool = True,
     ):
         super().__init__(origin=origin, engine=engine, namespace=namespace)
@@ -105,7 +106,7 @@ class SqliteDatabase(Database):
         self._writeable = writeable
 
     @classmethod
-    def makeDefaultUri(cls, root: str) -> Optional[str]:
+    def makeDefaultUri(cls, root: str) -> str | None:
         return "sqlite:///" + os.path.join(root, "gen3.sqlite3")
 
     @classmethod
@@ -113,7 +114,7 @@ class SqliteDatabase(Database):
         cls,
         uri: str | sqlalchemy.engine.URL | None = None,
         *,
-        filename: Optional[str] = None,
+        filename: str | None = None,
         writeable: bool = True,
     ) -> sqlalchemy.engine.Engine:
         """Create a `sqlalchemy.engine.Engine` from a SQLAlchemy URI or
@@ -211,7 +212,7 @@ class SqliteDatabase(Database):
         engine: sqlalchemy.engine.Engine,
         *,
         origin: int,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         writeable: bool = True,
     ) -> Database:
         return cls(engine=engine, origin=origin, writeable=writeable, namespace=namespace)
@@ -268,7 +269,7 @@ class SqliteDatabase(Database):
                 spec.dtype = sqlalchemy.Integer
         return super()._convertFieldSpec(table, spec, metadata, **kwargs)
 
-    def _makeColumnConstraints(self, table: str, spec: ddl.FieldSpec) -> List[sqlalchemy.CheckConstraint]:
+    def _makeColumnConstraints(self, table: str, spec: ddl.FieldSpec) -> list[sqlalchemy.CheckConstraint]:
         # For sqlite we force constraints on all string columns since sqlite
         # ignores everything otherwise and this leads to problems with
         # other databases.
@@ -349,7 +350,7 @@ class SqliteDatabase(Database):
         self,
         fields: NamedValueAbstractSet[ddl.FieldSpec],
         *rows: dict,
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> sqlalchemy.sql.FromClause:
         # Docstring inherited.
         # While SQLite supports VALUES, it doesn't support assigning a name
@@ -369,7 +370,7 @@ class SqliteDatabase(Database):
         ]
         return sqlalchemy.sql.union_all(*selects).alias(name)
 
-    filename: Optional[str]
+    filename: str | None
     """Name of the file this database is connected to (`str` or `None`).
 
     Set to `None` for in-memory databases.

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -294,8 +294,8 @@ class SqliteDatabase(Database):
     def _convertTableSpec(
         self, name: str, spec: ddl.TableSpec, metadata: sqlalchemy.MetaData, **kwargs: Any
     ) -> sqlalchemy.schema.Table:
-        primaryKeyFieldNames = set(field.name for field in spec.fields if field.primaryKey)
-        autoincrFieldNames = set(field.name for field in spec.fields if field.autoincrement)
+        primaryKeyFieldNames = {field.name for field in spec.fields if field.primaryKey}
+        autoincrFieldNames = {field.name for field in spec.fields if field.autoincrement}
         if len(autoincrFieldNames) > 1:
             raise RuntimeError("At most one autoincrement field per table is allowed.")
         if len(primaryKeyFieldNames) > 1 and len(autoincrFieldNames) > 0:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -431,7 +431,8 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
             used to construct the new relation.
         requested_columns : `~collections.abc.Set` [ `str` ]
             Columns the relation should include.
-        collections : `Sequence` [ `tuple` [ `CollectionRecord`, `int` ] ]
+        collections : `~collections.abc.Sequence` [ `tuple` \
+                [ `CollectionRecord`, `int` ] ]
             Collections to search for the dataset and their ranks.
         context : `SqlQueryContext`
             Context that manages engines and state for the query.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
@@ -206,7 +206,7 @@ class CollectionSummaryManager:
         ----------
         collection : `CollectionRecord`
             Collection whose summary should be updated.
-        dataset_type_ids : `Iterable` [ `int` ]
+        dataset_type_ids : `~collections.abc.Iterable` [ `int` ]
             Integer IDs for the dataset types to associate with this
             collection.
         summary : `CollectionSummary`

--- a/python/lsst/daf/butler/registry/dimensions/table.py
+++ b/python/lsst/daf/butler/registry/dimensions/table.py
@@ -275,7 +275,7 @@ class TableDimensionRecordStorage(DatabaseDimensionRecordStorage):
 
         Parameters
         ----------
-        records : `Sequence` [ `DimensionRecord` ]
+        records : `~collections.abc.Sequence` [ `DimensionRecord` ]
             Records for ``self.element`` that are being inserted.
         replace : `bool`, optional
             If `True`, the given records are being inserted in a mode that may

--- a/python/lsst/daf/butler/registry/interfaces/_attributes.py
+++ b/python/lsst/daf/butler/registry/interfaces/_attributes.py
@@ -26,7 +26,8 @@ __all__ = [
 ]
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Iterable, Optional, Tuple
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from ._versioning import VersionedExtension, VersionTuple
 
@@ -87,7 +88,7 @@ class ButlerAttributeManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def get(self, name: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, name: str, default: str | None = None) -> str | None:
         """Retrieve value of a given attribute.
 
         Parameters
@@ -151,7 +152,7 @@ class ButlerAttributeManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def items(self) -> Iterable[Tuple[str, str]]:
+    def items(self) -> Iterable[tuple[str, str]]:
         """Iterate over attributes and yield their names and values.
 
         Yields

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 __all__ = ("DatastoreRegistryBridgeManager", "DatastoreRegistryBridge", "FakeDatasetRef", "DatasetIdRef")
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ContextManager, Iterable, Optional, Set, Tuple, Type, Union
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, ContextManager
 
 from lsst.utils.classes import immutable
 
@@ -82,7 +83,7 @@ class FakeDatasetRef:
         raise AttributeError("A FakeDatasetRef can not be associated with a valid DatasetType")
 
 
-DatasetIdRef = Union[DatasetRef, FakeDatasetRef]
+DatasetIdRef = DatasetRef | FakeDatasetRef
 """A type-annotation alias that matches both `DatasetRef` and `FakeDatasetRef`.
 """
 
@@ -128,7 +129,7 @@ class DatastoreRegistryBridge(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: Optional[DatastoreTransaction]) -> None:
+    def moveToTrash(self, refs: Iterable[DatasetIdRef], transaction: DatastoreTransaction | None) -> None:
         """Move dataset location information to trash.
 
         Parameters
@@ -161,11 +162,11 @@ class DatastoreRegistryBridge(ABC):
     @abstractmethod
     def emptyTrash(
         self,
-        records_table: Optional[OpaqueTableStorage] = None,
-        record_class: Optional[Type[StoredDatastoreItemInfo]] = None,
-        record_column: Optional[str] = None,
+        records_table: OpaqueTableStorage | None = None,
+        record_class: type[StoredDatastoreItemInfo] | None = None,
+        record_column: str | None = None,
     ) -> ContextManager[
-        Tuple[Iterable[Tuple[DatasetIdRef, Optional[StoredDatastoreItemInfo]]], Optional[Set[str]]]
+        tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]
     ]:
         """Retrieve all the dataset ref IDs that are in the trash
         associated for this datastore, and then remove them if the context
@@ -273,7 +274,7 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
         context: StaticTablesContext,
         *,
         opaque: OpaqueTableStorageManager,
-        datasets: Type[DatasetRecordStorageManager],
+        datasets: type[DatasetRecordStorageManager],
         universe: DimensionUniverse,
         registry_schema_version: VersionTuple | None = None,
     ) -> DatastoreRegistryBridgeManager:

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -108,7 +108,7 @@ class DatastoreRegistryBridge(ABC):
 
         Parameters
         ----------
-        refs : `Iterable` of `DatasetIdRef`
+        refs : `~collections.abc.Iterable` of `DatasetIdRef`
             References to the datasets.
         """
         raise NotImplementedError()
@@ -123,7 +123,7 @@ class DatastoreRegistryBridge(ABC):
 
         Parameters
         ----------
-        refs : `Iterable` of `DatasetIdRef`
+        refs : `~collections.abc.Iterable` of `DatasetIdRef`
             References to the datasets.
         """
         raise NotImplementedError()
@@ -134,7 +134,7 @@ class DatastoreRegistryBridge(ABC):
 
         Parameters
         ----------
-        refs : `Iterable` of `DatasetIdRef`
+        refs : `~collections.abc.Iterable` of `DatasetIdRef`
             References to the datasets.
         transaction : `DatastoreTransaction` or `None`
             Transaction object. Can be `None` in some bridges or if no rollback
@@ -153,7 +153,7 @@ class DatastoreRegistryBridge(ABC):
 
         Returns
         -------
-        present : `Iterable` [ `DatasetIdRef` ]
+        present : `~collections.abc.Iterable` [ `DatasetIdRef` ]
             Datasets from ``refs`` that are recorded as being in this
             datastore.
         """
@@ -354,7 +354,7 @@ class DatastoreRegistryBridgeManager(VersionedExtension):
 
         Returns
         -------
-        datastores : `Iterable` [ `str` ]
+        datastores : `~collections.abc.Iterable` [ `str` ]
             All the matching datastores holding this dataset. Empty if the
             dataset does not exist anywhere.
 

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1608,7 +1608,7 @@ class Database(ABC):
             # Nothing to calculate since we can always use IN
             column = columns[0]
             changing_columns = [column]
-            content[column] = set(row[column] for row in rows)
+            content[column] = {row[column] for row in rows}
         else:
             for row in rows:
                 for k, v in row.items():

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -394,7 +394,8 @@ class Database(ABC):
             outer transaction block was created with ``savepoint=True``, all
             inner blocks will be as well (regardless of the actual value
             passed).  This has no effect if this is the outermost transaction.
-        lock : `Iterable` [ `sqlalchemy.schema.Table` ], optional
+        lock : `~collections.abc.Iterable` [ `sqlalchemy.schema.Table` ], \
+                optional
             A list of tables to lock for the duration of this transaction.
             These locks are guaranteed to prevent concurrent writes and allow
             this transaction (only) to acquire the same locks (others should
@@ -525,7 +526,8 @@ class Database(ABC):
             outer transaction block was created with ``savepoint=True``, all
             inner blocks will be as well (regardless of the actual value
             passed).  This has no effect if this is the outermost transaction.
-        lock : `Iterable` [ `sqlalchemy.schema.Table` ], optional
+        lock : `~collections.abc.Iterable` [ `sqlalchemy.schema.Table` ], \
+                optional
             A list of tables to lock for the duration of this transaction.
             These locks are guaranteed to prevent concurrent writes and allow
             this transaction (only) to acquire the same locks (others should
@@ -588,7 +590,8 @@ class Database(ABC):
         connection : `sqlalchemy.engine.Connection`
             Database connection object. It is guaranteed that transaction is
             already in a progress for this connection.
-        tables : `Iterable` [ `sqlalchemy.schema.Table` ], optional
+        tables : `~collections.abc.Iterable` [ `sqlalchemy.schema.Table` ], \
+                optional
             A list of tables to lock for the duration of this transaction.
             These locks are guaranteed to prevent concurrent writes and allow
             this transaction (only) to acquire the same locks (others should
@@ -1423,7 +1426,7 @@ class Database(ABC):
         select : `sqlalchemy.sql.SelectBase`, optional
             A SELECT query expression to insert rows from.  Cannot be provided
             with either ``rows`` or ``returnIds=True``.
-        names : `Iterable` [ `str` ], optional
+        names : `~collections.abc.Iterable` [ `str` ], optional
             Names of columns in ``table`` to be populated, ordered to match the
             columns returned by ``select``.  Ignored if ``select`` is `None`.
             If not provided, the columns returned by ``select`` must be named

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -68,7 +68,7 @@ class DatasetRecordStorage(ABC):
         run : `RunRecord`
             The record object describing the `~CollectionType.RUN` collection
             this dataset will be associated with.
-        dataIds : `Iterable` [ `DataCoordinate` ]
+        dataIds : `~collections.abc.Iterable` [ `DataCoordinate` ]
             Expanded data IDs (`DataCoordinate` instances) for the
             datasets to be added.   The dimensions of all data IDs must be the
             same as ``self.datasetType.dimensions``.
@@ -80,7 +80,7 @@ class DatasetRecordStorage(ABC):
 
         Returns
         -------
-        datasets : `Iterable` [ `DatasetRef` ]
+        datasets : `~collections.abc.Iterable` [ `DatasetRef` ]
             References to the inserted datasets.
         """
         raise NotImplementedError()
@@ -107,7 +107,7 @@ class DatasetRecordStorage(ABC):
 
         Returns
         -------
-        datasets : `Iterable` [ `DatasetRef` ]
+        datasets : `~collections.abc.Iterable` [ `DatasetRef` ]
             References to the inserted or existing datasets.
 
         Notes
@@ -126,7 +126,7 @@ class DatasetRecordStorage(ABC):
 
         Parameters
         ----------
-         datasets : `Iterable` [ `DatasetRef` ]
+         datasets : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to be deleted.  All datasets must be resolved and have
             the same `DatasetType` as ``self``.
 
@@ -146,7 +146,7 @@ class DatasetRecordStorage(ABC):
         collection : `CollectionRecord`
             The record object describing the collection.  ``collection.type``
             must be `~CollectionType.TAGGED`.
-        datasets : `Iterable` [ `DatasetRef` ]
+        datasets : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to be associated.  All datasets must be resolved and have
             the same `DatasetType` as ``self``.
 
@@ -175,7 +175,7 @@ class DatasetRecordStorage(ABC):
         collection : `CollectionRecord`
             The record object describing the collection.  ``collection.type``
             must be `~CollectionType.TAGGED`.
-        datasets : `Iterable` [ `DatasetRef` ]
+        datasets : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to be disassociated.  All datasets must be resolved and
             have the same `DatasetType` as ``self``.
 
@@ -202,7 +202,7 @@ class DatasetRecordStorage(ABC):
         collection : `CollectionRecord`
             The record object describing the collection.  ``collection.type``
             must be `~CollectionType.CALIBRATION`.
-        datasets : `Iterable` [ `DatasetRef` ]
+        datasets : `~collections.abc.Iterable` [ `DatasetRef` ]
             Datasets to be associated.  All datasets must be resolved and have
             the same `DatasetType` as ``self``.
         timespan : `Timespan`
@@ -245,7 +245,7 @@ class DatasetRecordStorage(ABC):
             Datasets that overlap this range but are not contained by it will
             have their validity ranges adjusted to not overlap it, which may
             split a single dataset validity range into two.
-        dataIds : `Iterable` [ `DataCoordinate` ], optional
+        dataIds : `~collections.abc.Iterable` [ `DataCoordinate` ], optional
             Data IDs that should be decertified within the given validity range
             If `None`, all data IDs for ``self.datasetType`` will be
             decertified.

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -598,7 +598,7 @@ class DatabaseDimensionOverlapStorage(ABC):
 
         Returns
         -------
-        tables : `Iterable` [ `sqlalchemy.schema.Table` ]
+        tables : `~collections.abc.Iterable` [ `sqlalchemy.schema.Table` ]
             Possibly empty set of tables for schema digest calculations.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -31,7 +31,7 @@ __all__ = (
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Mapping, Set
-from typing import TYPE_CHECKING, Any, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 from lsst.daf.relation import Join, Relation, sql
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from ._database import Database, StaticTablesContext
 
 
-OverlapSide = Union[SkyPixDimension, Tuple[DatabaseDimensionElement, str]]
+OverlapSide = SkyPixDimension | tuple[DatabaseDimensionElement, str]
 
 
 class DimensionRecordStorage(ABC):

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -28,7 +28,7 @@ __all__ = ["ObsCoreTableManager"]
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Mapping
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Type
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 
@@ -60,7 +60,7 @@ class ObsCoreTableManager(VersionedExtension):
         *,
         universe: DimensionUniverse,
         config: Mapping,
-        datasets: Type[DatasetRecordStorageManager],
+        datasets: type[DatasetRecordStorageManager],
         dimensions: DimensionRecordStorageManager,
         registry_schema_version: VersionTuple | None = None,
     ) -> ObsCoreTableManager:

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -213,7 +213,8 @@ class ObsCoreTableManager(VersionedExtension):
         ----------
         instrument : `str`
             Instrument name.
-        region_data : `Iterable`[`tuple`[`int`, `int`, `~lsst.sphgeom.Region`]]
+        region_data : `~collections.abc.Iterable` [`tuple` [`int`, `int`, \
+                `~lsst.sphgeom.Region` ]]
             Sequence of tuples, each tuple contains three values - exposure ID,
             detector ID, and corresponding region.
 

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -27,7 +27,8 @@ from __future__ import annotations
 __all__ = ["OpaqueTableStorageManager", "OpaqueTableStorage"]
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Optional
+from collections.abc import Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any
 
 from ...core.ddl import TableSpec
 from ._database import Database, StaticTablesContext
@@ -165,7 +166,7 @@ class OpaqueTableStorageManager(VersionedExtension):
         return r
 
     @abstractmethod
-    def get(self, name: str) -> Optional[OpaqueTableStorage]:
+    def get(self, name: str) -> OpaqueTableStorage | None:
         """Return an object that provides access to the records associated with
         an opaque logical table.
 

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -306,7 +306,7 @@ class RegistryManagerTypes(
 
         Returns
         -------
-        extensions : `Mapping` [`str`, `VersionedExtension`]
+        extensions : `~collections.abc.Mapping` [`str`, `VersionedExtension`]
             Maps manager type name (e.g. "datasets") to its corresponding
             manager class. Only existing managers are returned.
         """
@@ -438,7 +438,7 @@ class RegistryManagerInstances(
 
         Returns
         -------
-        extensions : `Mapping` [`str`, `VersionedExtension`]
+        extensions : `~collections.abc.Mapping` [`str`, `VersionedExtension`]
             Maps manager type name (e.g. "datasets") to its corresponding
             manager instance. Only existing managers are returned.
         """

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -29,7 +29,7 @@ __all__ = (
 import dataclasses
 import logging
 from collections.abc import Mapping
-from typing import Any, Generic, Optional, Type, TypeVar
+from typing import Any, Generic, TypeVar
 
 import sqlalchemy
 from lsst.utils import doImportType
@@ -104,7 +104,7 @@ class _GenericRegistryManagers(
     """Manager for the interface between `Registry` and `Datastore`.
     """
 
-    obscore: Optional[_ObsCore]
+    obscore: _ObsCore | None
     """Manager for `ObsCore` table(s).
     """
 
@@ -112,13 +112,13 @@ class _GenericRegistryManagers(
 @dataclasses.dataclass(frozen=True, eq=False)
 class RegistryManagerTypes(
     _GenericRegistryManagers[
-        Type[ButlerAttributeManager],
-        Type[DimensionRecordStorageManager],
-        Type[CollectionManager],
-        Type[DatasetRecordStorageManager],
-        Type[OpaqueTableStorageManager],
-        Type[DatastoreRegistryBridgeManager],
-        Type[ObsCoreTableManager],
+        type[ButlerAttributeManager],
+        type[DimensionRecordStorageManager],
+        type[CollectionManager],
+        type[DatasetRecordStorageManager],
+        type[OpaqueTableStorageManager],
+        type[DatastoreRegistryBridgeManager],
+        type[ObsCoreTableManager],
     ]
 ):
     """A struct used to pass around the types of the manager objects that back
@@ -147,7 +147,7 @@ class RegistryManagerTypes(
         # Values of "config" sub-key, if any, indexed by manager name.
         configs: dict[str, Mapping] = {}
         schema_versions: dict[str, VersionTuple] = {}
-        manager_types: dict[str, Type] = {}
+        manager_types: dict[str, type] = {}
         for manager in managers:
             manager_config = config["managers"].get(manager)
             if isinstance(manager_config, Config):

--- a/python/lsst/daf/butler/registry/obscore/_config.py
+++ b/python/lsst/daf/butler/registry/obscore/_config.py
@@ -33,7 +33,7 @@ __all__ = [
 
 import enum
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator
 
@@ -58,10 +58,10 @@ class ExtraColumnConfig(BaseModel):
     type: ExtraColumnType = ExtraColumnType.string
     """Column type, formatted string will be converted to this actual type."""
 
-    length: Optional[int] = None
+    length: int | None = None
     """Optional length qualifier for a column, only used for strings."""
 
-    doc: Optional[str] = None
+    doc: str | None = None
     """Documentation string for this column."""
 
 
@@ -71,33 +71,33 @@ class DatasetTypeConfig(BaseModel):
     dataproduct_type: str
     """Value for the ``dataproduct_type`` column."""
 
-    dataproduct_subtype: Optional[str] = None
+    dataproduct_subtype: str | None = None
     """Value for the ``dataproduct_subtype`` column, optional."""
 
     calib_level: int
     """Value for the ``calib_level`` column."""
 
-    o_ucd: Optional[str] = None
+    o_ucd: str | None = None
     """Value for the ``o_ucd`` column, optional."""
 
-    access_format: Optional[str] = None
+    access_format: str | None = None
     """Value for the ``access_format`` column, optional."""
 
-    obs_id_fmt: Optional[str] = None
+    obs_id_fmt: str | None = None
     """Format string for ``obs_id`` column, optional. Uses `str.format`
     syntax.
     """
 
-    datalink_url_fmt: Optional[str] = None
+    datalink_url_fmt: str | None = None
     """Format string for ``access_url`` column for DataLink."""
 
-    obs_collection: Optional[str] = None
+    obs_collection: str | None = None
     """Value for the ``obs_collection`` column, if specified it overrides
     global value in `ObsCoreConfig`."""
 
-    extra_columns: Optional[
-        Dict[str, Union[StrictFloat, StrictInt, StrictBool, StrictStr, ExtraColumnConfig]]
-    ] = None
+    extra_columns: None | (
+        dict[str, StrictFloat | StrictInt | StrictBool | StrictStr | ExtraColumnConfig]
+    ) = None
     """Description for additional columns, optional.
 
     Keys are the names of the columns, values can be literal constants with the
@@ -110,7 +110,7 @@ class SpatialPluginConfig(BaseModel):
     cls: str
     """Name of the class implementing plugin methods."""
 
-    config: Dict[str, Any] = {}
+    config: dict[str, Any] = {}
     """Configuration object passed to plugin ``initialize()`` method."""
 
 
@@ -123,16 +123,16 @@ class ObsCoreConfig(BaseModel):
     datasets into obscore records.
     """
 
-    collections: Optional[List[str]] = None
+    collections: list[str] | None = None
     """Registry collections to include, if missing then all collections are
     used. Depending on implementation the name in the list can be either a
     full collection name or a regular expression.
     """
 
-    dataset_types: Dict[str, DatasetTypeConfig]
+    dataset_types: dict[str, DatasetTypeConfig]
     """Per-dataset type configuration, key is the dataset type name."""
 
-    obs_collection: Optional[str] = None
+    obs_collection: str | None = None
     """Value for the ``obs_collection`` column. This can be overridden in
     dataset type configuration.
     """
@@ -140,26 +140,26 @@ class ObsCoreConfig(BaseModel):
     facility_name: str
     """Value for the ``facility_name`` column."""
 
-    extra_columns: Optional[
-        Dict[str, Union[StrictFloat, StrictInt, StrictBool, StrictStr, ExtraColumnConfig]]
-    ] = None
+    extra_columns: None | (
+        dict[str, StrictFloat | StrictInt | StrictBool | StrictStr | ExtraColumnConfig]
+    ) = None
     """Description for additional columns, optional.
 
     Keys are the names of the columns, values can be literal constants with the
     values, or ExtraColumnConfig mappings."""
 
-    indices: Optional[Dict[str, Union[str, List[str]]]] = None
+    indices: dict[str, str | list[str]] | None = None
     """Description of indices, key is the index name, value is the list of
     column names or a single column name. The index name may not be used for
     an actual index.
     """
 
-    spectral_ranges: Dict[str, Tuple[float | None, float | None]] = {}
+    spectral_ranges: dict[str, tuple[float | None, float | None]] = {}
     """Maps band name or filter name to a min/max of spectral range. One or
     both ends can be specified as `None`.
     """
 
-    spatial_plugins: Dict[str, SpatialPluginConfig] = {}
+    spatial_plugins: dict[str, SpatialPluginConfig] = {}
     """Optional configuration for plugins managing spatial columns and
     indices. The key is an arbitrary name and the value is an object describing
     plugin class and its configuration options. By default there is no spatial
@@ -208,7 +208,7 @@ class ObsCoreManagerConfig(ObsCoreConfig):
         ``collection_type``.
         """
         if value is ConfigCollectionType.TAGGED:
-            collections: Optional[List[str]] = values["collections"]
+            collections: list[str] | None = values["collections"]
             if collections is None or len(collections) != 1:
                 raise ValueError("'collections' must have one element when 'collection_type' is TAGGED")
         return value

--- a/python/lsst/daf/butler/registry/obscore/_records.py
+++ b/python/lsst/daf/butler/registry/obscore/_records.py
@@ -26,8 +26,8 @@ __all__ = ["ExposureRegionFactory", "Record", "RecordFactory"]
 import logging
 import warnings
 from abc import abstractmethod
-from collections.abc import Collection, Mapping
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, cast
+from collections.abc import Callable, Collection, Mapping
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 import astropy.time
@@ -60,7 +60,7 @@ class ExposureRegionFactory:
     """Abstract interface for a class that returns a Region for an exposure."""
 
     @abstractmethod
-    def exposure_region(self, dataId: DataCoordinate, context: SqlQueryContext) -> Optional[Region]:
+    def exposure_region(self, dataId: DataCoordinate, context: SqlQueryContext) -> Region | None:
         """Return a region for a given DataId that corresponds to an exposure.
 
         Parameters
@@ -102,7 +102,7 @@ class RecordFactory:
         schema: ObsCoreSchema,
         universe: DimensionUniverse,
         spatial_plugins: Collection[SpatialObsCorePlugin],
-        exposure_region_factory: Optional[ExposureRegionFactory] = None,
+        exposure_region_factory: ExposureRegionFactory | None = None,
     ):
         self.config = config
         self.schema = schema
@@ -116,7 +116,7 @@ class RecordFactory:
         self.visit = universe["visit"]
         self.physical_filter = cast(Dimension, universe["physical_filter"])
 
-    def __call__(self, ref: DatasetRef, context: SqlQueryContext) -> Optional[Record]:
+    def __call__(self, ref: DatasetRef, context: SqlQueryContext) -> Record | None:
         """Make an ObsCore record from a dataset.
 
         Parameters
@@ -217,7 +217,7 @@ class RecordFactory:
 
         # Dictionary to use for substitutions when formatting various
         # strings.
-        fmt_kws: Dict[str, Any] = dict(records=dataId.records)
+        fmt_kws: dict[str, Any] = dict(records=dataId.records)
         fmt_kws.update(dataId.full.byName())
         fmt_kws.update(id=ref.id)
         fmt_kws.update(run=ref.run)
@@ -277,12 +277,12 @@ class RecordFactory:
                 record.update(plugin_record)
         return record
 
-    def _exposure_records(self, dimension_record: DimensionRecord, record: Dict[str, Any]) -> None:
+    def _exposure_records(self, dimension_record: DimensionRecord, record: dict[str, Any]) -> None:
         """Extract all needed info from a visit dimension record."""
         record["t_exptime"] = dimension_record.exposure_time
         record["target_name"] = dimension_record.target_name
 
-    def _visit_records(self, dimension_record: DimensionRecord, record: Dict[str, Any]) -> None:
+    def _visit_records(self, dimension_record: DimensionRecord, record: dict[str, Any]) -> None:
         """Extract all needed info from an exposure dimension record."""
         record["t_exptime"] = dimension_record.exposure_time
         record["target_name"] = dimension_record.target_name

--- a/python/lsst/daf/butler/registry/obscore/_schema.py
+++ b/python/lsst/daf/butler/registry/obscore/_schema.py
@@ -147,7 +147,7 @@ class ObsCoreSchema:
 
         fields = list(_STATIC_COLUMNS)
 
-        column_names = set(col.name for col in fields)
+        column_names = {col.name for col in fields}
 
         all_configs: list[ObsCoreConfig | DatasetTypeConfig] = [config]
         if config.dataset_types:

--- a/python/lsst/daf/butler/registry/obscore/_schema.py
+++ b/python/lsst/daf/butler/registry/obscore/_schema.py
@@ -25,7 +25,7 @@ __all__ = ["ObsCoreSchema"]
 
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, List, Optional, Type
+from typing import TYPE_CHECKING
 
 import sqlalchemy
 from lsst.daf.butler import ddl
@@ -141,7 +141,7 @@ class ObsCoreSchema:
         self,
         config: ObsCoreConfig,
         spatial_plugins: Sequence[SpatialObsCorePlugin],
-        datasets: Optional[Type[DatasetRecordStorageManager]] = None,
+        datasets: type[DatasetRecordStorageManager] | None = None,
     ):
         self._dimension_columns: dict[str, str] = {"instrument": "instrument_name"}
 
@@ -149,7 +149,7 @@ class ObsCoreSchema:
 
         column_names = set(col.name for col in fields)
 
-        all_configs: List[ObsCoreConfig | DatasetTypeConfig] = [config]
+        all_configs: list[ObsCoreConfig | DatasetTypeConfig] = [config]
         if config.dataset_types:
             all_configs += list(config.dataset_types.values())
         for cfg in all_configs:
@@ -157,7 +157,7 @@ class ObsCoreSchema:
                 for col_name, col_value in cfg.extra_columns.items():
                     if col_name in column_names:
                         continue
-                    doc: Optional[str] = None
+                    doc: str | None = None
                     if isinstance(col_value, ExtraColumnConfig):
                         col_type = ddl.VALID_CONFIG_COLUMN_TYPES.get(col_value.type.name)
                         col_length = col_value.length
@@ -179,7 +179,7 @@ class ObsCoreSchema:
                     fields.append(ddl.FieldSpec(name=col_name, dtype=col_type, length=col_length, doc=doc))
                     column_names.add(col_name)
 
-        indices: List[ddl.IndexSpec] = []
+        indices: list[ddl.IndexSpec] = []
         if config.indices:
             for columns in config.indices.values():
                 indices.append(ddl.IndexSpec(*ensure_iterable(columns)))
@@ -190,7 +190,7 @@ class ObsCoreSchema:
         for plugin in spatial_plugins:
             plugin.extend_table_spec(self._table_spec)
 
-        self._dataset_fk: Optional[ddl.FieldSpec] = None
+        self._dataset_fk: ddl.FieldSpec | None = None
         if datasets is not None:
             # Add FK to datasets, is also a PK for this table
             self._dataset_fk = datasets.addDatasetForeignKey(
@@ -204,7 +204,7 @@ class ObsCoreSchema:
         return self._table_spec
 
     @property
-    def dataset_fk(self) -> Optional[ddl.FieldSpec]:
+    def dataset_fk(self) -> ddl.FieldSpec | None:
         """Specification for the field which is a foreign key to ``datasets``
         table, and also a primary key for obscore table (`ddl.FieldSpec` or
         `None`).

--- a/python/lsst/daf/butler/registry/obscore/_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/_spatial.py
@@ -25,7 +25,7 @@ __all__ = ["MissingDatabaseError", "RegionTypeWarning", "SpatialObsCorePlugin"]
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from lsst.sphgeom import Region
 from lsst.utils import doImportType
@@ -58,9 +58,7 @@ class SpatialObsCorePlugin(ABC):
 
     @classmethod
     @abstractmethod
-    def initialize(
-        cls, *, name: str, config: Mapping[str, Any], db: Optional[Database]
-    ) -> SpatialObsCorePlugin:
+    def initialize(cls, *, name: str, config: Mapping[str, Any], db: Database | None) -> SpatialObsCorePlugin:
         """Construct an instance of the plugin.
 
         Parameters
@@ -106,7 +104,7 @@ class SpatialObsCorePlugin(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def make_records(self, region: Optional[Region]) -> Optional[Record]:
+    def make_records(self, region: Region | None) -> Record | None:
         """Return data for obscore records corresponding to a given region.
 
         Parameters
@@ -129,7 +127,7 @@ class SpatialObsCorePlugin(ABC):
 
     @classmethod
     def load_plugins(
-        cls, config: Mapping[str, SpatialPluginConfig], db: Optional[Database]
+        cls, config: Mapping[str, SpatialPluginConfig], db: Database | None
     ) -> Sequence[SpatialObsCorePlugin]:
         """Load all plugins based on plugin configurations.
 

--- a/python/lsst/daf/butler/registry/obscore/_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/_spatial.py
@@ -133,7 +133,7 @@ class SpatialObsCorePlugin(ABC):
 
         Parameters
         ----------
-        config : `Mapping` [ `str`, `SpatialPluginConfig` ]
+        config : `~collections.abc.Mapping` [ `str`, `SpatialPluginConfig` ]
             Configuration for plugins. The key is an arbitrary name and the
             value is an object describing plugin class and its configuration
             options.

--- a/python/lsst/daf/butler/registry/obscore/default_spatial.py
+++ b/python/lsst/daf/butler/registry/obscore/default_spatial.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ["DefaultSpatialObsCorePlugin"]
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 from lsst.sphgeom import ConvexPolygon, LonLat, Region
@@ -59,9 +59,7 @@ class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
         self._name = name
 
     @classmethod
-    def initialize(
-        cls, *, name: str, config: Mapping[str, Any], db: Optional[Database]
-    ) -> SpatialObsCorePlugin:
+    def initialize(cls, *, name: str, config: Mapping[str, Any], db: Database | None) -> SpatialObsCorePlugin:
         # docstring inherited.
         return cls(name=name, config=config)
 
@@ -69,7 +67,7 @@ class DefaultSpatialObsCorePlugin(SpatialObsCorePlugin):
         # docstring inherited.
         table_spec.fields.update(_COLUMNS)
 
-    def make_records(self, region: Optional[Region]) -> Optional[Record]:
+    def make_records(self, region: Region | None) -> Record | None:
         # docstring inherited.
 
         if region is None:

--- a/python/lsst/daf/butler/registry/obscore/pgsphere.py
+++ b/python/lsst/daf/butler/registry/obscore/pgsphere.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ["PgSphereObsCorePlugin"]
 
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 from lsst.sphgeom import ConvexPolygon, LonLat, Region
@@ -118,9 +118,7 @@ class PgSphereObsCorePlugin(SpatialObsCorePlugin):
         self._position_column_name = config.get("position_column", "pgsphere_position")
 
     @classmethod
-    def initialize(
-        cls, *, name: str, config: Mapping[str, Any], db: Optional[Database]
-    ) -> SpatialObsCorePlugin:
+    def initialize(cls, *, name: str, config: Mapping[str, Any], db: Database | None) -> SpatialObsCorePlugin:
         # docstring inherited.
 
         if db is None:
@@ -160,7 +158,7 @@ class PgSphereObsCorePlugin(SpatialObsCorePlugin):
         table_spec.indexes.add(ddl.IndexSpec(self._region_column_name, postgresql_using="gist"))
         table_spec.indexes.add(ddl.IndexSpec(self._position_column_name, postgresql_using="gist"))
 
-    def make_records(self, region: Optional[Region]) -> Optional[Record]:
+    def make_records(self, region: Region | None) -> Record | None:
         # docstring inherited.
 
         if region is None:

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -27,7 +27,8 @@ opaque tables for `Registry`.
 __all__ = ["ByNameOpaqueTableStorage", "ByNameOpaqueTableStorageManager"]
 
 import itertools
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, Iterator, List, Optional
+from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import sqlalchemy
 
@@ -96,7 +97,7 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
             """Generate a sequence of WHERE clauses with a limited number of
             items in IN clauses.
             """
-            batches: List[Iterable[Any]] = []
+            batches: list[Iterable[Any]] = []
             for k, v in where.items():
                 column = self._table.columns[k]
                 if isinstance(v, (list, tuple, set)):
@@ -149,7 +150,7 @@ class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
         super().__init__(registry_schema_version=registry_schema_version)
         self._db = db
         self._metaTable = metaTable
-        self._storage: Dict[str, OpaqueTableStorage] = {}
+        self._storage: dict[str, OpaqueTableStorage] = {}
 
     _META_TABLE_NAME: ClassVar[str] = "opaque_meta"
 
@@ -167,7 +168,7 @@ class ByNameOpaqueTableStorageManager(OpaqueTableStorageManager):
         metaTable = context.addTable(cls._META_TABLE_NAME, cls._META_TABLE_SPEC)
         return cls(db=db, metaTable=metaTable, registry_schema_version=registry_schema_version)
 
-    def get(self, name: str) -> Optional[OpaqueTableStorage]:
+    def get(self, name: str) -> OpaqueTableStorage | None:
         # Docstring inherited from OpaqueTableStorageManager.
         return self._storage.get(name)
 

--- a/python/lsst/daf/butler/registry/queries/_query.py
+++ b/python/lsst/daf/butler/registry/queries/_query.py
@@ -62,8 +62,8 @@ class Query:
     relation : `Relation`
         The relation tree representation of the query as a series of operations
         on tables.
-    governor_constraints : `Mapping` [ `str` [ `~collections.abc.Set`
-                [ `str` ] ] ]
+    governor_constraints : `~collections.abc.Mapping` [ `str`, \
+            `~collections.abc.Set` [ `str` ] ]
         Constraints on governor dimensions encoded in this query's relation.
         This is a mapping from governor dimension name to sets of values that
         dimension may take.
@@ -76,7 +76,8 @@ class Query:
         either have records present in ``record_caches`` or all columns present
         in ``relation``, while a specific `DimensionElement` means that element
         does.
-    record_caches : `Mapping` [ `DimensionElement`, `Mapping`
+    record_caches : `~collections.abc.Mapping` [ `DimensionElement`, \
+            `~collections.abc.Mapping`
             [ `DataCoordinate`, `DimensionRecord` ] ], optional
         Cached dimension record values, organized first by dimension element
         and then by data ID.
@@ -850,7 +851,7 @@ class Query:
 
         Returns
         -------
-        messages : `Iterable` [ `str` ]
+        messages : `~collections.abc.Iterable` [ `str` ]
             String messages that describe reasons the query might not yield any
             results.
         """
@@ -915,12 +916,13 @@ class Query:
             (this option is "sticky").
         dimensions : `DimensionGraph`, optional
             See class docs.
-        governor_constraints : `Mapping` [ `str` [ `~collections.abc.Set`
-                [ `str` ] ] ], optional
+        governor_constraints : `~collections.abc.Mapping` [ `str`, \
+                `~collections.abc.Set` [ `str` ] ], optional
             See class docs.
         has_record_columns : `bool` or `DimensionElement`, optional
             See class docs.
-        record_caches : `Mapping` [ `DimensionElement`, `Mapping`
+        record_caches : `~collections.abc.Mapping` [ `DimensionElement`, \
+                `~collections.abc.Mapping` \
                 [ `DataCoordinate`, `DimensionRecord` ] ], optional
             See class docs.
 

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -280,10 +280,10 @@ class QueryBackend(Generic[_C]):
 
         Parameters
         ----------
-        dataset_types : `Iterable` [ `DatasetType` ]
+        dataset_types : `~collections.abc.Iterable` [ `DatasetType` ]
             Dataset types that are being queried.  Must include only parent
             or standalone dataset types, not components.
-        collections : `Sequence` [ `CollectionRecord` ]
+        collections : `~collections.abc.Sequence` [ `CollectionRecord` ]
             Sequence of collections that will be searched.
         governor_constraints : `~collections.abc.Mapping` [ `str`, \
                 `~collections.abc.Set` [ `str` ] ], optional
@@ -331,8 +331,8 @@ class QueryBackend(Generic[_C]):
             Dataset type to be queried in the returned collections.
         collections : `CollectionWildcard`
             Expression for the collections to be queried.
-        governor_constraints : `Mapping` [ `str`, `~collections.abc.Set` ], \
-                optional
+        governor_constraints : `~collections.abc.Mapping` [ `str`, \
+                `~collections.abc.Set` ], optional
             Constraints imposed by other aspects of the query on governor
             dimensions; collections inconsistent with these constraints will be
             skipped.
@@ -425,7 +425,7 @@ class QueryBackend(Generic[_C]):
         ----------
         dataset_type : `DatasetType`
             Type for the datasets being queried.
-        collections : `Sequence` [ `CollectionRecord` ]
+        collections : `~collections.abc.Sequence` [ `CollectionRecord` ]
             Records for collections to query.  Should generally be the result
             of a call to `resolve_dataset_collections`, and must not be empty.
         context : `QueryContext`
@@ -458,7 +458,7 @@ class QueryBackend(Generic[_C]):
         ----------
         dataset_type : `DatasetType`
             Type for the datasets being search.
-        collections : `Sequence` [ `CollectionRecord` ]
+        collections : `~collections.abc.Sequence` [ `CollectionRecord` ]
             Records for collections to search.  Should generally be the result
             of a call to `resolve_dataset_collections`, and must not be empty.
         columns : `~collections.abc.Set` [ `str` ]
@@ -520,7 +520,7 @@ class QueryBackend(Generic[_C]):
         columns : `~collections.abc.Set` [ `str` ]
             Dataset columns to include (dimension key columns are always
             included).  See `make_dataset_query_relation` for allowed values.
-        messages : `Iterable` [ `str` ]
+        messages : `~collections.abc.Iterable` [ `str` ]
             Diagnostic messages that explain why the query is doomed to yield
             no rows.
         context : `QueryContext`
@@ -655,7 +655,8 @@ class QueryBackend(Generic[_C]):
 
         Returns
         -------
-        cache : `Mapping` [ `DataCoordinate`, `DimensionRecord` ] or `None`
+        cache : `~collections.abc.Mapping` [ `DataCoordinate`, \
+                `DimensionRecord` ] or `None`
             Mapping from data ID to dimension record, or `None` if this
             element's records are never cached.
         """

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -517,7 +517,7 @@ class QueryBackend(Generic[_C]):
         ----------
         dataset_type : `DatasetType`
             Dataset type being queried.
-        columns : `AbstractSet` [ `str` ]
+        columns : `~collections.abc.Set` [ `str` ]
             Dataset columns to include (dimension key columns are always
             included).  See `make_dataset_query_relation` for allowed values.
         messages : `Iterable` [ `str` ]

--- a/python/lsst/daf/butler/registry/queries/_query_context.py
+++ b/python/lsst/daf/butler/registry/queries/_query_context.py
@@ -430,7 +430,7 @@ class QueryContext(Processor, AbstractContextManager["QueryContext"]):
         data_ids : `~collections.abc.Set` [ `DataCoordinate` ]
             Data IDs to upload.  All must have at least the dimensions given,
             but may have more.
-        dimension_names : `Iterable` [ `str` ]
+        dimension_names : `~collections.abc.Iterable` [ `str` ]
             Names of dimensions that will be the columns of the relation.
 
         Returns

--- a/python/lsst/daf/butler/registry/queries/_readers.py
+++ b/python/lsst/daf/butler/registry/queries/_readers.py
@@ -72,7 +72,7 @@ class DataCoordinateReader(ABC):
             required dimensions.
         records : `bool`, optional
             Whether to attach dimension records.
-        record_caches : `Mapping`, optional
+        record_caches : `~collections.abc.Mapping`, optional
             Nested mapping (outer keys are dimension elements, inner keys are
             data IDs for that element) of cached dimension records.  Ignored
             unless ``records=True``.
@@ -109,7 +109,7 @@ class DataCoordinateReader(ABC):
 
         Parameters
         ----------
-        row : `Mapping`
+        row : `~collections.abc.Mapping`
             Mapping with `ColumnTag` keys representing a query result row.
 
         Returns
@@ -186,10 +186,10 @@ class _ExpandedDataCoordinateReader(DataCoordinateReader):
     ----------
     full_reader : `_FullDataCoordinateReader`
         Reader for full data IDs that don't have records.
-    record_caches : `Mapping`
+    record_caches : `~collections.abc.Mapping`
         Nested mapping (outer keys are dimension elements, inner keys are data
         IDs for that element) of cached dimension records.
-    record_readers : `Mapping`
+    record_readers : `~collections.abc.Mapping`
         Mapping from `DimensionElement` to `DimensionRecordReaders`.  Should
         include all elements in the data coordinate's dimensions that are not
         in ``record_cache``.
@@ -236,13 +236,13 @@ class DatasetRefReader:
     full : `bool`, optional
         Whether to expect and extract implied dimensions as well as required
         dimensions.
-    translate_collection : `Callable`, optional
+    translate_collection : `~collections.abc.Callable`, optional
         Callable that returns `str` collection names given collection primary
         key values.  Optional only for registries that use names as primary
         keys, or if ``run`` is always passed to `read`.
     records : `bool`, optional
         Whether to attach dimension records to data IDs.
-    record_caches : `Mapping`, optional
+    record_caches : `~collections.abc.Mapping`, optional
         Nested mapping (outer keys are dimension element names, inner keys
         are data IDs for that element) of cached dimension records.
         Ignored unless ``records=True``.
@@ -285,7 +285,7 @@ class DatasetRefReader:
 
         Parameters
         ----------
-        row : `Mapping`
+        row : `~collections.abc.Mapping`
             Mapping with `ColumnTag` keys representing a query result row.
         run : `str`, optional
             Name of the `~CollectionType.RUN` collection; when provided the run

--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -335,7 +335,7 @@ class DataCoordinateQueryResults(DataCoordinateIterable):
 
         Returns
         -------
-        messages : `Iterable` [ `str` ]
+        messages : `~collections.abc.Iterable` [ `str` ]
             String messages that describe reasons the query might not yield any
             results.
         """
@@ -406,7 +406,7 @@ class DatasetQueryResults(Iterable[DatasetRef]):
 
         Returns
         -------
-        iter : `Iterator` [ `ParentDatasetQueryResults` ]
+        iter : `~collections.abc.Iterator` [ `ParentDatasetQueryResults` ]
             An iterator over `DatasetQueryResults` instances that are each
             responsible for a single parent dataset type (either just that
             dataset type, one or more of its component dataset types, or both).
@@ -523,7 +523,7 @@ class DatasetQueryResults(Iterable[DatasetRef]):
 
         Returns
         -------
-        messages : `Iterable` [ `str` ]
+        messages : `~collections.abc.Iterable` [ `str` ]
             String messages that describe reasons the query might not yield any
             results.
         """
@@ -540,7 +540,7 @@ class ParentDatasetQueryResults(DatasetQueryResults):
         Low-level query object that backs these results.
     dataset_type : `DatasetType`
         Parent dataset type for all datasets returned by this query.
-    components : `Sequence` [ `str` or `None` ], optional
+    components : `~collections.abc.Sequence` [ `str` or `None` ], optional
         Names of components to include in iteration.  `None` may be included
         (at most once) to include the parent dataset type.
 
@@ -602,7 +602,7 @@ class ParentDatasetQueryResults(DatasetQueryResults):
         """Return a new query results object for the same parent datasets but
         different components.
 
-        components :  `Sequence` [ `str` or `None` ]
+        components :  `~collections.abc.Sequence` [ `str` or `None` ]
             Names of components to include in iteration.  `None` may be
             included (at most once) to include the parent dataset type.
         """
@@ -633,9 +633,9 @@ class ChainedDatasetQueryResults(DatasetQueryResults):
 
     Parameters
     ----------
-    chain : `Sequence` [ `ParentDatasetQueryResults` ]
+    chain : `~collections.abc.Sequence` [ `ParentDatasetQueryResults` ]
         The underlying results objects this object will chain together.
-    doomed_by : `Iterable` [ `str` ], optional
+    doomed_by : `~collections.abc.Iterable` [ `str` ], optional
         A list of messages (appropriate for e.g. logging or exceptions) that
         explain why the query is known to return no results even before it is
         executed.  Queries with a non-empty list will never be executed.
@@ -817,7 +817,7 @@ class DimensionRecordQueryResults(Iterable[DimensionRecord]):
 
         Returns
         -------
-        messages : `Iterable` [ `str` ]
+        messages : `~collections.abc.Iterable` [ `str` ]
             String messages that describe reasons the query might not yield any
             results.
         """

--- a/python/lsst/daf/butler/registry/queries/_sql_query_context.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_context.py
@@ -482,7 +482,7 @@ class _SqlRowTransformer:
 
     Parameters
     ----------
-    columns : `Iterable` [ `ColumnTag` ]
+    columns : `~collections.abc.Iterable` [ `ColumnTag` ]
         Set of columns to handle.  Rows must have at least these columns, but
         may have more.
     engine : `ButlerSqlEngine`
@@ -510,13 +510,13 @@ class _SqlRowTransformer:
 
         Parameters
         ----------
-        sql_row : `Mapping`
+        sql_row : `~collections.abc.Mapping`
             Mapping with `str` keys and possibly-unpacked values for timespan
             columns.
 
         Returns
         -------
-        relation_row : `Mapping`
+        relation_row : `~collections.abc.Mapping`
             Mapping with `ColumnTag` keys and `Timespan` objects for timespan
             columns.
         """
@@ -531,13 +531,13 @@ class _SqlRowTransformer:
 
         Parameters
         ----------
-        relation_row : `Mapping`
+        relation_row : `~collections.abc.Mapping`
             Mapping with `ColumnTag` keys and `Timespan` objects for timespan
             columns.
 
         Returns
         -------
-        sql_row : `Mapping`
+        sql_row : `~collections.abc.Mapping`
             Mapping with `str` keys and possibly-unpacked values for timespan
             columns.
         """

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -148,7 +148,7 @@ class QueryWhereClause:
     governor_constraints: Mapping[str, Set[str]]
     """Restrictions on the values governor dimensions can take in this query,
     imposed by the string expression and/or data ID
-    (`~collections.abc.Mapping` [ `set`,  `~collections.abc.Set` [ `str` ] ]).
+    (`~collections.abc.Mapping` [ `str`,  `~collections.abc.Set` [ `str` ] ]).
 
     Governor dimensions not present in this mapping are not constrained at all.
     """

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -85,7 +85,7 @@ class QueryWhereClause:
             A user-provided string expression.
         column_types : `ColumnTypeInfo`
             Information about column types.
-        bind : `Mapping` [ `str`, `object` ], optional
+        bind : `~collections.abc.Mapping` [ `str`, `object` ], optional
             Mapping containing literal values that should be injected into the
             query expression, keyed by the identifiers they replace.
         data_id : `DataCoordinate`, optional
@@ -148,7 +148,7 @@ class QueryWhereClause:
     governor_constraints: Mapping[str, Set[str]]
     """Restrictions on the values governor dimensions can take in this query,
     imposed by the string expression and/or data ID
-    (`Mapping` [ `set`,  `~collections.abc.Set` [ `str` ] ]).
+    (`~collections.abc.Mapping` [ `set`,  `~collections.abc.Set` [ `str` ] ]).
 
     Governor dimensions not present in this mapping are not constrained at all.
     """
@@ -179,7 +179,7 @@ class OrderByClause:
 
         Parameters
         ----------
-        order_by : `Iterable` [ `str` ]
+        order_by : `~collections.abc.Iterable` [ `str` ]
             Sequence of names to use for ordering with optional "-" prefix.
         graph : `DimensionGraph`
             Dimensions used by a query.
@@ -209,7 +209,7 @@ class OrderByClause:
 
         Parameters
         ----------
-        order_by : `Iterable` [ `str` ]
+        order_by : `~collections.abc.Iterable` [ `str` ]
             Sequence of names to use for ordering with optional "-" prefix.
         element : `DimensionElement`
             Single or primary dimension element in the query
@@ -269,7 +269,7 @@ class OrderByClause:
 
     terms: Iterable[SortTerm]
     """Columns that appear in the ORDER BY
-    (`Iterable` [ `OrderByClauseColumn` ]).
+    (`~collections.abc.Iterable` [ `OrderByClauseColumn` ]).
     """
 
     @property
@@ -290,7 +290,7 @@ class ElementOrderByClause:
 
     Parameters
     ----------
-    order_by : `Iterable` [ `str` ]
+    order_by : `~collections.abc.Iterable` [ `str` ]
         Sequence of names to use for ordering with optional "-" prefix.
     element : `DimensionElement`
         Dimensions used by a query.
@@ -312,7 +312,7 @@ class ElementOrderByClause:
 
     order_by_columns: Iterable[OrderByClauseColumn]
     """Columns that appear in the ORDER BY
-    (`Iterable` [ `OrderByClauseColumn` ]).
+    (`~collections.abc.Iterable` [ `OrderByClauseColumn` ]).
     """
 
 
@@ -340,18 +340,18 @@ class QuerySummary:
         A spatial constraint that all rows must overlap.
     timespan : `Timespan`, optional
         A temporal constraint that all rows must overlap.
-    bind : `Mapping` [ `str`, `object` ], optional
+    bind : `~collections.abc.Mapping` [ `str`, `object` ], optional
         Mapping containing literal values that should be injected into the
         query expression, keyed by the identifiers they replace.
     defaults : `DataCoordinate`, optional
         A data ID containing default for governor dimensions.
-    datasets : `Iterable` [ `DatasetType` ], optional
+    datasets : `~collections.abc.Iterable` [ `DatasetType` ], optional
         Dataset types whose searches may be joined into the query.  Callers
         must still call `QueryBuilder.joinDataset` explicitly to control how
         that join happens (e.g. which collections are searched), but by
         declaring them here first we can ensure that the query includes the
         right dimensions for those joins.
-    order_by : `Iterable` [ `str` ]
+    order_by : `~collections.abc.Iterable` [ `str` ]
         Sequence of names to use for ordering with optional "-" prefix.
     limit : `Tuple`, optional
         Limit on the number of returned rows and optional offset.

--- a/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
@@ -27,7 +27,7 @@ import datetime
 import types
 import warnings
 from collections.abc import Mapping, Set
-from typing import Any, Union, cast
+from typing import Any, cast
 
 import astropy.time
 import astropy.utils.exceptions
@@ -175,7 +175,7 @@ def make_string_expression_predicate(
     return predicate, governor_constraints
 
 
-VisitorResult = Union[Predicate, ColumnExpression, ColumnContainer]
+VisitorResult = Predicate | ColumnExpression | ColumnContainer
 
 
 class PredicateConversionVisitor(TreeVisitor[VisitorResult]):

--- a/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
@@ -97,7 +97,7 @@ def make_string_expression_predicate(
         expression.
     column_types : `ColumnTypeInfo`
         Information about column types.
-    bind : `Mapping` [ `str`, `Any` ], optional
+    bind : `~collections.abc.Mapping` [ `str`, `Any` ], optional
         Literal values referenced in the expression.
     data_id : `DataCoordinate`, optional
         A fully-expanded data ID identifying dimensions known in advance.
@@ -120,7 +120,8 @@ def make_string_expression_predicate(
     predicate : `lsst.daf.relation.colum_expressions.Predicate` or `None`
         New predicate derived from the string expression, or `None` if the
         string is empty.
-    governor_constraints : `Mapping` [ `str` , `~collections.abc.Set` ]
+    governor_constraints : `~collections.abc.Mapping` [ `str` , \
+            `~collections.abc.Set` ]
         Constraints on dimension values derived from the expression and data
         ID.
     """

--- a/python/lsst/daf/butler/registry/queries/expressions/categorize.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/categorize.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 __all__ = ()  # all symbols intentionally private; for internal package use.
 
 import enum
-from typing import Optional, Tuple, cast
+from typing import cast
 
 from ....core import Dimension, DimensionElement, DimensionGraph, DimensionUniverse
 
@@ -35,7 +35,7 @@ class ExpressionConstant(enum.Enum):
     INGEST_DATE = "ingest_date"
 
 
-def categorizeConstant(name: str) -> Optional[ExpressionConstant]:
+def categorizeConstant(name: str) -> ExpressionConstant | None:
     """Categorize an identifier in a parsed expression as one of a few global
     constants.
 
@@ -56,7 +56,7 @@ def categorizeConstant(name: str) -> Optional[ExpressionConstant]:
         return None
 
 
-def categorizeElementId(universe: DimensionUniverse, name: str) -> Tuple[DimensionElement, Optional[str]]:
+def categorizeElementId(universe: DimensionUniverse, name: str) -> tuple[DimensionElement, str | None]:
     """Categorize an identifier in a parsed expression as either a `Dimension`
     name (indicating the primary key for that dimension) or a non-primary-key
     column in a `DimensionElement` table.
@@ -121,7 +121,7 @@ def categorizeElementId(universe: DimensionUniverse, name: str) -> Tuple[Dimensi
         return dimension, None
 
 
-def categorizeOrderByName(graph: DimensionGraph, name: str) -> Tuple[DimensionElement, Optional[str]]:
+def categorizeOrderByName(graph: DimensionGraph, name: str) -> tuple[DimensionElement, str | None]:
     """Categorize an identifier in an ORDER BY clause.
 
     Parameters
@@ -164,7 +164,7 @@ def categorizeOrderByName(graph: DimensionGraph, name: str) -> Tuple[DimensionEl
       element from a graph is used.
     """
     element: DimensionElement
-    field_name: Optional[str] = None
+    field_name: str | None = None
     if name in ("timespan.begin", "timespan.end"):
         matches = [element for element in graph.elements if element.temporal]
         if len(matches) == 1:
@@ -224,7 +224,7 @@ def categorizeOrderByName(graph: DimensionGraph, name: str) -> Tuple[DimensionEl
     return element, field_name
 
 
-def categorizeElementOrderByName(element: DimensionElement, name: str) -> Optional[str]:
+def categorizeElementOrderByName(element: DimensionElement, name: str) -> str | None:
     """Categorize an identifier in an ORDER BY clause for a single element.
 
     Parameters
@@ -260,7 +260,7 @@ def categorizeElementOrderByName(element: DimensionElement, name: str) -> Option
     - Two special identifiers ``timespan.begin`` and ``timespan.end`` can be
       used with temporal elements.
     """
-    field_name: Optional[str] = None
+    field_name: str | None = None
     if name in ("timespan.begin", "timespan.end"):
         if element.temporal:
             field_name = name

--- a/python/lsst/daf/butler/registry/queries/expressions/check.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/check.py
@@ -192,7 +192,7 @@ class InspectionVisitor(TreeVisitor[TreeSummary]):
     ----------
     universe : `DimensionUniverse`
         All known dimensions.
-    bind : `Mapping` [ `str`, `object` ]
+    bind : `~collections.abc.Mapping` [ `str`, `object` ]
         Mapping containing literal values that should be injected into the
         query expression, keyed by the identifiers they replace.
     """
@@ -334,7 +334,7 @@ class CheckVisitor(NormalFormVisitor[TreeSummary, InnerSummary, OuterSummary]):
     graph : `DimensionGraph`
         The dimensions the query would include in the absence of this
         expression.
-    bind : `Mapping` [ `str`, `object` ]
+    bind : `~collections.abc.Mapping` [ `str`, `object` ]
         Mapping containing literal values that should be injected into the
         query expression, keyed by the identifiers they replace.
     defaults : `DataCoordinate`

--- a/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
@@ -29,7 +29,8 @@ __all__ = (
 
 import enum
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar
+from collections.abc import Iterator, Sequence
+from typing import Generic, TypeVar
 
 import astropy.time
 
@@ -294,7 +295,7 @@ class NormalFormExpression:
             Return value from calling ``visitor.visitOuter`` after visiting
             all other nodes.
         """
-        visitedOuterBranches: List[_U] = []
+        visitedOuterBranches: list[_U] = []
         for nodeInnerBranches in self._nodes:
             visitedInnerBranches = [visitor.visitBranch(node) for node in nodeInnerBranches]
             visitedOuterBranches.append(visitor.visitInner(visitedInnerBranches, self.form))
@@ -853,7 +854,7 @@ class LogicalBinaryOperation(TransformationWrapper):
         self._lhs = lhs
         self._operator = operator
         self._rhs = rhs
-        self._satisfiesCache: Dict[NormalForm, bool] = {}
+        self._satisfiesCache: dict[NormalForm, bool] = {}
 
     __slots__ = ("_lhs", "_operator", "_rhs", "_satisfiesCache")
 
@@ -1023,7 +1024,7 @@ class TransformationVisitor(TreeVisitor[TransformationWrapper]):
         return Opaque(node, PrecedenceTier.TOKEN)
 
     def visitRangeLiteral(
-        self, start: int, stop: int, stride: Optional[int], node: Node
+        self, start: int, stop: int, stride: int | None, node: Node
     ) -> TransformationWrapper:
         # Docstring inherited from TreeVisitor.visitRangeLiteral
         return Opaque(node, PrecedenceTier.TOKEN)
@@ -1060,7 +1061,7 @@ class TransformationVisitor(TreeVisitor[TransformationWrapper]):
     def visitIsIn(
         self,
         lhs: TransformationWrapper,
-        values: List[TransformationWrapper],
+        values: list[TransformationWrapper],
         not_in: bool,
         node: Node,
     ) -> TransformationWrapper:
@@ -1071,7 +1072,7 @@ class TransformationVisitor(TreeVisitor[TransformationWrapper]):
         # Docstring inherited from TreeVisitor.visitParens
         return expression
 
-    def visitTupleNode(self, items: Tuple[TransformationWrapper, ...], node: Node) -> TransformationWrapper:
+    def visitTupleNode(self, items: tuple[TransformationWrapper, ...], node: Node) -> TransformationWrapper:
         # Docstring inherited from TreeVisitor.visitTupleNode
         return Opaque(node, PrecedenceTier.TOKEN)
 

--- a/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
@@ -186,7 +186,7 @@ class NormalFormVisitor(Generic[_T, _U, _V]):
 
         Parameters
         ----------
-        branches : `Sequence`
+        branches : `~collections.abc.Sequence`
             Sequence of tuples, where the first element in each tuple is the
             result of a call to `visitBranch`, and the second is the `Node` on
             which `visitBranch` was called.
@@ -209,7 +209,7 @@ class NormalFormVisitor(Generic[_T, _U, _V]):
 
         Parameters
         ----------
-        branches : `Sequence`
+        branches : `~collections.abc.Sequence`
             Sequence of return values from calls to `visitInner`.
         form : `NormalForm`
             Form this expression is in.  ``form.outer`` is the operator that
@@ -233,7 +233,8 @@ class NormalFormExpression:
 
     Parameters
     ----------
-    nodes : `Sequence` [ `Sequence` [ `Node` ] ]
+    nodes : `~collections.abc.Sequence` [ `~collections.abc.Sequence` \
+            [ `Node` ] ]
         Non-AND, non-OR branches of three tree, with the AND and OR operations
         combining them represented by position in the nested sequence - the
         inner sequence is combined via ``form.inner``, and the outer sequence
@@ -525,7 +526,7 @@ class TransformationWrapper(ABC):
 
         Returns
         -------
-        operands : `Iterator` [ `TransformationWrapper` ]
+        operands : `~collections.abc.Iterator` [ `TransformationWrapper` ]
             Operands that, if combined with ``operator``, yield an expression
             equivalent to ``self``.
         """
@@ -1099,7 +1100,7 @@ class TreeReconstructionVisitor(NormalFormVisitor[Node, Node, Node]):
 
         Parameters
         ----------
-        branches : `Sequence`
+        branches : `~collections.abc.Sequence`
             Sequence of return values from calls to `visitBranch`, representing
             a visited set of operands combined in the expression by
             ``operator``.

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
@@ -51,7 +51,7 @@ __all__ = [
 #  Imports of standard modules --
 # -------------------------------
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 
 # -----------------------------
 #  Imports for other modules --
@@ -85,7 +85,7 @@ class Node(ABC):
         Possibly empty list of sub-nodes.
     """
 
-    def __init__(self, children: Tuple[Node, ...] | None = None):
+    def __init__(self, children: tuple[Node, ...] | None = None):
         self.children = tuple(children or ())
 
     @abstractmethod
@@ -269,7 +269,7 @@ class RangeLiteral(Node):
         stride was missing from literal.
     """
 
-    def __init__(self, start: int, stop: int, stride: Optional[int] = None):
+    def __init__(self, start: int, stop: int, stride: int | None = None):
         self.start = start
         self.stop = stop
         self.stride = stride
@@ -296,7 +296,7 @@ class IsIn(Node):
         If `True` then it is NOT IN expression, otherwise it is IN expression.
     """
 
-    def __init__(self, lhs: Node, values: List[Node], not_in: bool = False):
+    def __init__(self, lhs: Node, values: list[Node], not_in: bool = False):
         Node.__init__(self, (lhs,) + tuple(values))
         self.lhs = lhs
         self.values = values
@@ -351,7 +351,7 @@ class TupleNode(Node):
         Expressions inside parentheses.
     """
 
-    def __init__(self, items: Tuple[Node, ...]):
+    def __init__(self, items: tuple[Node, ...]):
         Node.__init__(self, items)
         self.items = items
 
@@ -376,7 +376,7 @@ class FunctionCall(Node):
         Arguments passed to function.
     """
 
-    def __init__(self, function: str, args: List[Node]):
+    def __init__(self, function: str, args: list[Node]):
         Node.__init__(self, tuple(args))
         self.name = function
         self.args = args[:]
@@ -417,7 +417,7 @@ class PointNode(Node):
         return f"POINT({self.ra}, {self.dec})"
 
 
-def function_call(function: str, args: List[Node]) -> Node:
+def function_call(function: str, args: list[Node]) -> Node:
     """Factory method for nodes representing function calls.
 
     Attributes

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
@@ -313,7 +313,7 @@ class IsIn(Node):
         not_in = ""
         if self.not_in:
             not_in = "NOT "
-        return "{lhs} {not_in}IN ({values})".format(lhs=self.lhs, not_in=not_in, values=values)
+        return f"{self.lhs} {not_in}IN ({values})"
 
 
 class Parens(Node):

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/parserLex.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/parserLex.py
@@ -67,7 +67,7 @@ class ParserLexError(Exception):
     """
 
     def __init__(self, expression, remain, pos, lineno):
-        Exception.__init__(self, "Unexpected character at position {}".format(pos))
+        Exception.__init__(self, f"Unexpected character at position {pos}")
         self.expression = expression
         self.remain = remain
         self.pos = pos

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 __all__ = ["TreeVisitor"]
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Generic, List, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     import astropy.time
@@ -87,7 +87,7 @@ class TreeVisitor(Generic[T]):
         """
 
     @abstractmethod
-    def visitRangeLiteral(self, start: int, stop: int, stride: Optional[int], node: Node) -> T:
+    def visitRangeLiteral(self, start: int, stop: int, stride: int | None, node: Node) -> T:
         """Visit RangeLiteral node.
 
         Parameters
@@ -151,7 +151,7 @@ class TreeVisitor(Generic[T]):
         """
 
     @abstractmethod
-    def visitIsIn(self, lhs: T, values: List[T], not_in: bool, node: Node) -> T:
+    def visitIsIn(self, lhs: T, values: list[T], not_in: bool, node: Node) -> T:
         """Visit IsIn node.
 
         Parameters
@@ -184,7 +184,7 @@ class TreeVisitor(Generic[T]):
         """
 
     @abstractmethod
-    def visitTupleNode(self, items: Tuple[T, ...], node: Node) -> T:
+    def visitTupleNode(self, items: tuple[T, ...], node: Node) -> T:
         """Visit TupleNode node.
 
         Parameters
@@ -197,7 +197,7 @@ class TreeVisitor(Generic[T]):
             Corresponding tree node, mostly useful for diagnostics.
         """
 
-    def visitFunctionCall(self, name: str, args: List[T], node: Node) -> T:
+    def visitFunctionCall(self, name: str, args: list[T], node: Node) -> T:
         """Visit FunctionCall node.
 
         Parameters

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -27,9 +27,10 @@ import itertools
 import warnings
 from abc import ABC, abstractmethod
 from collections import namedtuple
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from typing import Any, ContextManager, Iterable, Optional, Set, Tuple
+from typing import Any, ContextManager
 
 import astropy.time
 import sqlalchemy
@@ -93,7 +94,7 @@ def _patch_getExistingTable(db: Database) -> Database:
     """
     original_method = db.getExistingTable
 
-    def _getExistingTable(name: str, spec: ddl.TableSpec) -> Optional[sqlalchemy.schema.Table]:
+    def _getExistingTable(name: str, spec: ddl.TableSpec) -> sqlalchemy.schema.Table | None:
         # Return None on first call, but forward to original method after that
         db.getExistingTable = original_method
         return None
@@ -728,7 +729,7 @@ class DatabaseTests(ABC):
         with db1.declareStaticTables(create=True) as context:
             tables1 = context.addTableTuple(STATIC_TABLE_SPECS)
 
-        async def side1(lock: Iterable[str] = ()) -> Tuple[Set[str], Set[str]]:
+        async def side1(lock: Iterable[str] = ()) -> tuple[set[str], set[str]]:
             """One side of the concurrent locking test.
 
             This optionally locks the table (and maybe the whole database),

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -30,8 +30,9 @@ import unittest
 import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
+from collections.abc import Iterator
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Iterator, Optional, Type, Union
+from typing import TYPE_CHECKING
 
 import astropy.time
 import sqlalchemy
@@ -85,13 +86,13 @@ class RegistryTests(ABC):
     generate tests for different configurations.
     """
 
-    collectionsManager: Optional[str] = None
+    collectionsManager: str | None = None
     """Name of the collections manager class, if subclass provides value for
     this member then it overrides name specified in default configuration
     (`str`).
     """
 
-    datasetsManager: Optional[str | dict[str, str]] = None
+    datasetsManager: str | dict[str, str] | None = None
     """Name or configuration dictionary of the datasets manager class, if
     subclass provides value for this member then it overrides name specified
     in default configuration (`str` or `dict`).
@@ -120,7 +121,7 @@ class RegistryTests(ABC):
         return config
 
     @abstractmethod
-    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Optional[Registry]:
+    def makeRegistry(self, share_repo_with: Registry | None = None) -> Registry | None:
         """Return the Registry instance to be tested.
 
         Parameters
@@ -1507,7 +1508,7 @@ class RegistryTests(ABC):
         unknown_type = DatasetType("not_known", dimensions=bias.dimensions, storageClass="Exposure")
 
         # Test both string name and dataset type object.
-        test_type: Union[str, DatasetType]
+        test_type: str | DatasetType
         for test_type, test_type_name in (
             (unknown_type, unknown_type.name),
             (unknown_type.name, unknown_type.name),
@@ -2139,7 +2140,7 @@ class RegistryTests(ABC):
             pass
 
         def assertLookup(
-            detector: int, timespan: Timespan, expected: Optional[Union[DatasetRef, Type[Ambiguous]]]
+            detector: int, timespan: Timespan, expected: DatasetRef | type[Ambiguous] | None
         ) -> None:
             """Local function that asserts that a bias lookup returns the given
             expected result.

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -1062,36 +1062,36 @@ class RegistryTests(ABC):
         # with empty expression
         rows = registry.queryDataIds(dimensions, datasets=rawType, collections=run1).expanded().toSet()
         self.assertEqual(len(rows), 4 * 3)  # 4 exposures times 3 detectors
-        self.assertCountEqual(set(dataId["exposure"] for dataId in rows), (100, 101, 110, 111))
-        self.assertCountEqual(set(dataId["visit"] for dataId in rows), (10, 11))
-        self.assertCountEqual(set(dataId["detector"] for dataId in rows), (1, 2, 3))
+        self.assertCountEqual({dataId["exposure"] for dataId in rows}, (100, 101, 110, 111))
+        self.assertCountEqual({dataId["visit"] for dataId in rows}, (10, 11))
+        self.assertCountEqual({dataId["detector"] for dataId in rows}, (1, 2, 3))
 
         # second collection
         rows = registry.queryDataIds(dimensions, datasets=rawType, collections=tagged2).toSet()
         self.assertEqual(len(rows), 4 * 3)  # 4 exposures times 3 detectors
         for dataId in rows:
             self.assertCountEqual(dataId.keys(), ("instrument", "detector", "exposure", "visit"))
-        self.assertCountEqual(set(dataId["exposure"] for dataId in rows), (100, 101, 200, 201))
-        self.assertCountEqual(set(dataId["visit"] for dataId in rows), (10, 20))
-        self.assertCountEqual(set(dataId["detector"] for dataId in rows), (1, 2, 3, 4, 5))
+        self.assertCountEqual({dataId["exposure"] for dataId in rows}, (100, 101, 200, 201))
+        self.assertCountEqual({dataId["visit"] for dataId in rows}, (10, 20))
+        self.assertCountEqual({dataId["detector"] for dataId in rows}, (1, 2, 3, 4, 5))
 
         # with two input datasets
         rows = registry.queryDataIds(dimensions, datasets=rawType, collections=[run1, tagged2]).toSet()
         self.assertEqual(len(set(rows)), 6 * 3)  # 6 exposures times 3 detectors; set needed to de-dupe
         for dataId in rows:
             self.assertCountEqual(dataId.keys(), ("instrument", "detector", "exposure", "visit"))
-        self.assertCountEqual(set(dataId["exposure"] for dataId in rows), (100, 101, 110, 111, 200, 201))
-        self.assertCountEqual(set(dataId["visit"] for dataId in rows), (10, 11, 20))
-        self.assertCountEqual(set(dataId["detector"] for dataId in rows), (1, 2, 3, 4, 5))
+        self.assertCountEqual({dataId["exposure"] for dataId in rows}, (100, 101, 110, 111, 200, 201))
+        self.assertCountEqual({dataId["visit"] for dataId in rows}, (10, 11, 20))
+        self.assertCountEqual({dataId["detector"] for dataId in rows}, (1, 2, 3, 4, 5))
 
         # limit to single visit
         rows = registry.queryDataIds(
             dimensions, datasets=rawType, collections=run1, where="visit = 10", instrument="DummyCam"
         ).toSet()
         self.assertEqual(len(rows), 2 * 3)  # 2 exposures times 3 detectors
-        self.assertCountEqual(set(dataId["exposure"] for dataId in rows), (100, 101))
-        self.assertCountEqual(set(dataId["visit"] for dataId in rows), (10,))
-        self.assertCountEqual(set(dataId["detector"] for dataId in rows), (1, 2, 3))
+        self.assertCountEqual({dataId["exposure"] for dataId in rows}, (100, 101))
+        self.assertCountEqual({dataId["visit"] for dataId in rows}, (10,))
+        self.assertCountEqual({dataId["detector"] for dataId in rows}, (1, 2, 3))
 
         # more limiting expression, using link names instead of Table.column
         rows = registry.queryDataIds(
@@ -1101,9 +1101,9 @@ class RegistryTests(ABC):
             where="visit = 10 and detector > 1 and 'DummyCam'=instrument",
         ).toSet()
         self.assertEqual(len(rows), 2 * 2)  # 2 exposures times 2 detectors
-        self.assertCountEqual(set(dataId["exposure"] for dataId in rows), (100, 101))
-        self.assertCountEqual(set(dataId["visit"] for dataId in rows), (10,))
-        self.assertCountEqual(set(dataId["detector"] for dataId in rows), (2, 3))
+        self.assertCountEqual({dataId["exposure"] for dataId in rows}, (100, 101))
+        self.assertCountEqual({dataId["visit"] for dataId in rows}, (10,))
+        self.assertCountEqual({dataId["detector"] for dataId in rows}, (2, 3))
 
         # queryDataIds with only one of `datasets` and `collections` is an
         # error.
@@ -1128,9 +1128,9 @@ class RegistryTests(ABC):
             instrument="DummyCam",
         ).toSet()
         self.assertEqual(len(rows), 2 * 3)  # 2 exposures times 3 detectors
-        self.assertCountEqual(set(dataId["exposure"] for dataId in rows), (110, 111))
-        self.assertCountEqual(set(dataId["visit"] for dataId in rows), (11,))
-        self.assertCountEqual(set(dataId["detector"] for dataId in rows), (1, 2, 3))
+        self.assertCountEqual({dataId["exposure"] for dataId in rows}, (110, 111))
+        self.assertCountEqual({dataId["visit"] for dataId in rows}, (11,))
+        self.assertCountEqual({dataId["detector"] for dataId in rows}, (1, 2, 3))
 
     def testSkyMapDimensions(self):
         """Tests involving only skymap dimensions, no joins to instrument."""
@@ -1198,9 +1198,9 @@ class RegistryTests(ABC):
         self.assertEqual(len(rows), 3 * 4 * 2)  # 4 tracts x 4 patches x 2 filters
         for dataId in rows:
             self.assertCountEqual(dataId.keys(), ("skymap", "tract", "patch", "band"))
-        self.assertCountEqual(set(dataId["tract"] for dataId in rows), (1, 3, 5))
-        self.assertCountEqual(set(dataId["patch"] for dataId in rows), (2, 4, 6, 7))
-        self.assertCountEqual(set(dataId["band"] for dataId in rows), ("i", "r"))
+        self.assertCountEqual({dataId["tract"] for dataId in rows}, (1, 3, 5))
+        self.assertCountEqual({dataId["patch"] for dataId in rows}, (2, 4, 6, 7))
+        self.assertCountEqual({dataId["band"] for dataId in rows}, ("i", "r"))
 
         # limit to 2 tracts and 2 patches
         rows = registry.queryDataIds(
@@ -1211,18 +1211,18 @@ class RegistryTests(ABC):
             skymap="DummyMap",
         ).toSet()
         self.assertEqual(len(rows), 2 * 2 * 2)  # 2 tracts x 2 patches x 2 filters
-        self.assertCountEqual(set(dataId["tract"] for dataId in rows), (1, 5))
-        self.assertCountEqual(set(dataId["patch"] for dataId in rows), (2, 7))
-        self.assertCountEqual(set(dataId["band"] for dataId in rows), ("i", "r"))
+        self.assertCountEqual({dataId["tract"] for dataId in rows}, (1, 5))
+        self.assertCountEqual({dataId["patch"] for dataId in rows}, (2, 7))
+        self.assertCountEqual({dataId["band"] for dataId in rows}, ("i", "r"))
 
         # limit to single filter
         rows = registry.queryDataIds(
             dimensions, datasets=[calexpType, mergeType], collections=run, where="band = 'i'"
         ).toSet()
         self.assertEqual(len(rows), 3 * 4 * 1)  # 4 tracts x 4 patches x 2 filters
-        self.assertCountEqual(set(dataId["tract"] for dataId in rows), (1, 3, 5))
-        self.assertCountEqual(set(dataId["patch"] for dataId in rows), (2, 4, 6, 7))
-        self.assertCountEqual(set(dataId["band"] for dataId in rows), ("i",))
+        self.assertCountEqual({dataId["tract"] for dataId in rows}, (1, 3, 5))
+        self.assertCountEqual({dataId["patch"] for dataId in rows}, (2, 4, 6, 7))
+        self.assertCountEqual({dataId["band"] for dataId in rows}, ("i",))
 
         # Specifying non-existing skymap is an exception
         with self.assertRaisesRegex(DataIdValueError, "Unknown values specified for governor dimension"):

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -145,7 +145,7 @@ class RegistryTests(ABC):
         """
         from ...transfers import YamlRepoImportBackend
 
-        with open(os.path.join(self.getDataDir(), filename), "r") as stream:
+        with open(os.path.join(self.getDataDir(), filename)) as stream:
             backend = YamlRepoImportBackend(stream, registry)
         backend.register()
         backend.load(datastore=None)
@@ -1145,7 +1145,7 @@ class RegistryTests(ABC):
             dict(instrument="DummyCam", name="dummy_r", band="r"),
             dict(instrument="DummyCam", name="dummy_i", band="i"),
         )
-        registry.insertDimensionData("skymap", dict(name="DummyMap", hash="sha!".encode("utf8")))
+        registry.insertDimensionData("skymap", dict(name="DummyMap", hash=b"sha!"))
         for tract in range(10):
             registry.insertDimensionData("tract", dict(skymap="DummyMap", id=tract))
             registry.insertDimensionData(

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -88,13 +88,13 @@ class CategorizedWildcard:
             If `False` (`True` is default) raise `TypeError` if a `re.Pattern`
             is encountered, or if ``expression`` is a `CategorizedWildcard`
             with `patterns` not empty.
-        coerceUnrecognized: `Callable`, optional
+        coerceUnrecognized: `~collections.abc.Callable`, optional
             A callback that takes a single argument of arbitrary type and
             returns either a `str` - appended to `strings` - or a `tuple` of
             (`str`, `Any`) to be appended to `items`.  This will be called on
             objects of unrecognized type. Exceptions will be reraised as
             `TypeError` (and chained).
-        coerceItemValue: `Callable`, optional
+        coerceItemValue: `~collections.abc.Callable`, optional
             If provided, ``expression`` may be a mapping from `str` to any
             type that can be passed to this function; the result of that call
             will be stored instead as the value in ``self.items``.
@@ -458,7 +458,7 @@ class CollectionWildcard:
 
         Parameters
         ----------
-        names : `Iterable` [ `str` ]
+        names : `~collections.abc.Iterable` [ `str` ]
             Iterable of collection names.
 
         Returns

--- a/python/lsst/daf/butler/script/ingest_files.py
+++ b/python/lsst/daf/butler/script/ingest_files.py
@@ -103,7 +103,7 @@ def ingest_files(
     datasetType = butler.registry.getDatasetType(dataset_type)
 
     # Convert the k=v strings into a dataId dict.
-    universe = butler.registry.dimensions
+    universe = butler.dimensions
     common_data_id = parse_data_id_tuple(data_id, universe)
 
     # Read the table assuming that Astropy can work out the format.

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -186,10 +186,11 @@ def queryCollections(
     repo : `str`
         URI to the location of the repo or URI to a config file describing the
         repo and its location.
-    glob : `Iterable` [`str`]
+    glob : `~collections.abc.Iterable` [`str`]
         A list of glob-style search string that fully or partially identify
         the dataset type names to search for.
-    collection_type : `Iterable` [ `CollectionType` ], optional
+    collection_type : `~collections.abc.Iterable` [ `CollectionType` ], \
+            optional
         If provided, only return collections of these types.
     chains : `str`
         Must be one of "FLATTEN", "TABLE", or "TREE" (case sensitive).

--- a/python/lsst/daf/butler/script/register_dataset_type.py
+++ b/python/lsst/daf/butler/script/register_dataset_type.py
@@ -72,7 +72,7 @@ def register_dataset_type(
 
     # mypy does not think that Tuple[str, ...] is allowed for DatasetType
     # constructor so we have to do the conversion here.
-    graph = butler.registry.dimensions.extract(dimensions)
+    graph = butler.dimensions.extract(dimensions)
 
     datasetType = DatasetType(
         dataset_type,
@@ -80,7 +80,7 @@ def register_dataset_type(
         storage_class,
         parentStorageClass=None,
         isCalibration=is_calibration,
-        universe=butler.registry.dimensions,
+        universe=butler.dimensions,
     )
 
     return butler.registry.registerDatasetType(datasetType)

--- a/python/lsst/daf/butler/server.py
+++ b/python/lsst/daf/butler/server.py
@@ -136,7 +136,7 @@ registry:
 @app.get("/butler/v1/universe", response_model=dict[str, Any])
 def get_dimension_universe(butler: Butler = Depends(butler_readonly_dependency)) -> DimensionConfig:
     """Allow remote client to get dimensions definition."""
-    return butler.registry.dimensions.dimensionConfig
+    return butler.dimensions.dimensionConfig
 
 
 @app.get("/butler/v1/uri/{id}", response_model=str)

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -271,7 +271,7 @@ class MetricsExampleModel(BaseModel):
     data: list[Any] | None
 
     @classmethod
-    def from_metrics(cls, metrics: MetricsExample) -> "MetricsExampleModel":
+    def from_metrics(cls, metrics: MetricsExample) -> MetricsExampleModel:
         """Create a model based on an example."""
         return cls.parse_obj(metrics.exportAsDict())
 

--- a/python/lsst/daf/butler/tests/_testRepo.py
+++ b/python/lsst/daf/butler/tests/_testRepo.py
@@ -111,9 +111,9 @@ def makeTestRepo(
     # newConfig guards against location-related keywords like outfile
     newConfig = Butler.makeRepo(root, config=defaults, forceConfigRoot=False, **kwargs)
     butler = Butler(newConfig, writeable=True)
-    dimensionRecords = _makeRecords(dataIds, butler.registry.dimensions)
+    dimensionRecords = _makeRecords(dataIds, butler.dimensions)
     for dimension, records in dimensionRecords.items():
-        if butler.registry.dimensions[dimension].viewOf is None:
+        if butler.dimensions[dimension].viewOf is None:
             butler.registry.insertDimensionData(dimension, *records)
     return butler
 
@@ -435,7 +435,7 @@ def addDataIdValue(butler: Butler, dimension: str, value: str | int, **related: 
     # Example is not doctest, because it's probably unsafe to create even an
     # in-memory butler in that environment.
     try:
-        fullDimension = butler.registry.dimensions[dimension]
+        fullDimension = butler.dimensions[dimension]
     except KeyError as e:
         raise ValueError from e
     # Bad keys ignored by registry code
@@ -451,7 +451,7 @@ def addDataIdValue(butler: Butler, dimension: str, value: str | int, **related: 
     data_id.update(related)
 
     # Compute the set of all dimensions that these recursively depend on.
-    all_dimensions = butler.registry.dimensions.extract(data_id.keys())
+    all_dimensions = butler.dimensions.extract(data_id.keys())
 
     # Create dicts that will become DimensionRecords for all of these data IDs.
     # This iteration is guaranteed to be in topological order, so we can count
@@ -524,7 +524,7 @@ def addDatasetType(butler: Butler, name: str, dimensions: set[str], storageClass
     function does not need to be run for each collection.
     """
     try:
-        datasetType = DatasetType(name, dimensions, storageClass, universe=butler.registry.dimensions)
+        datasetType = DatasetType(name, dimensions, storageClass, universe=butler.dimensions)
         butler.registry.registerDatasetType(datasetType)
         return datasetType
     except KeyError as e:

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -290,7 +290,7 @@ class CliLogTestBase:
                 # There are cases where the newlines are stripped from the log
                 # output (like in Jenkins), since we can't depend on newlines
                 # in log output they are removed here from test output.
-                output = StringIO((result.stderr.decode().replace("\n", " ")))
+                output = StringIO(result.stderr.decode().replace("\n", " "))
                 startedWithTimestamp = any([timestampRegex.match(line) for line in output.readlines()])
                 output.seek(0)
                 startedWithModule = any(modulesRegex.match(line) for line in output.readlines())

--- a/python/lsst/daf/butler/tests/dict_convertible_model.py
+++ b/python/lsst/daf/butler/tests/dict_convertible_model.py
@@ -43,7 +43,7 @@ class DictConvertibleModel(BaseModel):
     """
 
     @classmethod
-    def from_dict(cls, content: Mapping[str, str], extra: str = "from_dict") -> "DictConvertibleModel":
+    def from_dict(cls, content: Mapping[str, str], extra: str = "from_dict") -> DictConvertibleModel:
         """Construct an instance from a `dict`.
 
         Parameters

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -139,7 +139,7 @@ class MetricsExampleFormatter(Formatter):
         # uses yaml or json.
         path = self.fileDescriptor.location.path
 
-        with open(path, "r") as fd:
+        with open(path) as fd:
             if path.endswith(".yaml"):
                 data = yaml.load(fd, Loader=yaml.SafeLoader)
             elif path.endswith(".json"):
@@ -232,7 +232,7 @@ class MetricsExampleDataFormatter(Formatter):
         # This formatter can not read a subset from disk because it
         # uses yaml.
         path = self.fileDescriptor.location.path
-        with open(path, "r") as fd:
+        with open(path) as fd:
             data = yaml.load(fd, Loader=yaml.SafeLoader)
 
         # We can slice up front if required

--- a/python/lsst/daf/butler/transfers/_context.py
+++ b/python/lsst/daf/butler/transfers/_context.py
@@ -128,7 +128,7 @@ class RepoExportContext:
         element : `str` or `DimensionElement`
             `DimensionElement` or `str` indicating the logical table these
             records are from.
-        records : `Iterable` [ `DimensionRecord` or `dict` ]
+        records : `~collections.abc.Iterable` [ `DimensionRecord` or `dict` ]
             Records to export, as an iterable containing `DimensionRecord` or
             `dict` instances.
         """

--- a/python/lsst/daf/butler/transfers/_context.py
+++ b/python/lsst/daf/butler/transfers/_context.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 __all__ = ["RepoExportContext"]
 
 from collections import defaultdict
-from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, AbstractSet
+from collections.abc import Callable, Iterable, Set
+from typing import TYPE_CHECKING
 
 from ..core import (
     DataCoordinate,
@@ -164,7 +164,7 @@ class RepoExportContext:
             Dimension elements whose records should be exported.  If `None`,
             records for all dimensions will be exported.
         """
-        standardized_elements: AbstractSet[DimensionElement]
+        standardized_elements: Set[DimensionElement]
         if elements is None:
             standardized_elements = frozenset(
                 element

--- a/python/lsst/daf/butler/transfers/_context.py
+++ b/python/lsst/daf/butler/transfers/_context.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 __all__ = ["RepoExportContext"]
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, AbstractSet, Callable, Dict, Iterable, List, Optional, Set, Union
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, AbstractSet
 
 from ..core import (
     DataCoordinate,
@@ -76,20 +77,20 @@ class RepoExportContext:
         datastore: Datastore,
         backend: RepoExportBackend,
         *,
-        directory: Optional[ResourcePathExpression] = None,
-        transfer: Optional[str] = None,
+        directory: ResourcePathExpression | None = None,
+        transfer: str | None = None,
     ):
         self._registry = registry
         self._datastore = datastore
         self._backend = backend
         self._directory = directory
         self._transfer = transfer
-        self._records: Dict[DimensionElement, Dict[DataCoordinate, DimensionRecord]] = defaultdict(dict)
-        self._dataset_ids: Set[DatasetId] = set()
-        self._datasets: Dict[DatasetType, Dict[str, List[FileDataset]]] = defaultdict(
+        self._records: dict[DimensionElement, dict[DataCoordinate, DimensionRecord]] = defaultdict(dict)
+        self._dataset_ids: set[DatasetId] = set()
+        self._datasets: dict[DatasetType, dict[str, list[FileDataset]]] = defaultdict(
             lambda: defaultdict(list)
         )
-        self._collections: Dict[str, CollectionRecord] = {}
+        self._collections: dict[str, CollectionRecord] = {}
 
     def saveCollection(self, name: str) -> None:
         """Export the given collection.
@@ -117,7 +118,7 @@ class RepoExportContext:
         self._collections[name] = self._registry._get_collection_record(name)
 
     def saveDimensionData(
-        self, element: Union[str, DimensionElement], records: Iterable[Union[dict, DimensionRecord]]
+        self, element: str | DimensionElement, records: Iterable[dict | DimensionRecord]
     ) -> None:
         """Export the given dimension records associated with one or more data
         IDs.
@@ -147,7 +148,7 @@ class RepoExportContext:
         self,
         dataIds: Iterable[DataCoordinate],
         *,
-        elements: Optional[Iterable[Union[str, DimensionElement]]] = None,
+        elements: Iterable[str | DimensionElement] | None = None,
     ) -> None:
         """Export the dimension records associated with one or more data IDs.
 
@@ -192,8 +193,8 @@ class RepoExportContext:
         self,
         refs: Iterable[DatasetRef],
         *,
-        elements: Optional[Iterable[Union[str, DimensionElement]]] = None,
-        rewrite: Optional[Callable[[FileDataset], FileDataset]] = None,
+        elements: Iterable[str | DimensionElement] | None = None,
+        rewrite: Callable[[FileDataset], FileDataset] | None = None,
     ) -> None:
         """Export one or more datasets.
 
@@ -291,7 +292,7 @@ class RepoExportContext:
             )
         self._backend.finish()
 
-    def _computeSortedCollections(self) -> List[str]:
+    def _computeSortedCollections(self) -> list[str]:
         """Sort collections in a way that is both deterministic and safe
         for registering them in a new repo in the presence of nested chains.
 
@@ -305,8 +306,8 @@ class RepoExportContext:
         # Split collections into CHAINED and everything else, and just
         # sort "everything else" lexicographically since there are no
         # dependencies.
-        chains: Dict[str, List[str]] = {}
-        result: List[str] = []
+        chains: dict[str, list[str]] = {}
+        result: list[str] = []
         for record in self._collections.values():
             if record.type is CollectionType.CHAINED:
                 assert isinstance(record, ChainedCollectionRecord)
@@ -331,7 +332,7 @@ class RepoExportContext:
                 del chains[name]
         return result
 
-    def _computeDatasetAssociations(self) -> Dict[str, List[DatasetAssociation]]:
+    def _computeDatasetAssociations(self) -> dict[str, list[DatasetAssociation]]:
         """Return datasets-collection associations, grouped by association.
 
         This queries for all associations between exported datasets and

--- a/python/lsst/daf/butler/transfers/_interfaces.py
+++ b/python/lsst/daf/butler/transfers/_interfaces.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 __all__ = ["RepoExportBackend", "RepoImportBackend", "RepoTransferFormatConfig"]
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Iterable, Optional, Set
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from ..core import (
     ConfigSubset,
@@ -72,7 +73,7 @@ class RepoExportBackend(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def saveCollection(self, record: CollectionRecord, doc: Optional[str]) -> None:
+    def saveCollection(self, record: CollectionRecord, doc: str | None) -> None:
         """Export a collection.
 
         This only exports the collection's own state, not its associations with
@@ -151,11 +152,11 @@ class RepoImportBackend(ABC):
     @abstractmethod
     def load(
         self,
-        datastore: Optional[Datastore],
+        datastore: Datastore | None,
         *,
         directory: ResourcePathExpression | None = None,
-        transfer: Optional[str] = None,
-        skip_dimensions: Optional[Set] = None,
+        transfer: str | None = None,
+        skip_dimensions: set | None = None,
     ) -> None:
         """Import information associated with the backend into the given
         registry and datastore.

--- a/python/lsst/daf/butler/transfers/_interfaces.py
+++ b/python/lsst/daf/butler/transfers/_interfaces.py
@@ -120,7 +120,7 @@ class RepoExportBackend(ABC):
             The type of the collection; either `CollectionType.TAGGED` or
             `CollectionType.CALIBRATION` (as other collection types are
             exported in other ways).
-        associations : `Iterable` [ `DatasetAssociation` ]
+        associations : `~collections.abc.Iterable` [ `DatasetAssociation` ]
             Structs representing an association between this collection and
             this dataset.
         """

--- a/tests/data/registry/spatial.py
+++ b/tests/data/registry/spatial.py
@@ -420,7 +420,7 @@ def write_yaml(filename: str):
             },
         ],
     }
-    with open(filename, mode="wt") as file:
+    with open(filename, mode="w") as file:
         file.write("# Spatial test data; see spatial.py for more information.\n")
         yaml.dump(document, file, sort_keys=False)
 

--- a/tests/data/registry/spatial.py
+++ b/tests/data/registry/spatial.py
@@ -39,7 +39,8 @@ in the future.
 
 import argparse
 import os.path
-from typing import Any, Callable, Iterable, Iterator, Optional, Union
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
 
 import lsst.daf.butler  # noqa:F401; register Time/YAML conversions.
 import numpy as np
@@ -424,7 +425,7 @@ def write_yaml(filename: str):
         yaml.dump(document, file, sort_keys=False)
 
 
-def lonlat_tuple(position: Union[LonLat, Vector3d]):
+def lonlat_tuple(position: LonLat | Vector3d):
     """Transform a `lsst.sphgeom.LonLat` or `lsst.sphgeom.Vector3d` to a
     2-tuple of `float` degrees.
     """
@@ -432,7 +433,7 @@ def lonlat_tuple(position: Union[LonLat, Vector3d]):
     return (lonlat.getLon().asDegrees(), lonlat.getLat().asDegrees())
 
 
-def make_tangent_wcs(position: Union[LonLat, Vector3d]) -> WCS:
+def make_tangent_wcs(position: LonLat | Vector3d) -> WCS:
     """Create an `astropy.WCS` that maps the sky to a tangent plane with
     degree-unit pixels at the given point.
 
@@ -531,7 +532,7 @@ def plot_hull(
         callback(indices, center, vertices)
 
 
-def polygons(label: Optional[str] = None, **kwargs: Any):
+def polygons(label: str | None = None, **kwargs: Any):
     """Return a callback for use with `plot_pixels` and `plot_hull` that plots
     polygon vertices.
 

--- a/tests/test_astropyTableFormatter.py
+++ b/tests/test_astropyTableFormatter.py
@@ -50,7 +50,7 @@ class AstropyTableFormatterTestCase(unittest.TestCase):
 
     def testAstropyTableFormatter(self):
         butler = Butler(self.root, run="testrun")
-        datasetType = DatasetType("table", [], "AstropyTable", universe=butler.registry.dimensions)
+        datasetType = DatasetType("table", [], "AstropyTable", universe=butler.dimensions)
         butler.registry.registerDatasetType(datasetType)
         ref = butler.put(self.table, datasetType)
         uri = butler.getURI(ref)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -199,7 +199,7 @@ class ButlerPutGetTests(TestCaseMixin):
         self.assertEqual(collections, set([run]))
 
         # Create and register a DatasetType
-        dimensions = butler.registry.dimensions.extract(["instrument", "visit"])
+        dimensions = butler.dimensions.extract(["instrument", "visit"])
 
         datasetType = self.addDatasetType(datasetTypeName, dimensions, storageClass, butler.registry)
 
@@ -488,7 +488,7 @@ class ButlerPutGetTests(TestCaseMixin):
         # Construct a butler with no run or collection, but make it writeable.
         butler = Butler(self.tmpConfigFile, writeable=True)
         # Create and register a DatasetType
-        dimensions = butler.registry.dimensions.extract(["instrument", "visit"])
+        dimensions = butler.dimensions.extract(["instrument", "visit"])
         datasetType = self.addDatasetType(
             "example", dimensions, self.storageClassFactory.getStorageClass("StructuredData"), butler.registry
         )
@@ -820,7 +820,7 @@ class ButlerTests(ButlerPutGetTests):
         butler = Butler(self.tmpConfigFile, run=self.default_run)
 
         # Create and register a DatasetType
-        dimensions = butler.registry.dimensions.extract(["instrument", "visit", "detector"])
+        dimensions = butler.dimensions.extract(["instrument", "visit", "detector"])
 
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataDictYaml")
         datasetTypeName = "metric"
@@ -978,7 +978,7 @@ class ButlerTests(ButlerPutGetTests):
 
     def testGetDatasetTypes(self) -> None:
         butler = Butler(self.tmpConfigFile, run=self.default_run)
-        dimensions = butler.registry.dimensions.extract(["instrument", "visit", "physical_filter"])
+        dimensions = butler.dimensions.extract(["instrument", "visit", "physical_filter"])
         dimensionEntries: list[tuple[str, list[Mapping[str, Any]]]] = [
             (
                 "instrument",
@@ -1053,7 +1053,7 @@ class ButlerTests(ButlerPutGetTests):
     def testTransaction(self) -> None:
         butler = Butler(self.tmpConfigFile, run=self.default_run)
         datasetTypeName = "test_metric"
-        dimensions = butler.registry.dimensions.extract(["instrument", "visit"])
+        dimensions = butler.dimensions.extract(["instrument", "visit"])
         dimensionEntries: tuple[tuple[str, Mapping[str, Any]], ...] = (
             ("instrument", {"instrument": "DummyCam"}),
             ("physical_filter", {"instrument": "DummyCam", "name": "d-r", "band": "R"}),
@@ -1168,7 +1168,7 @@ class ButlerTests(ButlerPutGetTests):
             "detector", {"instrument": "DummyCamComp", "id": 1, "full_name": "det1"}
         )
 
-        dimensions = butler.registry.dimensions.extract(["instrument", "exposure"])
+        dimensions = butler.dimensions.extract(["instrument", "exposure"])
         datasetType = DatasetType(datasetTypeName, dimensions, storageClass)
         butler.registry.registerDatasetType(datasetType)
 
@@ -1239,7 +1239,7 @@ class FileDatastoreButlerTests(ButlerTests):
 
         # Create two almost-identical DatasetTypes (both will use default
         # template)
-        dimensions = butler.registry.dimensions.extract(["instrument", "visit"])
+        dimensions = butler.dimensions.extract(["instrument", "visit"])
         butler.registry.registerDatasetType(DatasetType("metric1", dimensions, storageClass))
         butler.registry.registerDatasetType(DatasetType("metric2", dimensions, storageClass))
         butler.registry.registerDatasetType(DatasetType("metric3", dimensions, storageClass))
@@ -1361,7 +1361,7 @@ class FileDatastoreButlerTests(ButlerTests):
                         self.assertTrue(importButler.exists(ref.datasetType, ref.dataId))
                 self.assertEqual(
                     list(importButler.registry.queryDimensionRecords("skymap")),
-                    [importButler.registry.dimensions["skymap"].RecordClass(**skymapRecord)],
+                    [importButler.dimensions["skymap"].RecordClass(**skymapRecord)],
                 )
 
     def testRemoveRuns(self) -> None:
@@ -1377,7 +1377,7 @@ class FileDatastoreButlerTests(ButlerTests):
         butler.registry.registerRun(run2)
         # put a dataset in each
         metric = makeExampleMetrics()
-        dimensions = butler.registry.dimensions.extract(["instrument", "physical_filter"])
+        dimensions = butler.dimensions.extract(["instrument", "physical_filter"])
         datasetType = self.addDatasetType(
             "prune_collections_test_dataset", dimensions, storageClass, butler.registry
         )
@@ -1486,7 +1486,7 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         # put some datasets.  ref1 and ref2 have the same data ID, and are in
         # different runs.  ref3 has a different data ID.
         metric = makeExampleMetrics()
-        dimensions = butler.registry.dimensions.extract(["instrument", "physical_filter"])
+        dimensions = butler.dimensions.extract(["instrument", "physical_filter"])
         datasetType = self.addDatasetType(
             "prune_collections_test_dataset", dimensions, storageClass, butler.registry
         )
@@ -2083,7 +2083,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
         run = "run1"
         self.source_butler.registry.registerCollection(run, CollectionType.RUN)
 
-        dimensions = self.source_butler.registry.dimensions.extract(())
+        dimensions = self.source_butler.dimensions.extract(())
         datasetType = DatasetType(datasetTypeName, dimensions, storageClass)
         self.source_butler.registry.registerDatasetType(datasetType)
 
@@ -2140,7 +2140,7 @@ class PosixDatastoreTransfers(unittest.TestCase):
             )
 
         # Create dataset types in the source butler.
-        dimensions = self.source_butler.registry.dimensions.extract(["instrument", "exposure"])
+        dimensions = self.source_butler.dimensions.extract(["instrument", "exposure"])
         for datasetTypeName in datasetTypeNames:
             datasetType = DatasetType(datasetTypeName, dimensions, storageClass)
             self.source_butler.registry.registerDatasetType(datasetType)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -196,7 +196,7 @@ class ButlerPutGetTests(TestCaseMixin):
         butler = Butler(self.tmpConfigFile, run=run)
 
         collections = set(butler.registry.queryCollections())
-        self.assertEqual(collections, set([run]))
+        self.assertEqual(collections, {run})
 
         # Create and register a DatasetType
         dimensions = butler.dimensions.extract(["instrument", "visit"])
@@ -589,7 +589,7 @@ class ButlerTests(ButlerPutGetTests):
             with ResourcePath.temporary_uri(suffix=suffix) as temp_file:
                 butler_index.dumpToUri(temp_file)
                 with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": str(temp_file)}):
-                    self.assertEqual(Butler.get_known_repos(), set(("label", "bad_label")))
+                    self.assertEqual(Butler.get_known_repos(), {"label", "bad_label"})
                     uri = Butler.get_repo_uri("bad_label")
                     self.assertEqual(uri, ResourcePath(bad_label))
                     uri = Butler.get_repo_uri("label")

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1345,7 +1345,7 @@ class FileDatastoreButlerTests(ButlerTests):
                 # butler command line interface "import" subcommand. Functions
                 # in the script folder are generally considered protected and
                 # should not be used as public api.
-                with open(exportFile, "r") as f:
+                with open(exportFile) as f:
                     script.butlerImport(
                         importDir,
                         export_file=f,

--- a/tests/test_cliCmdConfigDump.py
+++ b/tests/test_cliCmdConfigDump.py
@@ -78,7 +78,7 @@ class ConfigDumpUseTest(unittest.TestCase):
             result = self.runner.invoke(butler.cli, ["config-dump", "here", "--file=there"])
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
             # check for some expected keywords:
-            with open("there", "r") as f:
+            with open("there") as f:
                 cfg = yaml.safe_load(f)
                 self.assertIn("datastore", cfg)
                 self.assertIn("composites", cfg["datastore"])

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -24,7 +24,6 @@
 
 import os
 import unittest
-from typing import List
 
 from astropy.table import Table
 from lsst.daf.butler import Butler, CollectionType
@@ -118,7 +117,7 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
     def setUp(self):
         self.runner = LogCliRunner()
 
-    def assertChain(self, args: List[str], expected: str):
+    def assertChain(self, args: list[str], expected: str):
         """Run collection-chain and check the expected result"""
         result = self.runner.invoke(cli, ["collection-chain", "here", *args])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))

--- a/tests/test_cliCmdQueryDataIds.py
+++ b/tests/test_cliCmdQueryDataIds.py
@@ -164,7 +164,7 @@ class QueryDataIdsTest(unittest.TestCase, ButlerTestHelper):
             "test_metric_dimensionless",
             (),
             "StructuredDataDict",
-            universe=butler.registry.dimensions,
+            universe=butler.dimensions,
         )
         butler.registry.registerDatasetType(new_dataset_type)
         res, msg = self._queryDataIds(repo=self.root, collections=("imported_g",), datasets=...)

--- a/tests/test_cliCmdQueryDataIds.py
+++ b/tests/test_cliCmdQueryDataIds.py
@@ -65,7 +65,7 @@ class QueryDataIdsTest(unittest.TestCase, ButlerTestHelper):
         """
         butler = Butler(self.repo, writeable=True)
         for filename in filenames:
-            with open(os.path.join(TESTDIR, "data", "registry", filename), "r") as stream:
+            with open(os.path.join(TESTDIR, "data", "registry", filename)) as stream:
                 # Go behind the back of the import code a bit to deal with
                 # the fact that this is just registry content with no actual
                 # files for the datastore.

--- a/tests/test_cliCmdQueryDatasets.py
+++ b/tests/test_cliCmdQueryDatasets.py
@@ -238,7 +238,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
                 names=("type", "run", "band", "instrument", "physical_filter", "visit"),
             ),
             AstropyTable(
-                array((("alt_test_metric_comp", "ingest/run", "R", "DummyCamComp", "d-r", "425"))),
+                array(("alt_test_metric_comp", "ingest/run", "R", "DummyCamComp", "d-r", "425")),
                 names=("type", "run", "band", "instrument", "physical_filter", "visit"),
             ),
         )

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -275,7 +275,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
         result = self.runner.invoke(butlerCli, ["query-dimension-records", self.root, "skymap"])
         self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
-        rows = array((("example_skymap", "0x3200000000000000", "None", "None", "None")))
+        rows = array(("example_skymap", "0x3200000000000000", "None", "None", "None"))
         expected = AstropyTable(rows, names=["name", "hash", "tract_max", "patch_nx_max", "patch_ny_max"])
         self.assertAstropyTablesEqual(readTable(result.output), expected)
 

--- a/tests/test_cliCmdRemoveCollections.py
+++ b/tests/test_cliCmdRemoveCollections.py
@@ -24,7 +24,7 @@
 
 import os
 import unittest
-from typing import Sequence, Tuple, Union
+from collections.abc import Sequence
 
 from astropy.table import Table
 from lsst.daf.butler import Butler, CollectionType
@@ -50,8 +50,8 @@ from numpy import array
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
-QueryCollectionsRow = Union[Tuple[str, str], Tuple[str, str, str]]
-RemoveCollectionRow = Tuple[str, str]
+QueryCollectionsRow = tuple[str, str] | tuple[str, str, str]
+RemoveCollectionRow = tuple[str, str]
 
 
 class RemoveCollectionTest(unittest.TestCase, ButlerTestHelper):

--- a/tests/test_cliCmdRemoveRuns.py
+++ b/tests/test_cliCmdRemoveRuns.py
@@ -58,7 +58,7 @@ class RemoveCollectionTest(unittest.TestCase):
             # Add a dataset type that will have no datasets to make sure it
             # isn't printed.
             repo.butler.registry.registerDatasetType(
-                DatasetType("no_datasets", repo.butler.registry.dimensions.empty, "StructuredDataDict")
+                DatasetType("no_datasets", repo.butler.dimensions.empty, "StructuredDataDict")
             )
 
             # Execute remove-runs but say no, check for expected outputs.

--- a/tests/test_cliCmdRetrieveArtifacts.py
+++ b/tests/test_cliCmdRetrieveArtifacts.py
@@ -24,7 +24,6 @@
 
 import os
 import unittest
-from typing import List
 
 from lsst.daf.butler import StorageClassFactory
 from lsst.daf.butler.cli.butler import cli
@@ -47,7 +46,7 @@ class CliRetrieveArtifactsTest(unittest.TestCase, ButlerTestHelper):
         removeTestTempDir(self.root)
 
     @staticmethod
-    def find_files(root: str) -> List[ResourcePath]:
+    def find_files(root: str) -> list[ResourcePath]:
         return list(ResourcePath.findFileResources([root]))
 
     def testRetrieveAll(self):

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -25,9 +25,9 @@ import math
 import os
 import pickle
 import unittest
+from collections.abc import Iterator
 from dataclasses import dataclass
 from random import Random
-from typing import Iterator, Optional
 
 import lsst.sphgeom
 from lsst.daf.butler import (
@@ -384,7 +384,7 @@ class SplitByStateFlags:
     values.
     """
 
-    minimal: Optional[DataCoordinateSequence] = None
+    minimal: DataCoordinateSequence | None = None
     """Data IDs that only contain values for required dimensions.
 
     `DataCoordinateSequence.hasFull()` will return `True` for this if and only
@@ -392,21 +392,21 @@ class SplitByStateFlags:
     `DataCoordinate.hasRecords()` will always return `False`.
     """
 
-    complete: Optional[DataCoordinateSequence] = None
+    complete: DataCoordinateSequence | None = None
     """Data IDs that contain values for all dimensions.
 
     `DataCoordinateSequence.hasFull()` will always `True` and
     `DataCoordinate.hasRecords()` will always return `True` for this attribute.
     """
 
-    expanded: Optional[DataCoordinateSequence] = None
+    expanded: DataCoordinateSequence | None = None
     """Data IDs that contain values for all dimensions as well as records.
 
     `DataCoordinateSequence.hasFull()` and `DataCoordinate.hasRecords()` will
     always return `True` for this attribute.
     """
 
-    def chain(self, n: Optional[int] = None) -> Iterator:
+    def chain(self, n: int | None = None) -> Iterator:
         """Iterate over the data IDs of different types.
 
         Parameters
@@ -442,7 +442,7 @@ class DataCoordinateTestCase(unittest.TestCase):
     def setUp(self):
         self.rng = Random(self.RANDOM_SEED)
 
-    def randomDataIds(self, n: int, dataIds: Optional[DataCoordinateSequence] = None):
+    def randomDataIds(self, n: int, dataIds: DataCoordinateSequence | None = None):
         """Select random data IDs from those loaded from test data.
 
         Parameters
@@ -467,7 +467,7 @@ class DataCoordinateTestCase(unittest.TestCase):
             check=False,
         )
 
-    def randomDimensionSubset(self, n: int = 3, graph: Optional[DimensionGraph] = None) -> DimensionGraph:
+    def randomDimensionSubset(self, n: int = 3, graph: DimensionGraph | None = None) -> DimensionGraph:
         """Generate a random `DimensionGraph` that has a subset of the
         dimensions in a given one.
 
@@ -493,7 +493,7 @@ class DataCoordinateTestCase(unittest.TestCase):
 
     def splitByStateFlags(
         self,
-        dataIds: Optional[DataCoordinateSequence] = None,
+        dataIds: DataCoordinateSequence | None = None,
         *,
         expanded: bool = True,
         complete: bool = True,

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -66,7 +66,7 @@ def loadDimensionData() -> DataCoordinateSequence:
     config = RegistryConfig()
     config["db"] = "sqlite://"
     registry = Registry.createFromConfig(config)
-    with open(DIMENSION_DATA_FILE, "r") as stream:
+    with open(DIMENSION_DATA_FILE) as stream:
         backend = YamlRepoImportBackend(stream, registry)
     backend.register()
     backend.load(datastore=None)

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -312,7 +312,7 @@ class ParserLexTestCase(unittest.TestCase):
         parser = ParserYacc()
 
         for op in ("=", "!=", "<", "<=", ">", ">="):
-            tree = parser.parse("a {} 10".format(op))
+            tree = parser.parse(f"a {op} 10")
             self.assertIsInstance(tree, exprTree.BinaryOp)
             self.assertEqual(tree.op, op)
             self.assertIsInstance(tree.lhs, exprTree.Identifier)
@@ -325,7 +325,7 @@ class ParserLexTestCase(unittest.TestCase):
         parser = ParserYacc()
 
         for op in ("OR", "AND"):
-            tree = parser.parse("a {} b".format(op))
+            tree = parser.parse(f"a {op} b")
             self.assertIsInstance(tree, exprTree.BinaryOp)
             self.assertEqual(tree.op, op)
             self.assertIsInstance(tree.lhs, exprTree.Identifier)

--- a/tests/test_logFormatter.py
+++ b/tests/test_logFormatter.py
@@ -44,9 +44,7 @@ class ButlerLogRecordsFormatterTestCase(unittest.TestCase):
 
         self.run = "testrun"
         self.butler = Butler(self.root, run=self.run)
-        self.datasetType = DatasetType(
-            "test_logs", [], "ButlerLogRecords", universe=self.butler.registry.dimensions
-        )
+        self.datasetType = DatasetType("test_logs", [], "ButlerLogRecords", universe=self.butler.dimensions)
 
         self.butler.registry.registerDatasetType(self.datasetType)
 

--- a/tests/test_matplotlibFormatter.py
+++ b/tests/test_matplotlibFormatter.py
@@ -60,7 +60,7 @@ class MatplotlibFormatterTestCase(unittest.TestCase):
 
     def testMatplotlibFormatter(self):
         butler = Butler(self.root, run="testrun")
-        datasetType = DatasetType("test_plot", [], "Plot", universe=butler.registry.dimensions)
+        datasetType = DatasetType("test_plot", [], "Plot", universe=butler.dimensions)
         butler.registry.registerDatasetType(datasetType)
         # Does not have to be a random image
         pyplot.imshow(

--- a/tests/test_normalFormExpression.py
+++ b/tests/test_normalFormExpression.py
@@ -22,7 +22,6 @@
 
 import random
 import unittest
-from typing import List, Optional, Union
 
 import astropy.time
 from lsst.daf.butler.registry.queries.expressions.normalForm import (
@@ -88,7 +87,7 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
     def visitIsIn(
         self,
         lhs: bool,
-        values: List[bool],
+        values: list[bool],
         not_in: bool,
         node: Node,
     ) -> bool:
@@ -99,7 +98,7 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
         # Docstring inherited from TreeVisitor.visitParens
         return expression
 
-    def visitRangeLiteral(self, start: int, stop: int, stride: Optional[int], node: Node) -> bool:
+    def visitRangeLiteral(self, start: int, stop: int, stride: int | None, node: Node) -> bool:
         # Docstring inherited from TreeVisitor.visitRangeLiteral
         raise NotImplementedError()
 
@@ -110,8 +109,8 @@ class NormalFormExpressionTestCase(unittest.TestCase):
     def check(
         self,
         expression: str,
-        conjunctive: Union[str, bool] = False,
-        disjunctive: Union[str, bool] = False,
+        conjunctive: str | bool = False,
+        disjunctive: str | bool = False,
     ) -> None:
         """Compare the results of transforming an expression to normal form
         against given expected values.

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -43,7 +43,7 @@ class PackagesFormatterTestCase(unittest.TestCase):
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
-            "data", dimensions=(), storageClass="Packages", universe=self.butler.registry.dimensions
+            "data", dimensions=(), storageClass="Packages", universe=self.butler.dimensions
         )
         self.butler.registry.registerDatasetType(self.datasetType)
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -281,7 +281,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
-            "data", dimensions=(), storageClass="DataFrame", universe=self.butler.registry.dimensions
+            "data", dimensions=(), storageClass="DataFrame", universe=self.butler.dimensions
         )
         self.butler.registry.registerDatasetType(self.datasetType)
 
@@ -406,7 +406,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
             "legacy_dataframe",
             dimensions=(),
             storageClass="DataFrame",
-            universe=self.butler.registry.dimensions,
+            universe=self.butler.dimensions,
         )
         self.butler.registry.registerDatasetType(legacy_type)
 
@@ -701,7 +701,7 @@ class ParquetFormatterArrowAstropyTestCase(unittest.TestCase):
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
-            "data", dimensions=(), storageClass="ArrowAstropy", universe=self.butler.registry.dimensions
+            "data", dimensions=(), storageClass="ArrowAstropy", universe=self.butler.dimensions
         )
         self.butler.registry.registerDatasetType(self.datasetType)
 
@@ -809,7 +809,7 @@ class ParquetFormatterArrowAstropyTestCase(unittest.TestCase):
             "astropy_parquet",
             dimensions=(),
             storageClass="ArrowAstropy",
-            universe=self.butler.registry.dimensions,
+            universe=self.butler.dimensions,
         )
         self.butler.registry.registerDatasetType(astropy_type)
 
@@ -1028,7 +1028,7 @@ class ParquetFormatterArrowNumpyTestCase(unittest.TestCase):
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
-            "data", dimensions=(), storageClass="ArrowNumpy", universe=self.butler.registry.dimensions
+            "data", dimensions=(), storageClass="ArrowNumpy", universe=self.butler.dimensions
         )
         self.butler.registry.registerDatasetType(self.datasetType)
 
@@ -1288,7 +1288,7 @@ class ParquetFormatterArrowTableTestCase(unittest.TestCase):
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
-            "data", dimensions=(), storageClass="ArrowTable", universe=self.butler.registry.dimensions
+            "data", dimensions=(), storageClass="ArrowTable", universe=self.butler.dimensions
         )
         self.butler.registry.registerDatasetType(self.datasetType)
 
@@ -1595,7 +1595,7 @@ class ParquetFormatterArrowNumpyDictTestCase(unittest.TestCase):
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
-            "data", dimensions=(), storageClass="ArrowNumpyDict", universe=self.butler.registry.dimensions
+            "data", dimensions=(), storageClass="ArrowNumpyDict", universe=self.butler.dimensions
         )
         self.butler.registry.registerDatasetType(self.datasetType)
 

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -26,7 +26,6 @@ import secrets
 import unittest
 import warnings
 from contextlib import contextmanager
-from typing import Optional
 
 import astropy.time
 
@@ -235,7 +234,7 @@ class PostgresqlRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
-    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Registry:
+    def makeRegistry(self, share_repo_with: Registry | None = None) -> Registry:
         if share_repo_with is None:
             namespace = f"namespace_{secrets.token_hex(8).lower()}"
         else:

--- a/tests/test_quantum.py
+++ b/tests/test_quantum.py
@@ -21,7 +21,7 @@
 
 import json
 import unittest
-from typing import Iterable, Tuple
+from collections.abc import Iterable
 
 from lsst.daf.butler import (
     DataCoordinate,
@@ -47,7 +47,7 @@ class MockTask:
 class QuantumTestCase(unittest.TestCase):
     """Test for Quantum."""
 
-    def _buildFullQuantum(self, taskName, addRecords=False) -> Tuple[Quantum, Iterable[DatasetType]]:
+    def _buildFullQuantum(self, taskName, addRecords=False) -> tuple[Quantum, Iterable[DatasetType]]:
         universe = DimensionUniverse()
         datasetTypeNameInit = "test_ds_init"
         datasetTypeNameInput = "test_ds_input"

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -174,8 +174,8 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         """Test state immediately after construction."""
 
         self.assertTrue(qbb.isWriteable())
-        self.assertEqual(qbb._predicted_inputs, set(ref.id for ref in self.all_input_refs))
-        self.assertEqual(qbb._predicted_outputs, set(ref.id for ref in self.output_refs))
+        self.assertEqual(qbb._predicted_inputs, {ref.id for ref in self.all_input_refs})
+        self.assertEqual(qbb._predicted_outputs, {ref.id for ref in self.output_refs})
         self.assertEqual(qbb._available_inputs, set())
         self.assertEqual(qbb._unavailable_inputs, set())
         self.assertEqual(qbb._actual_inputs, set())
@@ -202,7 +202,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         self.assertEqual(qbb._available_inputs, qbb._predicted_inputs)
         self.assertEqual(qbb._actual_inputs, qbb._predicted_inputs)
-        self.assertEqual(qbb._unavailable_inputs, set(ref.id for ref in self.missing_refs))
+        self.assertEqual(qbb._unavailable_inputs, {ref.id for ref in self.missing_refs})
 
         # Write all expected outputs.
         for ref in self.output_refs:
@@ -237,9 +237,9 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
                 data.get()
 
         # _avalable_inputs is not
-        self.assertEqual(qbb._available_inputs, set(ref.id for ref in input_refs + self.init_inputs_refs))
-        self.assertEqual(qbb._actual_inputs, set(ref.id for ref in input_refs + self.init_inputs_refs))
-        self.assertEqual(qbb._unavailable_inputs, set(ref.id for ref in self.missing_refs))
+        self.assertEqual(qbb._available_inputs, {ref.id for ref in input_refs + self.init_inputs_refs})
+        self.assertEqual(qbb._actual_inputs, {ref.id for ref in input_refs + self.init_inputs_refs})
+        self.assertEqual(qbb._unavailable_inputs, {ref.id for ref in self.missing_refs})
 
     def test_datasetExistsDirect(self) -> None:
         """Test for dataset existence method"""
@@ -272,7 +272,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
                 self.assertTrue(stored)
 
         # _available_inputs is not
-        self.assertEqual(qbb._available_inputs, set(ref.id for ref in input_refs + self.init_inputs_refs))
+        self.assertEqual(qbb._available_inputs, {ref.id for ref in input_refs + self.init_inputs_refs})
         self.assertEqual(qbb._actual_inputs, set())
         self.assertEqual(qbb._unavailable_inputs, set())  # this is not consistent with getDirect?
 
@@ -296,9 +296,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.assertEqual(qbb._actual_inputs, qbb._predicted_inputs)
 
         qbb.markInputUnused(self.input_refs[0])
-        self.assertEqual(
-            qbb._actual_inputs, set(ref.id for ref in self.input_refs[1:] + self.init_inputs_refs)
-        )
+        self.assertEqual(qbb._actual_inputs, {ref.id for ref in self.input_refs[1:] + self.init_inputs_refs})
 
     def test_pruneDatasets(self) -> None:
         """Test for pruneDatasets methods"""
@@ -365,11 +363,11 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         prov_json = provenance1.json()
         provenance2 = QuantumProvenanceData.direct(**json.loads(prov_json))
         for provenance in (provenance1, provenance2):
-            input_ids = set(ref.id for ref in self.input_refs + self.init_inputs_refs)
+            input_ids = {ref.id for ref in self.input_refs + self.init_inputs_refs}
             self.assertEqual(provenance.predicted_inputs, input_ids)
             self.assertEqual(provenance.available_inputs, input_ids)
             self.assertEqual(provenance.actual_inputs, input_ids)
-            output_ids = set(ref.id for ref in self.output_refs)
+            output_ids = {ref.id for ref in self.output_refs}
             self.assertEqual(provenance.predicted_outputs, output_ids)
             self.assertEqual(provenance.actual_outputs, output_ids)
             datastore_name = "FileDatastore@<butlerRoot>/datastore"
@@ -381,7 +379,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             self.assertEqual(set(datastore_records.records.keys()), {class_name})
             self.assertEqual(set(datastore_records.records[class_name].keys()), {table_name})
             self.assertEqual(
-                set(record["dataset_id"] for record in datastore_records.records[class_name][table_name]),
+                {record["dataset_id"] for record in datastore_records.records[class_name][table_name]},
                 output_ids,
             )
 

--- a/tests/test_query_relations.py
+++ b/tests/test_query_relations.py
@@ -60,7 +60,7 @@ class TestQueryRelationsTests(unittest.TestCase):
         # query system that simplify things as soon as it can spot that there
         # will be no overall results.
         data_file = os.path.normpath(os.path.join(TESTDIR, "data", "registry", "hsc-rc2-subset.yaml"))
-        with open(data_file, "r") as stream:
+        with open(data_file) as stream:
             backend = YamlRepoImportBackend(stream, cls.registry)
         backend.register()
         backend.load(datastore=None)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -87,7 +87,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
         self.assertIn("namespace", response.json())
 
     def test_registry(self):
-        universe = self.butler.registry.dimensions
+        universe = self.butler.dimensions
         self.assertEqual(universe.namespace, "daf_butler")
 
         dataset_type = self.butler.registry.getDatasetType("test_metric_comp")
@@ -131,9 +131,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
 
         # Create a DataCoordinate to test the alternate path for specifying
         # a data ID.
-        data_id = DataCoordinate.standardize(
-            {"instrument": "DummyCamComp"}, universe=self.butler.registry.dimensions
-        )
+        data_id = DataCoordinate.standardize({"instrument": "DummyCamComp"}, universe=self.butler.dimensions)
         records = list(self.butler.registry.queryDimensionRecords("physical_filter", dataId=data_id))
         self.assertEqual(len(records), 1)
 

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -571,7 +571,7 @@ class SimpleButlerTestCase(unittest.TestCase):
         butler.registry.insertDimensionData("instrument", {"name": "Cam2"})
         camera = DatasetType(
             "camera",
-            dimensions=butler.registry.dimensions["instrument"].graph,
+            dimensions=butler.dimensions["instrument"].graph,
             storageClass="Camera",
         )
         butler.registry.registerDatasetType(camera)
@@ -629,7 +629,7 @@ class SimpleButlerTestCase(unittest.TestCase):
 
                 # for minimal=False case also do a test without registry
                 if not minimal:
-                    from_json = type(test_item).from_json(json_str, universe=butler.registry.dimensions)
+                    from_json = type(test_item).from_json(json_str, universe=butler.dimensions)
                     self.assertEqual(from_json, test_item, msg=f"From JSON '{json_str}' using universe")
 
     def testJsonDimensionRecordsAndHtmlRepresentation(self):

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -109,7 +109,7 @@ class SimpleButlerTestCase(unittest.TestCase):
         # Spot-check a few things, but the most important test is just that
         # the above does not raise.
         self.assertGreaterEqual(
-            set(record.id for record in butler.registry.queryDimensionRecords("detector", instrument="HSC")),
+            {record.id for record in butler.registry.queryDimensionRecords("detector", instrument="HSC")},
             set(range(104)),  # should have all science CCDs; may have some focus ones.
         )
         self.assertGreaterEqual(

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -25,7 +25,6 @@ import stat
 import tempfile
 import unittest
 from contextlib import contextmanager
-from typing import Optional
 
 import sqlalchemy
 from lsst.daf.butler import ddl
@@ -196,7 +195,7 @@ class SqliteFileRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
-    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Registry:
+    def makeRegistry(self, share_repo_with: Registry | None = None) -> Registry:
         if share_repo_with is None:
             _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
         else:
@@ -242,7 +241,7 @@ class SqliteMemoryRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
-    def makeRegistry(self, share_repo_with: Optional[Registry] = None) -> Optional[Registry]:
+    def makeRegistry(self, share_repo_with: Registry | None = None) -> Registry | None:
         if share_repo_with is not None:
             return None
         config = self.makeRegistryConfig()

--- a/tests/test_storageClass.py
+++ b/tests/test_storageClass.py
@@ -362,7 +362,7 @@ class StorageClassFactoryTestCase(unittest.TestCase):
 
         # Try to coerce a type that is not supported.
         with self.assertRaises(TypeError):
-            sc.coerce_type(set([1, 2, 3]))
+            sc.coerce_type({1, 2, 3})
 
         # Coerce something that will fail to convert.
         with self.assertLogs(level=logging.ERROR) as cm:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -214,24 +214,24 @@ class TestFileTemplates(unittest.TestCase):
         testData = (
             (
                 "{run}/{datasetType}/{visit:05d}/{physical_filter}-trail",
-                set(["visit", "physical_filter"]),
+                {"visit", "physical_filter"},
                 set(),
-                set(["run", "datasetType"]),
+                {"run", "datasetType"},
                 set(),
             ),
             (
                 "{run}/{component:?}_{visit}",
-                set(["visit"]),
+                {"visit"},
                 set(),
-                set(["run"]),
-                set(["component"]),
+                {"run"},
+                {"component"},
             ),
             (
                 "{run}/{component:?}_{visit:?}_{physical_filter}_{instrument}_{datasetType}",
-                set(["physical_filter", "instrument"]),
-                set(["visit"]),
-                set(["run", "datasetType"]),
-                set(["component"]),
+                {"physical_filter", "instrument"},
+                {"visit"},
+                {"run", "datasetType"},
+                {"component"},
             ),
         )
         for tmplstr, mandatory, optional, special, optionalSpecial in testData:


### PR DESCRIPTION
This is the preferred interface and is part of the long-term goal of lowering the visibility of butler.registry.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
