### PR TITLE
DM-39663: Use Type rather than type[BaseModel] for protocol

### DIFF
--- a/python/lsst/daf/butler/core/json.py
+++ b/python/lsst/daf/butler/core/json.py
@@ -24,17 +24,15 @@ from __future__ import annotations
 __all__ = ("to_json_generic", "from_json_generic", "to_json_pydantic", "from_json_pydantic")
 
 import json
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, Type
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel
-
     from ..registry import Registry
     from .dimensions import DimensionUniverse
 
 
 class SupportsSimple(Protocol):
-    _serializedType: type[BaseModel]
+    _serializedType: Type
 
     def to_simple(self, minimal: bool) -> Any:
         ...


### PR DESCRIPTION
The "modern" version of the type confuses mypy, resulting in messages such as:

```python
python/lsst/pipe/base/graph/graph.py:1068: error: Invalid self argument "DatasetRef"  to attribute function "to_json" with type "Callable[[SupportsSimple, bool], str]"  [misc]
```

when using `ref.to_json()`.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
