### PR TITLE
DM-39665: Remove faked DataCoordinate from all tests

### DIFF
--- a/doc/changes/DM-39665.misc.rst
+++ b/doc/changes/DM-39665.misc.rst
@@ -1,0 +1,3 @@
+Changed all Butler code and tests to use conforming DataIDs.
+Removed the fake ``DataCoordinate`` classes from the datastore tests.
+Improved type annotations in some test files.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -2512,12 +2512,13 @@ class Butler(LimitedButler):
         # a DatasetRef for each defined instrument
         datasetRefs = []
 
+        dimensions = self.dimensions.extract(("instrument",))
         for datasetType in datasetTypes:
             if "instrument" in datasetType.dimensions:
                 for instrument in instruments:
                     datasetRef = DatasetRef(
                         datasetType,
-                        {"instrument": instrument},  # type: ignore
+                        DataCoordinate.standardize(instrument=instrument, graph=dimensions),
                         conform=False,
                         run="validate",
                     )

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -2505,24 +2505,26 @@ class Butler(LimitedButler):
         else:
             ignore = set()
 
-        # Find all the registered instruments
-        instruments = {record.name for record in self.registry.queryDimensionRecords("instrument")}
-
         # For each datasetType that has an instrument dimension, create
         # a DatasetRef for each defined instrument
         datasetRefs = []
 
-        dimensions = self.dimensions.extract(("instrument",))
-        for datasetType in datasetTypes:
-            if "instrument" in datasetType.dimensions:
-                for instrument in instruments:
-                    datasetRef = DatasetRef(
-                        datasetType,
-                        DataCoordinate.standardize(instrument=instrument, graph=dimensions),
-                        conform=False,
-                        run="validate",
-                    )
-                    datasetRefs.append(datasetRef)
+        # Find all the registered instruments (if "instrument" is in the
+        # universe).
+        if "instrument" in self.dimensions:
+            instruments = {record.name for record in self.registry.queryDimensionRecords("instrument")}
+
+            dimensions = self.dimensions.extract(("instrument",))
+            for datasetType in datasetTypes:
+                if "instrument" in datasetType.dimensions:
+                    for instrument in instruments:
+                        datasetRef = DatasetRef(
+                            datasetType,
+                            DataCoordinate.standardize(instrument=instrument, graph=dimensions),
+                            conform=False,
+                            run="validate",
+                        )
+                        datasetRefs.append(datasetRef)
 
         entities: list[DatasetType | DatasetRef] = []
         entities.extend(datasetTypes)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -2514,14 +2514,19 @@ class Butler(LimitedButler):
         if "instrument" in self.dimensions:
             instruments = {record.name for record in self.registry.queryDimensionRecords("instrument")}
 
-            dimensions = self.dimensions.extract(("instrument",))
             for datasetType in datasetTypes:
                 if "instrument" in datasetType.dimensions:
+                    # In order to create a conforming dataset ref, create
+                    # fake DataCoordinate values for the non-instrument
+                    # dimensions. The type of the value does not matter here.
+                    dataId = {dim.name: 1 for dim in datasetType.dimensions if dim.name != "instrument"}
+
                     for instrument in instruments:
                         datasetRef = DatasetRef(
                             datasetType,
-                            DataCoordinate.standardize(instrument=instrument, graph=dimensions),
-                            conform=False,
+                            DataCoordinate.standardize(
+                                dataId, instrument=instrument, graph=datasetType.dimensions
+                            ),
                             run="validate",
                         )
                         datasetRefs.append(datasetRef)

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -690,7 +690,7 @@ class QueryBackend(Generic[_C]):
         could easily correct this by joining that dimension in directly.  But
         it's also missing the ``{instrument, exposure, physical_filter}``
         relationship we'd get from the ``exposure`` dimension's own relation
-        (``exposure`` implies ``phyiscal_filter``) and the similar
+        (``exposure`` implies ``physical_filter``) and the similar
         ``{instrument, physical_filter, band}`` relationship from the
         ``physical_filter`` dimension relation; we need the relationship logic
         to recognize that those dimensions need to be joined in as well in

--- a/python/lsst/daf/butler/tests/_datasetsHelper.py
+++ b/python/lsst/daf/butler/tests/_datasetsHelper.py
@@ -30,7 +30,6 @@ __all__ = (
 )
 
 import os
-import uuid
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
@@ -97,7 +96,6 @@ class DatastoreTestHelper:
     """Helper methods for Datastore tests"""
 
     root: str
-    id: DatasetId
     config: Config
     datastoreType: type[Datastore]
     configFile: str
@@ -105,11 +103,6 @@ class DatastoreTestHelper:
     def setUpDatastoreTests(self, registryClass: type[Registry], configClass: type[Config]) -> None:
         """Shared setUp code for all Datastore tests"""
         self.registry = registryClass()
-
-        # Need to keep ID for each datasetRef since we have no butler
-        # for these tests
-        self.id = uuid.uuid4()
-
         self.config = configClass(self.configFile)
 
         # Some subclasses override the working root directory

--- a/python/lsst/daf/butler/tests/_datasetsHelper.py
+++ b/python/lsst/daf/butler/tests/_datasetsHelper.py
@@ -96,7 +96,7 @@ class DatasetTestHelper:
 class DatastoreTestHelper:
     """Helper methods for Datastore tests"""
 
-    root: str
+    root: str | None
     config: Config
     datastoreType: type[Datastore]
     configFile: str

--- a/python/lsst/daf/butler/tests/_datasetsHelper.py
+++ b/python/lsst/daf/butler/tests/_datasetsHelper.py
@@ -30,7 +30,7 @@ __all__ = (
 )
 
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import DataCoordinate, DatasetRef, DatasetType, StorageClass
@@ -48,7 +48,7 @@ class DatasetTestHelper:
         datasetTypeName: str,
         dimensions: DimensionGraph | Iterable[str | Dimension],
         storageClass: StorageClass | str,
-        dataId: DataCoordinate,
+        dataId: DataCoordinate | Mapping[str, Any],
         *,
         id: DatasetId | None = None,
         run: str | None = None,
@@ -70,7 +70,7 @@ class DatasetTestHelper:
         datasetTypeName: str,
         dimensions: DimensionGraph | Iterable[str | Dimension],
         storageClass: StorageClass | str,
-        dataId: DataCoordinate,
+        dataId: DataCoordinate | Mapping,
         *,
         id: DatasetId | None = None,
         run: str | None = None,
@@ -88,7 +88,8 @@ class DatasetTestHelper:
 
         if run is None:
             run = "dummy"
-        dataId = DataCoordinate.standardize(dataId, graph=datasetType.dimensions)
+        if not isinstance(dataId, DataCoordinate):
+            dataId = DataCoordinate.standardize(dataId, graph=datasetType.dimensions)
         return DatasetRef(datasetType, dataId, id=id, run=run, conform=conform)
 
 

--- a/python/lsst/daf/butler/tests/_datasetsHelper.py
+++ b/python/lsst/daf/butler/tests/_datasetsHelper.py
@@ -34,19 +34,11 @@ import uuid
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
-from lsst.daf.butler import DatasetRef, DatasetType, StorageClass
+from lsst.daf.butler import DataCoordinate, DatasetRef, DatasetType, StorageClass
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 
 if TYPE_CHECKING:
-    from lsst.daf.butler import (
-        Config,
-        DataCoordinate,
-        DatasetId,
-        Datastore,
-        Dimension,
-        DimensionGraph,
-        Registry,
-    )
+    from lsst.daf.butler import Config, DatasetId, Datastore, Dimension, DimensionGraph, Registry
 
 
 class DatasetTestHelper:
@@ -65,7 +57,13 @@ class DatasetTestHelper:
     ) -> DatasetRef:
         """Make a DatasetType and wrap it in a DatasetRef for a test"""
         return self._makeDatasetRef(
-            datasetTypeName, dimensions, storageClass, dataId, id=id, run=run, conform=conform
+            datasetTypeName,
+            dimensions,
+            storageClass,
+            dataId,
+            id=id,
+            run=run,
+            conform=conform,
         )
 
     def _makeDatasetRef(
@@ -91,6 +89,7 @@ class DatasetTestHelper:
 
         if run is None:
             run = "dummy"
+        dataId = DataCoordinate.standardize(dataId, graph=datasetType.dimensions)
         return DatasetRef(datasetType, dataId, id=id, run=run, conform=conform)
 
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -46,7 +46,7 @@ try:
 except ImportError:
     boto3 = None
 
-    def mock_s3(cls):
+    def mock_s3(cls):  # type: ignore[no-untyped-def]
         """A no-op decorator in case moto mock_s3 can not be imported."""
         return cls
 
@@ -98,6 +98,8 @@ from lsst.utils import doImportType
 from lsst.utils.introspection import get_full_type_name
 
 if TYPE_CHECKING:
+    import types
+
     from lsst.daf.butler import Datastore, DimensionGraph, Registry, StorageClass
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
@@ -115,7 +117,7 @@ def clean_environment() -> None:
         os.environ.pop(k, None)
 
 
-def makeExampleMetrics():
+def makeExampleMetrics() -> MetricsExample:
     return MetricsExample(
         {"AM1": 5.2, "AM2": 30.6},
         {"a": [1, 2, 3], "b": {"blue": 5, "red": "green"}},
@@ -135,7 +137,7 @@ class ButlerConfigTests(unittest.TestCase):
     """Simple tests for ButlerConfig that are not tested in any other test
     cases."""
 
-    def testSearchPath(self):
+    def testSearchPath(self) -> None:
         configFile = os.path.join(TESTDIR, "config", "basic", "butler.yaml")
         with self.assertLogs("lsst.daf.butler", level="DEBUG") as cm:
             config1 = ButlerConfig(configFile)
@@ -175,7 +177,14 @@ class ButlerPutGetTests(TestCaseMixin):
         cls.storageClassFactory = StorageClassFactory()
         cls.storageClassFactory.addFromConfig(cls.configFile)
 
-    def assertGetComponents(self, butler, datasetRef, components, reference, collections=None) -> None:
+    def assertGetComponents(
+        self,
+        butler: Butler,
+        datasetRef: DatasetRef,
+        components: tuple[str, ...],
+        reference: Any,
+        collections: Any = None,
+    ) -> None:
         datasetType = datasetRef.datasetType
         dataId = datasetRef.dataId
         deferred = butler.getDeferred(datasetRef)
@@ -381,6 +390,7 @@ class ButlerPutGetTests(TestCaseMixin):
         self.assertNotEqual(metric, sliced)
         self.assertEqual(metric.summary, sliced.summary)
         self.assertEqual(metric.output, sliced.output)
+        assert metric.data is not None  # for mypy
         self.assertEqual(metric.data[:stop], sliced.data)
         # getDeferred with parameters
         sliced = butler.getDeferred(ref, parameters={"slice": slice(stop)}).get()
@@ -2314,7 +2324,7 @@ class ChainedDatastoreTransfers(PosixDatastoreTransfers):
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
 
 
-def setup_module(module) -> None:
+def setup_module(module: types.ModuleType) -> None:
     clean_environment()
 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -36,12 +36,25 @@ class ConstraintsTestCase(unittest.TestCase, DatasetTestHelper):
         dimensions = self.universe.extract(("visit", "physical_filter", "instrument"))
         sc = StorageClass("DummySC", dict, None)
         self.calexpA = self.makeDatasetRef(
-            "calexp", dimensions, sc, {"instrument": "A", "physical_filter": "u"}, conform=False
+            "calexp",
+            dimensions,
+            sc,
+            {"instrument": "A", "physical_filter": "u", "visit": 3},
         )
 
         dimensions = self.universe.extract(("visit", "detector", "instrument"))
-        self.pviA = self.makeDatasetRef("pvi", dimensions, sc, {"instrument": "A", "visit": 1}, conform=False)
-        self.pviB = self.makeDatasetRef("pvi", dimensions, sc, {"instrument": "B", "visit": 2}, conform=False)
+        self.pviA = self.makeDatasetRef(
+            "pvi",
+            dimensions,
+            sc,
+            {"instrument": "A", "visit": 1, "detector": 0},
+        )
+        self.pviB = self.makeDatasetRef(
+            "pvi",
+            dimensions,
+            sc,
+            {"instrument": "B", "visit": 2, "detector": 0},
+        )
 
     def testSimpleAccept(self):
         config = ConstraintsConfig({"accept": ["calexp", "ExposureF"]})

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -41,10 +41,10 @@ from lsst.daf.butler import (
 class DatasetTypeTestCase(unittest.TestCase):
     """Test for DatasetType."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.universe = DimensionUniverse()
 
-    def testConstructor(self):
+    def testConstructor(self) -> None:
         """Test construction preserves values.
 
         Note that construction doesn't check for valid storageClass.
@@ -63,7 +63,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         with self.assertRaises(ValueError, msg="Construct non-component with parent storage class"):
             DatasetType(datasetTypeName, dimensions, storageClass, parentStorageClass="NotAllowed")
 
-    def testConstructor2(self):
+    def testConstructor2(self) -> None:
         """Test construction from StorageClass name."""
         datasetTypeName = "test"
         storageClass = StorageClass("test_constructor2")
@@ -74,7 +74,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertEqual(datasetType.storageClass, storageClass)
         self.assertEqual(datasetType.dimensions, dimensions)
 
-    def testNameValidation(self):
+    def testNameValidation(self) -> None:
         """Test that dataset type names only contain certain characters
         in certain positions.
         """
@@ -95,6 +95,7 @@ class DatasetTypeTestCase(unittest.TestCase):
                 full = DatasetType.nameWithComponent(name, suffix)
                 component = composite.makeComponentDatasetType(suffix)
                 self.assertEqual(component.name, full)
+                assert component.parentStorageClass is not None
                 self.assertEqual(component.parentStorageClass.name, "test_StructuredData")
             for suffix in badNames:
                 full = DatasetType.nameWithComponent(name, suffix)
@@ -106,7 +107,7 @@ class DatasetTypeTestCase(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     DatasetType(name, dimensions, storageClass)
 
-    def testEquality(self):
+    def testEquality(self) -> None:
         storageA = StorageClass("test_a")
         storageB = StorageClass("test_b")
         parent = StorageClass("test")
@@ -253,7 +254,7 @@ class DatasetTypeTestCase(unittest.TestCase):
             DatasetType("a.b", dimensionsA, "test_b", parentStorageClass="storageB"),
         )
 
-    def testCompatibility(self):
+    def testCompatibility(self) -> None:
         storageA = StorageClass("test_a", pytype=set, converters={"list": "builtins.set"})
         storageB = StorageClass("test_b", pytype=list)
         storageC = StorageClass("test_c", pytype=dict)
@@ -270,7 +271,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         dA3 = DatasetType("a", dimensionsA, storageC)
         self.assertFalse(dA.is_compatible_with(dA3))
 
-    def testOverrideStorageClass(self):
+    def testOverrideStorageClass(self) -> None:
         storageA = StorageClass("test_a", pytype=list, converters={"dict": "builtins.list"})
         storageB = StorageClass("test_b", pytype=dict)
         dimensions = self.universe.extract(["instrument"])
@@ -292,7 +293,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertEqual(dp_B.storageClass, storageB)
         self.assertEqual(dp_B.parentStorageClass, parent)
 
-    def testJson(self):
+    def testJson(self) -> None:
         storageA = StorageClass("test_a")
         dimensionsA = self.universe.extract(["instrument"])
         self.assertEqual(
@@ -318,7 +319,7 @@ class DatasetTypeTestCase(unittest.TestCase):
             ),
         )
 
-    def testSorting(self):
+    def testSorting(self) -> None:
         """Can we sort a DatasetType"""
         storage = StorageClass("test_a")
         dimensions = self.universe.extract(["instrument"])
@@ -332,9 +333,9 @@ class DatasetTypeTestCase(unittest.TestCase):
 
         # Now with strings
         with self.assertRaises(TypeError):
-            sort = sorted(["z", d_p, "c", d_f, d_a, "d"])
+            sort = sorted(["z", d_p, "c", d_f, d_a, "d"])  # type: ignore [list-item]
 
-    def testHashability(self):
+    def testHashability(self) -> None:
         """Test `DatasetType.__hash__`.
 
         This test is performed by checking that `DatasetType` entries can
@@ -345,15 +346,15 @@ class DatasetTypeTestCase(unittest.TestCase):
         This does not check for uniformity of hashing or the actual values
         of the hash function.
         """
-        types = []
+        types: list[DatasetType] = []
         unique = 0
         storageC = StorageClass("test_c")
         storageD = StorageClass("test_d")
         for name in ["a", "b"]:
             for storageClass in [storageC, storageD]:
-                for dimensions in [("instrument",), ("skymap",)]:
-                    datasetType = DatasetType(name, self.universe.extract(dimensions), storageClass)
-                    datasetTypeCopy = DatasetType(name, self.universe.extract(dimensions), storageClass)
+                for dims in [("instrument",), ("skymap",)]:
+                    datasetType = DatasetType(name, self.universe.extract(dims), storageClass)
+                    datasetTypeCopy = DatasetType(name, self.universe.extract(dims), storageClass)
                     types.extend((datasetType, datasetTypeCopy))
                     unique += 1  # datasetType should always equal its copy
         self.assertEqual(len(set(types)), unique)  # all other combinations are unique
@@ -377,7 +378,7 @@ class DatasetTypeTestCase(unittest.TestCase):
             hash(DatasetType("a", dimensions, "test_c")), hash(DatasetType("a", dimensions, "test_d"))
         )
 
-    def testDeepCopy(self):
+    def testDeepCopy(self) -> None:
         """Test that we can copy a dataset type."""
         storageClass = StorageClass("test_copy")
         datasetTypeName = "test"
@@ -403,7 +404,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         dcopy = copy.deepcopy(componentDatasetType)
         self.assertEqual(dcopy, componentDatasetType)
 
-    def testPickle(self):
+    def testPickle(self) -> None:
         """Test pickle support."""
         storageClass = StorageClass("test_pickle")
         datasetTypeName = "test"
@@ -468,7 +469,7 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertEqual(datasetTypeOut, componentDatasetType)
         self.assertEqual(datasetTypeOut._parentStorageClassName, componentDatasetType._parentStorageClassName)
 
-    def test_composites(self):
+    def test_composites(self) -> None:
         """Test components within composite DatasetTypes."""
         storageClassA = StorageClass("compA")
         storageClassB = StorageClass("compB")
@@ -507,7 +508,7 @@ class DatasetTypeTestCase(unittest.TestCase):
 class DatasetRefTestCase(unittest.TestCase):
     """Test for DatasetRef."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.universe = DimensionUniverse()
         datasetTypeName = "test"
         self.componentStorageClass1 = StorageClass("Component1")
@@ -516,14 +517,16 @@ class DatasetRefTestCase(unittest.TestCase):
             "Parent", components={"a": self.componentStorageClass1, "b": self.componentStorageClass2}
         )
         dimensions = self.universe.extract(("instrument", "visit"))
-        self.dataId = dict(instrument="DummyCam", visit=42)
+        self.dataId = DataCoordinate.standardize(
+            dict(instrument="DummyCam", visit=42), universe=self.universe
+        )
         self.datasetType = DatasetType(datasetTypeName, dimensions, self.parentStorageClass)
 
-    def testConstructor(self):
+    def testConstructor(self) -> None:
         """Test that construction preserves and validates values."""
         # Constructing a ref requires a run.
         with self.assertRaises(TypeError):
-            DatasetRef(self.datasetType, self.dataId, id=uuid.uuid4())
+            DatasetRef(self.datasetType, self.dataId, id=uuid.uuid4())  # type: ignore [call-arg]
 
         # Constructing an unresolved ref with run and/or components should
         # issue a ref with an id.
@@ -536,8 +539,12 @@ class DatasetRefTestCase(unittest.TestCase):
         self.assertIsNotNone(ref.id)
 
         # Passing a data ID that is missing dimensions should fail.
+        # Create a full DataCoordinate to ensure that we are testing the
+        # right thing.
+        dimensions = self.universe.extract(("instrument",))
+        dataId = DataCoordinate.standardize(instrument="DummyCam", graph=dimensions)
         with self.assertRaises(KeyError):
-            DatasetRef(self.datasetType, {"instrument": "DummyCam"}, run="run")
+            DatasetRef(self.datasetType, dataId, run="run")
         # Constructing a resolved ref should preserve run as well as everything
         # else.
         id_ = uuid.uuid4()
@@ -551,14 +558,27 @@ class DatasetRefTestCase(unittest.TestCase):
         self.assertEqual(ref.run, run)
 
         with self.assertRaises(ValueError):
-            DatasetRef(self.datasetType, self.dataId, run=run, id_generation_mode=42)
+            DatasetRef(self.datasetType, self.dataId, run=run, id_generation_mode=42)  # type: ignore
 
-    def testSorting(self):
+    def testSorting(self) -> None:
         """Can we sort a DatasetRef"""
         # All refs have the same run.
-        ref1 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=1), run="run")
-        ref2 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=10), run="run")
-        ref3 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=22), run="run")
+        dimensions = self.universe.extract(("instrument", "visit"))
+        ref1 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=1, graph=dimensions),
+            run="run",
+        )
+        ref2 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=10, graph=dimensions),
+            run="run",
+        )
+        ref3 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=22, graph=dimensions),
+            run="run",
+        )
 
         # Enable detailed diff report
         self.maxDiff = None
@@ -568,11 +588,27 @@ class DatasetRefTestCase(unittest.TestCase):
         self.assertEqual(sort, [ref1, ref2, ref3], msg=f"Got order: {[r.dataId for r in sort]}")
 
         # Now include different runs.
-        ref1 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=43), run="b")
+        ref1 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=43, graph=dimensions),
+            run="b",
+        )
         self.assertEqual(ref1.run, "b")
-        ref4 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=10), run="b")
-        ref2 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=4), run="a")
-        ref3 = DatasetRef(self.datasetType, dict(instrument="DummyCam", visit=104), run="c")
+        ref4 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=10, graph=dimensions),
+            run="b",
+        )
+        ref2 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=4, graph=dimensions),
+            run="a",
+        )
+        ref3 = DatasetRef(
+            self.datasetType,
+            DataCoordinate.standardize(instrument="DummyCam", visit=104, graph=dimensions),
+            run="c",
+        )
 
         # This will sort them on run before visit
         sort = sorted([ref3, ref1, ref2, ref4])
@@ -580,9 +616,9 @@ class DatasetRefTestCase(unittest.TestCase):
 
         # Now with strings
         with self.assertRaises(TypeError):
-            sort = sorted(["z", ref1, "c"])
+            sort = sorted(["z", ref1, "c"])  # type: ignore [list-item]
 
-    def testOverrideStorageClass(self):
+    def testOverrideStorageClass(self) -> None:
         storageA = StorageClass("test_a", pytype=list)
 
         ref = DatasetRef(self.datasetType, self.dataId, run="somerun")
@@ -593,7 +629,7 @@ class DatasetRefTestCase(unittest.TestCase):
         self.assertEqual(ref_new.overrideStorageClass(ref.datasetType.storageClass), ref)
         self.assertTrue(ref.is_compatible_with(ref_new))
         with self.assertRaises(AttributeError):
-            ref_new.is_compatible_with(None)
+            ref_new.is_compatible_with(None)  # type: ignore
 
         # Check different code paths of incompatibility.
         ref_incompat = DatasetRef(ref.datasetType, ref.dataId, run="somerun2", id=ref.id)
@@ -607,17 +643,17 @@ class DatasetRefTestCase(unittest.TestCase):
             # of "object" which is compatible with everything.
             ref_new.overrideStorageClass(incompatible_sc)
 
-    def testPickle(self):
+    def testPickle(self) -> None:
         ref = DatasetRef(self.datasetType, self.dataId, run="somerun")
         s = pickle.dumps(ref)
         self.assertEqual(pickle.loads(s), ref)
 
-    def testJson(self):
+    def testJson(self) -> None:
         ref = DatasetRef(self.datasetType, self.dataId, run="somerun")
         s = ref.to_json()
         self.assertEqual(DatasetRef.from_json(s, universe=self.universe), ref)
 
-    def testFileDataset(self):
+    def testFileDataset(self) -> None:
         ref = DatasetRef(self.datasetType, self.dataId, run="somerun")
         file_dataset = FileDataset(path="something.yaml", refs=ref)
         self.assertEqual(file_dataset.refs, [ref])

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -151,7 +151,7 @@ class DatastoreTests(DatastoreTestsBase):
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
         dataId = dict({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
-        ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
         datastore.validateConfiguration([ref])
 
     def testParameterValidation(self) -> None:
@@ -159,7 +159,7 @@ class DatastoreTests(DatastoreTestsBase):
         sc = self.storageClassFactory.getStorageClass("ThingOne")
         dimensions = self.universe.extract(("visit", "physical_filter"))
         dataId = dict({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
-        ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
         datastore = self.makeDatastore()
         data = {1: 2, 3: 4}
         datastore.put(data, ref)
@@ -183,8 +183,8 @@ class DatastoreTests(DatastoreTestsBase):
         dataId2 = dict({"instrument": "dummy", "visit": 53, "physical_filter": "V", "band": "v"})
 
         for sc in storageClasses:
-            ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
-            ref2 = self.makeDatasetRef("metric", dimensions, sc, dataId2, conform=False)
+            ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
+            ref2 = self.makeDatasetRef("metric", dimensions, sc, dataId2)
 
             # Make sure that using getManyURIs without predicting before the
             # dataset has been put raises.
@@ -242,7 +242,7 @@ class DatastoreTests(DatastoreTestsBase):
         # get it back as None
         metricsNone = makeExampleMetrics(use_none=True)
         dataIdNone = {"instrument": "dummy", "visit": 54, "physical_filter": "V", "band": "v"}
-        refNone = self.makeDatasetRef("metric", dimensions, sc, dataIdNone, conform=False)
+        refNone = self.makeDatasetRef("metric", dimensions, sc, dataIdNone)
         datastore.put(metricsNone, refNone)
 
         comp = "data"
@@ -302,7 +302,7 @@ class DatastoreTests(DatastoreTestsBase):
 
             dataId = dict({"instrument": "dummy", "visit": 52 + i, "physical_filter": "V", "band": "v"})
 
-            ref = self.makeDatasetRef(datasetTypeName, dimensions, sc, dataId, conform=False)
+            ref = self.makeDatasetRef(datasetTypeName, dimensions, sc, dataId)
             datastore.put(metrics, ref)
 
             # Does it exist?
@@ -454,7 +454,7 @@ class DatastoreTests(DatastoreTestsBase):
                 # Create a different dataset type each time round
                 # so that a test failure in this subtest does not trigger
                 # a cascade of tests because of file clashes
-                ref = self.makeDatasetRef(f"metric_comp_{i}", dimensions, sc, dataId, conform=False)
+                ref = self.makeDatasetRef(f"metric_comp_{i}", dimensions, sc, dataId)
 
                 disassembled = sc.name not in {"StructuredData", "StructuredCompositeReadCompNoDisassembly"}
 
@@ -503,7 +503,7 @@ class DatastoreTests(DatastoreTestsBase):
         refs = []
         for i in range(n_refs):
             dataId = {"instrument": "dummy", "visit": 638 + i, "physical_filter": "U", "band": "u"}
-            ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+            ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
             datastore.put(metrics, ref)
 
             # Does it exist?
@@ -566,7 +566,7 @@ class DatastoreTests(DatastoreTestsBase):
         dataId = dict({"instrument": "dummy", "visit": 2048, "physical_filter": "Uprime", "band": "u"})
 
         sc = self.storageClassFactory.getStorageClass("StructuredData")
-        ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
 
         inputDatastore = self.makeDatastore("test_input_datastore")
         outputDatastore = self.makeDatastore("test_output_datastore")
@@ -588,7 +588,7 @@ class DatastoreTests(DatastoreTestsBase):
         ]
         data = [
             (
-                self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False),
+                self.makeDatasetRef("metric", dimensions, storageClass, dataId),
                 makeExampleMetrics(),
             )
             for dataId in dataIds
@@ -631,16 +631,16 @@ class DatastoreTests(DatastoreTestsBase):
         metrics = makeExampleMetrics()
 
         dataId = dict({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
-        refBefore = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+        refBefore = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
         datastore.put(metrics, refBefore)
         with self.assertRaises(TransactionTestError):
             with datastore.transaction():
                 dataId = dict({"instrument": "dummy", "visit": 1, "physical_filter": "V", "band": "v"})
-                refOuter = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+                refOuter = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
                 datastore.put(metrics, refOuter)
                 with datastore.transaction():
                     dataId = dict({"instrument": "dummy", "visit": 2, "physical_filter": "V", "band": "v"})
-                    refInner = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+                    refInner = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
                     datastore.put(metrics, refInner)
                 # All datasets should exist
                 for ref in (refBefore, refOuter, refInner):
@@ -662,7 +662,7 @@ class DatastoreTests(DatastoreTestsBase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         metrics = makeExampleMetrics()
         dataId = dict({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
-        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
         return metrics, ref
 
     def runIngestTest(
@@ -817,7 +817,7 @@ class DatastoreTests(DatastoreTestsBase):
         refs = []
         for visit in (2048, 2049, 2050):
             dataId = {"instrument": "dummy", "visit": visit, "physical_filter": "Uprime", "band": "u"}
-            ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+            ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
             datastore.put(metrics, ref)
             refs.append(ref)
         return datastore, refs
@@ -878,7 +878,7 @@ class DatastoreTests(DatastoreTestsBase):
         sc = self.storageClassFactory.getStorageClass("ThingOne")
         dimensions = self.universe.extract(("visit", "physical_filter"))
         dataId = dict({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
-        ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, sc, dataId)
         with self.assertRaises(FileNotFoundError):
             list(datastore.export(refs + [ref], transfer=None))
 
@@ -968,7 +968,7 @@ class PosixDatastoreTestCase(DatastoreTests, unittest.TestCase):
         metrics = makeExampleMetrics()
 
         dataId = dict({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
-        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
 
         with self.assertLogs("lsst.resources", "DEBUG") as cm:
             datastore.put(metrics, ref)
@@ -996,8 +996,8 @@ class PosixDatastoreTestCase(DatastoreTests, unittest.TestCase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         dataId = dict({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
 
-        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
-        compRef = self.makeDatasetRef("metric", dimensions, compositeStorageClass, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
+        compRef = self.makeDatasetRef("metric", dimensions, compositeStorageClass, dataId)
 
         def raiser(ref):
             raise DatasetTypeNotSupportedError()
@@ -1030,7 +1030,7 @@ class PosixDatastoreNoChecksumsTestCase(PosixDatastoreTestCase):
         metrics = makeExampleMetrics()
 
         dataId = dict({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
-        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
 
         # Configuration should have disabled checksum calculation
         datastore.put(metrics, ref)
@@ -1109,7 +1109,7 @@ class CleanupPosixDatastoreTestCase(DatastoreTestsBase, unittest.TestCase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         dataId = dict({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
 
-        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
+        ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
 
         # Determine where the file will end up (we assume Formatters use
         # the same file extension)
@@ -1202,7 +1202,7 @@ class DatastoreConstraintsTests(DatastoreTestsBase):
             testfile = testfile_j if sc.name.endswith("Json") else testfile_y
 
             with self.subTest(datasetTypeName=datasetTypeName, storageClass=sc.name, file=testfile.name):
-                ref = self.makeDatasetRef(datasetTypeName, dimensions, sc, dataId, conform=False)
+                ref = self.makeDatasetRef(datasetTypeName, dimensions, sc, dataId)
                 if accepted:
                     datastore.put(metrics, ref)
                     self.assertTrue(datastore.exists(ref))
@@ -1301,7 +1301,7 @@ class ChainedDatastorePerStoreConstraintsTests(DatastoreTestsBase, unittest.Test
             testfile = testfile_j if sc.name.endswith("Json") else testfile_y
 
             with self.subTest(datasetTypeName=typeName, dataId=dataId, sc=sc.name):
-                ref = self.makeDatasetRef(typeName, dimensions, sc, dataId, conform=False)
+                ref = self.makeDatasetRef(typeName, dimensions, sc, dataId)
                 if any(accept):
                     datastore.put(metrics, ref)
                     self.assertTrue(datastore.exists(ref))
@@ -1374,10 +1374,7 @@ class DatastoreCacheTestCase(DatasetTestHelper, unittest.TestCase):
 
         # Create list of refs and list of temporary files
         n_datasets = 10
-        self.refs = [
-            self.makeDatasetRef(f"metric{n}", dimensions, sc, dataId, conform=False)
-            for n in range(n_datasets)
-        ]
+        self.refs = [self.makeDatasetRef(f"metric{n}", dimensions, sc, dataId) for n in range(n_datasets)]
 
         root_uri = ResourcePath(self.root, forceDirectory=True)
         self.files = [root_uri.join(f"file{n}.txt") for n in range(n_datasets)]
@@ -1388,9 +1385,7 @@ class DatastoreCacheTestCase(DatasetTestHelper, unittest.TestCase):
 
         # Create some composite refs with component files.
         sc = self.storageClassFactory.getStorageClass("StructuredData")
-        self.composite_refs = [
-            self.makeDatasetRef(f"composite{n}", dimensions, sc, dataId, conform=False) for n in range(3)
-        ]
+        self.composite_refs = [self.makeDatasetRef(f"composite{n}", dimensions, sc, dataId) for n in range(3)]
         self.comp_files = []
         self.comp_refs = []
         for n, ref in enumerate(self.composite_refs):
@@ -1774,7 +1769,7 @@ class StoredFileInfoTestCase(DatasetTestHelper, unittest.TestCase):
 
     def test_StoredFileInfo(self) -> None:
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataDict")
-        ref = self.makeDatasetRef("metric", DimensionUniverse().extract(()), storageClass, {}, conform=False)
+        ref = self.makeDatasetRef("metric", DimensionUniverse().extract(()), storageClass, {})
 
         record = dict(
             storage_class="StructuredDataDict",
@@ -1790,7 +1785,7 @@ class StoredFileInfoTestCase(DatasetTestHelper, unittest.TestCase):
         self.assertEqual(info.dataset_id, ref.id)
         self.assertEqual(info.to_record(), record)
 
-        ref2 = self.makeDatasetRef("metric", DimensionUniverse().extract(()), storageClass, {}, conform=False)
+        ref2 = self.makeDatasetRef("metric", DimensionUniverse().extract(()), storageClass, {})
         rebased = info.rebase(ref2)
         self.assertEqual(rebased.dataset_id, ref2.id)
         self.assertEqual(rebased.rebase(ref), info)

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -220,7 +220,7 @@ class DatastoreTests(DatastoreTestsBase):
                 datastore.validateConfiguration([sc2], logFailures=True)
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
         ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
         datastore.validateConfiguration([ref])
 
@@ -228,7 +228,7 @@ class DatastoreTests(DatastoreTestsBase):
         """Check that parameters are validated"""
         sc = self.storageClassFactory.getStorageClass("ThingOne")
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
         ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
         datastore = self.makeDatastore()
         data = {1: 2, 3: 4}
@@ -249,8 +249,8 @@ class DatastoreTests(DatastoreTestsBase):
         ]
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
-        dataId2 = DataIdForTest({"instrument": "dummy", "visit": 53, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
+        dataId2 = DataIdForTest({"instrument": "dummy", "visit": 53, "physical_filter": "V", "band": "v"})
 
         for sc in storageClasses:
             ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
@@ -311,7 +311,7 @@ class DatastoreTests(DatastoreTestsBase):
         # Check that we can put a metric with None in a component and
         # get it back as None
         metricsNone = makeExampleMetrics(use_none=True)
-        dataIdNone = {"instrument": "dummy", "visit": 54, "physical_filter": "V"}
+        dataIdNone = {"instrument": "dummy", "visit": 54, "physical_filter": "V", "band": "v"}
         refNone = self.makeDatasetRef("metric", dimensions, sc, dataIdNone, conform=False)
         datastore.put(metricsNone, refNone)
 
@@ -370,7 +370,9 @@ class DatastoreTests(DatastoreTestsBase):
             sc = self.storageClassFactory.getStorageClass(sc_name)
             dimensions = self.universe.extract(("visit", "physical_filter"))
 
-            dataId = DataIdForTest({"instrument": "dummy", "visit": 52 + i, "physical_filter": "V"})
+            dataId = DataIdForTest(
+                {"instrument": "dummy", "visit": 52 + i, "physical_filter": "V", "band": "v"}
+            )
 
             ref = self.makeDatasetRef(datasetTypeName, dimensions, sc, dataId, conform=False)
             datastore.put(metrics, ref)
@@ -573,7 +575,7 @@ class DatastoreTests(DatastoreTestsBase):
         refs = []
         for i in range(n_refs):
             dataId = FakeDataCoordinate.from_dict(
-                {"instrument": "dummy", "visit": 638 + i, "physical_filter": "U"}
+                {"instrument": "dummy", "visit": 638 + i, "physical_filter": "U", "band": "u"}
             )
             ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
             datastore.put(metrics, ref)
@@ -635,7 +637,9 @@ class DatastoreTests(DatastoreTestsBase):
         metrics = makeExampleMetrics()
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 2048, "physical_filter": "Uprime"})
+        dataId = DataIdForTest(
+            {"instrument": "dummy", "visit": 2048, "physical_filter": "Uprime", "band": "u"}
+        )
 
         sc = self.storageClassFactory.getStorageClass("StructuredData")
         ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
@@ -655,7 +659,7 @@ class DatastoreTests(DatastoreTestsBase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         nDatasets = 6
         dataIds = [
-            DataIdForTest({"instrument": "dummy", "visit": i, "physical_filter": "V"})
+            DataIdForTest({"instrument": "dummy", "visit": i, "physical_filter": "V", "band": "v"})
             for i in range(nDatasets)
         ]
         data = [
@@ -702,16 +706,20 @@ class DatastoreTests(DatastoreTestsBase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         metrics = makeExampleMetrics()
 
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
         refBefore = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
         datastore.put(metrics, refBefore)
         with self.assertRaises(TransactionTestError):
             with datastore.transaction():
-                dataId = DataIdForTest({"instrument": "dummy", "visit": 1, "physical_filter": "V"})
+                dataId = DataIdForTest(
+                    {"instrument": "dummy", "visit": 1, "physical_filter": "V", "band": "v"}
+                )
                 refOuter = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
                 datastore.put(metrics, refOuter)
                 with datastore.transaction():
-                    dataId = DataIdForTest({"instrument": "dummy", "visit": 2, "physical_filter": "V"})
+                    dataId = DataIdForTest(
+                        {"instrument": "dummy", "visit": 2, "physical_filter": "V", "band": "v"}
+                    )
                     refInner = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
                     datastore.put(metrics, refInner)
                 # All datasets should exist
@@ -733,7 +741,7 @@ class DatastoreTests(DatastoreTestsBase):
         storageClass = self.storageClassFactory.getStorageClass("StructuredData")
         dimensions = self.universe.extract(("visit", "physical_filter"))
         metrics = makeExampleMetrics()
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
         ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
         return metrics, ref
 
@@ -887,7 +895,7 @@ class DatastoreTests(DatastoreTestsBase):
         refs = []
         for visit in (2048, 2049, 2050):
             dataId = FakeDataCoordinate.from_dict(
-                {"instrument": "dummy", "visit": visit, "physical_filter": "Uprime"}
+                {"instrument": "dummy", "visit": visit, "physical_filter": "Uprime", "band": "u"}
             )
             ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
             datastore.put(metrics, ref)
@@ -949,7 +957,7 @@ class DatastoreTests(DatastoreTestsBase):
         # export it.
         sc = self.storageClassFactory.getStorageClass("ThingOne")
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
         ref = self.makeDatasetRef("metric", dimensions, sc, dataId, conform=False)
         with self.assertRaises(FileNotFoundError):
             list(datastore.export(refs + [ref], transfer=None))
@@ -1039,7 +1047,7 @@ class PosixDatastoreTestCase(DatastoreTests, unittest.TestCase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         metrics = makeExampleMetrics()
 
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
         ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
 
         with self.assertLogs("lsst.resources", "DEBUG") as cm:
@@ -1066,7 +1074,7 @@ class PosixDatastoreTestCase(DatastoreTests, unittest.TestCase):
         )
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
 
         ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
         compRef = self.makeDatasetRef("metric", dimensions, compositeStorageClass, dataId, conform=False)
@@ -1101,7 +1109,7 @@ class PosixDatastoreNoChecksumsTestCase(PosixDatastoreTestCase):
         dimensions = self.universe.extract(("visit", "physical_filter"))
         metrics = makeExampleMetrics()
 
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 0, "physical_filter": "V", "band": "v"})
         ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
 
         # Configuration should have disabled checksum calculation
@@ -1179,7 +1187,7 @@ class CleanupPosixDatastoreTestCase(DatastoreTestsBase, unittest.TestCase):
         storageClass = self.storageClassFactory.getStorageClass("StructuredData")
 
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
 
         ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId, conform=False)
 
@@ -1259,7 +1267,9 @@ class DatastoreConstraintsTests(DatastoreTestsBase):
         sc1 = self.storageClassFactory.getStorageClass("StructuredData")
         sc2 = self.storageClassFactory.getStorageClass("StructuredDataJson")
         dimensions = self.universe.extract(("visit", "physical_filter", "instrument"))
-        dataId = DataIdForTest({"visit": 52, "physical_filter": "V", "instrument": "DummyCamComp"})
+        dataId = DataIdForTest(
+            {"visit": 52, "physical_filter": "V", "band": "v", "instrument": "DummyCamComp"}
+        )
 
         # Write empty file suitable for ingest check (JSON and YAML variants)
         testfile_y = tempfile.NamedTemporaryFile(suffix=".yaml")
@@ -1355,8 +1365,8 @@ class ChainedDatastorePerStoreConstraintsTests(DatastoreTestsBase, unittest.Test
         sc1 = self.storageClassFactory.getStorageClass("StructuredData")
         sc2 = self.storageClassFactory.getStorageClass("StructuredDataJson")
         dimensions = self.universe.extract(("visit", "physical_filter", "instrument"))
-        dataId1 = {"visit": 52, "physical_filter": "V", "instrument": "DummyCamComp"}
-        dataId2 = {"visit": 52, "physical_filter": "V", "instrument": "HSC"}
+        dataId1 = {"visit": 52, "physical_filter": "V", "band": "v", "instrument": "DummyCamComp"}
+        dataId2 = {"visit": 52, "physical_filter": "V", "band": "v", "instrument": "HSC"}
 
         # Write empty file suitable for ingest check (JSON and YAML variants)
         testfile_y = tempfile.NamedTemporaryFile(suffix=".yaml")
@@ -1442,7 +1452,7 @@ class DatastoreCacheTestCase(DatasetTestHelper, unittest.TestCase):
         # Create some test dataset refs and associated test files
         sc = self.storageClassFactory.getStorageClass("StructuredDataDict")
         dimensions = self.universe.extract(("visit", "physical_filter"))
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
 
         # Create list of refs and list of temporary files
         n_datasets = 10
@@ -1844,7 +1854,7 @@ class DataIdForTestTestCase(unittest.TestCase):
 
     def testImmutable(self):
         """Verify that an instance is immutable by default."""
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
         initial_hash = hash(dataId)
 
         with self.assertRaises(RuntimeError):
@@ -1872,7 +1882,7 @@ class DataIdForTestTestCase(unittest.TestCase):
 
     def testMutable(self):
         """Verify that an instance can be made mutable (unfrozen)."""
-        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V"})
+        dataId = DataIdForTest({"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"})
         initial_hash = hash(dataId)
         dataId.frozen = False
         self.assertEqual(initial_hash, hash(dataId))

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -62,6 +62,7 @@ from lsst.daf.butler.tests import (
     MetricsExample,
     MetricsExampleDataclass,
     MetricsExampleModel,
+    TestCaseMixin,
 )
 from lsst.daf.butler.tests.dict_convertible_model import DictConvertibleModel
 from lsst.resources import ResourcePath
@@ -90,7 +91,7 @@ class TransactionTestError(Exception):
     pass
 
 
-class DatastoreTestsBase(DatasetTestHelper, DatastoreTestHelper):
+class DatastoreTestsBase(DatasetTestHelper, DatastoreTestHelper, TestCaseMixin):
     """Support routines for datastore testing"""
 
     root = None

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -191,16 +191,23 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         # Create a DatasetRef with and without instrument matching the
         # one in the config file.
         dimensions = self.universe.extract(("visit", "physical_filter", "instrument"))
+        constant_dataId = {"physical_filter": "v", "visit": 1}
         sc = StorageClass("DummySC", dict, None)
         refPviHsc = self.makeDatasetRef(
-            "pvi", dimensions, sc, {"instrument": "DummyHSC", "physical_filter": "v"}, conform=False
+            "pvi",
+            dimensions,
+            sc,
+            {"instrument": "DummyHSC", **constant_dataId},
         )
         refPviHscFmt = self.factory.getFormatterClass(refPviHsc)
         self.assertIsFormatter(refPviHscFmt)
         self.assertIn("JsonFormatter", refPviHscFmt.name())
 
         refPviNotHsc = self.makeDatasetRef(
-            "pvi", dimensions, sc, {"instrument": "DummyNotHSC", "physical_filter": "v"}, conform=False
+            "pvi",
+            dimensions,
+            sc,
+            {"instrument": "DummyNotHSC", **constant_dataId},
         )
         refPviNotHscFmt = self.factory.getFormatterClass(refPviNotHsc)
         self.assertIsFormatter(refPviNotHscFmt)
@@ -208,7 +215,10 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
 
         # Create a DatasetRef that should fall back to using Dimensions
         refPvixHsc = self.makeDatasetRef(
-            "pvix", dimensions, sc, {"instrument": "DummyHSC", "physical_filter": "v"}, conform=False
+            "pvix",
+            dimensions,
+            sc,
+            {"instrument": "DummyHSC", **constant_dataId},
         )
         refPvixNotHscFmt = self.factory.getFormatterClass(refPvixHsc)
         self.assertIsFormatter(refPvixNotHscFmt)
@@ -217,7 +227,10 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
         # Create a DatasetRef that should fall back to using StorageClass
         dimensionsNoV = DimensionGraph(self.universe, names=("physical_filter", "instrument"))
         refPvixNotHscDims = self.makeDatasetRef(
-            "pvix", dimensionsNoV, sc, {"instrument": "DummyHSC", "physical_filter": "v"}, conform=False
+            "pvix",
+            dimensionsNoV,
+            sc,
+            {"instrument": "DummyHSC", "physical_filter": "v"},
         )
         refPvixNotHscDims_fmt = self.factory.getFormatterClass(refPvixNotHscDims)
         self.assertIsFormatter(refPvixNotHscDims_fmt)
@@ -225,7 +238,10 @@ class FormatterFactoryTestCase(unittest.TestCase, DatasetTestHelper):
 
         # Check that parameters are stored
         refParam = self.makeDatasetRef(
-            "paramtest", dimensions, sc, {"instrument": "DummyNotHSC", "physical_filter": "v"}, conform=False
+            "paramtest",
+            dimensions,
+            sc,
+            {"instrument": "DummyNotHSC", **constant_dataId},
         )
         lookup, refParam_fmt, kwargs = self.factory.getFormatterClassWithMatch(refParam)
         self.assertIn("writeParameters", kwargs)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -25,6 +25,7 @@ import os.path
 import unittest
 
 from lsst.daf.butler import (
+    DataCoordinate,
     DatasetRef,
     DatasetType,
     DimensionGraph,
@@ -48,8 +49,13 @@ class TestFileTemplates(unittest.TestCase):
         self, datasetTypeName, dataId=None, storageClassName="DefaultStorageClass", run="run2", conform=True
     ):
         """Make a simple DatasetRef"""
+
         if dataId is None:
             dataId = self.dataId
+        if "physical_filter" in dataId and "band" not in dataId:
+            dataId["band"] = "b"  # Add fake band.
+        dimensions = DimensionGraph(self.universe, names=dataId.keys())
+        dataId = DataCoordinate.standardize(dataId, graph=dimensions)
 
         # Pretend we have a parent if this looks like a composite
         compositeName, componentName = DatasetType.splitDatasetTypeName(datasetTypeName)
@@ -57,7 +63,7 @@ class TestFileTemplates(unittest.TestCase):
 
         datasetType = DatasetType(
             datasetTypeName,
-            DimensionGraph(self.universe, names=dataId.keys()),
+            dimensions,
             StorageClass(storageClassName),
             parentStorageClass=parentStorageClass,
         )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -83,42 +83,42 @@ class TestFileTemplates(unittest.TestCase):
         self.assertTemplate(
             tmplstr,
             "run2/calexp/00052/Most_Amazing_U_Filter_Ever",
-            self.makeDatasetRef("calexp", conform=False),
+            self.makeDatasetRef("calexp"),
         )
         tmplstr = "{run}/{datasetType}/{visit:05d}/{physical_filter}-trail"
         self.assertTemplate(
             tmplstr,
             "run2/calexp/00052/Most_Amazing_U_Filter_Ever-trail",
-            self.makeDatasetRef("calexp", conform=False),
+            self.makeDatasetRef("calexp"),
         )
 
         tmplstr = "{run}/{datasetType}/{visit:05d}/{physical_filter}-trail-{run}"
         self.assertTemplate(
             tmplstr,
             "run2/calexp/00052/Most_Amazing_U_Filter_Ever-trail-run2",
-            self.makeDatasetRef("calexp", conform=False),
+            self.makeDatasetRef("calexp"),
         )
         self.assertTemplate(
             tmplstr,
             "run_2/calexp/00052/Most_Amazing_U_Filter_Ever-trail-run_2",
-            self.makeDatasetRef("calexp", run="run/2", conform=False),
+            self.makeDatasetRef("calexp", run="run/2"),
         )
 
         # Check that the id is sufficient without any other information.
-        self.assertTemplate("{id}", "1", self.makeDatasetRef("calexp", run="run2", conform=False))
+        self.assertTemplate("{id}", "1", self.makeDatasetRef("calexp", run="run2"))
 
-        self.assertTemplate("{run}/{id}", "run2/1", self.makeDatasetRef("calexp", run="run2", conform=False))
+        self.assertTemplate("{run}/{id}", "run2/1", self.makeDatasetRef("calexp", run="run2"))
 
         self.assertTemplate(
             "fixed/{id}",
             "fixed/1",
-            self.makeDatasetRef("calexp", run="run2", conform=False),
+            self.makeDatasetRef("calexp", run="run2"),
         )
 
         self.assertTemplate(
             "fixed/{id}_{physical_filter}",
             "fixed/1_Most_Amazing_U_Filter_Ever",
-            self.makeDatasetRef("calexp", run="run2", conform=False),
+            self.makeDatasetRef("calexp", run="run2"),
         )
 
         # Retain any "/" in run
@@ -126,7 +126,7 @@ class TestFileTemplates(unittest.TestCase):
         self.assertTemplate(
             tmplstr,
             "run/2/calexp/00052/Most_Amazing_U_Filter_Ever-trail-run_2",
-            self.makeDatasetRef("calexp", run="run/2", conform=False),
+            self.makeDatasetRef("calexp", run="run/2"),
         )
 
         # Check that "." are replaced in the file basename, but not directory.
@@ -134,7 +134,7 @@ class TestFileTemplates(unittest.TestCase):
         self.assertTemplate(
             tmplstr,
             "run.2/calexp/00052/g_10-trail-run_2",
-            self.makeDatasetRef("calexp", run="run.2", dataId=dataId, conform=False),
+            self.makeDatasetRef("calexp", run="run.2", dataId=dataId),
         )
 
         with self.assertRaises(FileTemplateValidationError):
@@ -165,16 +165,16 @@ class TestFileTemplates(unittest.TestCase):
 
     def testOptional(self):
         """Optional units in templates."""
-        ref = self.makeDatasetRef("calexp", conform=False)
+        ref = self.makeDatasetRef("calexp")
         tmplstr = "{run}/{datasetType}/v{visit:05d}_f{physical_filter:?}"
         self.assertTemplate(
             tmplstr,
             "run2/calexp/v00052_fMost_Amazing_U_Filter_Ever",
-            self.makeDatasetRef("calexp", conform=False),
+            self.makeDatasetRef("calexp"),
         )
 
         du = {"visit": 48, "tract": 265, "skymap": "big", "instrument": "dummy"}
-        self.assertTemplate(tmplstr, "run2/calexpT/v00048", self.makeDatasetRef("calexpT", du, conform=False))
+        self.assertTemplate(tmplstr, "run2/calexpT/v00048", self.makeDatasetRef("calexpT", du))
 
         # Ensure that this returns a relative path even if the first field
         # is optional


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
