### PR TITLE
DM-37883: Demonstrate nitpick and fail-on-warnings mode for documentation CI.

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -46,8 +46,8 @@ jobs:
         run: pip install --no-deps -v .
 
       - name: Install documenteer
-        run: pip install 'documenteer[pipelines]<0.8'
+        run: pip install 'documenteer[pipelines] @ git+https://github.com/lsst-sqre/documenteer.git@tickets/DM-37783'
 
       - name: Build documentation
         working-directory: ./doc
-        run: package-docs build
+        run: package-docs build -W -n


### PR DESCRIPTION
The new `-n` and `-W` flags available enable nitpick mode (generates warnings for more types of errors, like unresolved links) and then escalates those warnings into fatal errors.

This should not be merged (yet) since Documenteer is being installed from a branch (https://github.com/lsst-sqre/documenteer/pull/164)

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
