### PR TITLE
DM-39876: Add bandaid for pydantic v2

### DIFF
--- a/doc/lsst.daf.butler/configuring.rst
+++ b/doc/lsst.daf.butler/configuring.rst
@@ -8,7 +8,7 @@ The main sections of the YAML file are handled separately by each sub configurat
 Each config specialization, registry, schema, storage class, composites, and dimensions knows the name of the key for its own section of the configuration and knows the names of files providing overrides and defaults for the configuration.
 Additionally, if the sub configuration contains a ``cls`` key, that class is imported and an additional configuration file name can be provided by asking the class for its defaultConfigFile  property.
 All the keys within a sub configuration are processed by the class constructed from ``cls``.
-The primary source of default values comes from the ``configs`` resource (accessed using `pkg_resources` and package ``lsst.daf.butler``) –- this directory contains YAML files matching the names specified in the sub config classes and also can include names specified by the corresponding component class (for example `~lsst.daf.butler.datastores.fileDatastore.FileDatastore`  specifies that configuration should be found in ``datastores/fileDatastore.yaml``.
+The primary source of default values comes from the ``configs`` resource (accessed using `importlib.resources` and package ``lsst.daf.butler``) –- this directory contains YAML files matching the names specified in the sub config classes and also can include names specified by the corresponding component class (for example `~lsst.daf.butler.datastores.fileDatastore.FileDatastore`  specifies that configuration should be found in ``datastores/fileDatastore.yaml``.
 There are additional search paths that can be included when a config object is constructed:
 
 1. Explicit list of directory paths to search passed into the constructor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "lsst-resources",
     "lsst-daf-relation",
     "deprecated >= 1.2",
-    "pydantic",
+    "pydantic <3.0",
 ]
 
 dynamic = ["version"]

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -32,7 +32,11 @@ from typing import TYPE_CHECKING, Any
 
 from deprecated.sphinx import deprecated
 from lsst.resources import ResourcePathExpression
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 from ._butlerConfig import ButlerConfig
 from ._deferredDatasetHandle import DeferredDatasetHandle

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -36,7 +36,7 @@ from lsst.resources import ResourcePathExpression
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from ._butlerConfig import ButlerConfig
 from ._deferredDatasetHandle import DeferredDatasetHandle

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -40,7 +40,7 @@ from lsst.utils.classes import immutable
 try:
     from pydantic.v1 import BaseModel, StrictStr, validator
 except ModuleNotFoundError:
-    from pydantic import BaseModel, StrictStr, validator
+    from pydantic import BaseModel, StrictStr, validator  # type: ignore
 
 from ..configSupport import LookupKey
 from ..dimensions import DataCoordinate, DimensionGraph, DimensionUniverse, SerializedDataCoordinate

--- a/python/lsst/daf/butler/core/datasets/ref.py
+++ b/python/lsst/daf/butler/core/datasets/ref.py
@@ -36,7 +36,11 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.utils.classes import immutable
-from pydantic import BaseModel, StrictStr, validator
+
+try:
+    from pydantic.v1 import BaseModel, StrictStr, validator
+except ModuleNotFoundError:
+    from pydantic import BaseModel, StrictStr, validator
 
 from ..configSupport import LookupKey
 from ..dimensions import DataCoordinate, DimensionGraph, DimensionUniverse, SerializedDataCoordinate

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -29,7 +29,10 @@ from copy import deepcopy
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pydantic import BaseModel, StrictBool, StrictStr
+try:
+    from pydantic.v1 import BaseModel, StrictBool, StrictStr
+except ModuleNotFoundError:
+    from pydantic import BaseModel, StrictBool, StrictStr
 
 from ..configSupport import LookupKey
 from ..dimensions import DimensionGraph, SerializedDimensionGraph

--- a/python/lsst/daf/butler/core/datasets/type.py
+++ b/python/lsst/daf/butler/core/datasets/type.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 try:
     from pydantic.v1 import BaseModel, StrictBool, StrictStr
 except ModuleNotFoundError:
-    from pydantic import BaseModel, StrictBool, StrictStr
+    from pydantic import BaseModel, StrictBool, StrictStr  # type: ignore
 
 from ..configSupport import LookupKey
 from ..dimensions import DimensionGraph, SerializedDimensionGraph

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -50,7 +50,7 @@ from lsst.resources import ResourcePath
 try:
     from pydantic.v1 import BaseModel, PrivateAttr
 except ModuleNotFoundError:
-    from pydantic import BaseModel, PrivateAttr
+    from pydantic import BaseModel, PrivateAttr  # type: ignore
 
 from .config import ConfigSubset
 from .configSupport import processLookupConfigs

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -135,7 +135,7 @@ class CacheEntry(BaseModel):
     ref: DatasetId
     """ID of this dataset."""
 
-    component: str | None
+    component: str | None = None
     """Component for this disassembled composite (optional)."""
 
     @classmethod

--- a/python/lsst/daf/butler/core/datastoreCacheManager.py
+++ b/python/lsst/daf/butler/core/datastoreCacheManager.py
@@ -46,7 +46,11 @@ from random import Random
 from typing import TYPE_CHECKING
 
 from lsst.resources import ResourcePath
-from pydantic import BaseModel, PrivateAttr
+
+try:
+    from pydantic.v1 import BaseModel, PrivateAttr
+except ModuleNotFoundError:
+    from pydantic import BaseModel, PrivateAttr
 
 from .config import ConfigSubset
 from .configSupport import processLookupConfigs

--- a/python/lsst/daf/butler/core/datastoreRecordData.py
+++ b/python/lsst/daf/butler/core/datastoreRecordData.py
@@ -32,7 +32,11 @@ from typing import TYPE_CHECKING, Any
 
 from lsst.utils import doImportType
 from lsst.utils.introspection import get_full_type_name
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 from .datasets import DatasetId
 from .dimensions import DimensionUniverse

--- a/python/lsst/daf/butler/core/datastoreRecordData.py
+++ b/python/lsst/daf/butler/core/datastoreRecordData.py
@@ -36,7 +36,7 @@ from lsst.utils.introspection import get_full_type_name
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from .datasets import DatasetId
 from .dimensions import DimensionUniverse

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -39,7 +39,7 @@ from lsst.sphgeom import IntersectionRegion, Region
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from ..json import from_json_pydantic, to_json_pydantic
 from ..named import NamedKeyDict, NamedKeyMapping, NamedValueAbstractSet, NameLookupMapping

--- a/python/lsst/daf/butler/core/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/core/dimensions/_coordinate.py
@@ -35,7 +35,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
 from deprecated.sphinx import deprecated
 from lsst.sphgeom import IntersectionRegion, Region
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 from ..json import from_json_pydantic, to_json_pydantic
 from ..named import NamedKeyDict, NamedKeyMapping, NamedValueAbstractSet, NameLookupMapping

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -33,7 +33,7 @@ from lsst.utils.classes import cached_getter, immutable
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from .._topology import TopologicalFamily, TopologicalSpace
 from ..json import from_json_pydantic, to_json_pydantic

--- a/python/lsst/daf/butler/core/dimensions/_graph.py
+++ b/python/lsst/daf/butler/core/dimensions/_graph.py
@@ -29,7 +29,11 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from lsst.utils.classes import cached_getter, immutable
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 from .._topology import TopologicalFamily, TopologicalSpace
 from ..json import from_json_pydantic, to_json_pydantic

--- a/python/lsst/daf/butler/core/dimensions/_records.py
+++ b/python/lsst/daf/butler/core/dimensions/_records.py
@@ -27,7 +27,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple
 
 import lsst.sphgeom
 from lsst.utils.classes import immutable
-from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, create_model
+
+try:
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, create_model
+except ModuleNotFoundError:
+    from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, create_model
 
 from ..json import from_json_pydantic, to_json_pydantic
 from ..persistenceContext import PersistenceContextVars

--- a/python/lsst/daf/butler/core/dimensions/_records.py
+++ b/python/lsst/daf/butler/core/dimensions/_records.py
@@ -31,7 +31,15 @@ from lsst.utils.classes import immutable
 try:
     from pydantic.v1 import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, create_model
 except ModuleNotFoundError:
-    from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, create_model
+    from pydantic import (  # type: ignore
+        BaseModel,
+        Field,
+        StrictBool,
+        StrictFloat,
+        StrictInt,
+        StrictStr,
+        create_model,
+    )
 
 from ..json import from_json_pydantic, to_json_pydantic
 from ..persistenceContext import PersistenceContextVars

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -31,7 +31,11 @@ from typing import IO, Any, ClassVar, Union, overload
 
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import isplit
-from pydantic import BaseModel, PrivateAttr
+
+try:
+    from pydantic.v1 import BaseModel, PrivateAttr
+except ModuleNotFoundError:
+    from pydantic import BaseModel, PrivateAttr
 
 _LONG_LOG_FORMAT = "{levelname} {asctime} {name} {filename}:{lineno} - {message}"
 """Default format for log records."""

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -175,10 +175,10 @@ class ButlerLogRecord(BaseModel):
     filename: str
     pathname: str
     lineno: int
-    funcName: str | None
+    funcName: str | None = None
     process: int
     processName: str
-    exc_info: str | None
+    exc_info: str | None = None
     MDC: dict[str, str]
 
     class Config:

--- a/python/lsst/daf/butler/core/logging.py
+++ b/python/lsst/daf/butler/core/logging.py
@@ -35,7 +35,7 @@ from lsst.utils.iteration import isplit
 try:
     from pydantic.v1 import BaseModel, PrivateAttr
 except ModuleNotFoundError:
-    from pydantic import BaseModel, PrivateAttr
+    from pydantic import BaseModel, PrivateAttr  # type: ignore
 
 _LONG_LOG_FORMAT = "{levelname} {asctime} {name} {filename}:{lineno} - {message}"
 """Default format for log records."""

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -30,7 +30,11 @@ from typing import Any
 
 from lsst.utils import doImportType
 from lsst.utils.introspection import find_outside_stacklevel
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 from .datasets import DatasetRef, DatasetType, SerializedDatasetRef, SerializedDatasetType
 from .datastoreRecordData import DatastoreRecordData, SerializedDatastoreRecordData

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -34,7 +34,7 @@ from lsst.utils.introspection import find_outside_stacklevel
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from .datasets import DatasetRef, DatasetType, SerializedDatasetRef, SerializedDatasetType
 from .datastoreRecordData import DatastoreRecordData, SerializedDatastoreRecordData

--- a/python/lsst/daf/butler/core/quantum.py
+++ b/python/lsst/daf/butler/core/quantum.py
@@ -72,8 +72,8 @@ def _reconstructDatasetRef(
 class SerializedQuantum(BaseModel):
     """Simplified model of a `Quantum` suitable for serialization."""
 
-    taskName: str | None
-    dataId: SerializedDataCoordinate | None
+    taskName: str | None = None
+    dataId: SerializedDataCoordinate | None = None
     datasetTypeMapping: Mapping[str, SerializedDatasetType]
     initInputs: Mapping[str, tuple[SerializedDatasetRef, list[int]]]
     inputs: Mapping[str, list[tuple[SerializedDatasetRef, list[int]]]]

--- a/python/lsst/daf/butler/core/serverModels.py
+++ b/python/lsst/daf/butler/core/serverModels.py
@@ -34,7 +34,11 @@ from collections.abc import Mapping
 from typing import Any, ClassVar
 
 from lsst.utils.iteration import ensure_iterable
-from pydantic import BaseModel, Field, validator
+
+try:
+    from pydantic.v1 import BaseModel, Field, validator
+except ModuleNotFoundError:
+    from pydantic import BaseModel, Field, validator
 
 from .dimensions import DataIdValue, SerializedDataCoordinate
 from .utils import globToRegex

--- a/python/lsst/daf/butler/core/serverModels.py
+++ b/python/lsst/daf/butler/core/serverModels.py
@@ -38,7 +38,7 @@ from lsst.utils.iteration import ensure_iterable
 try:
     from pydantic.v1 import BaseModel, Field, validator
 except ModuleNotFoundError:
-    from pydantic import BaseModel, Field, validator
+    from pydantic import BaseModel, Field, validator  # type: ignore
 
 from .dimensions import DataIdValue, SerializedDataCoordinate
 from .utils import globToRegex

--- a/python/lsst/daf/butler/registry/obscore/_config.py
+++ b/python/lsst/daf/butler/registry/obscore/_config.py
@@ -35,7 +35,10 @@ import enum
 from collections.abc import Mapping
 from typing import Any
 
-from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator
+try:
+    from pydantic.v1 import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator
+except ModuleNotFoundError:
+    from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator
 
 
 class ExtraColumnType(str, enum.Enum):

--- a/python/lsst/daf/butler/registry/obscore/_config.py
+++ b/python/lsst/daf/butler/registry/obscore/_config.py
@@ -38,7 +38,7 @@ from typing import Any
 try:
     from pydantic.v1 import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator
 except ModuleNotFoundError:
-    from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator
+    from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr, validator  # type: ignore
 
 
 class ExtraColumnType(str, enum.Enum):

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -39,7 +39,7 @@ from lsst.utils.iteration import ensure_iterable
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 from ..core import DatasetType
 from ..core.utils import globToRegex

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -35,7 +35,11 @@ from typing import Any
 
 from deprecated.sphinx import deprecated
 from lsst.utils.iteration import ensure_iterable
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 from ..core import DatasetType
 from ..core.utils import globToRegex

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -266,9 +266,9 @@ class MetricsExample:
 class MetricsExampleModel(BaseModel):
     """A variant of `MetricsExample` based on model."""
 
-    summary: dict[str, Any] | None
-    output: dict[str, Any] | None
-    data: list[Any] | None
+    summary: dict[str, Any] | None = None
+    output: dict[str, Any] | None = None
+    data: list[Any] | None = None
 
     @classmethod
     def from_metrics(cls, metrics: MetricsExample) -> MetricsExampleModel:

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -47,7 +47,7 @@ from lsst.daf.butler import StorageClass, StorageClassDelegate
 try:
     from pydantic.v1 import BaseModel
 except ModuleNotFoundError:
-    from pydantic import BaseModel
+    from pydantic import BaseModel  # type: ignore
 
 if TYPE_CHECKING:
     from lsst.daf.butler import Butler, Datastore, FormatterFactory

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -43,7 +43,11 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import StorageClass, StorageClassDelegate
-from pydantic import BaseModel
+
+try:
+    from pydantic.v1 import BaseModel
+except ModuleNotFoundError:
+    from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from lsst.daf.butler import Butler, Datastore, FormatterFactory

--- a/python/lsst/daf/butler/tests/dict_convertible_model.py
+++ b/python/lsst/daf/butler/tests/dict_convertible_model.py
@@ -25,7 +25,10 @@ __all__ = ()
 
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ModuleNotFoundError:
+    from pydantic import BaseModel, Field
 
 
 class DictConvertibleModel(BaseModel):

--- a/python/lsst/daf/butler/tests/dict_convertible_model.py
+++ b/python/lsst/daf/butler/tests/dict_convertible_model.py
@@ -28,7 +28,7 @@ from collections.abc import Mapping
 try:
     from pydantic.v1 import BaseModel, Field
 except ModuleNotFoundError:
-    from pydantic import BaseModel, Field
+    from pydantic import BaseModel, Field  # type: ignore
 
 
 class DictConvertibleModel(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyyaml >= 5.1
 astropy >= 4.0
 click >7.0
 sqlalchemy >= 1.4
-pydantic
+pydantic <3.0
 httpx
 deprecated >=1.2
 git+https://github.com/lsst/sphgeom@main#egg=lsst-sphgeom

--- a/types.txt
+++ b/types.txt
@@ -1,4 +1,3 @@
 types-requests
 types-PyYAML
-types-pkg_resources
 types-Deprecated


### PR DESCRIPTION
Pydantic v2 breaks everything. Rather than pinning to <2 instead use the facility provided by v2 to import v1 APIs. This will give us some flexibility on timeline for fixing things to work only with v2.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
