### PR TITLE
DM-40120: Add without_datastore flag to Butler

### DIFF
--- a/doc/changes/DM-40120.api.rst
+++ b/doc/changes/DM-40120.api.rst
@@ -1,0 +1,2 @@
+Added new parameter ``without_datastore`` to the ``Butler`` and ``ButlerConfig`` constructors to allow a butler to be created that can not access a datastore.
+This can be helpful if you want to query registry without requiring the overhead of the datastore.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -222,7 +222,7 @@ class Butler(LimitedButler):
             self.storageClasses = butler.storageClasses
             self._config: ButlerConfig = butler._config
         else:
-            self._config = ButlerConfig(config, searchPaths=searchPaths)
+            self._config = ButlerConfig(config, searchPaths=searchPaths, skip_datastore=skip_datastore)
             try:
                 if "root" in self._config:
                     butlerRoot = self._config["root"]

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -150,7 +150,7 @@ class Butler(LimitedButler):
         the default for that dimension.  Nonexistent collections are ignored.
         If a default value is provided explicitly for a governor dimension via
         ``**kwargs``, no default will be inferred for that dimension.
-    skip_datastore : `bool`, optional
+    without_datastore : `bool`, optional
         If `True` do not attach a datastore to this butler. Any attempts
         to use a datastore will fail.
     **kwargs : `str`
@@ -207,7 +207,7 @@ class Butler(LimitedButler):
         searchPaths: Sequence[ResourcePathExpression] | None = None,
         writeable: bool | None = None,
         inferDefaults: bool = True,
-        skip_datastore: bool = False,
+        without_datastore: bool = False,
         **kwargs: str,
     ):
         defaults = RegistryDefaults(collections=collections, run=run, infer=inferDefaults, **kwargs)
@@ -222,7 +222,7 @@ class Butler(LimitedButler):
             self.storageClasses = butler.storageClasses
             self._config: ButlerConfig = butler._config
         else:
-            self._config = ButlerConfig(config, searchPaths=searchPaths, skip_datastore=skip_datastore)
+            self._config = ButlerConfig(config, searchPaths=searchPaths, without_datastore=without_datastore)
             try:
                 if "root" in self._config:
                     butlerRoot = self._config["root"]
@@ -233,7 +233,7 @@ class Butler(LimitedButler):
                 self._registry = _RegistryFactory(self._config).from_config(
                     butlerRoot=butlerRoot, writeable=writeable, defaults=defaults
                 )
-                if skip_datastore:
+                if without_datastore:
                     self._datastore = NullDatastore(None, None)
                 else:
                     self._datastore = Datastore.fromConfig(

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -61,7 +61,7 @@ class ButlerConfig(Config):
         than those read from the environment in
         `ConfigSubset.defaultSearchPaths()`.  They are only read if ``other``
         refers to a configuration file or directory.
-    skip_datastore : `bool`, optional
+    without_datastore : `bool`, optional
         If `True` remove the datastore configuration.
     """
 
@@ -69,7 +69,7 @@ class ButlerConfig(Config):
         self,
         other: ResourcePathExpression | Config | None = None,
         searchPaths: Sequence[ResourcePathExpression] | None = None,
-        skip_datastore: bool = False,
+        without_datastore: bool = False,
     ):
         self.configDir: ResourcePath | None = None
 
@@ -160,7 +160,7 @@ class ButlerConfig(Config):
         for configClass in CONFIG_COMPONENT_CLASSES:
             assert configClass.component is not None, "Config class component cannot be None"
 
-            if skip_datastore and configClass is DatastoreConfig:
+            if without_datastore and configClass is DatastoreConfig:
                 if configClass.component in butlerConfig:
                     del butlerConfig[configClass.component]
                 continue

--- a/python/lsst/daf/butler/_butlerConfig.py
+++ b/python/lsst/daf/butler/_butlerConfig.py
@@ -61,12 +61,15 @@ class ButlerConfig(Config):
         than those read from the environment in
         `ConfigSubset.defaultSearchPaths()`.  They are only read if ``other``
         refers to a configuration file or directory.
+    skip_datastore : `bool`, optional
+        If `True` remove the datastore configuration.
     """
 
     def __init__(
         self,
         other: ResourcePathExpression | Config | None = None,
         searchPaths: Sequence[ResourcePathExpression] | None = None,
+        skip_datastore: bool = False,
     ):
         self.configDir: ResourcePath | None = None
 
@@ -155,6 +158,13 @@ class ButlerConfig(Config):
         # configuration classes. We ask each of them to apply defaults to
         # the values we have been supplied by the user.
         for configClass in CONFIG_COMPONENT_CLASSES:
+            assert configClass.component is not None, "Config class component cannot be None"
+
+            if skip_datastore and configClass is DatastoreConfig:
+                if configClass.component in butlerConfig:
+                    del butlerConfig[configClass.component]
+                continue
+
             # Only send the parent config if the child
             # config component is present (otherwise it assumes that the
             # keys from other components are part of the child)
@@ -163,7 +173,6 @@ class ButlerConfig(Config):
                 localOverrides = butlerConfig
             config = configClass(localOverrides, searchPaths=searchPaths)
             # Re-attach it using the global namespace
-            assert configClass.component is not None, "Config class component cannot be None"
             self.update({configClass.component: config})
             # Remove the key from the butlerConfig since we have already
             # merged that information.

--- a/python/lsst/daf/butler/core/datastore.py
+++ b/python/lsst/daf/butler/core/datastore.py
@@ -1245,7 +1245,7 @@ class NullDatastore(Datastore):
         parameters: Mapping[str, Any] | None = None,
         storageClass: StorageClass | str | None = None,
     ) -> Any:
-        raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
+        raise FileNotFoundError("This is a no-op datastore that can not access a real datastore")
 
     def put(self, inMemoryDataset: Any, datasetRef: DatasetRef) -> None:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
@@ -1265,10 +1265,10 @@ class NullDatastore(Datastore):
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
     def getURIs(self, datasetRef: DatasetRef, predict: bool = False) -> DatasetRefURIs:
-        raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
+        raise FileNotFoundError("This is a no-op datastore that can not access a real datastore")
 
     def getURI(self, datasetRef: DatasetRef, predict: bool = False) -> ResourcePath:
-        raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
+        raise FileNotFoundError("This is a no-op datastore that can not access a real datastore")
 
     def retrieveArtifacts(
         self,

--- a/python/lsst/daf/butler/script/certifyCalibrations.py
+++ b/python/lsst/daf/butler/script/certifyCalibrations.py
@@ -63,7 +63,7 @@ def certifyCalibrations(
         Search all children of the inputCollection if it is a CHAINED
         collection, instead of just the most recent one.
     """
-    butler = Butler(repo, writeable=True, datastore_optional=True)
+    butler = Butler(repo, writeable=True, skip_datastore=True)
     registry = butler.registry
     timespan = Timespan(
         begin=astropy.time.Time(begin_date, scale="tai") if begin_date is not None else None,

--- a/python/lsst/daf/butler/script/certifyCalibrations.py
+++ b/python/lsst/daf/butler/script/certifyCalibrations.py
@@ -63,7 +63,7 @@ def certifyCalibrations(
         Search all children of the inputCollection if it is a CHAINED
         collection, instead of just the most recent one.
     """
-    butler = Butler(repo, writeable=True)
+    butler = Butler(repo, writeable=True, datastore_optional=True)
     registry = butler.registry
     timespan = Timespan(
         begin=astropy.time.Time(begin_date, scale="tai") if begin_date is not None else None,

--- a/python/lsst/daf/butler/script/certifyCalibrations.py
+++ b/python/lsst/daf/butler/script/certifyCalibrations.py
@@ -63,7 +63,7 @@ def certifyCalibrations(
         Search all children of the inputCollection if it is a CHAINED
         collection, instead of just the most recent one.
     """
-    butler = Butler(repo, writeable=True, skip_datastore=True)
+    butler = Butler(repo, writeable=True, without_datastore=True)
     registry = butler.registry
     timespan = Timespan(
         begin=astropy.time.Time(begin_date, scale="tai") if begin_date is not None else None,

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -65,7 +65,7 @@ def collectionChain(
     chain : `tuple` of `str`
         The collections in the chain following this command.
     """
-    butler = Butler(repo, writeable=True, datastore_optional=True)
+    butler = Butler(repo, writeable=True, skip_datastore=True)
 
     # Every mode needs children except pop.
     if not children and mode != "pop":

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -65,7 +65,7 @@ def collectionChain(
     chain : `tuple` of `str`
         The collections in the chain following this command.
     """
-    butler = Butler(repo, writeable=True, skip_datastore=True)
+    butler = Butler(repo, writeable=True, without_datastore=True)
 
     # Every mode needs children except pop.
     if not children and mode != "pop":

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -65,7 +65,7 @@ def collectionChain(
     chain : `tuple` of `str`
         The collections in the chain following this command.
     """
-    butler = Butler(repo, writeable=True)
+    butler = Butler(repo, writeable=True, datastore_optional=True)
 
     # Every mode needs children except pop.
     if not children and mode != "pop":

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -134,7 +134,7 @@ def _getTree(
         names=("Name", "Type"),
         dtype=(str, str),
     )
-    butler = Butler(repo, datastore_optional=True)
+    butler = Butler(repo, skip_datastore=True)
 
     def addCollection(name: str, level: int = 0) -> None:
         collectionType = butler.registry.getCollectionType(name)

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -134,7 +134,7 @@ def _getTree(
         names=("Name", "Type"),
         dtype=(str, str),
     )
-    butler = Butler(repo)
+    butler = Butler(repo, datastore_optional=True)
 
     def addCollection(name: str, level: int = 0) -> None:
         collectionType = butler.registry.getCollectionType(name)

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -134,7 +134,7 @@ def _getTree(
         names=("Name", "Type"),
         dtype=(str, str),
     )
-    butler = Butler(repo, skip_datastore=True)
+    butler = Butler(repo, without_datastore=True)
 
     def addCollection(name: str, level: int = 0) -> None:
         collectionType = butler.registry.getCollectionType(name)

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -103,7 +103,7 @@ def queryDataIds(
     Docstring for supported parameters is the same as
     `~lsst.daf.butler.Registry.queryDataIds`.
     """
-    butler = Butler(repo)
+    butler = Butler(repo, datastore_optional=True)
 
     if datasets and collections and not dimensions:
         # Determine the dimensions relevant to all given dataset types.

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -103,7 +103,7 @@ def queryDataIds(
     Docstring for supported parameters is the same as
     `~lsst.daf.butler.Registry.queryDataIds`.
     """
-    butler = Butler(repo, datastore_optional=True)
+    butler = Butler(repo, skip_datastore=True)
 
     if datasets and collections and not dimensions:
         # Determine the dimensions relevant to all given dataset types.

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -103,7 +103,7 @@ def queryDataIds(
     Docstring for supported parameters is the same as
     `~lsst.daf.butler.Registry.queryDataIds`.
     """
-    butler = Butler(repo, skip_datastore=True)
+    butler = Butler(repo, without_datastore=True)
 
     if datasets and collections and not dimensions:
         # Determine the dimensions relevant to all given dataset types.

--- a/python/lsst/daf/butler/script/queryDatasetTypes.py
+++ b/python/lsst/daf/butler/script/queryDatasetTypes.py
@@ -55,7 +55,7 @@ def queryDatasetTypes(repo: str, verbose: bool, glob: Iterable[str], components:
         A dict whose key is "datasetTypes" and whose value is a list of
         collection names.
     """
-    butler = Butler(repo, skip_datastore=True)
+    butler = Butler(repo, without_datastore=True)
     expression = glob if glob else ...
     datasetTypes = butler.registry.queryDatasetTypes(components=components, expression=expression)
     if verbose:

--- a/python/lsst/daf/butler/script/queryDatasetTypes.py
+++ b/python/lsst/daf/butler/script/queryDatasetTypes.py
@@ -55,7 +55,7 @@ def queryDatasetTypes(repo: str, verbose: bool, glob: Iterable[str], components:
         A dict whose key is "datasetTypes" and whose value is a list of
         collection names.
     """
-    butler = Butler(repo, datastore_optional=True)
+    butler = Butler(repo, skip_datastore=True)
     expression = glob if glob else ...
     datasetTypes = butler.registry.queryDatasetTypes(components=components, expression=expression)
     if verbose:

--- a/python/lsst/daf/butler/script/queryDatasetTypes.py
+++ b/python/lsst/daf/butler/script/queryDatasetTypes.py
@@ -55,7 +55,7 @@ def queryDatasetTypes(repo: str, verbose: bool, glob: Iterable[str], components:
         A dict whose key is "datasetTypes" and whose value is a list of
         collection names.
     """
-    butler = Butler(repo)
+    butler = Butler(repo, datastore_optional=True)
     expression = glob if glob else ...
     datasetTypes = butler.registry.queryDatasetTypes(components=components, expression=expression)
     if verbose:

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -168,8 +168,8 @@ class QueryDatasets:
         if (repo and butler) or (not repo and not butler):
             raise RuntimeError("One of repo and butler must be provided and the other must be None.")
         # show_uri requires a datastore.
-        skip_datastore = False if show_uri else True
-        self.butler = butler or Butler(repo, skip_datastore=skip_datastore)
+        without_datastore = False if show_uri else True
+        self.butler = butler or Butler(repo, without_datastore=without_datastore)
         self._getDatasets(glob, collections, where, find_first)
         self.showUri = show_uri
 

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -168,8 +168,8 @@ class QueryDatasets:
         if (repo and butler) or (not repo and not butler):
             raise RuntimeError("One of repo and butler must be provided and the other must be None.")
         # show_uri requires a datastore.
-        datastore_optional = False if show_uri else True
-        self.butler = butler or Butler(repo, datastore_optional=datastore_optional)
+        skip_datastore = False if show_uri else True
+        self.butler = butler or Butler(repo, skip_datastore=skip_datastore)
         self._getDatasets(glob, collections, where, find_first)
         self.showUri = show_uri
 

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -167,7 +167,9 @@ class QueryDatasets:
     ):
         if (repo and butler) or (not repo and not butler):
             raise RuntimeError("One of repo and butler must be provided and the other must be None.")
-        self.butler = butler or Butler(repo)
+        # show_uri requires a datastore.
+        datastore_optional = False if show_uri else True
+        self.butler = butler or Butler(repo, datastore_optional=datastore_optional)
         self._getDatasets(glob, collections, where, find_first)
         self.showUri = show_uri
 

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -48,7 +48,7 @@ def queryDimensionRecords(
     `~lsst.daf.butler.Registry.queryDimensionRecords` except for ``no_check``,
     which is the inverse of ``check``.
     """
-    butler = Butler(repo)
+    butler = Butler(repo, datastore_optional=True)
 
     query_collections: Iterable[str] | EllipsisType | None = None
     if datasets:

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -48,7 +48,7 @@ def queryDimensionRecords(
     `~lsst.daf.butler.Registry.queryDimensionRecords` except for ``no_check``,
     which is the inverse of ``check``.
     """
-    butler = Butler(repo, datastore_optional=True)
+    butler = Butler(repo, skip_datastore=True)
 
     query_collections: Iterable[str] | EllipsisType | None = None
     if datasets:

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -48,7 +48,7 @@ def queryDimensionRecords(
     `~lsst.daf.butler.Registry.queryDimensionRecords` except for ``no_check``,
     which is the inverse of ``check``.
     """
-    butler = Butler(repo, skip_datastore=True)
+    butler = Butler(repo, without_datastore=True)
 
     query_collections: Iterable[str] | EllipsisType | None = None
     if datasets:

--- a/python/lsst/daf/butler/script/register_dataset_type.py
+++ b/python/lsst/daf/butler/script/register_dataset_type.py
@@ -63,7 +63,7 @@ def register_dataset_type(
         be created by this command. They are always derived from the composite
         dataset type.
     """
-    butler = Butler(repo, writeable=True, skip_datastore=True)
+    butler = Butler(repo, writeable=True, without_datastore=True)
 
     composite, component = DatasetType.splitDatasetTypeName(dataset_type)
     if component:

--- a/python/lsst/daf/butler/script/register_dataset_type.py
+++ b/python/lsst/daf/butler/script/register_dataset_type.py
@@ -63,7 +63,7 @@ def register_dataset_type(
         be created by this command. They are always derived from the composite
         dataset type.
     """
-    butler = Butler(repo, writeable=True, datastore_optional=True)
+    butler = Butler(repo, writeable=True, skip_datastore=True)
 
     composite, component = DatasetType.splitDatasetTypeName(dataset_type)
     if component:

--- a/python/lsst/daf/butler/script/register_dataset_type.py
+++ b/python/lsst/daf/butler/script/register_dataset_type.py
@@ -63,7 +63,7 @@ def register_dataset_type(
         be created by this command. They are always derived from the composite
         dataset type.
     """
-    butler = Butler(repo, writeable=True)
+    butler = Butler(repo, writeable=True, datastore_optional=True)
 
     composite, component = DatasetType.splitDatasetTypeName(dataset_type)
     if component:

--- a/python/lsst/daf/butler/script/removeDatasetType.py
+++ b/python/lsst/daf/butler/script/removeDatasetType.py
@@ -37,5 +37,5 @@ def removeDatasetType(repo: str, dataset_type_name: tuple[str, ...]) -> None:
     datasetTypeName : `str`
         The name of the dataset type to be removed.
     """
-    butler = Butler(repo, writeable=True)
+    butler = Butler(repo, writeable=True, datastore_optional=True)
     butler.registry.removeDatasetType(dataset_type_name)

--- a/python/lsst/daf/butler/script/removeDatasetType.py
+++ b/python/lsst/daf/butler/script/removeDatasetType.py
@@ -37,5 +37,5 @@ def removeDatasetType(repo: str, dataset_type_name: tuple[str, ...]) -> None:
     datasetTypeName : `str`
         The name of the dataset type to be removed.
     """
-    butler = Butler(repo, writeable=True, datastore_optional=True)
+    butler = Butler(repo, writeable=True, skip_datastore=True)
     butler.registry.removeDatasetType(dataset_type_name)

--- a/python/lsst/daf/butler/script/removeDatasetType.py
+++ b/python/lsst/daf/butler/script/removeDatasetType.py
@@ -37,5 +37,5 @@ def removeDatasetType(repo: str, dataset_type_name: tuple[str, ...]) -> None:
     datasetTypeName : `str`
         The name of the dataset type to be removed.
     """
-    butler = Butler(repo, writeable=True, skip_datastore=True)
+    butler = Butler(repo, writeable=True, without_datastore=True)
     butler.registry.removeDatasetType(dataset_type_name)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2377,8 +2377,10 @@ class NullDatastoreTestCase(unittest.TestCase):
         ref = DatasetRef(datasetType, {}, run="MYRUN")
 
         # Check that datastore will complain.
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(FileNotFoundError):
             butler.get(ref)
+        with self.assertRaises(FileNotFoundError):
+            butler.getURI(ref)
 
 
 def setup_module(module: types.ModuleType) -> None:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2360,7 +2360,7 @@ class NullDatastoreTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             Butler(bad_config)
 
-        butler = Butler(bad_config, writeable=True, skip_datastore=True)
+        butler = Butler(bad_config, writeable=True, without_datastore=True)
         self.assertIsInstance(butler._datastore, NullDatastore)
 
         # Check that registry is working.

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -49,6 +49,7 @@ from lsst.daf.butler import (
     DatastoreValidationError,
     DimensionUniverse,
     FileDataset,
+    NullDatastore,
     StorageClass,
     StorageClassFactory,
     StoredFileInfo,
@@ -1742,6 +1743,59 @@ cached:
             self.assertIsNone(found)
         with cache_manager.find_in_cache(self.refs[2], ".txt") as found:
             self.assertIsInstance(found, ResourcePath)
+
+
+class NullDatastoreTestCase(DatasetTestHelper, unittest.TestCase):
+    """Test the null datastore."""
+
+    storageClassFactory = StorageClassFactory()
+
+    def test_basics(self) -> None:
+        storageClass = self.storageClassFactory.getStorageClass("StructuredDataDict")
+        ref = self.makeDatasetRef("metric", DimensionUniverse().extract(()), storageClass, {})
+
+        null = NullDatastore(None, None)
+
+        self.assertFalse(null.exists(ref))
+        self.assertFalse(null.knows(ref))
+        knows = null.knows_these([ref])
+        self.assertFalse(knows[ref])
+        null.validateConfiguration(ref)
+
+        with self.assertRaises(NotImplementedError):
+            null.get(ref)
+        with self.assertRaises(NotImplementedError):
+            null.put("", ref)
+        with self.assertRaises(NotImplementedError):
+            null.getURI(ref)
+        with self.assertRaises(NotImplementedError):
+            null.getURIs(ref)
+        with self.assertRaises(NotImplementedError):
+            null.getManyURIs([ref])
+        with self.assertRaises(NotImplementedError):
+            null.getLookupKeys()
+        with self.assertRaises(NotImplementedError):
+            null.import_records({})
+        with self.assertRaises(NotImplementedError):
+            null.export_records([])
+        with self.assertRaises(NotImplementedError):
+            null.export([ref])
+        with self.assertRaises(NotImplementedError):
+            null.transfer(null, ref)
+        with self.assertRaises(NotImplementedError):
+            null.emptyTrash()
+        with self.assertRaises(NotImplementedError):
+            null.trash(ref)
+        with self.assertRaises(NotImplementedError):
+            null.forget([ref])
+        with self.assertRaises(NotImplementedError):
+            null.remove(ref)
+        with self.assertRaises(NotImplementedError):
+            null.retrieveArtifacts([ref], ResourcePath("."))
+        with self.assertRaises(NotImplementedError):
+            null.transfer_from(null, [ref])
+        with self.assertRaises(NotImplementedError):
+            null.ingest()
 
 
 class DatasetRefURIsTestCase(unittest.TestCase):

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1762,15 +1762,15 @@ class NullDatastoreTestCase(DatasetTestHelper, unittest.TestCase):
         self.assertFalse(knows[ref])
         null.validateConfiguration(ref)
 
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(FileNotFoundError):
             null.get(ref)
         with self.assertRaises(NotImplementedError):
             null.put("", ref)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(FileNotFoundError):
             null.getURI(ref)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(FileNotFoundError):
             null.getURIs(ref)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(FileNotFoundError):
             null.getManyURIs([ref])
         with self.assertRaises(NotImplementedError):
             null.getLookupKeys()


### PR DESCRIPTION
This allows `butler = Butler(uri, skip_datastore=True)` to return a Butler instance that has no connection to a real datastore. I've also modified script implementations to add the flag where appropriate.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
