### PR TITLE
DM-40257: Enable skip_datastore for remove collections command

### DIFF
--- a/python/lsst/daf/butler/script/removeCollections.py
+++ b/python/lsst/daf/butler/script/removeCollections.py
@@ -76,7 +76,7 @@ def _getCollectionInfo(
     collectionInfo : `CollectionInfo`
         Contains tables with run and non-run collection info.
     """
-    butler = Butler(repo)
+    butler = Butler(repo, without_datastore=True)
     try:
         names = sorted(
             butler.registry.queryCollections(
@@ -129,7 +129,7 @@ def removeCollections(
 
     def doRemove(collections: Table) -> None:
         """Perform the prune collection step."""
-        butler = Butler(repo, writeable=True)
+        butler = Butler(repo, writeable=True, without_datastore=True)
         for name in collections["Collection"]:
             butler.registry.removeCollection(name)
 


### PR DESCRIPTION
This command explicitly does not remove RUN collections so only affects registry.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
