### PR TITLE
DM-40395: Allow datastore record inserts to use ensure or replace

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1914,7 +1914,7 @@ class Butler(LimitedButler):
         *datasets: FileDataset,
         transfer: str | None = "auto",
         run: str | None = None,
-        idGenerationMode: DatasetIdGenEnum = DatasetIdGenEnum.UNIQUE,
+        idGenerationMode: DatasetIdGenEnum | None = None,
         record_validation_info: bool = True,
     ) -> None:
         """Store and register one or more datasets that already exist on disk.
@@ -1941,8 +1941,8 @@ class Butler(LimitedButler):
             overriding ``self.run``. This parameter is now deprecated since
             the run is encoded in the ``FileDataset``.
         idGenerationMode : `DatasetIdGenEnum`, optional
-            Specifies option for generating dataset IDs. By default unique IDs
-            are generated for each inserted dataset.
+            Specifies option for generating dataset IDs. Parameter is
+            deprecated.
         record_validation_info : `bool`, optional
             If `True`, the default, the datastore can record validation
             information associated with the file. If `False` the datastore
@@ -1983,6 +1983,14 @@ class Butler(LimitedButler):
         log.verbose("Ingesting %d file dataset%s.", len(datasets), "" if len(datasets) == 1 else "s")
         if not datasets:
             return
+
+        if idGenerationMode is not None:
+            warnings.warn(
+                "The idGenerationMode parameter is no longer used and is ignored. "
+                " Will be removed after v26.0",
+                FutureWarning,
+                stacklevel=2,
+            )
 
         progress = Progress("lsst.daf.butler.Butler.ingest", level=logging.DEBUG)
 

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2761,7 +2761,12 @@ class FileDatastore(GenericBaseDatastore):
                 "" if len(direct_transfers) == 1 else "s",
             )
 
-        self._register_datasets(artifacts, insert_mode=DatabaseInsertMode.INSERT)
+        # We are overwriting previous datasets that may have already
+        # existed. We therefore should ensure that we force the
+        # datastore records to agree. Note that this can potentially lead
+        # to difficulties if the dataset has previously been ingested
+        # disassembled and is somehow now assembled, or vice versa.
+        self._register_datasets(artifacts, insert_mode=DatabaseInsertMode.REPLACE)
 
         if already_present:
             n_skipped = len(already_present)

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -54,7 +54,9 @@ class GenericBaseDatastore(Datastore):
         raise NotImplementedError()
 
     @abstractmethod
-    def addStoredItemInfo(self, refs: Iterable[DatasetRef], infos: Iterable[Any]) -> None:
+    def addStoredItemInfo(
+        self, refs: Iterable[DatasetRef], infos: Iterable[Any], insert_mode: str = "insert"
+    ) -> None:
         """Record internal storage information associated with one or more
         datasets.
 
@@ -64,6 +66,11 @@ class GenericBaseDatastore(Datastore):
             The datasets that have been stored.
         infos : sequence of `StoredDatastoreItemInfo`
             Metadata associated with the stored datasets.
+        insert_mode : `str`, optional
+            Mode to use to insert the new records into the table. The
+            options are "insert" (error if pre-existing), "replace" (replace
+            content with new values), and "ensure" (skip if the row already
+            exists).
         """
         raise NotImplementedError()
 
@@ -98,7 +105,9 @@ class GenericBaseDatastore(Datastore):
         """
         raise NotImplementedError()
 
-    def _register_datasets(self, refsAndInfos: Iterable[tuple[DatasetRef, StoredDatastoreItemInfo]]) -> None:
+    def _register_datasets(
+        self, refsAndInfos: Iterable[tuple[DatasetRef, StoredDatastoreItemInfo]], insert_mode: str = "insert"
+    ) -> None:
         """Update registry to indicate that one or more datasets have been
         stored.
 
@@ -108,6 +117,10 @@ class GenericBaseDatastore(Datastore):
                                          `StoredDatastoreItemInfo`]
             Datasets to register and the internal datastore metadata associated
             with them.
+        insert_mode : `str`, optional
+            Indicate whether the new records should be new ("insert", default),
+            or allowed to exists ("ensure") or be replaced if already present
+            ("replace").
         """
         expandedRefs: list[DatasetRef] = []
         expandedItemInfos = []
@@ -120,8 +133,13 @@ class GenericBaseDatastore(Datastore):
         # disassembled in datastore we have to deduplicate. Since they
         # will have different datasetTypes we can't use a set
         registryRefs = {r.id: r for r in expandedRefs}
-        self.bridge.insert(registryRefs.values())
-        self.addStoredItemInfo(expandedRefs, expandedItemInfos)
+        if insert_mode == "insert":
+            self.bridge.insert(registryRefs.values())
+        else:
+            # There are only two columns and all that matters is the
+            # dataset ID.
+            self.bridge.ensure(registryRefs.values())
+        self.addStoredItemInfo(expandedRefs, expandedItemInfos, insert_mode=insert_mode)
 
     def _post_process_get(
         self,

--- a/python/lsst/daf/butler/datastores/genericDatastore.py
+++ b/python/lsst/daf/butler/datastores/genericDatastore.py
@@ -33,6 +33,8 @@ from typing import TYPE_CHECKING, Any
 from lsst.daf.butler import DatasetTypeNotSupportedError, Datastore
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
 
+from ..registry.interfaces import DatabaseInsertMode
+
 if TYPE_CHECKING:
     from lsst.daf.butler import DatasetRef, StorageClass, StoredDatastoreItemInfo
 
@@ -55,7 +57,10 @@ class GenericBaseDatastore(Datastore):
 
     @abstractmethod
     def addStoredItemInfo(
-        self, refs: Iterable[DatasetRef], infos: Iterable[Any], insert_mode: str = "insert"
+        self,
+        refs: Iterable[DatasetRef],
+        infos: Iterable[Any],
+        insert_mode: DatabaseInsertMode = DatabaseInsertMode.INSERT,
     ) -> None:
         """Record internal storage information associated with one or more
         datasets.
@@ -66,11 +71,11 @@ class GenericBaseDatastore(Datastore):
             The datasets that have been stored.
         infos : sequence of `StoredDatastoreItemInfo`
             Metadata associated with the stored datasets.
-        insert_mode : `str`, optional
+        insert_mode : `~lsst.daf.butler.registry.interfaces.DatabaseInsertMode`
             Mode to use to insert the new records into the table. The
-            options are "insert" (error if pre-existing), "replace" (replace
-            content with new values), and "ensure" (skip if the row already
-            exists).
+            options are ``INSERT`` (error if pre-existing), ``REPLACE``
+            (replace content with new values), and ``ENSURE`` (skip if the row
+            already exists).
         """
         raise NotImplementedError()
 
@@ -106,7 +111,9 @@ class GenericBaseDatastore(Datastore):
         raise NotImplementedError()
 
     def _register_datasets(
-        self, refsAndInfos: Iterable[tuple[DatasetRef, StoredDatastoreItemInfo]], insert_mode: str = "insert"
+        self,
+        refsAndInfos: Iterable[tuple[DatasetRef, StoredDatastoreItemInfo]],
+        insert_mode: DatabaseInsertMode = DatabaseInsertMode.INSERT,
     ) -> None:
         """Update registry to indicate that one or more datasets have been
         stored.
@@ -133,7 +140,7 @@ class GenericBaseDatastore(Datastore):
         # disassembled in datastore we have to deduplicate. Since they
         # will have different datasetTypes we can't use a set
         registryRefs = {r.id: r for r in expandedRefs}
-        if insert_mode == "insert":
+        if insert_mode == DatabaseInsertMode.INSERT:
             self.bridge.insert(registryRefs.values())
         else:
             # There are only two columns and all that matters is the

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -178,7 +178,9 @@ class InMemoryDatastore(GenericBaseDatastore):
         # Docstring inherited from GenericBaseDatastore.
         return self._bridge
 
-    def addStoredItemInfo(self, refs: Iterable[DatasetRef], infos: Iterable[StoredMemoryItemInfo]) -> None:
+    def addStoredItemInfo(
+        self, refs: Iterable[DatasetRef], infos: Iterable[StoredMemoryItemInfo], insert_mode: str = "insert"
+    ) -> None:
         # Docstring inherited from GenericBaseDatastore.
         for ref, info in zip(refs, infos, strict=True):
             self.records[ref.id] = info

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -44,6 +44,7 @@ from lsst.daf.butler.core.utils import transactional
 from lsst.daf.butler.registry.interfaces import DatastoreRegistryBridge
 from lsst.resources import ResourcePath
 
+from ..registry.interfaces import DatabaseInsertMode
 from .genericDatastore import GenericBaseDatastore
 
 if TYPE_CHECKING:
@@ -179,7 +180,10 @@ class InMemoryDatastore(GenericBaseDatastore):
         return self._bridge
 
     def addStoredItemInfo(
-        self, refs: Iterable[DatasetRef], infos: Iterable[StoredMemoryItemInfo], insert_mode: str = "insert"
+        self,
+        refs: Iterable[DatasetRef],
+        infos: Iterable[StoredMemoryItemInfo],
+        insert_mode: DatabaseInsertMode = DatabaseInsertMode.INSERT,
     ) -> None:
         # Docstring inherited from GenericBaseDatastore.
         for ref, info in zip(refs, infos, strict=True):

--- a/python/lsst/daf/butler/registry/bridge/ephemeral.py
+++ b/python/lsst/daf/butler/registry/bridge/ephemeral.py
@@ -61,6 +61,10 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Docstring inherited from DatastoreRegistryBridge
         self._datasetIds.update(ref.id for ref in refs)
 
+    def ensure(self, refs: Iterable[DatasetIdRef]) -> None:
+        # Docstring inherited from DatastoreRegistryBridge
+        self._datasetIds.update(ref.id for ref in refs)
+
     def forget(self, refs: Iterable[DatasetIdRef]) -> None:
         self._datasetIds.difference_update(ref.id for ref in refs)
 

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -150,6 +150,10 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         """
         return [{"datastore_name": self.datastoreName, "dataset_id": ref.id} for ref in refs]
 
+    def ensure(self, refs: Iterable[DatasetIdRef]) -> None:
+        # Docstring inherited from DatastoreRegistryBridge
+        self._db.ensure(self._tables.dataset_location, *self._refsToRows(refs))
+
     def insert(self, refs: Iterable[DatasetIdRef]) -> None:
         # Docstring inherited from DatastoreRegistryBridge
         self._db.insert(self._tables.dataset_location, *self._refsToRows(refs))

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -115,6 +115,18 @@ class DatastoreRegistryBridge(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def ensure(self, refs: Iterable[DatasetIdRef]) -> None:
+        """Record that a datastore holds the given datasets, skipping if
+        the ref is already registered.
+
+        Parameters
+        ----------
+        refs : `~collections.abc.Iterable` of `DatasetIdRef`
+            References to the datasets.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def forget(self, refs: Iterable[DatasetIdRef]) -> None:
         """Remove dataset location information without any attempt to put it
         in the trash while waiting for external deletes.

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -24,10 +24,12 @@ __all__ = [
     "Database",
     "ReadOnlyDatabaseError",
     "DatabaseConflictError",
+    "DatabaseInsertMode",
     "SchemaAlreadyDefinedError",
     "StaticTablesContext",
 ]
 
+import enum
 import uuid
 import warnings
 from abc import ABC, abstractmethod
@@ -42,6 +44,19 @@ import sqlalchemy
 from ...core import TimespanDatabaseRepresentation, ddl, time_utils
 from ...core.named import NamedValueAbstractSet
 from .._exceptions import ConflictingDefinitionError
+
+
+class DatabaseInsertMode(enum.Enum):
+    """Mode options available for inserting database records."""
+
+    INSERT = enum.auto()
+    """Insert records, failing if they already exist."""
+
+    REPLACE = enum.auto()
+    """Replace records, overwriting existing."""
+
+    ENSURE = enum.auto()
+    """Insert records, skipping any that already exist."""
 
 
 # TODO: method is called with list[ReflectedColumn] in SA 2, and

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -70,6 +70,41 @@ class OpaqueTableStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def ensure(self, *data: dict, transaction: DatastoreTransaction | None = None) -> None:
+        """Insert records into the table, skipping rows that already exist.
+
+        Parameters
+        ----------
+        *data
+            Each additional positional argument is a dictionary that represents
+            a single row to be added.
+        transaction : `DatastoreTransaction`, optional
+            Transaction object that can be used to enable an explicit rollback
+            of the insert to be registered. Can be ignored if rollback is
+            handled via a different mechanism, such as by a database. Can be
+            `None` if no external transaction is available.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def replace(self, *data: dict, transaction: DatastoreTransaction | None = None) -> None:
+        """Insert records into the table, replacing if previously existing
+        but different.
+
+        Parameters
+        ----------
+        *data
+            Each additional positional argument is a dictionary that represents
+            a single row to be added.
+        transaction : `DatastoreTransaction`, optional
+            Transaction object that can be used to enable an explicit rollback
+            of the insert to be registered. Can be ignored if rollback is
+            handled via a different mechanism, such as by a database. Can be
+            `None` if no external transaction is available.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def fetch(self, **where: Any) -> Iterator[Mapping[Any, Any]]:
         """Retrieve records from an opaque table.
 

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -79,6 +79,18 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         # the database itself providing any rollback functionality.
         self._db.insert(self._table, *data)
 
+    def ensure(self, *data: dict, transaction: DatastoreTransaction | None = None) -> None:
+        # Docstring inherited from OpaqueTableStorage.
+        # The provided transaction object can be ignored since we rely on
+        # the database itself providing any rollback functionality.
+        self._db.ensure(self._table, *data)
+
+    def replace(self, *data: dict, transaction: DatastoreTransaction | None = None) -> None:
+        # Docstring inherited from OpaqueTableStorage.
+        # The provided transaction object can be ignored since we rely on
+        # the database itself providing any rollback functionality.
+        self._db.replace(self._table, *data)
+
     def fetch(self, **where: Any) -> Iterator[sqlalchemy.RowMapping]:
         # Docstring inherited from OpaqueTableStorage.
 

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -277,7 +277,7 @@ class MetricsExampleModel(BaseModel):
         d = metrics.exportAsDict()
         # Assume pydantic v2 but fallback to v1
         try:
-            return cls.model_validate(d)
+            return cls.model_validate(d)  # type: ignore
         except AttributeError:
             return cls.parse_obj(d)
 


### PR DESCRIPTION
This doesn't solve the real problem of the files being overwritten without us knowing whether the datastore records are allowed to be modified but it does give the option.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
