### PR TITLE
DM-39514: Fix misleading doc for Registry.queryDatasetAssociations.

### DIFF
--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1479,9 +1479,8 @@ class Registry(ABC):
             If provided, only yield associations from collections of these
             types.
         flattenChains : `bool`, optional
-            If `True` (default) search in the children of
-            `~CollectionType.CHAINED` collections.  If `False`, ``CHAINED``
-            collections are ignored.
+            If `True`, search in the children of `~CollectionType.CHAINED`
+            collections.  If `False`, ``CHAINED`` collections are ignored.
 
         Yields
         ------


### PR DESCRIPTION
This PR corrects the docstring for `queryDatasetAssociations` so that it is consistent with its actual (and desired) behavior. No subclass docstrings needed to be changed.