### PR TITLE
DM-35599: Add transfer option that does not include -t

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
           - "--unsafe"
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.285
+    rev: v0.0.289
     hooks:
       - id: ruff

--- a/doc/changes/DM-35599.api.rst
+++ b/doc/changes/DM-35599.api.rst
@@ -1,0 +1,1 @@
+Added new ``transfer_option_no_short`` that creates the ``--transfer`` option without the associated ``-t`` alias.

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -48,6 +48,7 @@ __all__ = (
     "run_option",
     "transfer_dimensions_option",
     "transfer_option",
+    "transfer_option_no_short",
     "verbose_option",
     "where_option",
     "order_by_option",
@@ -243,16 +244,24 @@ register_dataset_types_option = MWOptionDecorator(
 
 run_option = MWOptionDecorator("--output-run", help="The name of the run datasets should be output to.")
 
-
-transfer_option = MWOptionDecorator(
-    "-t",
-    "--transfer",
+_transfer_params = dict(
     default="auto",  # set to `None` if using `required=True`
     help="The external data transfer mode.",
     type=click.Choice(
         choices=["auto", "link", "symlink", "hardlink", "copy", "move", "relsymlink", "direct"],
         case_sensitive=False,
     ),
+)
+
+transfer_option_no_short = MWOptionDecorator(
+    "--transfer",
+    **_transfer_params,
+)
+
+transfer_option = MWOptionDecorator(
+    "-t",
+    "--transfer",
+    **_transfer_params,
 )
 
 


### PR DESCRIPTION
This allows pipetask to use the --transfer option without also overriding its own -t option.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
