### PR TITLE
DM-41226: Remove datastore records from serialized DatasetRef

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -709,13 +709,13 @@ class DatasetRefTestCase(unittest.TestCase):
         s = ref.to_json()
         self.assertEqual(DatasetRef.from_json(s, universe=self.universe), ref)
 
-        # Also test ref with datastore records
+        # Also test ref with datastore records, serialization does not
+        # preserve those.
         ref = self._make_datastore_records(ref, "/path1", "/path2")
         s = ref.to_json()
         ref2 = DatasetRef.from_json(s, universe=self.universe)
         self.assertEqual(ref2, ref)
-        self.assertIsNotNone(ref2._datastore_records)
-        self.assertEqual(ref2._datastore_records, ref._datastore_records)
+        self.assertIsNone(ref2._datastore_records)
 
     def testFileDataset(self) -> None:
         ref = DatasetRef(self.datasetType, self.dataId, run="somerun")


### PR DESCRIPTION
This removes the piece of code for (de-)serializing datastore records in DatasetRef that was added on DM-40053. We worry that serialized QuantumGraph could grow in size, though presently we do not fill datastore records when we make refs for quantum graph. In the future the whole thing will be replaced by a more efficient data structures, so this serialization will likely disappear entirely.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
