### PR TITLE
DM-41562: Rewrite much of DatasetRef.from_simple to fix cache problem.

### DIFF
--- a/doc/changes/DM-41562.bugfix.md
+++ b/doc/changes/DM-41562.bugfix.md
@@ -1,0 +1,3 @@
+Fix caching in DatasetRef deserialization that caused the serialized storage class to be ignored.
+
+This caused intermittent failures when running pipelines that use multiple storage classes for the same dataset type.

--- a/python/lsst/daf/butler/persistence_context.py
+++ b/python/lsst/daf/butler/persistence_context.py
@@ -117,10 +117,12 @@ class PersistenceContextVars:
     r"""A cache of `DataCoordinate`\ s.
     """
 
-    datasetRefs: ContextVar[dict[tuple[int, str], DatasetRef] | None] = ContextVar(
-        "datasetRefs", default=None
-    )
+    datasetRefs: ContextVar[dict[int, DatasetRef] | None] = ContextVar("datasetRefs", default=None)
     r"""A cache of `DatasetRef`\ s.
+
+    Keys are UUID converted to int, but only refs of parent dataset types are
+    cached AND THE STORAGE CLASS IS UNSPECIFIED; consumers of this cache must
+    call overrideStorageClass on the result.
     """
 
     dimensionRecords: ContextVar[dict[Hashable, DimensionRecord] | None] = ContextVar(


### PR DESCRIPTION
The previous caching did not respect storage class overrides; all DatasetRefs with the same UUID and component would end up using the first storage class deserialized.

The fix here is to always call overrideStorageClass when using the cache, rather than add the storage class to the cache key.  That's because we expect the value of the cache to mostly be in avoiding reconstruction of the data ID, and overrideStorageClass doesn't touch that.

By the same token, the dataset type name has been removed from the cache key as well, with only refs for parent dataset types cached. This should shrink the cache a bit and improve performance in the usual (no-component) case.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
