### PR TITLE
DM-41966: Add Butler.transfer_dimension_records_from API

### DIFF
--- a/doc/changes/DM-41966.feature.rst
+++ b/doc/changes/DM-41966.feature.rst
@@ -1,0 +1,4 @@
+* Added new API ``Butler.transfer_dimension_records_from()`` to copy dimension records out of some refs and add them to the target butler.
+* This and ``Butler.transfer_from()`` now copy related dimension records as well as the records associated directly with the refs.
+  For example, if visit is being transferred additional records such as visit_definition will also be copied.
+  This requires a full Butler and not a limited Butler (such as the one backed by a quantum graph).

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1249,6 +1249,25 @@ class Butler(LimitedButler):
         raise NotImplementedError()
 
     @abstractmethod
+    def transfer_dimension_records_from(
+        self, source_butler: LimitedButler, source_refs: Iterable[DatasetRef]
+    ) -> None:
+        """Transfer dimension records to this Butler from another Butler.
+
+        Parameters
+        ----------
+        source_butler : `LimitedButler`
+            Butler from which the records are to be transferred. If data IDs
+            in ``source_refs`` are not expanded then this has to be a full
+            `Butler` whose registry will be used to expand data IDs.
+        source_refs : iterable of `DatasetRef`
+            Datasets defined in the source butler whose dimension records
+            should be transferred to this butler. In most circumstances.
+            transfer is faster if the dataset refs are expanded.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def transfer_from(
         self,
         source_butler: LimitedButler,

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1250,16 +1250,18 @@ class Butler(LimitedButler):
 
     @abstractmethod
     def transfer_dimension_records_from(
-        self, source_butler: LimitedButler, source_refs: Iterable[DatasetRef]
+        self, source_butler: LimitedButler | Butler, source_refs: Iterable[DatasetRef]
     ) -> None:
         """Transfer dimension records to this Butler from another Butler.
 
         Parameters
         ----------
-        source_butler : `LimitedButler`
+        source_butler : `LimitedButler` or `Butler`
             Butler from which the records are to be transferred. If data IDs
             in ``source_refs`` are not expanded then this has to be a full
-            `Butler` whose registry will be used to expand data IDs.
+            `Butler` whose registry will be used to expand data IDs. If the
+            source refs contain coordinates that are used to populate other
+            records then this will also need to be a full `Butler`.
         source_refs : iterable of `DatasetRef`
             Datasets defined in the source butler whose dimension records
             should be transferred to this butler. In most circumstances.

--- a/python/lsst/daf/butler/dimensions/_universe.py
+++ b/python/lsst/daf/butler/dimensions/_universe.py
@@ -596,7 +596,7 @@ class DimensionUniverse:
 
     def get_elements_populated_by(self, dimension: Dimension) -> NamedValueAbstractSet[DimensionElement]:
         """Return the set of `DimensionElement` objects whose
-        `~DimensionElement.populated_by` atttribute is the given dimension.
+        `~DimensionElement.populated_by` attribute is the given dimension.
         """
         return self._populates[dimension.name]
 

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -1894,8 +1894,9 @@ class DirectButler(Butler):
             source_butler, data_ids, elements
         )
 
-        for element, r in dimension_records.items():
-            records = [r[dataId] for dataId in r]
+        # Insert order is important.
+        for element in self.dimensions.sorted(dimension_records.keys()):
+            records = [r for r in dimension_records[element].values()]
             # Assume that if the record is already present that we can
             # use it without having to check that the record metadata
             # is consistent.
@@ -2101,8 +2102,9 @@ class DirectButler(Butler):
         with self.transaction():
             if dimension_records:
                 _LOG.verbose("Ensuring that dimension records exist for transferred datasets.")
-                for element, r in dimension_records.items():
-                    records = [r[dataId] for dataId in r]
+                # Order matters.
+                for element in self.dimensions.sorted(dimension_records.keys()):
+                    records = [r for r in dimension_records[element].values()]
                     # Assume that if the record is already present that we can
                     # use it without having to check that the record metadata
                     # is consistent.

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -407,6 +407,12 @@ class RemoteButler(Butler):
         # Docstring inherited.
         raise NotImplementedError()
 
+    def transfer_dimension_records_from(
+        self, source_butler: LimitedButler, source_refs: Iterable[DatasetRef]
+    ) -> None:
+        # Docstring inherited.
+        raise NotImplementedError()
+
     def transfer_from(
         self,
         source_butler: LimitedButler,

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -408,7 +408,7 @@ class RemoteButler(Butler):
         raise NotImplementedError()
 
     def transfer_dimension_records_from(
-        self, source_butler: LimitedButler, source_refs: Iterable[DatasetRef]
+        self, source_butler: LimitedButler | Butler, source_refs: Iterable[DatasetRef]
     ) -> None:
         # Docstring inherited.
         raise NotImplementedError()

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2308,6 +2308,11 @@ class PosixDatastoreTransfers(unittest.TestCase):
         # Can remove with DM-35498.
         self.target_butler.registry.refresh()
 
+        # Transfer the records for one ref to test the alternative API.
+        with self.assertLogs(logger="lsst", level=logging.DEBUG) as log_cm:
+            self.target_butler.transfer_dimension_records_from(self.source_butler, [source_refs[0]])
+        self.assertIn("number of records transferred: 1", ";".join(log_cm.output))
+
         # Now transfer them to the second butler, including dimensions.
         with self.assertLogs(logger="lsst", level=logging.DEBUG) as log_cm:
             transferred = self.target_butler.transfer_from(

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -603,6 +603,25 @@ class SimpleButlerTestCase(unittest.TestCase):
                     from_json = type(test_item).from_json(json_str, universe=butler.dimensions)
                     self.assertEqual(from_json, test_item, msg=f"From JSON '{json_str}' using universe")
 
+    def test_populated_by(self):
+        """Test that dimension records can find other records."""
+        butler = self.makeButler(writeable=True)
+        butler.import_(filename=os.path.join(TESTDIR, "data", "registry", "hsc-rc2-subset.yaml"))
+
+        elements = frozenset(
+            element for element in butler.dimensions.elements if element.hasTable() and element.viewOf is None
+        )
+
+        # Get a visit-based dataId.
+        data_ids = set(butler.registry.queryDataIds("visit", visit=1232, instrument="HSC"))
+
+        # Request all the records related to it.
+        records = butler._extract_all_dimension_records_from_data_ids(butler, data_ids, elements)
+
+        self.assertIn(butler.dimensions["visit_detector_region"], records, f"Keys: {records.keys()}")
+        self.assertIn(butler.dimensions["visit_system_membership"], records)
+        self.assertIn(butler.dimensions["visit_system"], records)
+
     def testJsonDimensionRecordsAndHtmlRepresentation(self):
         # Dimension Records
         butler = self.makeButler(writeable=True)

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -324,7 +324,8 @@ class SimpleButlerTestCase(unittest.TestCase):
             try:
                 flat_id, _ = butler.get("flat", dataId=dataId, collections=coll, **kwds)
             except Exception as e:
-                raise type(e)(f"{str(e)}: dataId={dataId}, kwds={kwds}") from e
+                e.add_note(f"dataId={dataId}, kwds={kwds}")
+                raise
             self.assertEqual(flat_id, flat2g.id, msg=f"DataId: {dataId}, kwds: {kwds}")
 
         # Check that bad combinations raise.


### PR DESCRIPTION
Uses populated_by field to find other records to pull along.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
