### PR TITLE
DM-40150: Remove some APIs scheduled for removal after v26

### DIFF
--- a/doc/changes/DM-40150.removal.rst
+++ b/doc/changes/DM-40150.removal.rst
@@ -1,0 +1,6 @@
+* Removed ``Butler.datastore`` property. The datastore can no longer be accessed directly.
+* Removed ``Butler.datasetExists`` (and the "direct" variant). Please use ``Butler.exists()`` and ``Butler.stored()`` instead.
+* Removed ``Butler.getDirect`` and related APIs. ``Butler.get()`` et al now use the ``DatasetRef`` directly if one is given.
+* Removed the ``run`` and ``ideGenerationMode`` parameters from ``Butler.ingest()``. They were no longer being used.
+* Removed the ``--reuse-ids`` option for the ``butler import`` command-line. This option was no longer used now that UUIDs are used throughout.
+* Removed the ``reconsitutedDimension`` parameter from ``Quantum.from_simple``.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1123,7 +1123,6 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         self,
         *datasets: FileDataset,
         transfer: str | None = "auto",
-        run: str | None = None,
         record_validation_info: bool = True,
     ) -> None:
         """Store and register one or more datasets that already exist on disk.
@@ -1145,10 +1144,6 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             If not `None`, must be one of 'auto', 'move', 'copy', 'direct',
             'split', 'hardlink', 'relsymlink' or 'symlink', indicating how to
             transfer the file.
-        run : `str`, optional
-            The name of the run ingested datasets should be added to,
-            overriding ``self.run``. This parameter is now deprecated since
-            the run is encoded in the ``FileDataset``.
         record_validation_info : `bool`, optional
             If `True`, the default, the datastore can record validation
             information associated with the file. If `False` the datastore

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -50,7 +50,7 @@ from .repo_relocation import BUTLER_ROOT_TAG
 
 if TYPE_CHECKING:
     from ._dataset_existence import DatasetExistence
-    from ._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef
+    from ._dataset_ref import DatasetId, DatasetRef
     from ._dataset_type import DatasetType
     from ._deferredDatasetHandle import DeferredDatasetHandle
     from ._file_dataset import FileDataset
@@ -1124,7 +1124,6 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         *datasets: FileDataset,
         transfer: str | None = "auto",
         run: str | None = None,
-        idGenerationMode: DatasetIdGenEnum | None = None,
         record_validation_info: bool = True,
     ) -> None:
         """Store and register one or more datasets that already exist on disk.
@@ -1150,9 +1149,6 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             The name of the run ingested datasets should be added to,
             overriding ``self.run``. This parameter is now deprecated since
             the run is encoded in the ``FileDataset``.
-        idGenerationMode : `DatasetIdGenEnum`, optional
-            Specifies option for generating dataset IDs. Parameter is
-            deprecated.
         record_validation_info : `bool`, optional
             If `True`, the default, the datastore can record validation
             information associated with the file. If `False` the datastore

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -343,28 +343,6 @@ class LimitedButler(ABC):
         """
         return self._datastore.mexists(refs)
 
-    # TODO: remove on DM-40079.
-    @deprecated(
-        reason="Butler.datasetExistsDirect() has been replaced by Butler.stored(). "
-        "Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def datasetExistsDirect(self, ref: DatasetRef) -> bool:
-        """Return `True` if a dataset is actually present in the Datastore.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Resolved reference to a dataset.
-
-        Returns
-        -------
-        exists : `bool`
-            Whether the dataset exists in the Datastore.
-        """
-        return self.stored(ref)
-
     def markInputUnused(self, ref: DatasetRef) -> None:
         """Indicate that a predicted input was not actually used when
         processing a `Quantum`.

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -34,7 +34,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import Any, ClassVar
 
-from deprecated.sphinx import deprecated
 from lsst.resources import ResourcePath
 
 from ._dataset_ref import DatasetRef
@@ -420,18 +419,6 @@ class LimitedButler(ABC):
         repository (`DimensionUniverse`).
         """
         raise NotImplementedError()
-
-    # TODO: remove on DM-40080.
-    @property
-    @deprecated(
-        reason="The Butler.datastore property is now deprecated. Butler APIs should now exist with the "
-        "relevant functionality. Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def datastore(self) -> Datastore:
-        """The object that manages actual dataset storage (`Datastore`)."""
-        return self._datastore
 
     _datastore: Datastore
     """The object that manages actual dataset storage (`Datastore`)."""

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -64,43 +64,6 @@ class LimitedButler(ABC):
         """Return `True` if this `Butler` supports write operations."""
         raise NotImplementedError()
 
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.put() now behaves like Butler.putDirect() when given a DatasetRef."
-        " Please use Butler.put(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def putDirect(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
-        """Store a dataset that already has a UUID and ``RUN`` collection.
-
-        Parameters
-        ----------
-        obj : `object`
-            The dataset.
-        ref : `DatasetRef`
-            Resolved reference for a not-yet-stored dataset.
-
-        Returns
-        -------
-        ref : `DatasetRef`
-            The same as the given, for convenience and symmetry with
-            `Butler.put`.
-
-        Raises
-        ------
-        TypeError
-            Raised if the butler is read-only.
-
-        Notes
-        -----
-        Whether this method inserts the given dataset into a ``Registry`` is
-        implementation defined (some `LimitedButler` subclasses do not have a
-        `Registry`), but it always adds the dataset to a `Datastore`, and the
-        given ``ref.id`` and ``ref.run`` are always preserved.
-        """
-        return self.put(obj, ref)
-
     @abstractmethod
     def put(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
         """Store a dataset that already has a UUID and ``RUN`` collection.
@@ -173,81 +136,6 @@ class LimitedButler(ABC):
         """
         log.debug("Butler get: %s, parameters=%s, storageClass: %s", ref, parameters, storageClass)
         return self._datastore.get(ref, parameters=parameters, storageClass=storageClass)
-
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.get() now behaves like Butler.getDirect() when given a DatasetRef."
-        " Please use Butler.get(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def getDirect(
-        self,
-        ref: DatasetRef,
-        *,
-        parameters: dict[str, Any] | None = None,
-        storageClass: str | StorageClass | None = None,
-    ) -> Any:
-        """Retrieve a stored dataset.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Resolved reference to an already stored dataset.
-        parameters : `dict`
-            Additional StorageClass-defined options to control reading,
-            typically used to efficiently read only a subset of the dataset.
-        storageClass : `StorageClass` or `str`, optional
-            The storage class to be used to override the Python type
-            returned by this method. By default the returned type matches
-            the dataset type definition for this dataset. Specifying a
-            read `StorageClass` can force a different type to be returned.
-            This type must be compatible with the original type.
-
-        Returns
-        -------
-        obj : `object`
-            The dataset.
-        """
-        return self._datastore.get(ref, parameters=parameters, storageClass=storageClass)
-
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.getDeferred() now behaves like getDirectDeferred() when given a DatasetRef. "
-        "Please use Butler.getDeferred(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def getDirectDeferred(
-        self,
-        ref: DatasetRef,
-        *,
-        parameters: dict[str, Any] | None = None,
-        storageClass: str | StorageClass | None = None,
-    ) -> DeferredDatasetHandle:
-        """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
-        from a resolved `DatasetRef`.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Resolved reference to an already stored dataset.
-        parameters : `dict`
-            Additional StorageClass-defined options to control reading,
-            typically used to efficiently read only a subset of the dataset.
-        storageClass : `StorageClass` or `str`, optional
-            The storage class to be used to override the Python type
-            returned by this method. By default the returned type matches
-            the dataset type definition for this dataset. Specifying a
-            read `StorageClass` can force a different type to be returned.
-            This type must be compatible with the original type.
-
-        Returns
-        -------
-        obj : `DeferredDatasetHandle`
-            A handle which can be used to retrieve a dataset at a later time.
-        """
-        return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters, storageClass=storageClass)
 
     def getDeferred(
         self,
@@ -489,7 +377,7 @@ class LimitedButler(ABC):
         Notes
         -----
         By default, a dataset is considered "actually used" if it is accessed
-        via `getDirect` or a handle to it is obtained via `getDirectDeferred`
+        via `get` or a handle to it is obtained via `getDeferred`
         (even if the handle is not used).  This method must be called after one
         of those in order to remove the dataset from the actual input list.
 

--- a/python/lsst/daf/butler/_quantum.py
+++ b/python/lsst/daf/butler/_quantum.py
@@ -30,13 +30,11 @@ from __future__ import annotations
 __all__ = ("Quantum", "SerializedQuantum", "DimensionRecordsAccumulator")
 
 import sys
-import warnings
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from typing import Any
 
 import pydantic
 from lsst.utils import doImportType
-from lsst.utils.introspection import find_outside_stacklevel
 
 from ._dataset_ref import DatasetRef, SerializedDatasetRef
 from ._dataset_type import DatasetType, SerializedDatasetType
@@ -409,7 +407,6 @@ class Quantum:
         cls,
         simple: SerializedQuantum,
         universe: DimensionUniverse,
-        reconstitutedDimensions: dict[int, tuple[str, DimensionRecord]] | None = None,
     ) -> Quantum:
         """Construct a new object from a simplified form.
 
@@ -421,24 +418,8 @@ class Quantum:
             The value returned by a call to `to_simple`.
         universe : `DimensionUniverse`
             The special graph of all known dimensions.
-        reconstitutedDimensions : `dict` of `int` to `DimensionRecord` or None
-            A mapping of ids to dimension records to be used when populating
-            dimensions for this Quantum. If supplied it will be used in place
-            of the dimension Records stored with the SerializedQuantum, if a
-            required dimension has already been loaded. Otherwise the record
-            will be unpersisted from the SerializedQuatnum and added to the
-            reconstitutedDimensions dict (if not None). Defaults to None.
-            Deprecated, any argument will be ignored.  Will be removed after
-            v26.
         """
         initInputs: MutableMapping[DatasetType, DatasetRef] = {}
-        if reconstitutedDimensions is not None:
-            # TODO: remove this argument on DM-40150.
-            warnings.warn(
-                "The reconstitutedDimensions argument is now ignored and may be removed after v26",
-                category=FutureWarning,
-                stacklevel=find_outside_stacklevel("lsst.daf.butler"),
-            )
 
         # Unpersist all the init inputs
         for key, (value, dimensionIds) in simple.initInputs.items():

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -523,7 +523,7 @@ class QuantumBackedButler(LimitedButler):
           aren't actually used.  We rely on task authors to use
           `markInputUnused` to address this.
 
-        - We assume that the execution system will call ``datasetExistsDirect``
+        - We assume that the execution system will call ``stored``
           on all predicted inputs prior to execution, in order to populate the
           "available inputs" set.  This is what I envision
           '`~lsst.ctrl.mpexec.SingleQuantumExecutor` doing after we update it

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -39,7 +39,6 @@ from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any
 
 import pydantic
-from deprecated.sphinx import deprecated
 from lsst.resources import ResourcePathExpression
 
 from ._butler_config import ButlerConfig
@@ -380,23 +379,6 @@ class QuantumBackedButler(LimitedButler):
         # Docstring inherited.
         return True
 
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.get() now behaves like Butler.getDirect() when given a DatasetRef."
-        " Please use Butler.get(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def getDirect(
-        self,
-        ref: DatasetRef,
-        *,
-        parameters: dict[str, Any] | None = None,
-        storageClass: str | StorageClass | None = None,
-    ) -> Any:
-        # Docstring inherited.
-        return self.get(ref, parameters=parameters, storageClass=storageClass)
-
     def get(
         self,
         ref: DatasetRef,
@@ -419,23 +401,6 @@ class QuantumBackedButler(LimitedButler):
             self._actual_inputs.add(ref.id)
             self._available_inputs.add(ref.id)
         return obj
-
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.getDeferred() now behaves like getDirectDeferred() when given a DatasetRef. "
-        "Please use Butler.getDeferred(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def getDirectDeferred(
-        self,
-        ref: DatasetRef,
-        *,
-        parameters: dict[str, Any] | None = None,
-        storageClass: str | StorageClass | None = None,
-    ) -> DeferredDatasetHandle:
-        # Docstring inherited.
-        return self.getDeferred(ref, parameters=parameters, storageClass=storageClass)
 
     def getDeferred(
         self,
@@ -553,7 +518,7 @@ class QuantumBackedButler(LimitedButler):
         authors from having to worry about while still recording very
         detailed information.  But it has two small weaknesses:
 
-        - Calling `getDirectDeferred` or `getDirect` is enough to mark a
+        - Calling `getDeferred` or `get` is enough to mark a
           dataset as an "actual input", which may mark some datasets that
           aren't actually used.  We rely on task authors to use
           `markInputUnused` to address this.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -113,15 +113,9 @@ def associate(**kwargs: Any) -> None:
     metavar=typeStrAcceptsMultiple,
     help="Dimensions that should be skipped during import",
 )
-@click.option("--reuse-ids", is_flag=True, help="Force re-use of imported dataset IDs for integer IDs.")
 @options_file_option()
 def butler_import(*args: Any, **kwargs: Any) -> None:
     """Import data into a butler repository."""
-    # `reuse_ids`` is not used by `butlerImport`.
-    reuse_ids = kwargs.pop("reuse_ids", False)
-    if reuse_ids:
-        click.echo("WARNING: --reuse-ids option is deprecated and will be removed after v26.")
-
     script.butlerImport(*args, **kwargs)
 
 

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -907,20 +907,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         return ref
 
-    # TODO: remove on DM-40067.
-    @transactional
-    @deprecated(
-        reason="Butler.put() now behaves like Butler.putDirect() when given a DatasetRef."
-        " Please use Butler.put(). Be aware that you may need to adjust your usage if you"
-        " were relying on the run parameter to determine the run."
-        " Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def putDirect(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
-        # Docstring inherited.
-        return self.put(obj, ref)
-
     @transactional
     def put(
         self,
@@ -1002,89 +988,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         self._datastore.put(obj, ref)
 
         return ref
-
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.get() now behaves like Butler.getDirect() when given a DatasetRef."
-        " Please use Butler.get(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def getDirect(
-        self,
-        ref: DatasetRef,
-        *,
-        parameters: dict[str, Any] | None = None,
-        storageClass: StorageClass | str | None = None,
-    ) -> Any:
-        """Retrieve a stored dataset.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Resolved reference to an already stored dataset.
-        parameters : `dict`
-            Additional StorageClass-defined options to control reading,
-            typically used to efficiently read only a subset of the dataset.
-        storageClass : `StorageClass` or `str`, optional
-            The storage class to be used to override the Python type
-            returned by this method. By default the returned type matches
-            the dataset type definition for this dataset. Specifying a
-            read `StorageClass` can force a different type to be returned.
-            This type must be compatible with the original type.
-
-        Returns
-        -------
-        obj : `object`
-            The dataset.
-        """
-        return self._datastore.get(ref, parameters=parameters, storageClass=storageClass)
-
-    # TODO: remove on DM-40067.
-    @deprecated(
-        reason="Butler.getDeferred() now behaves like getDirectDeferred() when given a DatasetRef. "
-        "Please use Butler.getDeferred(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def getDirectDeferred(
-        self,
-        ref: DatasetRef,
-        *,
-        parameters: dict[str, Any] | None = None,
-        storageClass: str | StorageClass | None = None,
-    ) -> DeferredDatasetHandle:
-        """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
-        from a resolved `DatasetRef`.
-
-        Parameters
-        ----------
-        ref : `DatasetRef`
-            Resolved reference to an already stored dataset.
-        parameters : `dict`
-            Additional StorageClass-defined options to control reading,
-            typically used to efficiently read only a subset of the dataset.
-        storageClass : `StorageClass` or `str`, optional
-            The storage class to be used to override the Python type
-            returned by this method. By default the returned type matches
-            the dataset type definition for this dataset. Specifying a
-            read `StorageClass` can force a different type to be returned.
-            This type must be compatible with the original type.
-
-        Returns
-        -------
-        obj : `DeferredDatasetHandle`
-            A handle which can be used to retrieve a dataset at a later time.
-
-        Raises
-        ------
-        LookupError
-            Raised if no matching dataset exists in the `Registry`.
-        """
-        # Check that dataset is known to the datastore.
-        if not self._datastore.knows(ref):
-            raise LookupError(f"Dataset reference {ref} is not known to datastore.")
-        return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters, storageClass=storageClass)
 
     def getDeferred(
         self,

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -46,7 +46,6 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, TextIO, cast
 
-from deprecated.sphinx import deprecated
 from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.utils.introspection import get_class_of
 from lsst.utils.iteration import ensure_iterable
@@ -1348,61 +1347,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
                     existence[ref] |= DatasetExistence._ASSUMED
 
         return existence
-
-    # TODO: remove on DM-40079.
-    @deprecated(
-        reason="Butler.datasetExists() has been replaced by Butler.exists(). Will be removed after v26.0.",
-        version="v26.0",
-        category=FutureWarning,
-    )
-    def datasetExists(
-        self,
-        datasetRefOrType: DatasetRef | DatasetType | str,
-        dataId: DataId | None = None,
-        *,
-        collections: Any = None,
-        **kwargs: Any,
-    ) -> bool:
-        """Return True if the Dataset is actually present in the Datastore.
-
-        Parameters
-        ----------
-        datasetRefOrType : `DatasetRef`, `DatasetType`, or `str`
-            When `DatasetRef` the `dataId` should be `None`.
-            Otherwise the `DatasetType` or name thereof.
-        dataId : `dict` or `DataCoordinate`
-            A `dict` of `Dimension` link name, value pairs that label the
-            `DatasetRef` within a Collection. When `None`, a `DatasetRef`
-            should be provided as the first argument.
-        collections : Any, optional
-            Collections to be searched, overriding ``self.collections``.
-            Can be any of the types supported by the ``collections`` argument
-            to butler construction.
-        **kwargs
-            Additional keyword arguments used to augment or construct a
-            `DataCoordinate`.  See `DataCoordinate.standardize`
-            parameters.
-
-        Raises
-        ------
-        LookupError
-            Raised if the dataset is not even present in the Registry.
-        ValueError
-            Raised if a resolved `DatasetRef` was passed as an input, but it
-            differs from the one found in the registry.
-        NoDefaultCollectionError
-            Raised if no collections were provided.
-        """
-        # A resolved ref may be given that is not known to this butler.
-        if isinstance(datasetRefOrType, DatasetRef):
-            ref = self._registry.getDataset(datasetRefOrType.id)
-            if ref is None:
-                raise LookupError(
-                    f"Resolved DatasetRef with id {datasetRefOrType.id} is not known to registry."
-                )
-        else:
-            ref = self._findDatasetRef(datasetRefOrType, dataId, collections=collections, **kwargs)
-        return self._datastore.exists(ref)
 
     def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
         # Docstring inherited.

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -84,7 +84,7 @@ from .utils import transactional
 if TYPE_CHECKING:
     from lsst.resources import ResourceHandleProtocol
 
-    from ._dataset_ref import DatasetId, DatasetIdGenEnum
+    from ._dataset_ref import DatasetId
     from ._file_dataset import FileDataset
     from ._query import Query
     from .datastore import DatasetRefURIs
@@ -1441,7 +1441,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         *datasets: FileDataset,
         transfer: str | None = "auto",
         run: str | None = None,
-        idGenerationMode: DatasetIdGenEnum | None = None,
         record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited.
@@ -1451,14 +1450,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         _LOG.verbose("Ingesting %d file dataset%s.", len(datasets), "" if len(datasets) == 1 else "s")
         if not datasets:
             return
-
-        if idGenerationMode is not None:
-            warnings.warn(
-                "The idGenerationMode parameter is no longer used and is ignored. "
-                " Will be removed after v26.0",
-                FutureWarning,
-                stacklevel=2,
-            )
 
         progress = Progress("lsst.daf.butler.Butler.ingest", level=logging.DEBUG)
 

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -447,7 +447,6 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         self,
         *datasets: FileDataset,
         transfer: str | None = "auto",
-        run: str | None = None,
         record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited.

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -43,7 +43,7 @@ from pydantic import BaseModel, TypeAdapter
 
 from .._butler import Butler
 from .._butler_instance_options import ButlerInstanceOptions
-from .._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef, SerializedDatasetRef
+from .._dataset_ref import DatasetId, DatasetRef, SerializedDatasetRef
 from .._dataset_type import DatasetType, SerializedDatasetType
 from .._storage_class import StorageClass
 from .._utilities.locked_object import LockedObject
@@ -448,7 +448,6 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         *datasets: FileDataset,
         transfer: str | None = "auto",
         run: str | None = None,
-        idGenerationMode: DatasetIdGenEnum | None = None,
         record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -289,7 +289,7 @@ class ButlerPutGetTests(TestCaseMixin):
                 ref = butler.put(metric, *args, **kwargs)
                 self.assertIsInstance(ref, DatasetRef)
 
-                # Test getDirect
+                # Test get of a ref.
                 metricOut = butler.get(ref)
                 self.assertEqual(metric, metricOut)
                 # Test get
@@ -1101,7 +1101,7 @@ class ButlerTests(ButlerPutGetTests):
                 # Store a dataset
                 ref = butler.put(metric, datasetTypeName, dataId)
                 self.assertIsInstance(ref, DatasetRef)
-                # Test getDirect
+                # Test get of a ref.
                 metricOut = butler.get(ref)
                 self.assertEqual(metric, metricOut)
                 # Test get

--- a/tests/test_quantum.py
+++ b/tests/test_quantum.py
@@ -178,14 +178,14 @@ class QuantumTestCase(unittest.TestCase):
         self.assertEqual(quantum, quantum.from_simple(serialized, DimensionUniverse()))
 
         # verify direct works
-        jsonVersion = json.loads(serialized.json())
+        jsonVersion = json.loads(serialized.model_dump_json())
         fromDirect = SerializedQuantum.direct(**jsonVersion)
         self.assertEqual(fromDirect, serialized)
 
         # verify direct with records works
         quantum, _ = self._buildFullQuantum(taskName, addRecords=True)
         serialized = quantum.to_simple()
-        jsonVersion = json.loads(serialized.json())
+        jsonVersion = json.loads(serialized.model_dump_json())
         fromDirect = SerializedQuantum.direct(**jsonVersion)
         self.assertEqual(fromDirect, serialized)
 

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -243,7 +243,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.assertEqual(qbb._actual_inputs, {ref.id for ref in input_refs + self.init_inputs_refs})
         self.assertEqual(qbb._unavailable_inputs, {ref.id for ref in self.missing_refs})
 
-    def test_datasetExistsDirect(self) -> None:
+    def test_stored(self) -> None:
         """Test for dataset existence method"""
         quantum = self.make_quantum()
         qbb = QuantumBackedButler.initialize(

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -186,7 +186,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.assertEqual(qbb._actual_output_refs, set())
 
     def test_getput(self) -> None:
-        """Test for getDirect/putDirect methods"""
+        """Test for get/put methods"""
         quantum = self.make_quantum()
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
@@ -219,7 +219,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         self.assertEqual(qbb._actual_output_refs, set(self.output_refs))
 
     def test_getDeferred(self) -> None:
-        """Test for getDirectDeferred method"""
+        """Test for getDeferred method"""
         quantum = self.make_quantum()
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
@@ -275,7 +275,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         # _available_inputs is not
         self.assertEqual(qbb._available_inputs, {ref.id for ref in input_refs + self.init_inputs_refs})
         self.assertEqual(qbb._actual_inputs, set())
-        self.assertEqual(qbb._unavailable_inputs, set())  # this is not consistent with getDirect?
+        self.assertEqual(qbb._unavailable_inputs, set())  # this is not consistent with get?
 
     def test_markInputUnused(self) -> None:
         """Test for markInputUnused method"""

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -358,7 +358,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             qbb.put({"data": cast(int, ref.dataId["detector"]) ** 2}, ref)
 
         provenance1 = qbb.extract_provenance_data()
-        prov_json = provenance1.json()
+        prov_json = provenance1.model_dump_json()
         provenance2 = QuantumProvenanceData.direct(**json.loads(prov_json))
         for provenance in (provenance1, provenance2):
             input_ids = {ref.id for ref in self.input_refs + self.init_inputs_refs}


### PR DESCRIPTION
* Butler.datastore
* Butler.getDirect*
* Butler.datasetExists
* `run` and `idGenerationMode` removed from `Butler.ingest`

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
