### PR TITLE
DM-42416: Modify without_datastore test to use file config

### DIFF
--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2397,13 +2397,18 @@ class NullDatastoreTestCase(unittest.TestCase):
 
     def test_fallback(self) -> None:
         # Read the butler config and mess with the datastore section.
-        bad_config = Config(os.path.join(self.root, "butler.yaml"))
+        config_path = os.path.join(self.root, "butler.yaml")
+        bad_config = Config(config_path)
         bad_config["datastore", "cls"] = "lsst.not.a.datastore.Datastore"
+        bad_config.dumpToUri(config_path)
 
         with self.assertRaises(RuntimeError):
-            Butler.from_config(bad_config)
+            Butler(self.root, without_datastore=False)
 
-        butler = Butler.from_config(bad_config, writeable=True, without_datastore=True)
+        with self.assertRaises(RuntimeError):
+            Butler.from_config(self.root, without_datastore=False)
+
+        butler = Butler.from_config(self.root, writeable=True, without_datastore=True)
         self.assertIsInstance(butler._datastore, NullDatastore)
 
         # Check that registry is working.


### PR DESCRIPTION
In w.2023.50 the test passed because the config was sent as a Config object, but would fail if a path to a Config was used instead. Rewrite the test to use a file (which works now due to a later reorganization).

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
