### PR TITLE
DM-42190: Add optional dependencies for RemoteButler

### DIFF
--- a/doc/changes/DM-42190.feature.rst
+++ b/doc/changes/DM-42190.feature.rst
@@ -1,0 +1,1 @@
+Added a new optional dependency set ``remote``, which can be used to install the dependencies required by the client half of Butler client/server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,12 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 postgres = ["psycopg2"]
+remote = [
+    "httpx",
+    # RemoteButler always uses HTTPS URLs for accessing files in the Datastore,
+    # so we need resources to have HTTPS support.
+    "lsst-resources[https]"
+]
 server = [
     "fastapi",
     "safir >= 3.4.0"


### PR DESCRIPTION
Add a "remote" entry in pyproject.toml for the optional dependencies required to use RemoteButler.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
