### PR TITLE
DM-42580: Do not attempt to convert the label to a ResourcePath in butler config

### DIFF
--- a/python/lsst/daf/butler/_butler_config.py
+++ b/python/lsst/daf/butler/_butler_config.py
@@ -102,7 +102,7 @@ class ButlerConfig(Config):
                 # Force back to a string because the resolved URI
                 # might not refer explicitly to a directory and we have
                 # check below to guess that.
-                other = str(ButlerRepoIndex.get_repo_uri(other, True))
+                other = str(ButlerRepoIndex.get_repo_uri(other, False))
             if other != original_other:
                 resolved_alias = True
 


### PR DESCRIPTION
With the recent change in ResourcePath to force /repo/main to an absolute URI the code that was seeing if anything was found got confused a bit because file:///repo/main was not the same as /repo/main. Change it to allow the get_repo_uri call to raise and if it raises continue to use the original label.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
