### PR TITLE
DM-42605: list chained collection children in search order

### DIFF
--- a/doc/changes/DM-42605.bugfix.rst
+++ b/doc/changes/DM-42605.bugfix.rst
@@ -1,0 +1,1 @@
+butler query-collections --chains=TABLE now lists children in search order, not alphabetical order.

--- a/python/lsst/daf/butler/script/queryCollections.py
+++ b/python/lsst/daf/butler/script/queryCollections.py
@@ -96,7 +96,7 @@ def _getTable(
                 children = butler.registry.getCollectionChain(name)
                 if children:
                     first = True
-                    for child in sorted(children):
+                    for child in children:
                         table.add_row((name if first else "", type.name if first else "", child))
                         first = False
                 else:

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -225,9 +225,9 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
                 array(
                     (
                         ("calibration1", "CALIBRATION", ""),
-                        ("chain1", "CHAINED", "chain2"),
+                        ("chain1", "CHAINED", "tag1"),
                         ("", "", "run1"),
-                        ("", "", "tag1"),
+                        ("", "", "chain2"),
                         ("chain2", "CHAINED", "calibration1"),
                         ("", "", "run1"),
                         ("imported_g", "RUN", ""),


### PR DESCRIPTION
This PR fixes a bug where the `TABLE` mode of `butler query-collections` listed children in alphabetical order, obscuring the exact definition of a chained collection.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
