### PR TITLE
DM-42645: Log request ID for Butler client/server

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/_server.py
+++ b/python/lsst/daf/butler/remote_butler/server/_server.py
@@ -29,17 +29,21 @@ from __future__ import annotations
 
 __all__ = ("create_app",)
 
-import logging
+from typing import Awaitable, Callable
 
-from fastapi import FastAPI, Request
+import safir.dependencies.logger
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
 from lsst.daf.butler import MissingDatasetTypeError
+from safir.logging import configure_logging, configure_uvicorn_logging
 
+from ..server_models import CLIENT_REQUEST_ID_HEADER_NAME
 from .handlers._external import external_router
 from .handlers._internal import internal_router
 
-log = logging.getLogger(__name__)
+configure_logging(name="lsst.daf.butler.remote_butler.server")
+configure_uvicorn_logging()
 
 
 def create_app() -> FastAPI:
@@ -54,6 +58,30 @@ def create_app() -> FastAPI:
     default_api_path = "/api/butler"
     app.include_router(external_router, prefix=f"{default_api_path}/repo/{repository_placeholder}")
     app.include_router(internal_router)
+
+    # Any time an exception is returned by a handler, add a log message that
+    # includes the username and request ID from the client.  This will make it
+    # easier to track down user-reported issues in the logs.
+    #
+    # This middleware is higher in the middleware stack than FastAPI's
+    # HttpException and ValidationError handling middleware, so it only
+    # catches unhandled errors that would result in a 500 Internal
+    # Server Error.
+    @app.middleware("http")
+    async def _log_exceptions_middleware(
+        request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        try:
+            return await call_next(request)
+        except Exception as e:
+            logger = await safir.dependencies.logger.logger_dependency(request)
+            await logger.aerror(
+                "Exception",
+                exc_info=e,
+                clientRequestId=request.headers.get(CLIENT_REQUEST_ID_HEADER_NAME, "(unknown)"),
+                user=request.headers.get("X-Auth-Request-User", "(unknown)"),
+            )
+            raise
 
     @app.exception_handler(MissingDatasetTypeError)
     def missing_dataset_type_exception_handler(

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -27,13 +27,21 @@
 
 """Models used for client/server communication."""
 
-__all__ = ["FindDatasetModel", "GetFileResponseModel"]
+__all__ = [
+    "CLIENT_REQUEST_ID_HEADER_NAME",
+    "CollectionList",
+    "DatasetTypeName",
+    "FindDatasetModel",
+    "GetFileResponseModel",
+]
 
 from typing import NewType
 
 import pydantic
 from lsst.daf.butler import SerializedDataId
 from lsst.daf.butler.datastores.fileDatastoreClient import FileDatastoreGetPayload
+
+CLIENT_REQUEST_ID_HEADER_NAME = "X-Butler-Client-Request-Id"
 
 CollectionList = NewType("CollectionList", list[str])
 DatasetTypeName = NewType("DatasetTypeName", str)


### PR DESCRIPTION
RemoteButler now sends a request ID header with all of its requests.  When a server-side exception occurs, it logs the caller's username and request ID along with the exception.  On the client side, we raise a ButlerServerError that includes the request ID.  This will allow us to quickly locate the error information for any user-reported issues in the server logs.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
