### PR TITLE
DM-42660: Allow direct configuration of repository index

### DIFF
--- a/doc/changes/DM-42660.feature.md
+++ b/doc/changes/DM-42660.feature.md
@@ -1,0 +1,1 @@
+The Butler repository index can now be configured by a new environment variable `DAF_BUTLER_REPOSITORIES`, which contains the configuration directly instead of requiring lookup via a URI.


### PR DESCRIPTION
Instead of requiring the repository index to be loaded from a file, allow direct configuration as a string in a new environment variable DAF_BUTLER_REPOSITORIES.

The file was problematic for services for a few reasons:
1. We don't have anywhere to host it -- currently it is stored in S3, but services using Butler server will not have the credentials to access it.
2. There are cache invalidation issues.  If it's configured directly, Phalanx can automatically restart services using it when the configuration changes.
3. Manually editing live configuration files is error-prone.  If this configuration lives in Phalanx, we are able to validate the configuration before deploying it.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
