### PR TITLE
DM-42771: Allow server tags without making a PyPI release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,9 @@ jobs:
   pypi:
     runs-on: ubuntu-latest
     needs: [build_and_test]
-    if: startsWith(github.ref, 'refs/tags/')
+    # The "not starts with 's'" is meant to catch server release tags in the
+    # form 'server/x.y.z'
+    if: startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/tags/s')
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Decouple releases of Butler server containers from the PyPI release by adding a check to skip tags in the form 'server/x.y.z'.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
