### PR TITLE
DM-42934: Run existing unit tests against RemoteButler

### DIFF
--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -287,7 +287,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             dataset_id = datasetRefOrType.id
             response = self._get(f"get_file/{dataset_id}", expected_errors=(404,))
             if response.status_code == 404:
-                raise LookupError(f"Dataset not found: {datasetRefOrType}")
+                raise FileNotFoundError(f"Dataset not found: {datasetRefOrType}")
         else:
             request = GetFileByDataIdRequestModel(
                 dataset_type_name=self._normalize_dataset_type_name(datasetRefOrType),
@@ -296,7 +296,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             )
             response = self._post("get_file_by_data_id", request, expected_errors=(404,))
             if response.status_code == 404:
-                raise LookupError(
+                raise FileNotFoundError(
                     f"Dataset not found with DataId: {dataId} DatasetType: {datasetRefOrType}"
                     f" collections: {collections}"
                 )

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -284,6 +284,8 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         associated with a dataset.
         """
         if isinstance(datasetRefOrType, DatasetRef):
+            if dataId is not None:
+                raise ValueError("DatasetRef given, cannot use dataId as well")
             dataset_id = datasetRefOrType.id
             response = self._get(f"get_file/{dataset_id}", expected_errors=(404,))
             if response.status_code == 404:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -112,6 +112,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     _registry_defaults: RegistryDefaults
     _client: httpx.Client
     _server_url: str
+    _access_token: str
     _headers: dict[str, str]
     _cache: RemoteButlerCache
 
@@ -137,6 +138,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         self._client = http_client
         self._server_url = server_url
         self._cache = cache
+        self._access_token = access_token
 
         # TODO: RegistryDefaults should have finish() called on it, but this
         # requires getCollectionSummary() which is not yet implemented
@@ -682,7 +684,19 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         inferDefaults: bool = True,
         **kwargs: Any,
     ) -> RemoteButler:
-        raise NotImplementedError()
+        return RemoteButler(
+            server_url=self._server_url,
+            http_client=self._client,
+            access_token=self._access_token,
+            cache=self._cache,
+            options=ButlerInstanceOptions(
+                collections=collections,
+                run=run,
+                writeable=self.isWriteable(),
+                inferDefaults=inferDefaults,
+                kwargs=kwargs,
+            ),
+        )
 
 
 def _extract_dataset_type(datasetRefOrType: DatasetRef | DatasetType | str) -> DatasetType | None:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -700,6 +700,9 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             ),
         )
 
+    def __str__(self) -> str:
+        return f"RemoteButler({self._server_url})"
+
 
 def _extract_dataset_type(datasetRefOrType: DatasetRef | DatasetType | str) -> DatasetType | None:
     """Return the DatasetType associated with the argument, or None if the

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -1,0 +1,433 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from contextlib import AbstractContextManager
+from typing import Any, TextIO, cast
+
+from lsst.resources import ResourcePath, ResourcePathExpression
+
+from .._butler import Butler
+from .._dataset_existence import DatasetExistence
+from .._dataset_ref import DatasetId, DatasetRef
+from .._dataset_type import DatasetType
+from .._deferredDatasetHandle import DeferredDatasetHandle
+from .._file_dataset import FileDataset
+from .._limited_butler import LimitedButler
+from .._query import Query
+from .._storage_class import StorageClass
+from .._timespan import Timespan
+from ..datastore import DatasetRefURIs
+from ..dimensions import DataCoordinate, DataId, DimensionGroup, DimensionRecord, DimensionUniverse
+from ..registry import CollectionArgType, Registry
+from ..remote_butler import RemoteButler
+from ..transfers import RepoExportContext
+
+
+class HybridButler(Butler):
+    """A `Butler` that delegates methods to internal RemoteButler and
+    DirectButler instances.  Intended to allow testing of RemoteButler before
+    its implementation is complete, by delegating unsupported methods to
+    DirectButler.
+    """
+
+    _remote_butler: RemoteButler
+    _direct_butler: Butler
+
+    def __new__(cls, remote_butler: RemoteButler, direct_butler: Butler) -> HybridButler:
+        self = cast(HybridButler, super().__new__(cls))
+        self._remote_butler = remote_butler
+        self._direct_butler = direct_butler
+        self._datastore = direct_butler._datastore
+        return self
+
+    def isWriteable(self) -> bool:
+        return self._remote_butler.isWriteable()
+
+    def _caching_context(self) -> AbstractContextManager[None]:
+        return self._direct_butler._caching_context()
+
+    def transaction(self) -> AbstractContextManager[None]:
+        return self._direct_butler.transaction()
+
+    def put(
+        self,
+        obj: Any,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        /,
+        dataId: DataId | None = None,
+        *,
+        run: str | None = None,
+        **kwargs: Any,
+    ) -> DatasetRef:
+        return self._direct_butler.put(obj, datasetRefOrType, dataId, run=run, **kwargs)
+
+    def getDeferred(
+        self,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        /,
+        dataId: DataId | None = None,
+        *,
+        parameters: dict | None = None,
+        collections: Any = None,
+        storageClass: str | StorageClass | None = None,
+        **kwargs: Any,
+    ) -> DeferredDatasetHandle:
+        return self._direct_butler.getDeferred(
+            datasetRefOrType,
+            dataId,
+            parameters=parameters,
+            collections=collections,
+            storageClass=storageClass,
+            **kwargs,
+        )
+
+    def get(
+        self,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        /,
+        dataId: DataId | None = None,
+        *,
+        parameters: dict[str, Any] | None = None,
+        collections: Any = None,
+        storageClass: StorageClass | str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return self._remote_butler.get(
+            datasetRefOrType,
+            dataId,
+            parameters=parameters,
+            collections=collections,
+            storageClass=storageClass,
+            **kwargs,
+        )
+
+    def getURIs(
+        self,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        /,
+        dataId: DataId | None = None,
+        *,
+        predict: bool = False,
+        collections: Any = None,
+        run: str | None = None,
+        **kwargs: Any,
+    ) -> DatasetRefURIs:
+        return self._remote_butler.getURIs(
+            datasetRefOrType, dataId, predict=predict, collections=collections, run=run, **kwargs
+        )
+
+    def getURI(
+        self,
+        datasetRefOrType: DatasetRef | DatasetType | str,
+        /,
+        dataId: DataId | None = None,
+        *,
+        predict: bool = False,
+        collections: Any = None,
+        run: str | None = None,
+        **kwargs: Any,
+    ) -> ResourcePath:
+        return self._remote_butler.getURI(
+            datasetRefOrType, dataId, predict=predict, collections=collections, run=run, **kwargs
+        )
+
+    def get_dataset_type(self, name: str) -> DatasetType:
+        return self._remote_butler.get_dataset_type(name)
+
+    def get_dataset(
+        self,
+        id: DatasetId,
+        *,
+        storage_class: str | StorageClass | None = None,
+        dimension_records: bool = False,
+        datastore_records: bool = False,
+    ) -> DatasetRef | None:
+        return self._remote_butler.get_dataset(
+            id,
+            storage_class=storage_class,
+            dimension_records=dimension_records,
+            datastore_records=datastore_records,
+        )
+
+    def find_dataset(
+        self,
+        dataset_type: DatasetType | str,
+        data_id: DataId | None = None,
+        *,
+        collections: str | Sequence[str] | None = None,
+        timespan: Timespan | None = None,
+        storage_class: str | StorageClass | None = None,
+        dimension_records: bool = False,
+        datastore_records: bool = False,
+        **kwargs: Any,
+    ) -> DatasetRef | None:
+        return self._remote_butler.find_dataset(
+            dataset_type,
+            data_id,
+            collections=collections,
+            timespan=timespan,
+            storage_class=storage_class,
+            dimension_records=dimension_records,
+            datastore_records=datastore_records,
+            **kwargs,
+        )
+
+    def retrieveArtifacts(
+        self,
+        refs: Iterable[DatasetRef],
+        destination: ResourcePathExpression,
+        transfer: str = "auto",
+        preserve_path: bool = True,
+        overwrite: bool = False,
+    ) -> list[ResourcePath]:
+        return self._direct_butler.retrieveArtifacts(refs, destination, transfer, preserve_path, overwrite)
+
+    def exists(
+        self,
+        dataset_ref_or_type: DatasetRef | DatasetType | str,
+        /,
+        data_id: DataId | None = None,
+        *,
+        full_check: bool = True,
+        collections: Any = None,
+        **kwargs: Any,
+    ) -> DatasetExistence:
+        return self._direct_butler.exists(
+            dataset_ref_or_type, data_id, full_check=full_check, collections=collections, **kwargs
+        )
+
+    def _exists_many(
+        self,
+        refs: Iterable[DatasetRef],
+        /,
+        *,
+        full_check: bool = True,
+    ) -> dict[DatasetRef, DatasetExistence]:
+        return self._direct_butler._exists_many(refs, full_check=full_check)
+
+    def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
+        return self._direct_butler.removeRuns(names, unstore)
+
+    def ingest(
+        self,
+        *datasets: FileDataset,
+        transfer: str | None = "auto",
+        record_validation_info: bool = True,
+    ) -> None:
+        return self._direct_butler.ingest(
+            *datasets, transfer=transfer, record_validation_info=record_validation_info
+        )
+
+    def export(
+        self,
+        *,
+        directory: str | None = None,
+        filename: str | None = None,
+        format: str | None = None,
+        transfer: str | None = None,
+    ) -> AbstractContextManager[RepoExportContext]:
+        return self._direct_butler.export(
+            directory=directory, filename=filename, format=format, transfer=transfer
+        )
+
+    def import_(
+        self,
+        *,
+        directory: ResourcePathExpression | None = None,
+        filename: ResourcePathExpression | TextIO | None = None,
+        format: str | None = None,
+        transfer: str | None = None,
+        skip_dimensions: set | None = None,
+    ) -> None:
+        self._direct_butler.import_(
+            directory=directory,
+            filename=filename,
+            format=format,
+            transfer=transfer,
+            skip_dimensions=skip_dimensions,
+        )
+
+    def transfer_dimension_records_from(
+        self, source_butler: LimitedButler | Butler, source_refs: Iterable[DatasetRef]
+    ) -> None:
+        return self._direct_butler.transfer_dimension_records_from(source_butler, source_refs)
+
+    def transfer_from(
+        self,
+        source_butler: LimitedButler,
+        source_refs: Iterable[DatasetRef],
+        transfer: str = "auto",
+        skip_missing: bool = True,
+        register_dataset_types: bool = False,
+        transfer_dimensions: bool = False,
+        dry_run: bool = False,
+    ) -> Collection[DatasetRef]:
+        return self._direct_butler.transfer_from(
+            source_butler,
+            source_refs,
+            transfer,
+            skip_missing,
+            register_dataset_types,
+            transfer_dimensions,
+            dry_run,
+        )
+
+    def validateConfiguration(
+        self,
+        logFailures: bool = False,
+        datasetTypeNames: Iterable[str] | None = None,
+        ignore: Iterable[str] | None = None,
+    ) -> None:
+        return self._direct_butler.validateConfiguration(logFailures, datasetTypeNames, ignore)
+
+    @property
+    def collections(self) -> Sequence[str]:
+        return self._remote_butler.collections
+
+    @property
+    def run(self) -> str | None:
+        return self._remote_butler.run
+
+    @property
+    def registry(self) -> Registry:
+        return self._direct_butler.registry
+
+    def _query(self) -> AbstractContextManager[Query]:
+        return self._direct_butler._query()
+
+    def _query_data_ids(
+        self,
+        dimensions: DimensionGroup | Iterable[str] | str,
+        *,
+        data_id: DataId | None = None,
+        where: str = "",
+        bind: Mapping[str, Any] | None = None,
+        expanded: bool = False,
+        order_by: Iterable[str] | str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        explain: bool = True,
+        **kwargs: Any,
+    ) -> list[DataCoordinate]:
+        return self._direct_butler._query_data_ids(
+            dimensions,
+            data_id=data_id,
+            where=where,
+            bind=bind,
+            expanded=expanded,
+            order_by=order_by,
+            limit=limit,
+            offset=offset,
+            explain=explain,
+            **kwargs,
+        )
+
+    def _query_datasets(
+        self,
+        dataset_type: Any,
+        collections: CollectionArgType | None = None,
+        *,
+        find_first: bool = True,
+        data_id: DataId | None = None,
+        where: str = "",
+        bind: Mapping[str, Any] | None = None,
+        expanded: bool = False,
+        explain: bool = True,
+        **kwargs: Any,
+    ) -> list[DatasetRef]:
+        return self._direct_butler._query_datasets(
+            dataset_type,
+            collections,
+            find_first=find_first,
+            data_id=data_id,
+            where=where,
+            bind=bind,
+            expanded=expanded,
+            explain=explain,
+            **kwargs,
+        )
+
+    def _query_dimension_records(
+        self,
+        element: str,
+        *,
+        data_id: DataId | None = None,
+        where: str = "",
+        bind: Mapping[str, Any] | None = None,
+        order_by: Iterable[str] | str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        explain: bool = True,
+        **kwargs: Any,
+    ) -> list[DimensionRecord]:
+        return self._direct_butler._query_dimension_records(
+            element,
+            data_id=data_id,
+            where=where,
+            bind=bind,
+            order_by=order_by,
+            limit=limit,
+            offset=offset,
+            explain=explain,
+            **kwargs,
+        )
+
+    def _clone(
+        self,
+        *,
+        collections: Any = None,
+        run: str | None = None,
+        inferDefaults: bool = True,
+        **kwargs: Any,
+    ) -> HybridButler:
+        remote_butler = self._remote_butler._clone(
+            collections=collections, run=run, inferDefaults=inferDefaults, **kwargs
+        )
+        direct_butler = self._direct_butler._clone(
+            collections=collections, run=run, inferDefaults=inferDefaults, **kwargs
+        )
+        return HybridButler(remote_butler, direct_butler)
+
+    def pruneDatasets(
+        self,
+        refs: Iterable[DatasetRef],
+        *,
+        disassociate: bool = True,
+        unstore: bool = False,
+        tags: Iterable[str] = (),
+        purge: bool = False,
+    ) -> None:
+        return self._direct_butler.pruneDatasets(
+            refs, disassociate=disassociate, unstore=unstore, tags=tags, purge=purge
+        )
+
+    @property
+    def dimensions(self) -> DimensionUniverse:
+        return self._remote_butler.dimensions

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -57,8 +57,14 @@ class TestServerInstance:
 
 
 @contextmanager
-def create_test_server() -> Iterator[TestServerInstance]:
+def create_test_server(test_directory: str) -> Iterator[TestServerInstance]:
     """Create a temporary Butler server instance for testing.
+
+    Parameters
+    ----------
+    test_directory : `str`
+        Path to the ``tests/`` directory at the root of the repository,
+        containing Butler test configuration files.
 
     Returns
     -------
@@ -72,9 +78,7 @@ def create_test_server() -> Iterator[TestServerInstance]:
     # Note that all files are stored in memory.
     with clean_test_environment_for_s3():
         with mock_aws():
-            # The tests/ directory at the top of the repository
-            test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../tests"))
-            base_config_path = os.path.join(test_dir, "config/basic/server.yaml")
+            base_config_path = os.path.join(test_directory, "config/basic/server.yaml")
             # Create S3 buckets used for the datastore in server.yaml.
             for bucket in ["mutable-bucket", "immutable-bucket"]:
                 getS3Client().create_bucket(Bucket=bucket)

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -1,0 +1,110 @@
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from tempfile import TemporaryDirectory
+
+from fastapi.testclient import TestClient
+from lsst.daf.butler import Butler, Config, LabeledButlerFactory
+from lsst.daf.butler.remote_butler import RemoteButler, RemoteButlerFactory
+from lsst.daf.butler.remote_butler.server import create_app
+from lsst.daf.butler.remote_butler.server._dependencies import butler_factory_dependency
+from lsst.daf.butler.tests.server_utils import add_auth_header_check_middleware
+from lsst.resources.s3utils import clean_test_environment_for_s3, getS3Client
+
+try:
+    # moto v5
+    from moto import mock_aws  # type: ignore
+except ImportError:
+    # moto v4 and earlier
+    from moto import mock_s3 as mock_aws  # type: ignore
+
+__all__ = ("create_test_server", "TestServerInstance", "TEST_REPOSITORY_NAME")
+
+
+TEST_REPOSITORY_NAME = "testrepo"
+
+
+@dataclass(frozen=True)
+class TestServerInstance:
+    """Butler instances and other data associated with a temporary server
+    instance.
+    """
+
+    config_file_path: str
+    """Path to the Butler config file used by the server."""
+    client: TestClient
+    """HTTPX client connected to the temporary server."""
+    remote_butler: RemoteButler
+    """`RemoteButler` connected to the temporary server."""
+    remote_butler_without_error_propagation: RemoteButler
+    """`RemoteButler` connected to the temporary server.
+
+    By default, the TestClient instance raises any unhandled exceptions
+    from the server as if they had originated in the client to ease debugging.
+    However, this can make it appear that error propagation is working
+    correctly when in a real deployment the server exception would cause a 500
+    Internal Server Error.  This instance of the butler is set up so that any
+    unhandled server exceptions do return a 500 status code."""
+    direct_butler: Butler
+    """`DirectButler` instance connected to the same repository as the
+    temporary server.
+    """
+
+
+@contextmanager
+def create_test_server() -> Iterator[TestServerInstance]:
+    """Create a temporary Butler server instance for testing.
+
+    Returns
+    -------
+    instance : `TestServerInstance`
+        Object containing Butler instances connected to the server and
+        associated information.
+    """
+    # Set up a mock S3 environment using Moto.  Moto also monkeypatches the
+    # `requests` library so that any HTTP requests to presigned S3 URLs get
+    # redirected to the mocked S3.
+    # Note that all files are stored in memory.
+    with clean_test_environment_for_s3():
+        with mock_aws():
+            # The tests/ directory at the top of the repository
+            test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../tests"))
+            base_config_path = os.path.join(test_dir, "config/basic/server.yaml")
+            # Create S3 buckets used for the datastore in server.yaml.
+            for bucket in ["mutable-bucket", "immutable-bucket"]:
+                getS3Client().create_bucket(Bucket=bucket)
+
+            with TemporaryDirectory() as root:
+                Butler.makeRepo(root, config=Config(base_config_path), forceConfigRoot=False)
+                config_file_path = os.path.join(root, "butler.yaml")
+
+                app = create_app()
+                add_auth_header_check_middleware(app)
+                # Override the server's Butler initialization to point at our
+                # test repo
+                server_butler_factory = LabeledButlerFactory({TEST_REPOSITORY_NAME: config_file_path})
+                app.dependency_overrides[butler_factory_dependency] = lambda: server_butler_factory
+
+                client = TestClient(app)
+                client_without_error_propagation = TestClient(app, raise_server_exceptions=False)
+
+                remote_butler = _make_remote_butler(client)
+                direct_butler = Butler.from_config(config_file_path, writeable=True)
+
+                yield TestServerInstance(
+                    config_file_path=config_file_path,
+                    client=client,
+                    direct_butler=direct_butler,
+                    remote_butler=remote_butler,
+                    remote_butler_without_error_propagation=_make_remote_butler(
+                        client_without_error_propagation
+                    ),
+                )
+
+
+def _make_remote_butler(client: TestClient) -> RemoteButler:
+    remote_butler_factory = RemoteButlerFactory(
+        f"https://test.example/api/butler/repo/{TEST_REPOSITORY_NAME}", client
+    )
+    return remote_butler_factory.create_butler_for_access_token("fake-access-token")

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2544,9 +2544,10 @@ class ButlerServerTests(ButlerTests, unittest.TestCase):
         return super().testPickle()
 
     def testStringification(self) -> None:
-        # RemoteButler does not have datastore/registry strings like
-        # DirectButler does.
-        pass
+        self.assertEqual(
+            str(self.server_instance.remote_butler),
+            "RemoteButler(https://test.example/api/butler/repo/testrepo)",
+        )
 
     def testTransaction(self) -> None:
         # Transactions will never be supported for RemoteButler.

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -63,6 +63,11 @@ except ImportError:
 
 
 try:
+    from lsst.daf.butler.tests.server import create_test_server
+except ImportError:
+    create_test_server = None
+
+try:
     # It's possible but silly to have testing.postgresql installed without
     # having the postgresql server installed (because then nothing in
     # testing.postgresql would work), so we use the presence of that module
@@ -168,7 +173,7 @@ class ButlerPutGetTests(TestCaseMixin):
     root: str
     default_run = "ingésτ😺"
     storageClassFactory: StorageClassFactory
-    configFile: str
+    configFile: str | None
     tmpConfigFile: str
 
     @staticmethod
@@ -183,7 +188,8 @@ class ButlerPutGetTests(TestCaseMixin):
     @classmethod
     def setUpClass(cls) -> None:
         cls.storageClassFactory = StorageClassFactory()
-        cls.storageClassFactory.addFromConfig(cls.configFile)
+        if cls.configFile is not None:
+            cls.storageClassFactory.addFromConfig(cls.configFile)
 
     def assertGetComponents(
         self,
@@ -205,17 +211,27 @@ class ButlerPutGetTests(TestCaseMixin):
             self.assertEqual(result_deferred, result)
 
     def tearDown(self) -> None:
-        removeTestTempDir(self.root)
+        if self.root is not None:
+            removeTestTempDir(self.root)
+
+    def create_empty_butler(self, run: str | None = None, writeable: bool | None = None):
+        """Create a Butler for the test repository, without inserting test
+        data.
+        """
+        butler = Butler.from_config(self.tmpConfigFile, run=run, writeable=writeable)
+        assert isinstance(butler, DirectButler), "Expect DirectButler in configuration"
+        return butler
 
     def create_butler(
         self, run: str, storageClass: StorageClass | str, datasetTypeName: str
-    ) -> tuple[DirectButler, DatasetType]:
-        butler = Butler.from_config(self.tmpConfigFile, run=run)
-        assert isinstance(butler, DirectButler), "Expect DirectButler in configuration"
+    ) -> tuple[Butler, DatasetType]:
+        """Create a Butler for the test repository and insert some test data
+        into it.
+        """
+        butler = self.create_empty_butler(run=run)
 
         collections = set(butler.registry.queryCollections())
         self.assertEqual(collections, {run})
-
         # Create and register a DatasetType
         dimensions = butler.dimensions.conform(["instrument", "visit"])
 
@@ -256,7 +272,7 @@ class ButlerPutGetTests(TestCaseMixin):
             )
         return butler, datasetType
 
-    def runPutGetTest(self, storageClass: StorageClass, datasetTypeName: str) -> DirectButler:
+    def runPutGetTest(self, storageClass: StorageClass, datasetTypeName: str) -> Butler:
         # New datasets will be added to run and tag, but we will only look in
         # tag when looking up datasets.
         run = self.default_run
@@ -458,7 +474,11 @@ class ButlerPutGetTests(TestCaseMixin):
         )
 
         # Getting with a dataset type that does not match registry fails
-        with self.assertRaisesRegex(ValueError, "Supplied dataset type .* inconsistent with registry"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "(Supplied dataset type .* inconsistent with registry)"
+            "|(The new storage class .* is not compatible with the existing storage class)",
+        ):
             butler.get(inconsistentDatasetType, dataId)
 
         # Combining a DatasetRef with a dataId should fail
@@ -519,7 +539,7 @@ class ButlerPutGetTests(TestCaseMixin):
 
     def testDeferredCollectionPassing(self) -> None:
         # Construct a butler with no run or collection, but make it writeable.
-        butler = Butler.from_config(self.tmpConfigFile, writeable=True)
+        butler = self.create_empty_butler(writeable=True)
         # Create and register a DatasetType
         dimensions = butler.dimensions.conform(["instrument", "visit"])
         datasetType = self.addDatasetType(
@@ -874,7 +894,7 @@ class ButlerTests(ButlerPutGetTests):
         self.assertEqual(get_full_type_name(test_dict3), "dict")
 
     def testIngest(self) -> None:
-        butler = Butler.from_config(self.tmpConfigFile, run=self.default_run)
+        butler = self.create_empty_butler(run=self.default_run)
 
         # Create and register a DatasetType
         dimensions = butler.dimensions.conform(["instrument", "visit", "detector"])
@@ -1026,7 +1046,7 @@ class ButlerTests(ButlerPutGetTests):
 
     def testPickle(self) -> None:
         """Test pickle support."""
-        butler = Butler.from_config(self.tmpConfigFile, run=self.default_run)
+        butler = self.create_empty_butler(run=self.default_run)
         assert isinstance(butler, DirectButler), "Expect DirectButler in configuration"
         butlerOut = pickle.loads(pickle.dumps(butler))
         self.assertIsInstance(butlerOut, Butler)
@@ -1035,7 +1055,7 @@ class ButlerTests(ButlerPutGetTests):
         self.assertEqual(butlerOut.run, butler.run)
 
     def testGetDatasetTypes(self) -> None:
-        butler = Butler.from_config(self.tmpConfigFile, run=self.default_run)
+        butler = self.create_empty_butler(run=self.default_run)
         dimensions = butler.dimensions.conform(["instrument", "visit", "physical_filter"])
         dimensionEntries: list[tuple[str, list[Mapping[str, Any]]]] = [
             (
@@ -1109,7 +1129,7 @@ class ButlerTests(ButlerPutGetTests):
         )
 
     def testTransaction(self) -> None:
-        butler = Butler.from_config(self.tmpConfigFile, run=self.default_run)
+        butler = self.create_empty_butler(run=self.default_run)
         datasetTypeName = "test_metric"
         dimensions = butler.dimensions.conform(["instrument", "visit"])
         dimensionEntries: tuple[tuple[str, Mapping[str, Any]], ...] = (
@@ -1213,7 +1233,7 @@ class ButlerTests(ButlerPutGetTests):
 
     def testButlerRewriteDataId(self) -> None:
         """Test that dataIds can be rewritten based on dimension records."""
-        butler = Butler.from_config(self.tmpConfigFile, run=self.default_run)
+        butler = self.create_empty_butler(run=self.default_run)
 
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataDict")
         datasetTypeName = "random_data"
@@ -1267,7 +1287,7 @@ class ButlerTests(ButlerPutGetTests):
         # MissingCollectionError if you tried to fetch a dataset that was added
         # after the collection cache was last updated.
         reader_butler, datasetType = self.create_butler(self.default_run, "int", "datasettypename")
-        writer_butler = Butler.from_config(self.tmpConfigFile, writeable=True, run="new_run")
+        writer_butler = self.create_empty_butler(writeable=True, run="new_run")
         dataId = {"instrument": "DummyCamComp", "visit": 423}
         put_ref = writer_butler.put(123, datasetType, dataId)
         get_ref = reader_butler.get_dataset(put_ref.id)
@@ -2476,6 +2496,63 @@ class NullDatastoreTestCase(unittest.TestCase):
             butler.get(ref)
         with self.assertRaises(FileNotFoundError):
             butler.getURI(ref)
+
+
+@unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
+class ButlerServerTests(ButlerTests, unittest.TestCase):
+    """Test RemoteButler and Butler server."""
+
+    configFile = None
+
+    def setUp(self):
+        self.server_instance = self.enterContext(create_test_server())
+
+    def tearDown(self):
+        pass
+
+    def create_empty_butler(self, run: str | None = None, writeable: bool | None = None) -> Butler:
+        return self.server_instance.hybrid_butler._clone(run=run)
+
+    def testConstructor(self):
+        # RemoteButler constructor is tested elsewhere.
+        pass
+
+    def testDafButlerRepositories(self):
+        # Repository index is tested elsewhere.
+        pass
+
+    # Predict mode not implemented.
+    @unittest.expectedFailure
+    def testCompositePutGetConcrete(self) -> None:
+        return super().testCompositePutGetConcrete()
+
+    # Predict mode not implemented.
+    @unittest.expectedFailure
+    def testCompositePutGetVirtual(self) -> None:
+        return super().testCompositePutGetVirtual()
+
+    # Call to validateConfiguration is failing, not sure why.
+    @unittest.expectedFailure
+    def testGetDatasetTypes(self) -> None:
+        return super().testGetDatasetTypes()
+
+    def testMakeRepo(self) -> None:
+        # Only applies to DirectButler.
+        pass
+
+    # Pickling not yet implemented for RemoteButler/HybridButler.
+    @unittest.expectedFailure
+    def testPickle(self) -> None:
+        return super().testPickle()
+
+    def testStringification(self) -> None:
+        # RemoteButler does not have datastore/registry strings like
+        # DirectButler does.
+        pass
+
+    def testTransaction(self) -> None:
+        # Transactions will never be supported for RemoteButler.
+        pass
 
 
 def setup_module(module: types.ModuleType) -> None:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2505,7 +2505,7 @@ class ButlerServerTests(ButlerTests, unittest.TestCase):
     configFile = None
 
     def setUp(self):
-        self.server_instance = self.enterContext(create_test_server())
+        self.server_instance = self.enterContext(create_test_server(TESTDIR))
 
     def tearDown(self):
         pass

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -230,7 +230,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
         self.assertEqual(metric, kwarg_data_coordinate_metric)
         # Test get() of a non-existent DataId.
         invalid_data_id = {"instrument": "NotAValidlInstrument", "visit": 423}
-        with self.assertRaises(LookupError):
+        with self.assertRaises(FileNotFoundError):
             self.butler_without_error_propagation.get(
                 dataset_type, dataId=invalid_data_id, collections=collections
             )
@@ -246,7 +246,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
 
         # Test looking up a non-existent ref
         invalid_ref = ref.replace(id=uuid.uuid4())
-        with self.assertRaises(LookupError):
+        with self.assertRaises(FileNotFoundError):
             self.butler_without_error_propagation.get(invalid_ref)
 
         with self.assertRaises(RuntimeError):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,7 +70,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        server_instance = cls.enterClassContext(create_test_server())
+        server_instance = cls.enterClassContext(create_test_server(TESTDIR))
         cls.client = server_instance.client
         cls.butler = server_instance.remote_butler
         cls.butler_without_error_propagation = server_instance.remote_butler_without_error_propagation

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -135,7 +135,6 @@ class ButlerClientServerTestCase(unittest.TestCase):
         # Set up the RemoteButler that will connect to the server
         cls.client = _make_test_client(app)
         cls.butler = _make_remote_butler(cls.client)
-        cls.butler_with_default_collection = _make_remote_butler(cls.client, collections="ingest/run")
         # By default, the TestClient instance raises any unhandled exceptions
         # from the server as if they had originated in the client to ease
         # debugging.  However, this can make it appear that error propagation
@@ -300,7 +299,8 @@ class ButlerClientServerTestCase(unittest.TestCase):
             )
 
         # Test get() by DataId with default collections.
-        default_collection_metric = self.butler_with_default_collection.get(dataset_type, dataId=data_id)
+        butler_with_default_collection = self.butler._clone(collections="ingest/run")
+        default_collection_metric = butler_with_default_collection.get(dataset_type, dataId=data_id)
         self.assertEqual(metric, default_collection_metric)
 
         # Test get() by DataId with no collections specified.


### PR DESCRIPTION
Added a new Butler subclass HybridButler that delegates methods to RemoteButler where implemented, and uses DirectButler for the rest.  Extracted the test server setup from test_server.py into a reusable function.  Modified test_butler.py to run tests against Butler server via HybridButler.

This revealed a few minor incompatibilities between RemoteButler and DirectButler, so updated RemoteButler to conform with the DirectButler behavior.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
