### PR TITLE
DM-42945: Implement RemoteButler.exists

### DIFF
--- a/doc/changes/DM-42945.bugfix.md
+++ b/doc/changes/DM-42945.bugfix.md
@@ -1,0 +1,1 @@
+`Butler.exists` will now throw a `NoDefaultCollectionError` when attempting to query for a `DataId` without specifying any collections to search.  Previously it would return `False`, hiding the user error.

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -602,7 +602,7 @@ class Datastore(metaclass=ABCMeta):
         """
         raise NotImplementedError("Must be implemented by subclass")
 
-    def prepare_get_for_external_client(self, ref: DatasetRef) -> object:
+    def prepare_get_for_external_client(self, ref: DatasetRef) -> object | None:
         """Retrieve serializable data that can be used to execute a ``get()``.
 
         Parameters
@@ -612,10 +612,11 @@ class Datastore(metaclass=ABCMeta):
 
         Returns
         -------
-        payload : `object`
+        payload : `object` | `None`
             Serializable payload containing the information needed to perform a
             get() operation.  This payload may be sent over the wire to another
-            system to perform the get().
+            system to perform the get().  Returns `None` if the dataset is not
+            known to this datastore.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -399,16 +399,20 @@ class ChainedDatastore(Datastore):
 
         raise FileNotFoundError(f"Dataset {ref} could not be found in any of the datastores")
 
-    def prepare_get_for_external_client(self, ref: DatasetRef) -> object:
-        return self._get_matching_datastore(ref).prepare_get_for_external_client(ref)
+    def prepare_get_for_external_client(self, ref: DatasetRef) -> object | None:
+        datastore = self._get_matching_datastore(ref)
+        if datastore is None:
+            return None
 
-    def _get_matching_datastore(self, ref: DatasetRef) -> Datastore:
+        return datastore.prepare_get_for_external_client(ref)
+
+    def _get_matching_datastore(self, ref: DatasetRef) -> Datastore | None:
         """Return the first child datastore that owns the specified dataset."""
         for datastore in self.datastores:
             if datastore.knows(ref):
                 return datastore
 
-        raise FileNotFoundError(f"Dataset {ref} could not be found in any of the datastores")
+        return None
 
     def put(self, inMemoryDataset: Any, ref: DatasetRef) -> None:
         """Write a InMemoryDataset with a given `DatasetRef` to each

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2042,7 +2042,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             allGetInfo, ref=ref, parameters=parameters, cache_manager=self.cacheManager
         )
 
-    def prepare_get_for_external_client(self, ref: DatasetRef) -> FileDatastoreGetPayload:
+    def prepare_get_for_external_client(self, ref: DatasetRef) -> FileDatastoreGetPayload | None:
         # Docstring inherited
 
         # 1 hour.  Chosen somewhat arbitrarily -- this is long enough that the
@@ -2066,11 +2066,10 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         locations = self._get_dataset_locations_info(ref)
         if len(locations) == 0:
-            raise FileNotFoundError(f"No artifacts found for DatasetId '{ref.id}'")
+            return None
 
         return FileDatastoreGetPayload(
             datastore_type="file",
-            dataset_ref=ref.to_simple(),
             file_info=[to_file_info_payload(info) for info in locations],
         )
 

--- a/python/lsst/daf/butler/datastores/fileDatastoreClient.py
+++ b/python/lsst/daf/butler/datastores/fileDatastoreClient.py
@@ -3,7 +3,7 @@ __all__ = ("get_dataset_as_python_object", "FileDatastoreGetPayload")
 from typing import Any, Literal
 
 import pydantic
-from lsst.daf.butler import DatasetRef, DimensionUniverse, Location, SerializedDatasetRef, StorageClass
+from lsst.daf.butler import DatasetRef, Location, StorageClass
 from lsst.daf.butler.datastore.cache_manager import DatastoreDisabledCacheManager
 from lsst.daf.butler.datastore.stored_file_info import SerializedStoredFileInfo, StoredFileInfo
 from lsst.daf.butler.datastores.file_datastore.get import (
@@ -41,14 +41,11 @@ class FileDatastoreGetPayload(pydantic.BaseModel):
     artifact.
     """
 
-    dataset_ref: SerializedDatasetRef
-    """Registry information associated with this artifact."""
-
 
 def get_dataset_as_python_object(
+    ref: DatasetRef,
     payload: FileDatastoreGetPayload,
     *,
-    universe: DimensionUniverse,
     parameters: Mapping[str, Any] | None,
     storageClass: StorageClass | str | None,
     component: str | None,
@@ -57,12 +54,11 @@ def get_dataset_as_python_object(
 
     Parameters
     ----------
+    ref : `DatasetRef`
+        Metadata about this artifact.
     payload : `FileDatastoreGetPayload`
         Pre-processed information about each file associated with this
         artifact.
-    universe : `DimensionUniverse`
-        The universe of dimensions associated with the `DatasetRef` contained
-        in ``payload``.
     parameters : `Mapping`[`str`, `typing.Any`]
         `StorageClass` and `Formatter` parameters to be used when converting
         the artifact to a Python object.
@@ -82,8 +78,6 @@ def get_dataset_as_python_object(
         (Location(None, str(file_info.url)), StoredFileInfo.from_simple(file_info.datastoreRecords))
         for file_info in payload.file_info
     ]
-
-    ref = DatasetRef.from_simple(payload.dataset_ref, universe=universe)
 
     # If we have both a component override and a storage class override, the
     # component override has to be applied first.  DatasetRef cares because it

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -73,7 +73,6 @@ from .registry import (
     ConflictingDefinitionError,
     DataIdError,
     MissingDatasetTypeError,
-    NoDefaultCollectionError,
     RegistryDefaults,
     _RegistryFactory,
 )
@@ -1300,7 +1299,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         else:
             try:
                 ref = self._findDatasetRef(dataset_ref_or_type, data_id, collections=collections, **kwargs)
-            except (LookupError, TypeError, NoDefaultCollectionError):
+            except (LookupError, TypeError):
                 return existence
             existence |= DatasetExistence.RECORDED
 

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -437,26 +437,22 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             response = self._get_file_info(
                 dataset_ref_or_type, dataId=data_id, collections=collections, kwargs=kwargs
             )
-            if response.artifact is None:
-                if full_check:
-                    return DatasetExistence.RECORDED
-                else:
-                    return DatasetExistence.RECORDED | DatasetExistence._ASSUMED
-
-            if full_check:
-                for file in response.artifact.file_info:
-                    if not ResourcePath(str(file.url)).exists():
-                        return DatasetExistence.RECORDED | DatasetExistence.DATASTORE
-                return DatasetExistence.VERIFIED
-            else:
-                return DatasetExistence.KNOWN
         except FileNotFoundError:
             return DatasetExistence.UNRECOGNIZED
-        except NoDefaultCollectionError:
-            # Although it seems like this exception is caused by user error and
-            # raising it would be helpful, DirectButler explicitly swallows it
-            # and the unit tests confirm this is the expected behavior.
-            return DatasetExistence.UNRECOGNIZED
+
+        if response.artifact is None:
+            if full_check:
+                return DatasetExistence.RECORDED
+            else:
+                return DatasetExistence.RECORDED | DatasetExistence._ASSUMED
+
+        if full_check:
+            for file in response.artifact.file_info:
+                if not ResourcePath(str(file.url)).exists():
+                    return DatasetExistence.RECORDED | DatasetExistence.DATASTORE
+            return DatasetExistence.VERIFIED
+        else:
+            return DatasetExistence.KNOWN
 
     def _exists_many(
         self,

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -191,4 +191,4 @@ def get_file_by_data_id(
 def _get_file_by_ref(butler: Butler, ref: DatasetRef) -> GetFileResponseModel:
     """Return file information associated with ``ref``."""
     payload = butler._datastore.prepare_get_for_external_client(ref)
-    return GetFileResponseModel.model_validate(payload)
+    return GetFileResponseModel(dataset_ref=ref.to_simple(), artifact=payload)

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -38,7 +38,7 @@ __all__ = [
 from typing import NewType
 
 import pydantic
-from lsst.daf.butler import SerializedDataId
+from lsst.daf.butler import SerializedDataId, SerializedDatasetRef
 from lsst.daf.butler.datastores.fileDatastoreClient import FileDatastoreGetPayload
 
 CLIENT_REQUEST_ID_HEADER_NAME = "X-Butler-Client-Request-Id"
@@ -64,4 +64,17 @@ class GetFileByDataIdRequestModel(pydantic.BaseModel):
     collections: CollectionList
 
 
-GetFileResponseModel = FileDatastoreGetPayload
+class GetFileResponseModel(pydantic.BaseModel):
+    """Response model for get_file and get_file_by_data_id."""
+
+    dataset_ref: SerializedDatasetRef
+    artifact: FileDatastoreGetPayload | None
+    """The data needed to retrieve and use an artifact. If this is `None`, that
+    means this dataset is known to the Butler but the associated files are no
+    longer available ("known to registry but not known to datastore".)
+
+    An example of a situation where this would be `None` is a per-visit image
+    that is an intermediate file in the processing pipelines.  It is deleted to
+    save space, but the fact that it was once available must be recorded for
+    provenance tracking.
+    """

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -230,7 +230,7 @@ class HybridButler(Butler):
         *,
         full_check: bool = True,
     ) -> dict[DatasetRef, DatasetExistence]:
-        return self._direct_butler._exists_many(refs, full_check=full_check)
+        return self._remote_butler._exists_many(refs, full_check=full_check)
 
     def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
         return self._direct_butler.removeRuns(names, unstore)

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -219,7 +219,7 @@ class HybridButler(Butler):
         collections: Any = None,
         **kwargs: Any,
     ) -> DatasetExistence:
-        return self._direct_butler.exists(
+        return self._remote_butler.exists(
             dataset_ref_or_type, data_id, full_check=full_check, collections=collections, **kwargs
         )
 

--- a/tests/config/basic/server.yaml
+++ b/tests/config/basic/server.yaml
@@ -15,6 +15,12 @@ datastore:
         name: FileDatastore@s3://immutable-bucket/dc2
         cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
         root: s3://immutable-bucket/dc2
+        cached:
+          # Server does not do anything that would use the file cache, but some
+          # unit tests reach in the back via DirectButler.  The presence of the
+          # cache alters some unit test results related to deleting files
+          # outside the Butler's knowledge.
+          default: false
     - datastore:
         name: FileDatastore@s3://mutable-bucket
         cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
@@ -23,4 +29,6 @@ datastore:
           table: user_datastore_records
         formatters: !include formatters.yaml
         composites: !include composites.yaml
+        cached:
+          default: false
 storageClasses: !include storageClasses.yaml

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1314,7 +1314,7 @@ class FileDatastoreButlerTests(ButlerTests):
 
     def testPutTemplates(self) -> None:
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
-        butler = Butler.from_config(self.tmpConfigFile, run=self.default_run)
+        butler = self.create_empty_butler(run=self.default_run)
 
         # Add needed Dimensions
         butler.registry.insertDimensionData("instrument", {"name": "DummyCamComp"})
@@ -1463,7 +1463,7 @@ class FileDatastoreButlerTests(ButlerTests):
 
     def testRemoveRuns(self) -> None:
         storageClass = self.storageClassFactory.getStorageClass("StructuredDataNoComponents")
-        butler = Butler.from_config(self.tmpConfigFile, writeable=True)
+        butler = self.create_empty_butler(writeable=True)
         # Load registry data with dimensions to hang datasets off of.
         registryDataDir = os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
         butler.import_(filename=os.path.join(registryDataDir, "base.yaml"))
@@ -2503,7 +2503,7 @@ class NullDatastoreTestCase(unittest.TestCase):
 
 
 @unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
-class ButlerServerTests(ButlerTests, unittest.TestCase):
+class ButlerServerTests(FileDatastoreButlerTests, unittest.TestCase):
     """Test RemoteButler and Butler server."""
 
     configFile = None
@@ -2551,6 +2551,11 @@ class ButlerServerTests(ButlerTests, unittest.TestCase):
 
     def testTransaction(self) -> None:
         # Transactions will never be supported for RemoteButler.
+        pass
+
+    def testPutTemplates(self) -> None:
+        # The Butler server instance is configured with different file naming
+        # templates than this test is expecting.
         pass
 
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -89,6 +89,7 @@ from lsst.daf.butler import (
     DatasetRef,
     DatasetType,
     FileDataset,
+    NoDefaultCollectionError,
     StorageClassFactory,
     ValidationError,
     script,
@@ -572,8 +573,9 @@ class ButlerPutGetTests(TestCaseMixin):
         # a deferred dataset handle.
         self.assertEqual(metric, butler.get(datasetType, dataId, collections=[run]))
         self.assertEqual(metric, butler.getDeferred(datasetType, dataId, collections=[run]).get())
-        # Trying to find the dataset without any collection is a TypeError.
-        self.assertFalse(butler.exists(datasetType, dataId))
+        # Trying to find the dataset without any collection is an error.
+        with self.assertRaises(NoDefaultCollectionError):
+            butler.exists(datasetType, dataId)
         with self.assertRaises(CollectionError):
             butler.get(datasetType, dataId)
         # Associate the dataset with a different collection.

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1092,10 +1092,9 @@ class PosixDatastoreTestCase(DatastoreTests, unittest.TestCase):
         dimensions = self.universe.conform(("visit", "physical_filter"))
         dataId = {"instrument": "dummy", "visit": 52, "physical_filter": "V", "band": "v"}
         ref = self.makeDatasetRef("metric", dimensions, storageClass, dataId)
-        with self.assertRaises(FileNotFoundError):
-            # Most of the coverage for this function is in test_server.py,
-            # because it requires a file backend that supports URL signing.
-            datastore.prepare_get_for_external_client(ref)
+        # Most of the coverage for this function is in test_server.py,
+        # because it requires a file backend that supports URL signing.
+        self.assertIsNone(datastore.prepare_get_for_external_client(ref))
 
 
 class PosixDatastoreNoChecksumsTestCase(PosixDatastoreTestCase):


### PR DESCRIPTION
Implemented `RemoteButler.exists()` and `RemoteButler._exists_many()`.  To get test coverage for these methods, expanded the set of tests run against Butler server to include those from `FileDatastoreButlerTests`, and moved `testPruneDatasets` from `PosixDatastoreButlerTestCase` to `FileDatastoreButlerTests`.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
