### PR TITLE
DM-43117: Allow exposure.day_obs in a WHERE clause

### DIFF
--- a/python/lsst/daf/butler/registry/queries/expressions/categorize.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/categorize.py
@@ -112,16 +112,8 @@ def categorizeElementId(universe: DimensionUniverse, name: str) -> tuple[Dimensi
         elif column in element.dimensions.names:
             # User said something like "patch.tract = x" or
             # "tract.tract = x" instead of just "tract = x" or
-            # "tract.id = x", which is at least needlessly confusing and
-            # possibly not actually a column name, though we can guess
-            # what they were trying to do.
-            # Encourage them to clean that up and try again.
-            name = universe[column].primaryKey.name  # type: ignore
-            raise RuntimeError(
-                f"Invalid reference to '{table}.{column}' "
-                f"in expression; please use '{column}' or "
-                f"'{column}.{name}' instead."
-            )
+            # "tract.id = x". Return the column as the element instead.
+            return element.dimensions[column], None
         else:
             return element, column
     else:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1351,6 +1351,26 @@ class ButlerTests(ButlerPutGetTests):
             new_metric = butler.get(datasetTypeName, dataId=dataId)
             self.assertEqual(new_metric, metric)
 
+        # Check that we can find the datasets using the day_obs or the
+        # exposure.day_obs.
+        datasets_1 = list(
+            butler.registry.queryDatasets(
+                datasetType,
+                collections=self.default_run,
+                where="day_obs = dayObs AND instrument = instr",
+                bind={"dayObs": dayobs, "instr": "DummyCamComp"},
+            )
+        )
+        datasets_2 = list(
+            butler.registry.queryDatasets(
+                datasetType,
+                collections=self.default_run,
+                where="exposure.day_obs = dayObs AND instrument = instr",
+                bind={"dayObs": dayobs, "instr": "DummyCamComp"},
+            )
+        )
+        self.assertEqual(datasets_1, datasets_2)
+
     def testGetDatasetCollectionCaching(self):
         # Prior to DM-41117, there was a bug where get_dataset would throw
         # MissingCollectionError if you tried to fetch a dataset that was added


### PR DESCRIPTION
Previously we completely disallowed this if the modifier was an implied dimension, but now that day_obs has suddenly become an implied dimension there are many existing places that would need to be fixed if we do not allow it.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
