### PR TITLE
DM-43105: Add exposure.can_see_sky metadata field

### DIFF
--- a/doc/lsst.daf.butler/dimensions.rst
+++ b/doc/lsst.daf.butler/dimensions.rst
@@ -109,5 +109,7 @@ The default namespace has had the following version changes:
 4. Added "populated_by" information to visit fields to allow related dimensions to be discovered automatically.
 5. Changed the length of the ``instrument.name`` field from 16 to 32 characters.
 6. Made ``day_obs`` and ``group`` full dimensions.
+7. Added ``can_see_sky`` metadata field to ``exposure``.
+   This field can indicate whether the detector received photons from the sky taking into account the camera shutter and the dome and telescope alignment.
 
 Prior to October 2020 there were no version numbers for the dimension universe.

--- a/python/lsst/daf/butler/configs/dimensions.yaml
+++ b/python/lsst/daf/butler/configs/dimensions.yaml
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 namespace: daf_butler
 skypix:
   # 'common' is the skypix system and level used to relate all other spatial
@@ -312,6 +312,13 @@ elements:
           This can be if the data itself were simulated or if
           parts of the header came from simulated systems, such as observations
           in the lab that are recorded as on-sky.
+      - name: can_see_sky
+        type: bool
+        doc: >
+          True if the detector could see the sky during this exposure. This
+          can be used to definitively determine whether an observation was
+          on sky, taking into account dome state as well as camera shutter.
+
     storage:
       cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
 


### PR DESCRIPTION
Defaults to None when importing old YAML files. The importer can't really work out what the flag should be on import in that situation.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
