### PR TITLE
DM-43187: Fix masked column reading into astropy tables.

### DIFF
--- a/doc/changes/DM-43187.bugfix.md
+++ b/doc/changes/DM-43187.bugfix.md
@@ -1,0 +1,4 @@
+Reading masked parquet columns into astropy Tables will now use appropriate
+fill values.  In addition, floating point columns will be filled with NaN
+instead of using a masked column.  This fixes discrepancies when accessing
+masked columns with .filled() or not.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -302,6 +302,7 @@ def arrow_to_numpy_dict(arrow_table: pa.Table) -> dict[str, np.ndarray]:
                 case t if t in (pa.string(), pa.binary()):
                     null_value = ""
                 case _:
+                    # This is the fallback for unsigned ints in particular.
                     null_value = 0
 
             if use_masked:

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -287,9 +287,13 @@ def arrow_to_numpy_dict(arrow_table: pa.Table) -> dict[str, np.ndarray]:
             # For a masked column, we need to ask arrow to fill the null
             # values with an appropriately typed value before conversion.
             # Then we apply the mask to get a masked array of the correct type.
+            use_masked = True
             match t:
                 case t if t in (pa.float64(), pa.float32(), pa.float16()):
+                    # When filling with nans we do not need to use
+                    # the masked array.
                     null_value = np.nan
+                    use_masked = False
                 case t if t in (pa.int64(), pa.int32(), pa.int16(), pa.int8()):
                     null_value = -1
                 case t if t in (pa.bool_(),):
@@ -299,11 +303,14 @@ def arrow_to_numpy_dict(arrow_table: pa.Table) -> dict[str, np.ndarray]:
                 case _:
                     null_value = 0
 
-            col = np.ma.masked_array(
-                data=arrow_table[name].fill_null(null_value).to_numpy(),
-                mask=arrow_table[name].is_null().to_numpy(),
-                fill_value=null_value,
-            )
+            if use_masked:
+                col = np.ma.masked_array(
+                    data=arrow_table[name].fill_null(null_value).to_numpy(),
+                    mask=arrow_table[name].is_null().to_numpy(),
+                    fill_value=null_value,
+                )
+            else:
+                col = arrow_table[name].fill_null(null_value).to_numpy()
 
         if t in (pa.string(), pa.binary()):
             col = col.astype(_arrow_string_to_numpy_dtype(schema, name, col))

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -288,6 +288,7 @@ def arrow_to_numpy_dict(arrow_table: pa.Table) -> dict[str, np.ndarray]:
             # values with an appropriately typed value before conversion.
             # Then we apply the mask to get a masked array of the correct type.
             use_masked = True
+            null_value: Any
             match t:
                 case t if t in (pa.float64(), pa.float32(), pa.float16()):
                     # When filling with nans we do not need to use


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`

Reading masked parquet columns into astropy Tables will now use appropriate
fill values.  In addition, floating point columns will be filled with NaN
instead of using a masked column.  This fixes discrepancies when accessing
masked columns with `.filled()` or not.
