### PR TITLE
DM-42079: Enable caching in one storage class for S3 tests

### DIFF
--- a/tests/config/basic/s3Datastore.yaml
+++ b/tests/config/basic/s3Datastore.yaml
@@ -10,4 +10,4 @@ datastore:
       mode: files
       threshold: 1
     cacheable:
-      StructuredDataDictYaml: false
+      StructuredDataDictYaml: true


### PR DESCRIPTION
This triggers the cache even though the formatter supports fromBytes and the serialized size if below the byte limit, because in one of the tests the file size is not stored and is -1.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
