### PR TITLE
DM-43101: Add exposure.can_see_sky metadata field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
+    rev: 24.3.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,7 +23,7 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.3.3
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/doc/changes/DM-43101.feature.rst
+++ b/doc/changes/DM-43101.feature.rst
@@ -1,0 +1,2 @@
+Added ``can_see_sky`` metadata field to ``exposure`` dimension record (dimension universe v7).
+This field can indicate whether the detector received photons from the sky taking into account the camera shutter and the dome and telescope alignment.

--- a/doc/lsst.daf.butler/dimensions.rst
+++ b/doc/lsst.daf.butler/dimensions.rst
@@ -109,5 +109,7 @@ The default namespace has had the following version changes:
 4. Added "populated_by" information to visit fields to allow related dimensions to be discovered automatically.
 5. Changed the length of the ``instrument.name`` field from 16 to 32 characters.
 6. Made ``day_obs`` and ``group`` full dimensions.
+7. Added ``can_see_sky`` metadata field to ``exposure``.
+   This field can indicate whether the detector received photons from the sky taking into account the camera shutter and the dome and telescope alignment.
 
 Prior to October 2020 there were no version numbers for the dimension universe.

--- a/doc/lsst.daf.butler/dimensions.rst
+++ b/doc/lsst.daf.butler/dimensions.rst
@@ -109,6 +109,7 @@ The default namespace has had the following version changes:
 4. Added "populated_by" information to visit fields to allow related dimensions to be discovered automatically.
 5. Changed the length of the ``instrument.name`` field from 16 to 32 characters.
 6. Made ``day_obs`` and ``group`` full dimensions.
+   Dropped ``group_id`` from ``exposure`` and renamed ``group_name`` to ``group``.
 7. Added ``can_see_sky`` metadata field to ``exposure``.
    This field can indicate whether the detector received photons from the sky taking into account the camera shutter and the dome and telescope alignment.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,11 +162,15 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+line-length = 110
+target-version = "py311"
 exclude = [
     "__init__.py",
     "lex.py",
     "yacc.py",
 ]
+
+[tool.ruff.lint]
 ignore = [
     "N802",
     "N803",
@@ -184,7 +188,6 @@ ignore = [
     "D205",
     "D400",
 ]
-line-length = 110
 select = [
     "E",  # pycodestyle
     "F",  # pycodestyle
@@ -192,21 +195,20 @@ select = [
     "W",  # pycodestyle
     "D",  # pydocstyle
 ]
-target-version = "py311"
 # Commented out to suppress "unused noqa" in jenkins which has older ruff not
 # generating E721.
 #extend-select = [
 #    "RUF100", # Warn about unused noqa
 #]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # parserYacc docstrings can not be fixed. Docstrings are used to define grammar.
 "python/lsst/daf/butler/registry/queries/expressions/parser/parserYacc.py" = ["D401", "D403"]
 
-[tool.ruff.pycodestyle]
+[tool.ruff.lint.pycodestyle]
 max-doc-length = 79
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.numpydoc_validation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,7 @@ ignore = [
     "D200",
     "D205",
     "D400",
+    "UP007",  # Allow UNION in type annotation
 ]
 select = [
     "E",  # pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,7 @@ select = [
     "N",  # pep8-naming
     "W",  # pycodestyle
     "D",  # pydocstyle
+    "UP",  # pyupgrade
 ]
 # Commented out to suppress "unused noqa" in jenkins which has older ruff not
 # generating E721.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -588,6 +588,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         parameters: dict | None = None,
         collections: Any = None,
         storageClass: str | StorageClass | None = None,
+        timespan: Timespan | None = None,
         **kwargs: Any,
     ) -> DeferredDatasetHandle:
         """Create a `DeferredDatasetHandle` which can later retrieve a dataset,
@@ -615,6 +616,11 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             the dataset type definition for this dataset. Specifying a
             read `StorageClass` can force a different type to be returned.
             This type must be compatible with the original type.
+        timespan : `Timespan` or `None`, optional
+            A timespan that the validity range of the dataset must overlap.
+            If not provided and this is a calibration dataset type, an attempt
+            will be made to find the timespan from any temporal coordinate
+            in the data ID.
         **kwargs
             Additional keyword arguments used to augment or construct a
             `DataId`.  See `DataId` parameters.
@@ -647,6 +653,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         parameters: dict[str, Any] | None = None,
         collections: Any = None,
         storageClass: StorageClass | str | None = None,
+        timespan: Timespan | None = None,
         **kwargs: Any,
     ) -> Any:
         """Retrieve a stored dataset.
@@ -675,6 +682,11 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             the dataset type definition for this dataset. Specifying a
             read `StorageClass` can force a different type to be returned.
             This type must be compatible with the original type.
+        timespan : `Timespan` or `None`, optional
+            A timespan that the validity range of the dataset must overlap.
+            If not provided and this is a calibration dataset type, an attempt
+            will be made to find the timespan from any temporal coordinate
+            in the data ID.
         **kwargs
             Additional keyword arguments used to augment or construct a
             `DataCoordinate`.  See `DataCoordinate.standardize`

--- a/python/lsst/daf/butler/_timespan.py
+++ b/python/lsst/daf/butler/_timespan.py
@@ -34,7 +34,7 @@ __all__ = (
 import enum
 import warnings
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Union
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, TypeAlias
 
 import astropy.time
 import astropy.utils.exceptions
@@ -74,7 +74,7 @@ class _SpecialTimespanBound(enum.Enum):
     """
 
 
-TimespanBound = Union[astropy.time.Time, _SpecialTimespanBound, None]
+TimespanBound: TypeAlias = astropy.time.Time | _SpecialTimespanBound | None
 
 SerializedTimespan = Annotated[list[int], Field(min_length=2, max_length=2)]
 """JSON-serializable representation of the Timespan class, as a list of two

--- a/python/lsst/daf/butler/configs/dimensions.yaml
+++ b/python/lsst/daf/butler/configs/dimensions.yaml
@@ -1,4 +1,4 @@
-version: 6
+version: 7
 namespace: daf_butler
 skypix:
   # 'common' is the skypix system and level used to relate all other spatial
@@ -312,6 +312,13 @@ elements:
           This can be if the data itself were simulated or if
           parts of the header came from simulated systems, such as observations
           in the lab that are recorded as on-sky.
+      - name: can_see_sky
+        type: bool
+        doc: >
+          True if the detector could see the sky during this exposure. This
+          can be used to definitively determine whether an observation was
+          on sky, taking into account dome state as well as camera shutter.
+
     storage:
       cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
 

--- a/python/lsst/daf/butler/configs/old_dimensions/daf_butler_universe7.yaml
+++ b/python/lsst/daf/butler/configs/old_dimensions/daf_butler_universe7.yaml
@@ -1,0 +1,462 @@
+version: 7
+namespace: daf_butler
+skypix:
+  # 'common' is the skypix system and level used to relate all other spatial
+  # dimensions.  Its value is a string formed by concatenating one of the
+  # other keys under the 'skypix' headerin (i.e. the name of a skypix system)
+  # with an integer level (with no zero-padding).
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
+  healpix:
+    class: lsst.sphgeom.HealpixPixelization
+    max_level: 17
+
+elements:
+  instrument:
+    doc: >
+      An entity that produces observations.  An instrument defines a set of
+      physical_filters and detectors and a numbering system for the exposures
+      and visits that represent observations with it.
+    keys:
+      - name: name
+        type: string
+        length: 32
+    metadata:
+      - name: visit_max
+        type: int
+        doc: >
+          Maximum value for the 'visit' field for visits associated with
+          this instrument (exclusive).
+      - name: visit_system
+        type: int
+        doc: >
+          The preferred visit system for this instrument.
+      - name: exposure_max
+        type: int
+        doc: >
+          Maximum value for the 'exposure' field for exposures associated with
+          this instrument (exclusive).
+      - name: detector_max
+        type: int
+        doc: >
+          Maximum value for the 'detector' field for detectors associated with
+          this instrument (exclusive).
+      - name: class_name
+        type: string
+        length: 64
+        doc: >
+          Full class name of the Instrument class associated with this
+          instrument.
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  band:
+    doc: >
+      A filter that is not associated with a particular instrument.  An
+      abstract filter can be used to relate similar physical filters, and
+      is typically the filter associated with coadds.
+    keys:
+      - name: name
+        type: string
+        length: 32
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.query.QueryDimensionRecordStorage
+        view_of: physical_filter
+
+  physical_filter:
+    doc: >
+      A filter associated with a particular instrument.  physical_filters are
+      used to identify datasets that can only be associated with a single
+      observation.
+    keys:
+      - name: name
+        type: string
+        length: 32
+    requires:
+      - instrument
+    implies:
+      - band
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  subfilter:
+    doc: >
+      A mathematical division of an band. Subfilters are used to
+      model wavelength-dependent effects such as differential chromatic
+      refraction.
+    keys:
+      - name: id
+        type: int
+    requires:
+      - band
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  detector:
+    doc: >
+      A detector associated with a particular instrument (not an observation
+      of that detector; that requires specifying an exposure or visit as
+      well).
+    keys:
+      - name: id
+        type: int
+      - name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      - name: name_in_raft
+        type: string
+        length: 32
+      - name: raft
+        type: string
+        length: 32
+        doc: >
+          A string name for a group of detectors with an instrument-dependent
+          interpretation.
+      - name: purpose
+        type: string
+        length: 32
+        doc: >
+          Role of the detector; typically one of "SCIENCE", "WAVEFRONT",
+          or "GUIDE", though instruments may define additional values.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  group:
+    doc: >
+      A group of observations defined at the time they were observed by the
+      acquisition system.
+    keys:
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  day_obs:
+    doc: >
+      A day and night of observations that rolls over during daylight hours.
+      The identifier is an decimal integer-concatenated date, i.e. YYYYMMDD,
+      with the exact rollover time observatory-dependent.
+    keys:
+      - name: id
+        type: int
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit:
+    doc: >
+      A sequence of observations processed together, comprised of one or
+      more exposures from the same instrument with the same pointing and
+      physical_filter.
+      The visit table contains metadata that is both meaningful only for
+      science exposures and the same for all exposures in a visit.
+    keys:
+      - name: id
+        type: int
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    implies: [physical_filter, day_obs]
+    metadata:
+      - name: seq_num
+        type: int
+        doc: >
+          The sequence number of the first exposure that is part of this visit.
+      - name: exposure_time
+        type: float
+        doc: >
+          The total exposure time of the visit in seconds.  This should
+          be equal to the sum of the exposure_time values for all
+          constituent exposures (i.e. it should not include time between
+          exposures).
+      - name: target_name
+        type: string
+        length: 64
+        doc: Object of interest for this visit or survey field name.
+      - name: observation_reason
+        type: string
+        length: 68
+        doc: >
+          The reason this visit was taken. (e.g. science,
+          filter scan, unknown, various).
+      - name: science_program
+        type: string
+        length: 64
+        doc: Observing program (survey or proposal) identifier.
+      - name: azimuth
+        type: float
+        doc: >
+          Approximate azimuth of the telescope in degrees during the visit.
+          Can only be approximate since it is continually changing during
+          an observation and multiple exposures can be combined from a
+          relatively long period.
+      - name: zenith_angle
+        type: float
+        doc: >
+          Approximate zenith angle in degrees during the visit.
+          Can only be approximate since it is continuously changing during
+          an observation and multiple exposures can be combined from a
+          relatively long period.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  exposure:
+    doc: >
+      An observation associated with a particular instrument.  All direct
+      observations are identified with an exposure, but derived datasets
+      that may be based on more than one exposure (e.g. multiple snaps) are
+      typically identified with visits instead, even for instruments that
+      don't have multiple exposures per visit.  As a result, instruments
+      that don't have multiple exposures per visit will typically have visit
+      entries that are essentially duplicates of their exposure entries.
+
+      The exposure table contains metadata entries that are relevant for
+      calibration exposures, and does not duplicate entries in visit that
+      would be the same for all exposures within a visit with the exception
+      of the exposure.group entry.
+    keys:
+      - name: id
+        type: int
+      - name: obs_id
+        type: string
+        length: 64
+    requires: [instrument]
+    implies: [physical_filter, group, day_obs]
+    metadata:
+      - name: exposure_time
+        type: float
+        doc: Duration of the exposure with shutter open (seconds).
+      - name: dark_time
+        type: float
+        doc: Duration of the exposure with shutter closed (seconds).
+      - name: observation_type
+        type: string
+        length: 16
+        doc: The observation type of this exposure (e.g. dark, bias, science).
+      - name: observation_reason
+        type: string
+        length: 68
+        doc: >
+          The reason this observation was taken. (e.g. science,
+          filter scan, unknown).
+      - name: seq_num
+        type: int
+        doc: >
+          Counter for the observation within a larger sequence. Context
+          of the sequence number is observatory specific. Can be
+          a global counter or counter within day_obs.
+      - name: seq_start
+        type: int
+        doc: >
+          Earliest sequence number that might be related to this exposure.
+      - name: seq_end
+        type: int
+        doc: >
+          Oldest sequence number that might be related to this exposure.
+      - name: target_name
+        type: string
+        length: 64
+        doc: Object of interest for this observation or survey field name.
+      - name: science_program
+        type: string
+        length: 64
+        doc: >
+          Observing program (survey, proposal, engineering project)
+          identifier.
+      - name: tracking_ra
+        type: float
+        doc: >
+          Tracking ICRS Right Ascension of boresight in degrees. Can be NULL
+          for observations that are not on sky.
+      - name: tracking_dec
+        type: float
+        doc: >
+          Tracking ICRS Declination of boresight in degrees. Can be NULL for
+          observations that are not on sky.
+      - name: sky_angle
+        type: float
+        doc: >
+          Angle of the instrument focal plane on the sky in degrees. Can
+          be NULL for observations that are not on sky, or for observations
+          where the sky angle changes during the observation.
+      - name: azimuth
+        type: float
+        doc: >
+          Azimuth of the telescope at the start of the exposure in degrees.
+          Can be NULL for observations that are not on sky, or for observations
+          where the azimuth is not relevant.
+      - name: zenith_angle
+        type: float
+        doc: >
+          Angle in degrees from the zenith at the start of the exposure.
+      - name: has_simulated
+        type: bool
+        doc: >
+          True if this exposure has some content that was simulated.
+          This can be if the data itself were simulated or if
+          parts of the header came from simulated systems, such as observations
+          in the lab that are recorded as on-sky.
+      - name: can_see_sky
+        type: bool
+        doc: >
+          True if the detector could see the sky during this exposure. This
+          can be used to definitively determine whether an observation was
+          on sky, taking into account dome state as well as camera shutter.
+
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  skymap:
+    doc: >
+      A set of tracts and patches that subdivide the sky into rectangular
+      regions with simple projections and intentional overlaps.
+    keys:
+      - name: name
+        type: string
+        length: 64
+      - name: hash
+        type: hash
+        nbytes: 40
+        doc: >
+          A hash of the skymap's parameters.
+    metadata:
+      - name: tract_max
+        type: int
+        doc: >
+          Maximum ID for tracts in this skymap, exclusive.
+      - name: patch_nx_max
+        type: int
+        doc: >
+          Number of patches in the x direction in each tract.
+      - name: patch_ny_max
+        type: int
+        doc: >
+          Number of patches in the y direction in each tract.
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  tract:
+    doc: >
+      A large rectangular region mapped to the sky with a single map
+      projection, associated with a particular skymap.
+    keys:
+      - name: id
+        type: int
+    requires: [skymap]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  patch:
+    doc: >
+      A rectangular region within a tract.
+    keys:
+      - name: id
+        type: int
+    requires: [skymap, tract]
+    metadata:
+      - name: cell_x
+        type: int
+        nullable: false
+        doc: >
+          Which column this patch occupies in the tract's grid of patches.
+      - name: cell_y
+        type: int
+        nullable: false
+        doc: >
+          Which row this patch occupies in the tract's grid of patches.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_detector_region:
+    doc: >
+      A many-to-many join table that provides region information for
+      visit-detector combinations.
+    requires: [visit, detector]
+    populated_by: visit
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_system:
+    doc: >
+      A system of self-consistent visit definitions, within which each
+      exposure should appear at most once.
+
+      A visit may belong to multiple visit systems, if the logical definitions
+      for those systems happen to result in the same set of exposures - the
+      main (and probably only) example is when a single-snap visit is observed,
+      for which both the "one-to-one" visit system and a "group by header metadata" visit
+      system will define the same single-exposure visit.
+    keys:
+      - name: id
+        type: int
+      - name: name
+        type: string
+        length: 32
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_definition:
+    doc: >
+      A many-to-many join table that relates exposures to the visits they
+      belong to.
+    requires: [exposure, visit]
+    populated_by: visit
+    always_join: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit_system_membership:
+    doc: >
+      A many-to-many join table that relates visits to the visit_systems they
+      belong to.
+    requires: [visit, visit_system]
+    populated_by: visit
+    always_join: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+topology:
+  spatial:
+    observation_regions: [visit_detector_region, visit]
+    skymap_regions: [patch, tract]
+
+  temporal:
+    observation_timespans: [exposure, visit, day_obs]
+
+packers:
+  visit_detector:
+    fixed: [instrument]
+    dimensions: [instrument, visit, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+  exposure_detector:
+    fixed: [instrument]
+    dimensions: [instrument, exposure, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+  tract_patch:
+    fixed: [skymap]
+    dimensions: [skymap, tract, patch]
+    cls: lsst.skymap.packers.SkyMapDimensionPacker
+  tract_patch_band:
+    fixed: [skymap]
+    dimensions: [skymap, tract, patch, band]
+    cls: lsst.skymap.packers.SkyMapDimensionPacker

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -953,10 +953,10 @@ class Datastore(metaclass=ABCMeta):
             except FileNotFoundError:
                 missing_refs.append(ref)
         if missing_refs and not allow_missing:
+            num_missing = len(missing_refs)
             raise FileNotFoundError(
-                "Missing {} refs from datastore out of {} and predict=False.".format(
-                    num_missing := len(missing_refs), num_missing + len(uris)
-                )
+                f"Missing {num_missing} refs from datastore out of "
+                f"{num_missing + len(uris)} and predict=False."
             )
         return uris
 

--- a/python/lsst/daf/butler/dimensions/_graph.py
+++ b/python/lsst/daf/butler/dimensions/_graph.py
@@ -495,7 +495,7 @@ class DimensionGraph:  # numpydoc ignore=PR02
 
     def __eq__(self, other: Any) -> bool:
         """Test the arguments have exactly the same dimensions & elements."""
-        if isinstance(other, (DimensionGraph, DimensionGroup)):
+        if isinstance(other, DimensionGraph | DimensionGroup):
             return self._group == other.as_group()
         return False
 

--- a/python/lsst/daf/butler/dimensions/_group.py
+++ b/python/lsst/daf/butler/dimensions/_group.py
@@ -352,7 +352,7 @@ class DimensionGroup:  # numpydoc ignore=PR02
         from ._graph import DimensionGraph
 
         # TODO: Drop DimensionGraph support here on DM-41326.
-        if isinstance(other, (DimensionGroup, DimensionGraph)):
+        if isinstance(other, DimensionGroup | DimensionGraph):
             return self.names == other.names
         else:
             return False

--- a/python/lsst/daf/butler/dimensions/_records.py
+++ b/python/lsst/daf/butler/dimensions/_records.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 __all__ = ("DimensionRecord", "SerializedDimensionRecord")
 
 from collections.abc import Hashable
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import lsst.sphgeom
 from lsst.utils.classes import immutable
@@ -108,7 +108,7 @@ def _createSimpleRecordSubclass(definition: DimensionElement) -> type[SpecificSe
             field_type = Optional[field_type]  # type: ignore
         members[field.name] = (field_type, ...)
     if definition.temporal:
-        members["timespan"] = (Optional[Tuple[int, int]], ...)  # type: ignore
+        members["timespan"] = (Optional[tuple[int, int]], ...)  # type: ignore
     if definition.spatial:
         members["region"] = (str, ...)
 

--- a/python/lsst/daf/butler/dimensions/_records.py
+++ b/python/lsst/daf/butler/dimensions/_records.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 __all__ = ("DimensionRecord", "SerializedDimensionRecord")
 
 from collections.abc import Hashable
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import lsst.sphgeom
 from lsst.utils.classes import immutable
@@ -105,10 +105,10 @@ def _createSimpleRecordSubclass(definition: DimensionElement) -> type[SpecificSe
         field_type = field.getPythonType()
         field_type = type_map.get(field_type, field_type)
         if field.nullable:
-            field_type = Optional[field_type]  # type: ignore
+            field_type = field_type | None  # type: ignore
         members[field.name] = (field_type, ...)
     if definition.temporal:
-        members["timespan"] = (Optional[tuple[int, int]], ...)  # type: ignore
+        members["timespan"] = (tuple[int, int] | None, ...)  # type: ignore
     if definition.spatial:
         members["region"] = (str, ...)
 

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -302,8 +302,9 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         )
 
     def __str__(self) -> str:
-        return "Butler(collections={}, run={}, datastore='{}', registry='{}')".format(
-            self.collections, self.run, self._datastore, self._registry
+        return (
+            f"Butler(collections={self.collections}, run={self.run}, "
+            f"datastore='{self._datastore}', registry='{self._registry}')"
         )
 
     def isWriteable(self) -> bool:

--- a/python/lsst/daf/butler/json.py
+++ b/python/lsst/daf/butler/json.py
@@ -30,7 +30,9 @@ from __future__ import annotations
 __all__ = ("to_json_generic", "from_json_generic", "to_json_pydantic", "from_json_pydantic")
 
 import json
-from typing import TYPE_CHECKING, Any, Protocol, Type
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from .dimensions import DimensionUniverse
@@ -42,7 +44,7 @@ class SupportsSimple(Protocol):
     serialization using "simple" methods names.
     """
 
-    _serializedType: Type
+    _serializedType: ClassVar[type[BaseModel]]
 
     def to_simple(self, minimal: bool) -> Any: ...
 

--- a/python/lsst/daf/butler/logging.py
+++ b/python/lsst/daf/butler/logging.py
@@ -25,6 +25,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 __all__ = ("ButlerMDC", "ButlerLogRecords", "ButlerLogRecordHandler", "ButlerLogRecord", "JsonLogFormatter")
 
 import datetime
@@ -33,7 +35,7 @@ import traceback
 from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
 from logging import Formatter, LogRecord, StreamHandler
-from typing import IO, Any, ClassVar, Union, overload
+from typing import IO, Any, ClassVar, overload
 
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import isplit
@@ -200,7 +202,7 @@ class ButlerLogRecord(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     @classmethod
-    def from_record(cls, record: LogRecord) -> "ButlerLogRecord":
+    def from_record(cls, record: LogRecord) -> ButlerLogRecord:
         """Create a new instance from a `~logging.LogRecord`.
 
         Parameters
@@ -292,7 +294,7 @@ class ButlerLogRecords(_ButlerLogRecords):
     _log_format: str | None = PrivateAttr(None)
 
     @classmethod
-    def from_records(cls, records: Iterable[ButlerLogRecord]) -> "ButlerLogRecords":
+    def from_records(cls, records: Iterable[ButlerLogRecord]) -> ButlerLogRecords:
         """Create collection from iterable.
 
         Parameters
@@ -303,7 +305,7 @@ class ButlerLogRecords(_ButlerLogRecords):
         return cls.model_construct(root=list(records))
 
     @classmethod
-    def from_file(cls, filename: str) -> "ButlerLogRecords":
+    def from_file(cls, filename: str) -> ButlerLogRecords:
         """Read records from file.
 
         Parameters
@@ -374,7 +376,7 @@ class ButlerLogRecords(_ButlerLogRecords):
         return False
 
     @classmethod
-    def from_stream(cls, stream: IO) -> "ButlerLogRecords":
+    def from_stream(cls, stream: IO) -> ButlerLogRecords:
         """Read records from I/O stream.
 
         Parameters
@@ -411,7 +413,7 @@ class ButlerLogRecords(_ButlerLogRecords):
         return cls.from_records(records)
 
     @classmethod
-    def from_raw(cls, serialized: str | bytes) -> "ButlerLogRecords":
+    def from_raw(cls, serialized: str | bytes) -> ButlerLogRecords:
         """Parse raw serialized form and return records.
 
         Parameters
@@ -489,9 +491,9 @@ class ButlerLogRecords(_ButlerLogRecords):
     def __getitem__(self, index: int) -> ButlerLogRecord: ...
 
     @overload
-    def __getitem__(self, index: slice) -> "ButlerLogRecords": ...
+    def __getitem__(self, index: slice) -> ButlerLogRecords: ...
 
-    def __getitem__(self, index: slice | int) -> "Union[ButlerLogRecords, ButlerLogRecord]":
+    def __getitem__(self, index: slice | int) -> ButlerLogRecords | ButlerLogRecord:
         # Handles slices and returns a new collection in that
         # case.
         item = self.root[index]

--- a/python/lsst/daf/butler/mapping_factory.py
+++ b/python/lsst/daf/butler/mapping_factory.py
@@ -264,9 +264,8 @@ class MappingFactory:
                 return
 
             raise KeyError(
-                "Item with key {} already registered with different value ({} != {})".format(
-                    key, self._registry[key], typeName
-                )
+                f"Item with key {key} already registered with different value "
+                f"({self._registry[key]} != {typeName})"
             )
 
         self._registry[key] = {

--- a/python/lsst/daf/butler/queries/result_specs.py
+++ b/python/lsst/daf/butler/queries/result_specs.py
@@ -36,7 +36,7 @@ __all__ = (
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Annotated, Literal, TypeAlias, Union, cast
+from typing import Annotated, Literal, TypeAlias, cast
 
 import pydantic
 
@@ -254,6 +254,6 @@ class GeneralResultSpec(ResultSpecBase):
 
 
 ResultSpec: TypeAlias = Annotated[
-    Union[DataCoordinateResultSpec, DimensionRecordResultSpec, DatasetRefResultSpec, GeneralResultSpec],
+    DataCoordinateResultSpec | DimensionRecordResultSpec | DatasetRefResultSpec | GeneralResultSpec,
     pydantic.Field(discriminator="result_type"),
 ]

--- a/python/lsst/daf/butler/queries/tree/_column_expression.py
+++ b/python/lsst/daf/butler/queries/tree/_column_expression.py
@@ -38,7 +38,7 @@ __all__ = (
     "validate_order_expression",
 )
 
-from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeVar, Union, final
+from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeVar, final
 
 import pydantic
 
@@ -184,12 +184,7 @@ class BinaryExpression(ColumnExpressionBase):
 # in other unions that will add that annotation.  It's not clear whether it
 # would work to just nest the annotated ones, but it seems safest not to rely
 # on undocumented behavior.
-_ColumnExpression: TypeAlias = Union[
-    ColumnLiteral,
-    ColumnReference,
-    UnaryExpression,
-    BinaryExpression,
-]
+_ColumnExpression: TypeAlias = ColumnLiteral | ColumnReference | UnaryExpression | BinaryExpression
 
 
 ColumnExpression: TypeAlias = Annotated[_ColumnExpression, pydantic.Field(discriminator="expression_type")]
@@ -248,7 +243,7 @@ def validate_order_expression(expression: _ColumnExpression | Reversed) -> _Colu
 
 
 OrderExpression: TypeAlias = Annotated[
-    Union[_ColumnExpression, Reversed],
+    _ColumnExpression | Reversed,
     pydantic.Field(discriminator="expression_type"),
     pydantic.AfterValidator(validate_order_expression),
 ]

--- a/python/lsst/daf/butler/queries/tree/_column_literal.py
+++ b/python/lsst/daf/butler/queries/tree/_column_literal.py
@@ -46,7 +46,7 @@ from ..._timespan import Timespan
 from ...time_utils import TimeConverter
 from ._base import ColumnLiteralBase
 
-LiteralValue: TypeAlias = Union[int, str, float, bytes, uuid.UUID, astropy.time.Time, Timespan, Region]
+LiteralValue: TypeAlias = int | str | float | bytes | uuid.UUID | astropy.time.Time | Timespan | Region
 
 
 @final

--- a/python/lsst/daf/butler/queries/tree/_predicate.py
+++ b/python/lsst/daf/butler/queries/tree/_predicate.py
@@ -37,7 +37,8 @@ __all__ = (
 
 import itertools
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Annotated, Iterable, Literal, TypeAlias, TypeVar, Union, cast, final
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeVar, Union, cast, final
 
 import pydantic
 

--- a/python/lsst/daf/butler/queries/tree/_predicate.py
+++ b/python/lsst/daf/butler/queries/tree/_predicate.py
@@ -38,7 +38,7 @@ __all__ = (
 import itertools
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeVar, Union, cast, final
+from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeVar, cast, final
 
 import pydantic
 
@@ -622,15 +622,9 @@ class InQuery(PredicateLeafBase):
         return self
 
 
-LogicalNotOperand: TypeAlias = Union[
-    IsNull,
-    Comparison,
-    InContainer,
-    InRange,
-    InQuery,
-]
+LogicalNotOperand: TypeAlias = IsNull | Comparison | InContainer | InRange | InQuery
 PredicateLeaf: TypeAlias = Annotated[
-    Union[LogicalNotOperand, LogicalNot], pydantic.Field(discriminator="predicate_type")
+    LogicalNotOperand | LogicalNot, pydantic.Field(discriminator="predicate_type")
 ]
 
 PredicateOperands: TypeAlias = tuple[tuple[PredicateLeaf, ...], ...]

--- a/python/lsst/daf/butler/remote_butler/server/_server.py
+++ b/python/lsst/daf/butler/remote_butler/server/_server.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 __all__ = ("create_app",)
 
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
 
 import safir.dependencies.logger
 from fastapi import FastAPI, Request, Response

--- a/python/lsst/daf/butler/timespan_database_representation.py
+++ b/python/lsst/daf/butler/timespan_database_representation.py
@@ -28,13 +28,10 @@ from __future__ import annotations
 
 __all__ = ("TimespanDatabaseRepresentation",)
 
-import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
-import astropy.time
-import astropy.utils.exceptions
 import sqlalchemy
 
 # As of astropy 4.2, the erfa interface is shipped independently and
@@ -51,22 +48,6 @@ from .time_utils import TimeConverter
 
 if TYPE_CHECKING:  # Imports needed only for type annotations; may be circular.
     pass
-
-
-class _SpecialTimespanBound(enum.Enum):
-    """Enumeration to provide a singleton value for empty timespan bounds.
-
-    This enum's only member should generally be accessed via the
-    `Timespan.EMPTY` alias.
-    """
-
-    EMPTY = enum.auto()
-    """The value used for both `Timespan.begin` and `Timespan.end` for empty
-    Timespans that contain no points.
-    """
-
-
-TimespanBound: TypeAlias = astropy.time.Time | _SpecialTimespanBound | None
 
 
 _S = TypeVar("_S", bound="TimespanDatabaseRepresentation")

--- a/python/lsst/daf/butler/timespan_database_representation.py
+++ b/python/lsst/daf/butler/timespan_database_representation.py
@@ -31,7 +31,7 @@ __all__ = ("TimespanDatabaseRepresentation",)
 import enum
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias, TypeVar
 
 import astropy.time
 import astropy.utils.exceptions
@@ -66,7 +66,7 @@ class _SpecialTimespanBound(enum.Enum):
     """
 
 
-TimespanBound = Union[astropy.time.Time, _SpecialTimespanBound, None]
+TimespanBound: TypeAlias = astropy.time.Time | _SpecialTimespanBound | None
 
 
 _S = TypeVar("_S", bound="TimespanDatabaseRepresentation")

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -36,8 +36,8 @@ import time
 import unittest
 import unittest.mock
 import uuid
-from collections.abc import Callable
-from typing import Any, Iterator, cast
+from collections.abc import Callable, Iterator
+from typing import Any, cast
 
 import lsst.utils.tests
 import yaml

--- a/tests/test_query_utilities.py
+++ b/tests/test_query_utilities.py
@@ -32,7 +32,7 @@ any Butler or QueryDriver implementation.
 from __future__ import annotations
 
 import unittest
-from typing import Iterable
+from collections.abc import Iterable
 
 import astropy.time
 from lsst.daf.butler import DimensionUniverse, Timespan

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -95,6 +95,12 @@ class ButlerClientServerTestCase(unittest.TestCase):
         direct_butler.import_(filename=os.path.join(TESTDIR, "data", "registry", "datasets.yaml"))
 
     def test_health_check(self):
+        try:
+            import importlib.metadata
+
+            importlib.metadata.metadata("lsst.daf.butler")
+        except ModuleNotFoundError:
+            raise self.skipTest("Standard python package metadata not available. Butler not pip installed.")
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["name"], "butler")


### PR DESCRIPTION
No attempt is made to generate a value when importing from an old universe. (replaces #972)

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [x] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
