### PR TITLE
DM-43430: Add SLAC RSP to RemoteButler whitelist

### DIFF
--- a/python/lsst/daf/butler/remote_butler/_authentication.py
+++ b/python/lsst/daf/butler/remote_butler/_authentication.py
@@ -31,7 +31,7 @@ import os
 from fnmatch import fnmatchcase
 from urllib.parse import urlparse
 
-_SERVER_WHITELIST = ["*.lsst.cloud"]
+_SERVER_WHITELIST = ["*.lsst.cloud", "*.slac.stanford.edu"]
 _EXPLICIT_BUTLER_ACCESS_TOKEN_ENVIRONMENT_KEY = "BUTLER_RUBIN_ACCESS_TOKEN"
 _RSP_JUPYTER_ACCESS_TOKEN_ENVIRONMENT_KEY = "ACCESS_TOKEN"
 


### PR DESCRIPTION
Butler server is now deployed at USDF, so add it to RemoteButler's authentication whitelist to allow it to work from notebooks.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
