### PR TITLE
DM-43101: Fix type annotation of _serializedType property

### DIFF
--- a/python/lsst/daf/butler/_dataset_ref.py
+++ b/python/lsst/daf/butler/_dataset_ref.py
@@ -309,7 +309,7 @@ class DatasetRef:
     See also :ref:`daf_butler_organizing_datasets`
     """
 
-    _serializedType = SerializedDatasetRef
+    _serializedType: ClassVar[type[pydantic.BaseModel]] = SerializedDatasetRef
     __slots__ = (
         "_id",
         "datasetType",

--- a/python/lsst/daf/butler/_dataset_type.py
+++ b/python/lsst/daf/butler/_dataset_type.py
@@ -182,7 +182,7 @@ class DatasetType:
         "_isCalibration",
     )
 
-    _serializedType = SerializedDatasetType
+    _serializedType: ClassVar[type[BaseModel]] = SerializedDatasetType
 
     VALID_NAME_REGEX = re.compile("^[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
 

--- a/python/lsst/daf/butler/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/dimensions/_coordinate.py
@@ -167,7 +167,7 @@ class DataCoordinate(NamedKeyMapping[Dimension, DataIdValue]):
 
     __slots__ = ()
 
-    _serializedType = SerializedDataCoordinate
+    _serializedType: ClassVar[type[pydantic.BaseModel]] = SerializedDataCoordinate
 
     @staticmethod
     def standardize(

--- a/python/lsst/daf/butler/dimensions/_graph.py
+++ b/python/lsst/daf/butler/dimensions/_graph.py
@@ -229,7 +229,7 @@ class DimensionGraph:  # numpydoc ignore=PR02
     required.
     """
 
-    _serializedType = SerializedDimensionGraph
+    _serializedType: ClassVar[type[pydantic.BaseModel]] = SerializedDimensionGraph
 
     def __new__(
         cls,

--- a/python/lsst/daf/butler/dimensions/_records.py
+++ b/python/lsst/daf/butler/dimensions/_records.py
@@ -265,7 +265,7 @@ class DimensionRecord:
     # when they access self.__slots__.
     __slots__ = ("dataId",)
 
-    _serializedType = SerializedDimensionRecord
+    _serializedType: ClassVar[type[BaseModel]] = SerializedDimensionRecord
 
     def __init__(self, **kwargs: Any):
         # Accept either the dimension name or the actual name of its primary


### PR DESCRIPTION
Without this the SupportsSimple protocol wouldn't match things like DatasetRef.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
