### PR TITLE
DM-43671: Implement atomic collection prepend

### DIFF
--- a/doc/changes/DM-43671.bugfix.md
+++ b/doc/changes/DM-43671.bugfix.md
@@ -1,0 +1,3 @@
+The `flatten` flag for the `butler collection-chain` CLI command now works as documented: it only flattens the specified children instead of flattening the entire collection chain.
+
+`registry.setCollectionChain` will no longer throw unique constraint violation exceptions when there are concurrent calls to this function. Instead, all calls will succeed and the last write will win. As a side-effect of this change, if calls to `setCollectionChain` occur within an explicit call to `Butler.transaction`, other processes attempting to modify the same chain will block until the transaction completes.

--- a/doc/changes/DM-43671.feature.md
+++ b/doc/changes/DM-43671.feature.md
@@ -1,0 +1,1 @@
+Added a new method `Butler.prepend_collection_chain`.  This allows you to insert collections at the beginning of a chain. It is an "atomic" operation that can be safely used concurrently from multiple processes.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1742,6 +1742,9 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
     ) -> None:
         """Add children to the beginning of a CHAINED collection.
 
+        If any of the children already existed in the chain, they will be moved
+        to the new position at the beginning of the chain.
+
         Parameters
         ----------
         parent_collection_name : `str`

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1735,3 +1735,33 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         ``inferDefaults``, and default data ID.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def prepend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        """Add children to the beginning of a CHAINED collection.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will add new children.
+        child_collection_names : `Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1756,6 +1756,8 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             If any of the specified collections do not exist.
         CollectionTypeError
             If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
 
         Notes
         -----

--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -28,6 +28,7 @@
 """Specialized Butler exceptions."""
 __all__ = (
     "CalibrationLookupError",
+    "CollectionCycleError",
     "DatasetNotFoundError",
     "DimensionNameError",
     "ButlerUserError",
@@ -77,6 +78,14 @@ class CalibrationLookupError(LookupError, ButlerUserError):
     """Exception raised for failures to look up a calibration dataset."""
 
     error_type = "calibration_lookup"
+
+
+class CollectionCycleError(ValueError, ButlerUserError):
+    """Raised when an operation would cause a chained collection to be a child
+    of itself.
+    """
+
+    error_type = "collection_cycle"
 
 
 class DatasetNotFoundError(LookupError, ButlerUserError):
@@ -158,6 +167,7 @@ class UnknownButlerUserError(ButlerUserError):
 
 _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     CalibrationLookupError,
+    CollectionCycleError,
     DimensionNameError,
     DimensionValueError,
     DatasetNotFoundError,

--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -29,6 +29,7 @@
 __all__ = (
     "CalibrationLookupError",
     "CollectionCycleError",
+    "CollectionTypeError",
     "DatasetNotFoundError",
     "DimensionNameError",
     "ButlerUserError",
@@ -86,6 +87,12 @@ class CollectionCycleError(ValueError, ButlerUserError):
     """
 
     error_type = "collection_cycle"
+
+
+class CollectionTypeError(CollectionError, ButlerUserError):
+    """Exception raised when type of a collection is incorrect."""
+
+    error_type = "collection_type"
 
 
 class DatasetNotFoundError(LookupError, ButlerUserError):
@@ -168,6 +175,7 @@ class UnknownButlerUserError(ButlerUserError):
 _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     CalibrationLookupError,
     CollectionCycleError,
+    CollectionTypeError,
     DimensionNameError,
     DimensionValueError,
     DatasetNotFoundError,

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, TextIO, cast
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.utils.introspection import get_class_of
+from lsst.utils.iteration import ensure_iterable
 from lsst.utils.logging import VERBOSE, getLogger
 from sqlalchemy.exc import IntegrityError
 
@@ -2140,6 +2141,13 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
     def _preload_cache(self) -> None:
         """Immediately load caches that are used for common operations."""
         self._registry.preload_cache()
+
+    def prepend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._registry._managers.collections.prepend_collection_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
 
     _config: ButlerConfig
     """Configuration for this Butler instance."""

--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -27,7 +27,12 @@
 
 # Re-export some top-level exception types for backwards compatibility -- these
 # used to be part of registry.
-from .._exceptions import DimensionNameError, MissingCollectionError, MissingDatasetTypeError
+from .._exceptions import (
+    CollectionTypeError,
+    DimensionNameError,
+    MissingCollectionError,
+    MissingDatasetTypeError,
+)
 from .._exceptions_legacy import CollectionError, DataIdError, DatasetTypeError, RegistryError
 
 # Registry imports.

--- a/python/lsst/daf/butler/registry/_exceptions.py
+++ b/python/lsst/daf/butler/registry/_exceptions.py
@@ -29,7 +29,6 @@
 __all__ = (
     "ArgumentError",
     "CollectionExpressionError",
-    "CollectionTypeError",
     "ConflictingDefinitionError",
     "DataIdValueError",
     "DatasetTypeExpressionError",
@@ -62,10 +61,6 @@ class InconsistentDataIdError(DataIdError):
     """Exception raised when a data ID contains contradictory key-value pairs,
     according to dimension relationships.
     """
-
-
-class CollectionTypeError(CollectionError):
-    """Exception raised when type of a collection is incorrect."""
 
 
 class CollectionExpressionError(CollectionError):

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -32,9 +32,8 @@ __all__ = ()
 
 import itertools
 from abc import abstractmethod
-from collections import namedtuple
 from collections.abc import Iterable, Iterator, Set
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar, cast
 
 import sqlalchemy
 
@@ -77,7 +76,13 @@ def _makeCollectionForeignKey(
     return ddl.ForeignKeySpec("collection", source=(sourceColumnName,), target=(collectionIdName,), **kwargs)
 
 
-CollectionTablesTuple = namedtuple("CollectionTablesTuple", ["collection", "run", "collection_chain"])
+_T = TypeVar("_T")
+
+
+class CollectionTablesTuple(NamedTuple, Generic[_T]):
+    collection: _T
+    run: _T
+    collection_chain: _T
 
 
 def makeRunTableSpec(
@@ -188,7 +193,7 @@ class DefaultCollectionManager(CollectionManager[K]):
     def __init__(
         self,
         db: Database,
-        tables: CollectionTablesTuple,
+        tables: CollectionTablesTuple[sqlalchemy.Table],
         collectionIdName: str,
         *,
         caching_context: CachingContext,

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -426,7 +426,9 @@ class DefaultCollectionManager(CollectionManager[K]):
         child_records = self.resolve_wildcard(CollectionWildcard.from_names(children), flatten_chains=False)
         names = [child.name for child in child_records]
         with self._db.transaction():
+            self._find_and_lock_collection_chain(chain.name)
             self._db.delete(self._tables.collection_chain, ["parent"], {"parent": chain.key})
+            self._block_for_concurrency_test()
             self._insert_collection_chain_rows(chain.key, 0, [child.key for child in child_records])
 
         record = ChainedCollectionRecord[K](chain.key, chain.name, children=tuple(names))

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -468,6 +468,8 @@ class DefaultCollectionManager(CollectionManager[K]):
             starting_position = self._find_lowest_position_in_collection_chain(parent_key) - len(child_keys)
             self._insert_collection_chain_rows(parent_key, starting_position, child_keys)
 
+        self._refresh_cache_for_key(parent_key)
+
     def _find_lowest_position_in_collection_chain(self, chain_key: K) -> int:
         """Return the lowest-numbered position in a collection chain, or 0 if
         the chain is empty.
@@ -544,3 +546,12 @@ class DefaultCollectionManager(CollectionManager[K]):
         - ``type`` : the collection type
         """
         raise NotImplementedError()
+
+    def _refresh_cache_for_key(self, key: K) -> None:
+        """Refresh the data in the cache for a single collection."""
+        cache = self._caching_context.collection_records
+        if cache is not None:
+            records = self._fetch_by_key([key])
+            if records:
+                assert len(records) == 1
+                cache.add(records[0])

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -30,7 +30,6 @@ from ... import ddl
 
 __all__ = ()
 
-import itertools
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Set
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar, cast
@@ -462,14 +461,13 @@ class DefaultCollectionManager(CollectionManager[K]):
         starting_position: int,
         child_keys: list[K],
     ) -> None:
-        position = itertools.count(starting_position)
         rows = [
             {
                 "parent": parent_key,
                 "child": child,
-                "position": next(position),
+                "position": position,
             }
-            for child in child_keys
+            for position, child in enumerate(child_keys, starting_position)
         ]
         self._db.insert(self._tables.collection_chain, *rows)
 

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -37,10 +37,9 @@ from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar, cast
 
 import sqlalchemy
 
-from ..._exceptions import CollectionCycleError, MissingCollectionError
+from ..._exceptions import CollectionCycleError, CollectionTypeError, MissingCollectionError
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from .._collection_type import CollectionType
-from .._exceptions import CollectionTypeError
 from ..interfaces import ChainedCollectionRecord, CollectionManager, CollectionRecord, RunRecord, VersionTuple
 from ..wildcards import CollectionWildcard
 

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -486,6 +486,7 @@ class DefaultCollectionManager(CollectionManager[K]):
         with self._db.transaction():
             parent_key = self._find_and_lock_collection_chain(parent_collection_name)
             starting_position = self._find_lowest_position_in_collection_chain(parent_key) - len(child_keys)
+            self._block_for_concurrency_test()
             self._insert_collection_chain_rows(parent_key, starting_position, child_keys)
 
         self._refresh_cache_for_key(parent_key)

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -285,6 +285,12 @@ class NameKeyCollectionManager(DefaultCollectionManager[str]):
 
         return records
 
+    def _select_pkey_by_name(self, collection_name: str) -> sqlalchemy.Select:
+        table = self._tables.collection
+        return sqlalchemy.select(table.c.name.label("key"), table.c.type).where(
+            table.c.name == collection_name
+        )
+
     @classmethod
     def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -63,7 +63,9 @@ _VERSION = VersionTuple(2, 0, 0)
 _LOG = logging.getLogger(__name__)
 
 
-def _makeTableSpecs(TimespanReprClass: type[TimespanDatabaseRepresentation]) -> CollectionTablesTuple:
+def _makeTableSpecs(
+    TimespanReprClass: type[TimespanDatabaseRepresentation],
+) -> CollectionTablesTuple[ddl.TableSpec]:
     return CollectionTablesTuple(
         collection=ddl.TableSpec(
             fields=[

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -302,6 +302,12 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager[int]):
 
         return records
 
+    def _select_pkey_by_name(self, collection_name: str) -> sqlalchemy.Select:
+        table = self._tables.collection
+        return sqlalchemy.select(table.c.collection_id.label("key"), table.c.type).where(
+            table.c.name == collection_name
+        )
+
     @classmethod
     def currentVersions(cls) -> list[VersionTuple]:
         # Docstring inherited from VersionedExtension.

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -63,7 +63,9 @@ _VERSION = VersionTuple(2, 0, 0)
 _LOG = logging.getLogger(__name__)
 
 
-def _makeTableSpecs(TimespanReprClass: type[TimespanDatabaseRepresentation]) -> CollectionTablesTuple:
+def _makeTableSpecs(
+    TimespanReprClass: type[TimespanDatabaseRepresentation],
+) -> CollectionTablesTuple[ddl.TableSpec]:
     return CollectionTablesTuple(
         collection=ddl.TableSpec(
             fields=[

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -44,11 +44,12 @@ from ...._column_tags import DatasetColumnTag, DimensionKeyColumnTag
 from ...._column_type_info import LogicalColumn
 from ...._dataset_ref import DatasetId, DatasetIdFactory, DatasetIdGenEnum, DatasetRef
 from ...._dataset_type import DatasetType
+from ...._exceptions import CollectionTypeError
 from ...._timespan import Timespan
 from ....dimensions import DataCoordinate
 from ..._collection_summary import CollectionSummary
 from ..._collection_type import CollectionType
-from ..._exceptions import CollectionTypeError, ConflictingDefinitionError
+from ..._exceptions import ConflictingDefinitionError
 from ...interfaces import DatasetRecordStorage
 from ...queries import SqlQueryContext
 from .tables import makeTagTableSpec

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -621,3 +621,32 @@ class CollectionManager(Generic[_Key], VersionedExtension):
             `~CollectionType.CHAINED` collections in ``children`` first.
         """
         raise NotImplementedError()
+
+    def prepend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: list[str]
+    ) -> None:
+        """Add children to the beginning of a CHAINED collection.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will add new children.
+        child_collection_names : `list` [ `str ` ]
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -641,6 +641,8 @@ class CollectionManager(Generic[_Key], VersionedExtension):
             If any of the specified collections do not exist.
         CollectionTypeError
             If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
 
         Notes
         -----

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -622,6 +622,7 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def prepend_collection_chain(
         self, parent_collection_name: str, child_collection_names: list[str]
     ) -> None:
@@ -652,3 +653,8 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         transactions short.
         """
         raise NotImplementedError()
+
+    def _block_for_concurrency_test(self) -> None:
+        """No-op normally. Provide a place for unit tests to hook in and
+        verify locking behavior.
+        """

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -623,6 +623,13 @@ class SqlRegistry:
             `~CollectionType.CHAINED` collection.
         CollectionCycleError
             Raised if the given collections contains a cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
         """
         record = self._managers.collections.find(parent)
         if record.type is not CollectionType.CHAINED:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -621,7 +621,7 @@ class SqlRegistry:
         lsst.daf.butler.registry.CollectionTypeError
             Raised if ``parent`` does not correspond to a
             `~CollectionType.CHAINED` collection.
-        ValueError
+        CollectionCycleError
             Raised if the given collections contains a cycle.
         """
         record = self._managers.collections.find(parent)

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -57,7 +57,7 @@ from lsst.daf.relation import Relation, RelationalAlgebraError, Transfer, iterat
 from ..._dataset_association import DatasetAssociation
 from ..._dataset_ref import DatasetIdFactory, DatasetIdGenEnum, DatasetRef
 from ..._dataset_type import DatasetType
-from ..._exceptions import MissingCollectionError, MissingDatasetTypeError
+from ..._exceptions import CollectionTypeError, MissingCollectionError, MissingDatasetTypeError
 from ..._exceptions_legacy import DatasetTypeError
 from ..._storage_class import StorageClass
 from ..._timespan import Timespan
@@ -68,7 +68,6 @@ from .._config import RegistryConfig
 from .._exceptions import (
     ArgumentError,
     CollectionError,
-    CollectionTypeError,
     ConflictingDefinitionError,
     DataIdValueError,
     DatasetTypeExpressionError,

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -570,6 +570,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         # Docstring inherited.
         return self._registry_defaults.collections
 
+    def prepend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        raise NotImplementedError()
+
     @property
     def run(self) -> str | None:
         # Docstring inherited.

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -452,3 +452,8 @@ class HybridButler(Butler):
         return self._direct_butler._extract_all_dimension_records_from_data_ids(
             source_butler, data_ids, allowed_elements
         )
+
+    def prepend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._direct_butler.prepend_collection_chain(parent_collection_name, child_collection_names)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1390,14 +1390,7 @@ class ButlerTests(ButlerPutGetTests):
 
     def testCollectionChainPrepend(self):
         butler = self.create_empty_butler(writeable=True)
-        self._testCollectionChainPrepend(butler)
 
-    def testCollectionChainPrependCached(self):
-        butler = self.create_empty_butler(writeable=True)
-        with butler._caching_context():
-            self._testCollectionChainPrepend(butler)
-
-    def _testCollectionChainPrepend(self, butler: Butler) -> None:
         butler.registry.registerCollection("chain", CollectionType.CHAINED)
 
         runs = ["a", "b", "c", "d"]
@@ -1446,6 +1439,10 @@ class ButlerTests(ButlerPutGetTests):
 
         # Make sure none of those operations interfered with unrelated chains
         self.assertEqual(["a", "b"], list(butler.registry.getCollectionChain("staticchain")))
+
+        with butler._caching_context():
+            with self.assertRaisesRegex(RuntimeError, "Chained collection modification not permitted"):
+                butler.prepend_collection_chain("chain", "a")
 
 
 class FileDatastoreButlerTests(ButlerTests):

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1389,6 +1389,14 @@ class ButlerTests(ButlerPutGetTests):
 
     def testCollectionChainPrepend(self):
         butler = self.create_empty_butler(writeable=True)
+        self._testCollectionChainPrepend(butler)
+
+    def testCollectionChainPrependCached(self):
+        butler = self.create_empty_butler(writeable=True)
+        with butler._caching_context():
+            self._testCollectionChainPrepend(butler)
+
+    def _testCollectionChainPrepend(self, butler: Butler) -> None:
         butler.registry.registerCollection("chain", CollectionType.CHAINED)
         runs = ["a", "b", "c", "d"]
         for run in runs:

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -161,6 +161,11 @@ class RemoteButlerRegistryTests(RegistryTests, unittest.TestCase):
         # the client side.
         pass
 
+    def testCollectionChainConcurrency(self):
+        # This tests an implementation detail that requires access to the
+        # collection manager object.
+        pass
+
     def testAttributeManager(self):
         # Tests a non-public API that isn't relevant on the client side.
         pass

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -161,7 +161,12 @@ class RemoteButlerRegistryTests(RegistryTests, unittest.TestCase):
         # the client side.
         pass
 
-    def testCollectionChainConcurrency(self):
+    def testCollectionChainPrependConcurrency(self):
+        # This tests an implementation detail that requires access to the
+        # collection manager object.
+        pass
+
+    def testCollectionChainReplaceConcurrency(self):
         # This tests an implementation detail that requires access to the
         # collection manager object.
         pass


### PR DESCRIPTION
Added an atomic chained collection prepend method to Butler.  It works by taking a row lock on the parent collection's row in the collections tables, which acts as a mutex for the modification of the collection_chain table.  The existing setCollectionChain method now also uses this lock, so that it can interact safely with the new operation.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
