### PR TITLE
DM-43315: Implement additional collection chain operations

### DIFF
--- a/doc/changes/DM-43315.feature.md
+++ b/doc/changes/DM-43315.feature.md
@@ -1,0 +1,1 @@
+Added additional collection chain methods to the top-level `Butler` interface: `extend_collection_chain`, `remove_from_collection_chain`, and `redefine_collection_chain`.  These methods are all "atomic" functions that can safely be used concurrently from multiple processes.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1772,6 +1772,41 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         raise NotImplementedError()
 
     @abstractmethod
+    def extend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        """Add children to the end of a CHAINED collection.
+
+        If any of the children already existed in the chain, they will be moved
+        to the new position at the end of the chain.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will add new children.
+        child_collection_names : `Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def remove_from_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1770,3 +1770,34 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         transactions short.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def remove_from_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        """Remove children from a CHAINED collection.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection from which we will remove
+            children.
+        child_collection_names : `Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            removed from the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1737,6 +1737,39 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         raise NotImplementedError()
 
     @abstractmethod
+    def redefine_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        """Replace the contents of a CHAINED collection with new children.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will assign new
+            children.
+        child_collection_names : `Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def prepend_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1747,7 +1747,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         parent_collection_name : `str`
             The name of a CHAINED collection to which we will assign new
             children.
-        child_collection_names : `Iterable` [ `str ` ] | `str`
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
             A child collection name or list of child collection names to be
             added to the parent.
 
@@ -1817,7 +1817,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         ----------
         parent_collection_name : `str`
             The name of a CHAINED collection to which we will add new children.
-        child_collection_names : `Iterable` [ `str ` ] | `str`
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
             A child collection name or list of child collection names to be
             added to the parent.
 
@@ -1850,7 +1850,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         parent_collection_name : `str`
             The name of a CHAINED collection from which we will remove
             children.
-        child_collection_names : `Iterable` [ `str ` ] | `str`
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
             A child collection name or list of child collection names to be
             removed from the parent.
 

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -168,7 +168,7 @@ class LogCliRunner(click.testing.CliRunner):
     `CliLog.defaultLsstLogLevel`.
     """
 
-    def invoke(self, *args: Any, **kwargs: Any) -> Any:
+    def invoke(self, *args: Any, **kwargs: Any) -> click.testing.Result:
         result = super().invoke(*args, **kwargs)
         CliLog.resetLog()
         return result

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -2156,6 +2156,13 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             parent_collection_name, list(ensure_iterable(child_collection_names))
         )
 
+    def remove_from_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._registry._managers.collections.remove_from_collection_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
+
     _config: ButlerConfig
     """Configuration for this Butler instance."""
 

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -2149,6 +2149,13 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         """Immediately load caches that are used for common operations."""
         self._registry.preload_cache()
 
+    def redefine_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        self._registry._managers.collections.update_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
+
     def prepend_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler.py
@@ -2156,6 +2156,13 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             parent_collection_name, list(ensure_iterable(child_collection_names))
         )
 
+    def extend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._registry._managers.collections.extend_collection_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
+
     def remove_from_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -408,7 +408,12 @@ class DefaultCollectionManager(CollectionManager[K]):
         """
         raise NotImplementedError()
 
-    def update_chain(self, parent_collection_name: str, child_collection_names: list[str]) -> None:
+    def update_chain(
+        self,
+        parent_collection_name: str,
+        child_collection_names: list[str],
+        allow_use_in_caching_context: bool = False,
+    ) -> None:
         with self._modify_collection_chain(
             parent_collection_name,
             child_collection_names,
@@ -416,7 +421,7 @@ class DefaultCollectionManager(CollectionManager[K]):
             # called within caching contexts.  (At least in Butler.import_ and
             # possibly other places.)  So, unlike the other collection chain
             # modification methods, it has to update the collection cache.
-            skip_caching_check=True,
+            skip_caching_check=allow_use_in_caching_context,
         ) as c:
             self._db.delete(self._tables.collection_chain, ["parent"], {"parent": c.parent_key})
             self._block_for_concurrency_test()

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -607,20 +607,32 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def update_chain(
-        self, record: ChainedCollectionRecord[_Key], children: Iterable[str], flatten: bool = False
-    ) -> ChainedCollectionRecord[_Key]:
-        """Update chained collection composition.
+    def update_chain(self, parent_collection_name: str, child_collection_names: list[str]) -> None:
+        """Replace all of the children in a chained collection with a new list.
 
         Parameters
         ----------
-        record : `ChainedCollectionRecord`
-            Chained collection record.
-        children : `~collections.abc.Iterable` [`str`]
-            Ordered names of children collections.
-        flatten : `bool`, optional
-            If `True`, recursively flatten out any nested
-            `~CollectionType.CHAINED` collections in ``children`` first.
+        parent_collection_name : `str`
+            The name of a CHAINED collection to be modified.
+        child_collection_names : `list` [ `str ` ]
+            A child collection name or list of child collection names to be
+            assigned to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -642,6 +642,9 @@ class CollectionManager(Generic[_Key], VersionedExtension):
     ) -> None:
         """Add children to the beginning of a CHAINED collection.
 
+        If any of the children already existed in the chain, they will be moved
+        to the new position at the beginning of the chain.
+
         Parameters
         ----------
         parent_collection_name : `str`
@@ -658,6 +661,37 @@ class CollectionManager(Generic[_Key], VersionedExtension):
             If the parent collection is not a CHAINED collection.
         CollectionCycleError
             If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def remove_from_collection_chain(
+        self, parent_collection_name: str, child_collection_names: list[str]
+    ) -> None:
+        """Remove children from a CHAINED collection.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection from which we will remove
+            children.
+        child_collection_names : `list` [ `str ` ]
+            A child collection name or list of child collection names to be
+            removed from the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
 
         Notes
         -----

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -607,7 +607,12 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def update_chain(self, parent_collection_name: str, child_collection_names: list[str]) -> None:
+    def update_chain(
+        self,
+        parent_collection_name: str,
+        child_collection_names: list[str],
+        allow_use_in_caching_context: bool = False,
+    ) -> None:
         """Replace all of the children in a chained collection with a new list.
 
         Parameters
@@ -617,6 +622,10 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         child_collection_names : `list` [ `str ` ]
             A child collection name or list of child collection names to be
             assigned to the parent.
+        allow_use_in_caching_context : `bool`, optional
+            If `True`, skip a check that would otherwise disallow this function
+            from being called inside an active caching context.
+            (Only exists for legacy use, will eventually be removed).
 
         Raises
         ------

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -672,6 +672,39 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
+    def extend_collection_chain(self, parent_collection_name: str, child_collection_names: list[str]) -> None:
+        """Add children to the end of a CHAINED collection.
+
+        If any of the children already existed in the chain, they will be moved
+        to the new position at the end of the chain.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will add new children.
+        child_collection_names : `list` [ `str ` ]
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def remove_from_collection_chain(
         self, parent_collection_name: str, child_collection_names: list[str]
     ) -> None:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -631,13 +631,11 @@ class SqlRegistry:
         parent collection until the end of the transaction.  Keep these
         transactions short.
         """
-        record = self._managers.collections.find(parent)
-        if record.type is not CollectionType.CHAINED:
-            raise CollectionTypeError(f"Collection '{parent}' has type {record.type.name}, not CHAINED.")
-        assert isinstance(record, ChainedCollectionRecord)
         children = CollectionWildcard.from_expression(children).require_ordered()
-        if children != record.children or flatten:
-            self._managers.collections.update_chain(record, children, flatten=flatten)
+        if flatten:
+            children = self.queryCollections(children, flattenChains=True)
+
+        self._managers.collections.update_chain(parent, list(children))
 
     def getCollectionParentChains(self, collection: str) -> set[str]:
         """Return the CHAINED collections that directly contain the given one.

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -635,7 +635,7 @@ class SqlRegistry:
         if flatten:
             children = self.queryCollections(children, flattenChains=True)
 
-        self._managers.collections.update_chain(parent, list(children))
+        self._managers.collections.update_chain(parent, list(children), allow_use_in_caching_context=True)
 
     def getCollectionParentChains(self, collection: str) -> set[str]:
         """Return the CHAINED collections that directly contain the given one.

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -512,6 +512,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         # Docstring inherited.
         return self._registry_defaults.collections
 
+    def redefine_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        raise NotImplementedError()
+
     def prepend_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -517,6 +517,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     ) -> None:
         raise NotImplementedError()
 
+    def extend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        raise NotImplementedError()
+
     def remove_from_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -517,6 +517,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     ) -> None:
         raise NotImplementedError()
 
+    def remove_from_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        raise NotImplementedError()
+
     @property
     def run(self) -> str | None:
         # Docstring inherited.

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -107,7 +107,7 @@ def _modify_collection_chain(butler: Butler, mode: str, parent: str, children: I
     if mode == "prepend":
         butler.prepend_collection_chain(parent, children)
     elif mode == "redefine":
-        butler.registry.setCollectionChain(parent, children)
+        butler.redefine_collection_chain(parent, children)
     elif mode == "remove":
         butler.remove_from_collection_chain(parent, children)
     elif mode == "pop":

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -114,9 +114,7 @@ def _modify_collection_chain(butler: Butler, mode: str, parent: str, children: I
         children_to_pop = _find_children_to_pop(butler, parent, children)
         butler.remove_from_collection_chain(parent, children_to_pop)
     elif mode == "extend":
-        current = list(butler.registry.getCollectionChain(parent))
-        current.extend(children)
-        butler.registry.setCollectionChain(parent, current)
+        butler.extend_collection_chain(parent, children)
     else:
         raise ValueError(f"Unrecognized update mode: '{mode}'")
 

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -110,39 +110,44 @@ def _modify_collection_chain(butler: Butler, mode: str, parent: str, children: I
         butler.registry.setCollectionChain(parent, children)
     elif mode == "remove":
         butler.remove_from_collection_chain(parent, children)
-    else:
+    elif mode == "pop":
+        children_to_pop = _find_children_to_pop(butler, parent, children)
+        butler.remove_from_collection_chain(parent, children_to_pop)
+    elif mode == "extend":
         current = list(butler.registry.getCollectionChain(parent))
+        current.extend(children)
+        butler.registry.setCollectionChain(parent, current)
+    else:
+        raise ValueError(f"Unrecognized update mode: '{mode}'")
 
-        if mode == "extend":
-            current.extend(children)
-            children = current
-        elif mode == "pop":
-            if children:
-                n_current = len(current)
 
-                def convert_index(i: int) -> int:
-                    """Convert negative index to positive."""
-                    if i >= 0:
-                        return i
-                    return n_current + i
+def _find_children_to_pop(butler: Butler, parent: str, children: Iterable[str]) -> list[str]:
+    """Find the names of the children in the parent collection corresponding to
+    the given indexes.
+    """
+    children = list(children)
+    current = butler.registry.getCollectionChain(parent)
+    n_current = len(current)
+    if children:
 
-                # For this mode the children should be integers.
-                # Convert negative integers to positive ones to allow
-                # sorting.
-                indices = [convert_index(int(child)) for child in children]
+        def convert_index(i: int) -> int:
+            """Convert negative index to positive."""
+            if i >= 0:
+                return i
+            return n_current + i
 
-                # Reverse sort order so we can remove from the end first
-                indices = sorted(indices, reverse=True)
+        # For this mode the children should be integers.
+        # Convert negative integers to positive ones to allow
+        # sorting.
+        indices = [convert_index(int(child)) for child in children]
+    else:
+        # Nothing specified, pop from the front of the chain.
+        indices = [0]
 
-            else:
-                # Nothing specified, pop from the front of the chain.
-                indices = [0]
+    for index in indices:
+        if index >= n_current:
+            raise IndexError(
+                f"Index {index} is out of range.  Parent collection {parent} has {n_current} children."
+            )
 
-            for i in indices:
-                current.pop(i)
-
-            children = current
-        else:
-            raise ValueError(f"Unrecognized update mode: '{mode}'")
-
-        butler.registry.setCollectionChain(parent, children)
+    return [current[i] for i in indices]

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -108,15 +108,13 @@ def _modify_collection_chain(butler: Butler, mode: str, parent: str, children: I
         butler.prepend_collection_chain(parent, children)
     elif mode == "redefine":
         butler.registry.setCollectionChain(parent, children)
+    elif mode == "remove":
+        butler.remove_from_collection_chain(parent, children)
     else:
         current = list(butler.registry.getCollectionChain(parent))
 
         if mode == "extend":
             current.extend(children)
-            children = current
-        elif mode == "remove":
-            for child in children:
-                current.remove(child)
             children = current
         elif mode == "pop":
             if children:

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -453,6 +453,11 @@ class HybridButler(Butler):
             source_butler, data_ids, allowed_elements
         )
 
+    def redefine_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._direct_butler.redefine_collection_chain(parent_collection_name, child_collection_names)
+
     def prepend_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -457,3 +457,10 @@ class HybridButler(Butler):
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:
         return self._direct_butler.prepend_collection_chain(parent_collection_name, child_collection_names)
+
+    def remove_from_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._direct_butler.remove_from_collection_chain(
+            parent_collection_name, child_collection_names
+        )

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -458,6 +458,11 @@ class HybridButler(Butler):
     ) -> None:
         return self._direct_butler.prepend_collection_chain(parent_collection_name, child_collection_names)
 
+    def extend_collection_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._direct_butler.extend_collection_chain(parent_collection_name, child_collection_names)
+
     def remove_from_collection_chain(
         self, parent_collection_name: str, child_collection_names: str | Iterable[str]
     ) -> None:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1388,6 +1388,22 @@ class ButlerTests(ButlerPutGetTests):
         get_ref = reader_butler.get_dataset(put_ref.id)
         self.assertEqual(get_ref.id, put_ref.id)
 
+    def testCollectionChainRedefine(self):
+        butler = self._setup_to_test_collection_chain()
+
+        butler.redefine_collection_chain("chain", "a")
+        self._check_chain(butler, ["a"])
+
+        # Duplicates are removed from the list of children
+        butler.redefine_collection_chain("chain", ["c", "b", "c"])
+        self._check_chain(butler, ["c", "b"])
+
+        # Empty list clears the chain
+        butler.redefine_collection_chain("chain", [])
+        self._check_chain(butler, [])
+
+        self._test_common_chain_functionality(butler, butler.redefine_collection_chain)
+
     def testCollectionChainPrepend(self):
         butler = self._setup_to_test_collection_chain()
 
@@ -1407,12 +1423,6 @@ class ButlerTests(ButlerPutGetTests):
         # their current position.
         butler.prepend_collection_chain("chain", ["d", "b", "c"])
         self._check_chain(butler, ["d", "b", "c", "a"])
-
-        # Prevent collection cycles
-        butler.registry.registerCollection("chain2", CollectionType.CHAINED)
-        butler.prepend_collection_chain("chain2", "chain")
-        with self.assertRaises(CollectionCycleError):
-            butler.prepend_collection_chain("chain", "chain2")
 
         self._test_common_chain_functionality(butler, butler.prepend_collection_chain)
 

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -299,6 +299,10 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
 
             self.assertChain(["--mode", "pop", "chain1", "--", "-1", "-3"], "[calibration1, run1, run3]")
 
+            # Out-of-bounds index
+            result = self.runner.invoke(cli, ["collection-chain", "here", "--mode", "pop", "chain1", "10"])
+            self.assertEqual(result.exit_code, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added additional collection chain methods to the top-level `Butler` interface: `extend_collection_chain`, `remove_from_collection_chain`, and `redefine_collection_chain`.  These methods are all "atomic" functions that can safely be used concurrently from multiple processes.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
