### PR TITLE
DM-43750: Fix crash when using NameKeyCollectionManager

### DIFF
--- a/doc/changes/DM-43750.bugfix.md
+++ b/doc/changes/DM-43750.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue where `registry.setCollectionChain` would raise a `KeyError` when assigning to a collection that was present in the collection cache.

--- a/python/lsst/daf/butler/registry/_collection_record_cache.py
+++ b/python/lsst/daf/butler/registry/_collection_record_cache.py
@@ -79,8 +79,7 @@ class CollectionRecordCache:
         if (old_record := self._by_key.get(record.key)) is not None:
             self._by_name.pop(old_record.name)
         self._by_name[record.name] = record
-        if not isinstance(record.key, str):
-            self._by_key[record.key] = record
+        self._by_key[record.key] = record
 
     def set(self, records: Iterable[CollectionRecord], *, full: bool = False) -> None:
         """Replace cache contents with the new set of records.
@@ -95,8 +94,7 @@ class CollectionRecordCache:
         self.clear()
         for record in records:
             self._by_name[record.name] = record
-            if not isinstance(record.key, str):
-                self._by_key[record.key] = record
+            self._by_key[record.key] = record
         self._full = full
 
     def clear(self) -> None:
@@ -114,8 +112,7 @@ class CollectionRecordCache:
             Collection record to remove.
         """
         self._by_name.pop(record.name, None)
-        if not isinstance(record.key, str):
-            self._by_key.pop(record.key, None)
+        self._by_key.pop(record.key, None)
 
     def get_by_name(self, name: str) -> CollectionRecord | None:
         """Return collection record given its name.
@@ -147,8 +144,6 @@ class CollectionRecordCache:
             Collection record, `None` is returned if the key is not in the
             cache.
         """
-        if isinstance(key, str):
-            return self._by_name.get(key)
         return self._by_key.get(key)
 
     def records(self) -> Iterator[CollectionRecord]:

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -834,6 +834,17 @@ class RegistryTests(ABC):
         with self.assertRaises(MissingCollectionError):
             registry.getCollectionType(tag1)
 
+    def testCollectionChainCaching(self):
+        registry = self.makeRegistry()
+        with registry.caching_context():
+            registry.registerCollection("a")
+            registry.registerCollection("chain", CollectionType.CHAINED)
+            # There used to be a caching bug (DM-43750) that would throw an
+            # exception if you modified a collection chain for a collection
+            # that was already in the cache.
+            registry.setCollectionChain("chain", ["a"])
+            self.assertEqual(list(registry.getCollectionChain("chain")), ["a"])
+
     def testCollectionChainFlatten(self):
         """Test that `SqlRegistry.setCollectionChain` obeys its 'flatten'
         option.

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -764,6 +764,8 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
         "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID"
     )
 
+    collectionsManager = "lsst.daf.butler.registry.collections.synthIntKey.SynthIntKeyCollectionManager"
+
     def setUp(self):
         self.root = makeTestTempDir(TESTDIR)
 
@@ -777,6 +779,7 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
         tmpdir = tempfile.mkdtemp(dir=self.root)
         config["registry", "db"] = f"sqlite:///{tmpdir}/gen3.sqlite3"
         config["registry", "managers", "datasets"] = self.datasetsManager
+        config["registry", "managers", "collections"] = self.collectionsManager
         config["root"] = self.root
 
         # have to make a registry first
@@ -786,6 +789,14 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
         butler = Butler.from_config(config, writeable=writeable)
         DatastoreMock.apply(butler)
         return butler
+
+
+class NameKeyCollectionManagerDirectSimpleButlerTestCase(DirectSimpleButlerTestCase, unittest.TestCase):
+    """Run tests against DirectButler implementation using the
+    NameKeyCollectionsManager.
+    """
+
+    collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
 
 
 @unittest.skipIf(create_test_server is None, "Server dependencies not installed.")


### PR DESCRIPTION
Fix an issue where NameKeyCollectionManager would throw an exception when assigning a collection chain for a collection whose record was already in the collection cache.

This was happening because of an optimization that caused the "by key" cache to not be populated when using NameKeyCollectionManager, but some code paths assumed that both the "by name" and "by key" caches are always available.  Fixed the bug by removing the optimization, ensuring the behavior is the same for all implementations.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
