### PR TITLE
DM-43759: Move collection chains interface to sub-object

### DIFF
--- a/doc/changes/DM-43315.feature.md
+++ b/doc/changes/DM-43315.feature.md
@@ -1,1 +1,1 @@
-Added additional collection chain methods to the top-level `Butler` interface: `extend_collection_chain`, `remove_from_collection_chain`, and `redefine_collection_chain`.  These methods are all "atomic" functions that can safely be used concurrently from multiple processes.
+Added additional collection chain methods to the `Butler.collection_chains` interface: `extend_chain`, `remove_from_chain`, and `redefine_chain`.  These methods are all "atomic" functions that can safely be used concurrently from multiple processes.

--- a/doc/changes/DM-43671.feature.md
+++ b/doc/changes/DM-43671.feature.md
@@ -1,1 +1,1 @@
-Added a new method `Butler.prepend_collection_chain`.  This allows you to insert collections at the beginning of a chain. It is an "atomic" operation that can be safely used concurrently from multiple processes.
+Added a new method `Butler.collection_chains.prepend_chain`.  This allows you to insert collections at the beginning of a chain. It is an "atomic" operation that can be safely used concurrently from multiple processes.

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -36,6 +36,7 @@ from . import logging  # most symbols are helpers only
 from . import progress  # most symbols are only used by handler implementors
 from . import ddl, time_utils
 from ._butler import *
+from ._butler_collections import *
 from ._butler_config import *
 from ._butler_repo_index import *
 from ._column_categorization import *

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -39,6 +39,7 @@ from lsst.utils import doImportType
 from lsst.utils.iteration import ensure_iterable
 from lsst.utils.logging import getLogger
 
+from ._butler_collections import ButlerCollections
 from ._butler_config import ButlerConfig, ButlerType
 from ._butler_instance_options import ButlerInstanceOptions
 from ._butler_repo_index import ButlerRepoIndex
@@ -1409,6 +1410,12 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
 
     @property
     @abstractmethod
+    def collection_chains(self) -> ButlerCollections:
+        """Object with methods for modifying collection chains."""
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
     def collections(self) -> Sequence[str]:
         """The collections to search by default, in order
         (`~collections.abc.Sequence` [ `str` ]).
@@ -1733,139 +1740,5 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         """Return a new Butler instance connected to the same repository
         as this one, but overriding ``collections``, ``run``,
         ``inferDefaults``, and default data ID.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def redefine_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        """Replace the contents of a CHAINED collection with new children.
-
-        Parameters
-        ----------
-        parent_collection_name : `str`
-            The name of a CHAINED collection to which we will assign new
-            children.
-        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
-            A child collection name or list of child collection names to be
-            added to the parent.
-
-        Raises
-        ------
-        MissingCollectionError
-            If any of the specified collections do not exist.
-        CollectionTypeError
-            If the parent collection is not a CHAINED collection.
-        CollectionCycleError
-            If this operation would create a collection cycle.
-
-        Notes
-        -----
-        If this function is called within a call to ``Butler.transaction``, it
-        will hold a lock that prevents other processes from modifying the
-        parent collection until the end of the transaction.  Keep these
-        transactions short.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def prepend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        """Add children to the beginning of a CHAINED collection.
-
-        If any of the children already existed in the chain, they will be moved
-        to the new position at the beginning of the chain.
-
-        Parameters
-        ----------
-        parent_collection_name : `str`
-            The name of a CHAINED collection to which we will add new children.
-        child_collection_names : `Iterable` [ `str ` ] | `str`
-            A child collection name or list of child collection names to be
-            added to the parent.
-
-        Raises
-        ------
-        MissingCollectionError
-            If any of the specified collections do not exist.
-        CollectionTypeError
-            If the parent collection is not a CHAINED collection.
-        CollectionCycleError
-            If this operation would create a collection cycle.
-
-        Notes
-        -----
-        If this function is called within a call to ``Butler.transaction``, it
-        will hold a lock that prevents other processes from modifying the
-        parent collection until the end of the transaction.  Keep these
-        transactions short.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def extend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        """Add children to the end of a CHAINED collection.
-
-        If any of the children already existed in the chain, they will be moved
-        to the new position at the end of the chain.
-
-        Parameters
-        ----------
-        parent_collection_name : `str`
-            The name of a CHAINED collection to which we will add new children.
-        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
-            A child collection name or list of child collection names to be
-            added to the parent.
-
-        Raises
-        ------
-        MissingCollectionError
-            If any of the specified collections do not exist.
-        CollectionTypeError
-            If the parent collection is not a CHAINED collection.
-        CollectionCycleError
-            If this operation would create a collection cycle.
-
-        Notes
-        -----
-        If this function is called within a call to ``Butler.transaction``, it
-        will hold a lock that prevents other processes from modifying the
-        parent collection until the end of the transaction.  Keep these
-        transactions short.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def remove_from_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        """Remove children from a CHAINED collection.
-
-        Parameters
-        ----------
-        parent_collection_name : `str`
-            The name of a CHAINED collection from which we will remove
-            children.
-        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
-            A child collection name or list of child collection names to be
-            removed from the parent.
-
-        Raises
-        ------
-        MissingCollectionError
-            If any of the specified collections do not exist.
-        CollectionTypeError
-            If the parent collection is not a CHAINED collection.
-
-        Notes
-        -----
-        If this function is called within a call to ``Butler.transaction``, it
-        will hold a lock that prevents other processes from modifying the
-        parent collection until the end of the transaction.  Keep these
-        transactions short.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -1,0 +1,167 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("ButlerCollections",)
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+
+
+class ButlerCollections(ABC):
+    """Methods for working with collections stored in the Butler."""
+
+    @abstractmethod
+    def extend_chain(self, parent_collection_name: str, child_collection_names: str | Iterable[str]) -> None:
+        """Add children to the end of a CHAINED collection.
+
+        If any of the children already existed in the chain, they will be moved
+        to the new position at the end of the chain.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will add new children.
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def prepend_chain(self, parent_collection_name: str, child_collection_names: str | Iterable[str]) -> None:
+        """Add children to the beginning of a CHAINED collection.
+
+        If any of the children already existed in the chain, they will be moved
+        to the new position at the beginning of the chain.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will add new children.
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def redefine_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        """Replace the contents of a CHAINED collection with new children.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection to which we will assign new
+            children.
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            added to the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+        CollectionCycleError
+            If this operation would create a collection cycle.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def remove_from_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        """Remove children from a CHAINED collection.
+
+        Parameters
+        ----------
+        parent_collection_name : `str`
+            The name of a CHAINED collection from which we will remove
+            children.
+        child_collection_names : `~collections.abc.Iterable` [ `str ` ] | `str`
+            A child collection name or list of child collection names to be
+            removed from the parent.
+
+        Raises
+        ------
+        MissingCollectionError
+            If any of the specified collections do not exist.
+        CollectionTypeError
+            If the parent collection is not a CHAINED collection.
+
+        Notes
+        -----
+        If this function is called within a call to ``Butler.transaction``, it
+        will hold a lock that prevents other processes from modifying the
+        parent collection until the end of the transaction.  Keep these
+        transactions short.
+        """
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/direct_butler/__init__.py
+++ b/python/lsst/daf/butler/direct_butler/__init__.py
@@ -1,0 +1,28 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ._direct_butler import *

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -48,7 +48,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, TextIO, cast
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.utils.introspection import get_class_of
-from lsst.utils.iteration import ensure_iterable
 from lsst.utils.logging import VERBOSE, getLogger
 from sqlalchemy.exc import IntegrityError
 
@@ -80,6 +79,7 @@ from ..registry import (
 from ..registry.sql_registry import SqlRegistry
 from ..transfers import RepoExportContext
 from ..utils import transactional
+from ._direct_butler_collections import DirectButlerCollections
 
 if TYPE_CHECKING:
     from lsst.resources import ResourceHandleProtocol
@@ -2095,6 +2095,11 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             raise ValidationError(";\n".join(messages))
 
     @property
+    def collection_chains(self) -> DirectButlerCollections:
+        """Object with methods for modifying collection chains."""
+        return DirectButlerCollections(self._registry)
+
+    @property
     def collections(self) -> Sequence[str]:
         """The collections to search by default, in order
         (`~collections.abc.Sequence` [ `str` ]).
@@ -2148,34 +2153,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
     def _preload_cache(self) -> None:
         """Immediately load caches that are used for common operations."""
         self._registry.preload_cache()
-
-    def redefine_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        self._registry._managers.collections.update_chain(
-            parent_collection_name, list(ensure_iterable(child_collection_names))
-        )
-
-    def prepend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._registry._managers.collections.prepend_collection_chain(
-            parent_collection_name, list(ensure_iterable(child_collection_names))
-        )
-
-    def extend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._registry._managers.collections.extend_collection_chain(
-            parent_collection_name, list(ensure_iterable(child_collection_names))
-        )
-
-    def remove_from_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._registry._managers.collections.remove_from_collection_chain(
-            parent_collection_name, list(ensure_iterable(child_collection_names))
-        )
 
     _config: ButlerConfig
     """Configuration for this Butler instance."""

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -52,24 +52,24 @@ from lsst.utils.iteration import ensure_iterable
 from lsst.utils.logging import VERBOSE, getLogger
 from sqlalchemy.exc import IntegrityError
 
-from ._butler import Butler
-from ._butler_config import ButlerConfig
-from ._butler_instance_options import ButlerInstanceOptions
-from ._dataset_existence import DatasetExistence
-from ._dataset_ref import DatasetRef
-from ._dataset_type import DatasetType
-from ._deferredDatasetHandle import DeferredDatasetHandle
-from ._exceptions import DatasetNotFoundError, DimensionValueError, ValidationError
-from ._limited_butler import LimitedButler
-from ._registry_shim import RegistryShim
-from ._storage_class import StorageClass, StorageClassFactory
-from ._timespan import Timespan
-from .datastore import Datastore, NullDatastore
-from .dimensions import DataCoordinate, Dimension
-from .direct_query_driver import DirectQueryDriver
-from .progress import Progress
-from .queries import Query
-from .registry import (
+from .._butler import Butler
+from .._butler_config import ButlerConfig
+from .._butler_instance_options import ButlerInstanceOptions
+from .._dataset_existence import DatasetExistence
+from .._dataset_ref import DatasetRef
+from .._dataset_type import DatasetType
+from .._deferredDatasetHandle import DeferredDatasetHandle
+from .._exceptions import DatasetNotFoundError, DimensionValueError, ValidationError
+from .._limited_butler import LimitedButler
+from .._registry_shim import RegistryShim
+from .._storage_class import StorageClass, StorageClassFactory
+from .._timespan import Timespan
+from ..datastore import Datastore, NullDatastore
+from ..dimensions import DataCoordinate, Dimension
+from ..direct_query_driver import DirectQueryDriver
+from ..progress import Progress
+from ..queries import Query
+from ..registry import (
     CollectionType,
     ConflictingDefinitionError,
     DataIdError,
@@ -77,19 +77,19 @@ from .registry import (
     RegistryDefaults,
     _RegistryFactory,
 )
-from .registry.sql_registry import SqlRegistry
-from .transfers import RepoExportContext
-from .utils import transactional
+from ..registry.sql_registry import SqlRegistry
+from ..transfers import RepoExportContext
+from ..utils import transactional
 
 if TYPE_CHECKING:
     from lsst.resources import ResourceHandleProtocol
 
-    from ._dataset_ref import DatasetId
-    from ._file_dataset import FileDataset
-    from .datastore import DatasetRefURIs
-    from .dimensions import DataId, DataIdValue, DimensionElement, DimensionRecord, DimensionUniverse
-    from .registry import Registry
-    from .transfers import RepoImportBackend
+    from .._dataset_ref import DatasetId
+    from .._file_dataset import FileDataset
+    from ..datastore import DatasetRefURIs
+    from ..dimensions import DataId, DataIdValue, DimensionElement, DimensionRecord, DimensionUniverse
+    from ..registry import Registry
+    from ..transfers import RepoImportBackend
 
 _LOG = getLogger(__name__)
 

--- a/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
@@ -42,7 +42,7 @@ class DirectButlerCollections(ButlerCollections):
 
     Parameters
     ----------
-    registry : `SqlRegistry`
+    registry : `~lsst.daf.butler.registry.sql_registry.SqlRegistry`
         Registry object used to work with the collections database.
     """
 

--- a/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
@@ -1,0 +1,74 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("DirectButlerCollections",)
+
+from collections.abc import Iterable
+
+from lsst.utils.iteration import ensure_iterable
+
+from .._butler_collections import ButlerCollections
+from ..registry.sql_registry import SqlRegistry
+
+
+class DirectButlerCollections(ButlerCollections):
+    """Implementation of ButlerCollections for DirectButler.
+
+    Parameters
+    ----------
+    registry : `SqlRegistry`
+        Registry object used to work with the collections database.
+    """
+
+    def __init__(self, registry: SqlRegistry):
+        self._registry = registry
+
+    def extend_chain(self, parent_collection_name: str, child_collection_names: str | Iterable[str]) -> None:
+        return self._registry._managers.collections.extend_collection_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
+
+    def prepend_chain(self, parent_collection_name: str, child_collection_names: str | Iterable[str]) -> None:
+        return self._registry._managers.collections.prepend_collection_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
+
+    def redefine_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        self._registry._managers.collections.update_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )
+
+    def remove_from_chain(
+        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
+    ) -> None:
+        return self._registry._managers.collections.remove_from_collection_chain(
+            parent_collection_name, list(ensure_iterable(child_collection_names))
+        )

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -44,6 +44,7 @@ from lsst.daf.butler.datastores.fileDatastoreClient import (
 from lsst.resources import ResourcePath, ResourcePathExpression
 
 from .._butler import Butler
+from .._butler_collections import ButlerCollections
 from .._butler_instance_options import ButlerInstanceOptions
 from .._dataset_existence import DatasetExistence
 from .._dataset_ref import DatasetId, DatasetRef, SerializedDatasetRef
@@ -147,6 +148,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     def isWriteable(self) -> bool:
         # Docstring inherited.
         return False
+
+    @property
+    def collection_chains(self) -> ButlerCollections:
+        """Object with methods for modifying collection chains."""
+        raise NotImplementedError()
 
     @property
     def dimensions(self) -> DimensionUniverse:
@@ -511,26 +517,6 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     def collections(self) -> Sequence[str]:
         # Docstring inherited.
         return self._registry_defaults.collections
-
-    def redefine_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        raise NotImplementedError()
-
-    def prepend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        raise NotImplementedError()
-
-    def extend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        raise NotImplementedError()
-
-    def remove_from_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        raise NotImplementedError()
 
     @property
     def run(self) -> str | None:

--- a/python/lsst/daf/butler/script/collectionChain.py
+++ b/python/lsst/daf/butler/script/collectionChain.py
@@ -105,16 +105,16 @@ def collectionChain(
 
 def _modify_collection_chain(butler: Butler, mode: str, parent: str, children: Iterable[str]) -> None:
     if mode == "prepend":
-        butler.prepend_collection_chain(parent, children)
+        butler.collection_chains.prepend_chain(parent, children)
     elif mode == "redefine":
-        butler.redefine_collection_chain(parent, children)
+        butler.collection_chains.redefine_chain(parent, children)
     elif mode == "remove":
-        butler.remove_from_collection_chain(parent, children)
+        butler.collection_chains.remove_from_chain(parent, children)
     elif mode == "pop":
         children_to_pop = _find_children_to_pop(butler, parent, children)
-        butler.remove_from_collection_chain(parent, children_to_pop)
+        butler.collection_chains.remove_from_chain(parent, children_to_pop)
     elif mode == "extend":
-        butler.extend_collection_chain(parent, children)
+        butler.collection_chains.extend_chain(parent, children)
     else:
         raise ValueError(f"Unrecognized update mode: '{mode}'")
 

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -34,6 +34,7 @@ from typing import Any, TextIO, cast
 from lsst.resources import ResourcePath, ResourcePathExpression
 
 from .._butler import Butler
+from .._butler_collections import ButlerCollections
 from .._dataset_existence import DatasetExistence
 from .._dataset_ref import DatasetId, DatasetRef
 from .._dataset_type import DatasetType
@@ -453,24 +454,6 @@ class HybridButler(Butler):
             source_butler, data_ids, allowed_elements
         )
 
-    def redefine_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._direct_butler.redefine_collection_chain(parent_collection_name, child_collection_names)
-
-    def prepend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._direct_butler.prepend_collection_chain(parent_collection_name, child_collection_names)
-
-    def extend_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._direct_butler.extend_collection_chain(parent_collection_name, child_collection_names)
-
-    def remove_from_collection_chain(
-        self, parent_collection_name: str, child_collection_names: str | Iterable[str]
-    ) -> None:
-        return self._direct_butler.remove_from_collection_chain(
-            parent_collection_name, child_collection_names
-        )
+    @property
+    def collection_chains(self) -> ButlerCollections:
+        return self._direct_butler.collection_chains

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1391,85 +1391,85 @@ class ButlerTests(ButlerPutGetTests):
     def testCollectionChainRedefine(self):
         butler = self._setup_to_test_collection_chain()
 
-        butler.redefine_collection_chain("chain", "a")
+        butler.collection_chains.redefine_chain("chain", "a")
         self._check_chain(butler, ["a"])
 
         # Duplicates are removed from the list of children
-        butler.redefine_collection_chain("chain", ["c", "b", "c"])
+        butler.collection_chains.redefine_chain("chain", ["c", "b", "c"])
         self._check_chain(butler, ["c", "b"])
 
         # Empty list clears the chain
-        butler.redefine_collection_chain("chain", [])
+        butler.collection_chains.redefine_chain("chain", [])
         self._check_chain(butler, [])
 
-        self._test_common_chain_functionality(butler, butler.redefine_collection_chain)
+        self._test_common_chain_functionality(butler, butler.collection_chains.redefine_chain)
 
     def testCollectionChainPrepend(self):
         butler = self._setup_to_test_collection_chain()
 
         # Duplicates are removed from the list of children
-        butler.prepend_collection_chain("chain", ["c", "b", "c"])
+        butler.collection_chains.prepend_chain("chain", ["c", "b", "c"])
         self._check_chain(butler, ["c", "b"])
 
         # Prepend goes on the front of existing chain
-        butler.prepend_collection_chain("chain", ["a"])
+        butler.collection_chains.prepend_chain("chain", ["a"])
         self._check_chain(butler, ["a", "c", "b"])
 
         # Empty prepend does nothing
-        butler.prepend_collection_chain("chain", [])
+        butler.collection_chains.prepend_chain("chain", [])
         self._check_chain(butler, ["a", "c", "b"])
 
         # Prepending children that already exist in the chain removes them from
         # their current position.
-        butler.prepend_collection_chain("chain", ["d", "b", "c"])
+        butler.collection_chains.prepend_chain("chain", ["d", "b", "c"])
         self._check_chain(butler, ["d", "b", "c", "a"])
 
-        self._test_common_chain_functionality(butler, butler.prepend_collection_chain)
+        self._test_common_chain_functionality(butler, butler.collection_chains.prepend_chain)
 
     def testCollectionChainExtend(self):
         butler = self._setup_to_test_collection_chain()
 
         # Duplicates are removed from the list of children
-        butler.extend_collection_chain("chain", ["c", "b", "c"])
+        butler.collection_chains.extend_chain("chain", ["c", "b", "c"])
         self._check_chain(butler, ["c", "b"])
 
         # Extend goes on the end of existing chain
-        butler.extend_collection_chain("chain", ["a"])
+        butler.collection_chains.extend_chain("chain", ["a"])
         self._check_chain(butler, ["c", "b", "a"])
 
         # Empty extend does nothing
-        butler.extend_collection_chain("chain", [])
+        butler.collection_chains.extend_chain("chain", [])
         self._check_chain(butler, ["c", "b", "a"])
 
         # Extending children that already exist in the chain removes them from
         # their current position.
-        butler.extend_collection_chain("chain", ["d", "b", "c"])
+        butler.collection_chains.extend_chain("chain", ["d", "b", "c"])
         self._check_chain(butler, ["a", "d", "b", "c"])
 
-        self._test_common_chain_functionality(butler, butler.extend_collection_chain)
+        self._test_common_chain_functionality(butler, butler.collection_chains.extend_chain)
 
     def testCollectionChainRemove(self) -> None:
         butler = self._setup_to_test_collection_chain()
 
         butler.registry.setCollectionChain("chain", ["a", "b", "c", "d"])
 
-        butler.remove_from_collection_chain("chain", "c")
+        butler.collection_chains.remove_from_chain("chain", "c")
         self._check_chain(butler, ["a", "b", "d"])
 
         # Duplicates are allowed in the list of children
-        butler.remove_from_collection_chain("chain", ["b", "b", "a"])
+        butler.collection_chains.remove_from_chain("chain", ["b", "b", "a"])
         self._check_chain(butler, ["d"])
 
         # Empty remove does nothing
-        butler.remove_from_collection_chain("chain", [])
+        butler.collection_chains.remove_from_chain("chain", [])
         self._check_chain(butler, ["d"])
 
         # Removing children that aren't in the chain does nothing
-        butler.remove_from_collection_chain("chain", ["a", "chain"])
+        butler.collection_chains.remove_from_chain("chain", ["a", "chain"])
         self._check_chain(butler, ["d"])
 
         self._test_common_chain_functionality(
-            butler, butler.remove_from_collection_chain, skip_cycle_check=True
+            butler, butler.collection_chains.remove_from_chain, skip_cycle_check=True
         )
 
     def _setup_to_test_collection_chain(self) -> Butler:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
