### PR TITLE
DM-43736: Add the persistence for the PSF matching kernel from image differencing

### DIFF
--- a/doc/changes/DM-43736.feature.md
+++ b/doc/changes/DM-43736.feature.md
@@ -1,0 +1,1 @@
+Added ``MatchingKernel`` storage class for persisting the PSF-matching kernel from image differencing.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -34,6 +34,7 @@ CrosstalkCalib: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 PhotonTransferCurveDataset: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Linearizer: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 BrighterFatterKernel: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
+MatchingKernel: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 FiberSpectrum: lsst.obs.base.formatters.fitsGeneric.FitsGenericFormatter
 Image: lsst.obs.base.formatters.fitsExposure.FitsImageFormatter
 ImageF: lsst.obs.base.formatters.fitsExposure.FitsImageFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -255,6 +255,8 @@ storageClasses:
     pytype: lsst.ip.isr.StrayLightData
   BrighterFatterKernel:
     pytype: lsst.ip.isr.BrighterFatterKernel
+  MatchingKernel:
+    ptype: lsst.afw.math.Kernel
   FilterLabel:
     pytype: lsst.afw.image.FilterLabel
   Exposure:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
