### PR TITLE
DM-43925: Add workarounds for pandas bugs when using non-floating-point masked columns.

### DIFF
--- a/doc/changes/DM-43925.bugfix.md
+++ b/doc/changes/DM-43925.bugfix.md
@@ -1,0 +1,1 @@
+Work around pandas bugs when using non-floating-point masked columns.

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -124,7 +124,7 @@ storageClasses:
     pytype: pandas.core.frame.DataFrame
     converters:
       pyarrow.Table: lsst.daf.butler.formatters.parquet.arrow_to_pandas
-      astropy.table.Table: astropy.table.Table.to_pandas
+      astropy.table.Table: lsst.daf.butler.formatters.parquet.astropy_to_pandas
       numpy.ndarray: pandas.DataFrame.from_records
       dict: pandas.DataFrame.from_records
     delegate: lsst.daf.butler.delegates.dataframe.DataFrameDelegate

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -589,7 +589,6 @@ def pandas_to_astropy(dataframe: pd.DataFrame) -> atable.Table:
         Converted astropy table.
     """
     import pandas as pd
-    from astropy.table import Table
 
     if isinstance(dataframe.columns, pd.MultiIndex):
         raise ValueError("Cannot convert a multi-index dataframe to an astropy table.")

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -594,7 +594,7 @@ def pandas_to_astropy(dataframe: pd.DataFrame) -> atable.Table:
     if isinstance(dataframe.columns, pd.MultiIndex):
         raise ValueError("Cannot convert a multi-index dataframe to an astropy table.")
 
-    return Table.from_pandas(dataframe, index=True)
+    return arrow_to_astropy(pandas_to_arrow(dataframe))
 
 
 def _pandas_to_numpy_dict(dataframe: pd.DataFrame) -> dict[str, np.ndarray]:

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1102,7 +1102,7 @@ def _arrow_string_to_numpy_dtype(
         # String/bytes length from header.
         strlen = int(schema.metadata[encoded])
     elif numpy_column is not None and len(numpy_column) > 0:
-        strlen = max(len(row) for row in numpy_column)
+        strlen = max([len(row) for row in numpy_column if row])
 
     dtype = f"U{strlen}" if schema.field(name).type == pa.string() else f"|S{strlen}"
 

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -493,7 +493,7 @@ def astropy_to_arrow(astropy_table: atable.Table) -> pa.Table:
     return arrow_table
 
 
-def astropy_to_pandas(astropy_table: atable.Table) -> pd.DataFrame:
+def astropy_to_pandas(astropy_table: atable.Table, index: str | None = None) -> pd.DataFrame:
     """Convert an astropy table to a pandas dataframe via arrow.
 
     By going via arrow we avoid pandas masked column bugs (e.g.
@@ -503,13 +503,22 @@ def astropy_to_pandas(astropy_table: atable.Table) -> pd.DataFrame:
     ----------
     astropy_table : `astropy.Table`
         Input astropy table.
+    index : `str`, optional
+        Name of column to set as index.
 
     Returns
     -------
     dataframe : `pandas.DataFrame`
         Output pandas dataframe.
     """
-    return arrow_to_pandas(astropy_to_arrow(astropy_table))
+    dataframe = arrow_to_pandas(astropy_to_arrow(astropy_table))
+
+    if isinstance(index, str):
+        dataframe = dataframe.set_index(index)
+    elif index:
+        raise RuntimeError("index must be a string or None.")
+
+    return dataframe
 
 
 def _astropy_to_numpy_dict(astropy_table: atable.Table) -> dict[str, np.ndarray]:

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -36,6 +36,7 @@ __all__ = (
     "pandas_to_arrow",
     "pandas_to_astropy",
     "astropy_to_arrow",
+    "astropy_to_pandas",
     "numpy_to_arrow",
     "numpy_to_astropy",
     "numpy_dict_to_arrow",
@@ -490,6 +491,25 @@ def astropy_to_arrow(astropy_table: atable.Table) -> pa.Table:
     arrow_table = pa.Table.from_arrays(arrays, schema=schema)
 
     return arrow_table
+
+
+def astropy_to_pandas(astropy_table: atable.Table) -> pd.DataFrame:
+    """Convert an astropy table to a pandas dataframe via arrow.
+
+    By going via arrow we avoid pandas masked column bugs (e.g.
+    https://github.com/pandas-dev/pandas/issues/58173)
+
+    Parameters
+    ----------
+    astropy_table : `astropy.Table`
+        Input astropy table.
+
+    Returns
+    -------
+    dataframe : `pandas.DataFrame`
+        Output pandas dataframe.
+    """
+    return arrow_to_pandas(astropy_to_arrow(astropy_table))
 
 
 def _astropy_to_numpy_dict(astropy_table: atable.Table) -> dict[str, np.ndarray]:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
