### PR TITLE
DM-43020: Implement region and time extraction for preload

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
 Copyright 2016-2021 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
 Copyright 2018-2021 Association of Universities for Research in Astronomy
 Copyright 2015, 2018-2021 The Trustees of Princeton University
-Copyright 2020 University of Washington
+Copyright 2020, 2024 University of Washington

--- a/doc/changes/DM-43020.bugfix.rst
+++ b/doc/changes/DM-43020.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue preventing dataset types with group dimensions from being put into a Butler repo.

--- a/doc/changes/DM-43020.misc.rst
+++ b/doc/changes/DM-43020.misc.rst
@@ -1,0 +1,1 @@
+Add storage class for daf.butler.Timespan.

--- a/doc/changes/DM-43020.misc.rst
+++ b/doc/changes/DM-43020.misc.rst
@@ -1,1 +1,1 @@
-Add storage class for daf.butler.Timespan.
+Add storage classes for daf.butler.Timespan and pipe.base.utils.RegionTimeInfo.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -17,7 +17,5 @@ The ``<TYPE>`` should be one of:
 
 An example file name would therefore look like ``DM-30291.misc.rst``.
 
-If the change concerns specifically the registry or a datastore the news fragment can be placed in the relevant subdirectory.
-
 You can test how the content will be integrated into the release notes by running ``towncrier build --draft --version=V.vv``.
 ``towncrier`` can be installed from PyPI or conda-forge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ convention = "numpy"
 checks = [
     "all",  # All except the rules listed below.
     "SA01",  # See Also section.
+    "SA04",  # We don't use descriptions with See Also.
     "EX01",  # Example section.
     "SS06",  # Summary can go into second line.
     "GL01",  # Summary text can start on same line as """

--- a/python/lsst/daf/butler/configs/datastores/fileDatastore.yaml
+++ b/python/lsst/daf/butler/configs/datastores/fileDatastore.yaml
@@ -5,7 +5,7 @@ datastore:
     table: file_datastore_records
   create: true
   templates:
-    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{visit.day_obs:?}/{exposure.day_obs:?}/{band:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{exposure.obs_id:?}/{datasetType}_{component:?}_{instrument:?}_{tract:?}_{patch:?}_{band:?}_{physical_filter:?}_{visit:?}_{exposure.obs_id:?}_{detector.full_name:?}_{skymap:?}_{skypix:?}_{run}"
+    default: "{run:/}/{datasetType}.{component:?}/{tract:?}/{patch:?}/{visit.day_obs:?}/{exposure.day_obs:?}/{band:?}/{subfilter:?}/{physical_filter:?}/{visit:?}/{exposure.obs_id:?}/{group:?}/{datasetType}_{component:?}_{instrument:?}_{tract:?}_{patch:?}_{band:?}_{physical_filter:?}_{visit:?}_{exposure.obs_id:?}_{group:?}_{detector.full_name:?}_{skymap:?}_{skypix:?}_{run}"
     # For raw-type files do not include band or filter in hierarchy
     # and remove band from file name
     physical_filter+detector+exposure: "{run:/}/{datasetType}.{component:?}/{exposure.day_obs}/{exposure.obs_id}/{datasetType}_{component:?}_{instrument:?}_{physical_filter}_{exposure.obs_id}_{detector.full_name}_{run}"

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -91,3 +91,4 @@ MetricMeasurementBundle: lsst.daf.butler.formatters.json.JsonFormatter
 MultipleCellCoadd: lsst.cell_coadds.CellCoaddFitsFormatter
 NNModelPackagePayload: lsst.meas.transiNet.modelPackages.NNModelPackageFormatter
 Timespan: lsst.daf.butler.formatters.json.JsonFormatter
+RegionTimeInfo: lsst.daf.butler.formatters.json.JsonFormatter

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -90,3 +90,4 @@ ScarletModelData: lsst.daf.butler.formatters.json.JsonFormatter
 MetricMeasurementBundle: lsst.daf.butler.formatters.json.JsonFormatter
 MultipleCellCoadd: lsst.cell_coadds.CellCoaddFitsFormatter
 NNModelPackagePayload: lsst.meas.transiNet.modelPackages.NNModelPackageFormatter
+Timespan: lsst.daf.butler.formatters.json.JsonFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -415,3 +415,5 @@ storageClasses:
     pytype: lsst.cell_coadds.MultipleCellCoadd
   NNModelPackagePayload:
     pytype: lsst.meas.transiNet.modelPackages.formatters.NNModelPackagePayload
+  Timespan:
+    pytype: lsst.daf.butler.Timespan

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -417,3 +417,5 @@ storageClasses:
     pytype: lsst.meas.transiNet.modelPackages.formatters.NNModelPackagePayload
   Timespan:
     pytype: lsst.daf.butler.Timespan
+  RegionTimeInfo:
+    pytype: lsst.pipe.base.utils.RegionTimeInfo

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -287,6 +287,10 @@ class Datastore(metaclass=ABCMeta):
         referring to a configuration file.
     bridgeManager : `DatastoreRegistryBridgeManager`
         Object that manages the interface between `Registry` and datastores.
+
+    See Also
+    --------
+    lsst.daf.butler.Butler
     """
 
     defaultConfigFile: ClassVar[str | None] = None

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -76,6 +76,10 @@ class Registry(ABC):
     All subclasses should store `~lsst.daf.butler.registry.RegistryDefaults` in
     a ``_defaults`` property. No other properties are assumed shared between
     implementations.
+
+    See Also
+    --------
+    lsst.daf.butler.Butler
     """
 
     @abstractmethod


### PR DESCRIPTION
This PR adds support for group datasets and the `Timespan` and `RegionTimeInfo` storage classes.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
