### PR TITLE
DM-44050: Configure Postgres connection pool parameters

### DIFF
--- a/doc/changes/DM-44050.bugfix.md
+++ b/doc/changes/DM-44050.bugfix.md
@@ -1,0 +1,1 @@
+Postgres database connections are now checked for liveness before they are used, significantly reducing the chance of exceptions being thrown due to stale connections.

--- a/doc/changes/DM-44050.perf.md
+++ b/doc/changes/DM-44050.perf.md
@@ -1,0 +1,1 @@
+Increased the Postgres connection pool size, fixing an issue where multi-threaded services would re-create the database connection excessively.

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -157,7 +157,15 @@ class PostgresqlDatabase(Database):
     def makeEngine(
         cls, uri: str | sqlalchemy.engine.URL, *, writeable: bool = True
     ) -> sqlalchemy.engine.Engine:
-        return sqlalchemy.engine.create_engine(uri, pool_size=1)
+        return sqlalchemy.engine.create_engine(
+            uri,
+            pool_size=1,
+            # Prevent stale database connections from throwing exeptions, at
+            # the expense of a round trip to the database server each time we
+            # check out a session.  Many services using the Butler operate in
+            # networks connections are frequently dropped.
+            pool_pre_ping=True,
+        )
 
     @classmethod
     def fromEngine(


### PR DESCRIPTION
Adjusted SQLAlchemy's connection parameters for postgres:
* Enabled `pool_pre_ping` to prevent exceptions from being thrown due to stale DB connections.
* Increased the pool size from 1 to 10, to prevent connections from being re-created excessively in multi-threaded services.

The pool_size increase is less risky than it at first appears... only a handful of services are constructing Butlers in a way that causes more than 1 connection to ever be created in the pool:
* At SLAC, it's just the Butler server which has only 1 instance and is rarely used currently.
* At the summit, it is only exposurelog.  This service is pretty low concurrency.  They are going to do a Butler update soon to get pool_pre_ping, so I will let them know to watch out for other side effects in their testing.
* If changing this breaks IDF we want to know that now, because it means we likely have serious scalability problems.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
