### PR TITLE
Fix ruff complaint about c-style formatting

### DIFF
--- a/python/lsst/daf/butler/ddl.py
+++ b/python/lsst/daf/butler/ddl.py
@@ -285,7 +285,7 @@ class GUID(sqlalchemy.TypeDecorator):
         if dialect.name == "postgresql":
             return str(value)
         else:
-            return "%.32x" % value.int
+            return f"{value.int:032x}"
 
     def process_result_value(
         self, value: str | uuid.UUID | None, dialect: sqlalchemy.Dialect


### PR DESCRIPTION
The new version of ruff no longer allows '%' formatting, instead requiring the use of f-strings.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
