### PR TITLE
DM-44109: Protect tests against httpx being available but no server deps

### DIFF
--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -63,7 +63,7 @@ class RemoteButlerConfigTests(unittest.TestCase):
             Butler({"cls": "lsst.daf.butler.remote_butler.RemoteButler", "remote_butler": {"url": "!"}})
 
 
-@unittest.skipIf(RemoteButler is None, "httpx is not installed")
+@unittest.skipIf(create_test_server is None, "Server dependencies not installed")
 class RemoteButlerErrorHandlingTests(unittest.TestCase):
     """Test RemoteButler error handling."""
 


### PR DESCRIPTION
776aaea2 changed the test assumptions. CernVMFS installations now do include httpx but do not include anything the server needs for testing.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
