### PR TITLE
DM-43316: Clarify usage of Butler.collection_chains.

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1411,7 +1411,11 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
     @property
     @abstractmethod
     def collection_chains(self) -> ButlerCollections:
-        """Object with methods for modifying collection chains."""
+        """Object with methods for modifying collection chains
+        (`~lsst.daf.butler.ButlerCollections`).
+
+        Use of this object is preferred over `registry` wherever possible.
+        """
         raise NotImplementedError()
 
     @property


### PR DESCRIPTION
This PR fleshes out the documentation of the `Butler.collection_chains` property to make it clearer to non-Middleware developers.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
