### PR TITLE
DM-44188: Fix template validation with alternates

### DIFF
--- a/python/lsst/daf/butler/datastore/file_templates.py
+++ b/python/lsst/daf/butler/datastore/file_templates.py
@@ -794,6 +794,8 @@ class FileTemplate:
             except AttributeError:
                 return
 
+        required = grouped_fields["standard"] | grouped_fields["parent"]
+
         # Replace specific skypix dimensions with generic one
         skypix_alias = self._determine_skypix_alias(entity)
         if skypix_alias is not None:
@@ -801,8 +803,12 @@ class FileTemplate:
             maximal.add("skypix")
             minimal.remove(skypix_alias)
             maximal.remove(skypix_alias)
-
-        required = grouped_fields["standard"] | grouped_fields["parent"]
+            if skypix_alias in required:
+                required.remove(skypix_alias)
+                required.add("skypix")
+            if skypix_alias in allfields:
+                allfields.remove(skypix_alias)
+                allfields.add("skypix")
 
         # Calculate any field usage that does not match a dimension
         if not required.issubset(maximal):

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -751,10 +751,14 @@ class SimpleButlerTests(TestCaseMixin):
         ref = DatasetRef(dataset_type, dataId, run="test")
         self.assertTrue(ref.dataId.hasRecords())
 
-        tmplstr = "{run}/{datasetType}/{visit.name|exposure.obs_id}_{skypix}_{htm7}_{skypix.id}_{htm7.id}"
+        tmplstr = (
+            "{run}/{datasetType}/{visit.name|exposure.obs_id}_"
+            "{instrument}_{skypix}_{htm7}_{skypix.id}_{htm7.id}"
+        )
         file_template = FileTemplate(tmplstr)
+        file_template.validateTemplate(ref)
         path = file_template.format(ref)
-        self.assertEqual(path, "test/warp/HSCA02713600_12345_12345_12345_12345")
+        self.assertEqual(path, "test/warp/HSCA02713600_HSC_12345_12345_12345_12345")
 
 
 class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -752,7 +752,7 @@ class SimpleButlerTests(TestCaseMixin):
         self.assertTrue(ref.dataId.hasRecords())
 
         tmplstr = (
-            "{run}/{datasetType}/{visit.name|exposure.obs_id}_"
+            "{run}/{datasetType}/{visit.name|exposure.obs_id|xyz}_"
             "{instrument}_{skypix}_{htm7}_{skypix.id}_{htm7.id}"
         )
         file_template = FileTemplate(tmplstr)


### PR DESCRIPTION
Now filter the alternates such that only the relevant values for the dataset type dimensions are used for validation.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
