### PR TITLE
DM-44294: Initial queryDataIds implementation for RemoteButler

### DIFF
--- a/python/lsst/daf/butler/direct_query_driver/_postprocessing.py
+++ b/python/lsst/daf/butler/direct_query_driver/_postprocessing.py
@@ -180,6 +180,7 @@ class Postprocessing:
         """
         if not (self or self.check_validity_match_count):
             yield from rows
+            return
         if self._limit == 0:
             return
         joins = [

--- a/python/lsst/daf/butler/queries/_expression_strings.py
+++ b/python/lsst/daf/butler/queries/_expression_strings.py
@@ -171,7 +171,12 @@ class _ConversionVisitor(TreeVisitor[_VisitorResult]):
     def visitIsIn(
         self, lhs: _VisitorResult, values: list[_VisitorResult], not_in: bool, node: Node
     ) -> _VisitorResult:
-        raise NotImplementedError("IN not supported yet")
+        assert isinstance(lhs, _ColExpr), "LHS of IN guaranteed to be scalar by parser."
+        predicates = [_convert_in_clause_to_predicate(lhs.value, rhs, node) for rhs in values]
+        result = Predicate.from_bool(False).logical_or(*predicates)
+        if not_in:
+            result = result.logical_not()
+        return result
 
     def visitIdentifier(self, name: str, node: Node) -> _VisitorResult:
         name = name.lower()
@@ -275,3 +280,26 @@ def _convert_comparison_operator(value: str) -> ComparisonOperator:
             return op
         case _:
             raise AssertionError(f"Unhandled comparison operator {value}")
+
+
+def _convert_in_clause_to_predicate(lhs: ColumnExpression, rhs: _VisitorResult, node: Node) -> Predicate:
+    """Convert ``lhs IN rhs`` expression to an equivalent ``Predicate``
+    value.
+    """
+    match rhs:
+        case _Sequence():
+            return Predicate.in_container(lhs, rhs.value)
+        case _RangeLiteral():
+            stride = rhs.value.stride
+            if stride is None:
+                stride = 1
+            # Expression strings use inclusive ranges, but Predicate uses
+            # ranges that exclude the stop value.
+            stop = rhs.value.stop + 1
+            return Predicate.in_range(lhs, rhs.value.start, stop, stride)
+        case _ColExpr():
+            return Predicate.compare(lhs, "==", rhs.value)
+        case _Null():
+            return Predicate.is_null(lhs)
+        case _:
+            raise InvalidQueryError(f"Invalid IN expression: '{node!s}")

--- a/python/lsst/daf/butler/queries/_expression_strings.py
+++ b/python/lsst/daf/butler/queries/_expression_strings.py
@@ -143,7 +143,7 @@ class _ConversionVisitor(TreeVisitor[_VisitorResult]):
                 return lhs.logical_and(rhs)
 
             # Handle comparison operators.
-            case [("=" | "!=" | "<" | ">" | "<=" | ">="), _ColExpr() as lhs, _ColExpr() as rhs]:
+            case [("=" | "!=" | "<" | ">" | "<=" | ">=" | "OVERLAPS"), _ColExpr() as lhs, _ColExpr() as rhs]:
                 return Predicate.compare(
                     a=lhs.value, b=rhs.value, operator=_convert_comparison_operator(operator)
                 )

--- a/python/lsst/daf/butler/queries/expression_factory.py
+++ b/python/lsst/daf/butler/queries/expression_factory.py
@@ -33,6 +33,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
+import astropy.time
 from lsst.sphgeom import Region
 
 from .._exceptions import InvalidQueryError
@@ -258,9 +259,9 @@ class TimespanProxy(ExpressionProxy):
             tree.UnaryExpression(operand=self._expression, operator="end_of")
         )
 
-    def overlaps(self, other: TimespanProxy | Timespan) -> tree.Predicate:
+    def overlaps(self, other: TimespanProxy | Timespan | astropy.time.Time) -> tree.Predicate:
         """Return a boolean expression representing an overlap test between
-        this timespan and another.
+        this timespan and another timespan or a datetime.
 
         Parameters
         ----------

--- a/python/lsst/daf/butler/queries/overlaps.py
+++ b/python/lsst/daf/butler/queries/overlaps.py
@@ -182,7 +182,10 @@ class OverlapsVisitor(SimplePredicateVisitor):
     ) -> tree.Predicate | None:
         # Docstring inherited.
         if operator == "overlaps":
-            if a.column_type == "region":
+            if tree.is_one_timespan_and_one_datetime(a, b):
+                # Can be transformed directly without special handling here.
+                return None
+            elif a.column_type == "region":
                 return self.visit_spatial_overlap(a, b, flags)
             elif b.column_type == "timespan":
                 return self.visit_temporal_overlap(a, b, flags)

--- a/python/lsst/daf/butler/queries/tree/_column_expression.py
+++ b/python/lsst/daf/butler/queries/tree/_column_expression.py
@@ -35,10 +35,11 @@ __all__ = (
     "Reversed",
     "UnaryOperator",
     "BinaryOperator",
+    "is_one_timespan_and_one_datetime",
     "validate_order_expression",
 )
 
-from typing import TYPE_CHECKING, Annotated, Literal, TypeAlias, TypeVar, final
+from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple, TypeAlias, TypeVar, final
 
 import pydantic
 
@@ -248,3 +249,28 @@ OrderExpression: TypeAlias = Annotated[
     pydantic.Field(discriminator="expression_type"),
     pydantic.AfterValidator(validate_order_expression),
 ]
+
+
+class TimespanAndDatetime(NamedTuple):
+    timespan: ColumnExpression
+    datetime: ColumnExpression
+
+
+def is_one_timespan_and_one_datetime(
+    a: ColumnExpression, b: ColumnExpression
+) -> TimespanAndDatetime | None:  # numpydoc ignore=PR01
+    """Check whether the two columns ``a`` and `b`` include one datetime column
+    and one timespan column.
+
+    Returns
+    -------
+    which_is_which : `TimespanAndDatetime` | None
+        An object telling which column is the datetime and which is the
+        timespan, or `None` if the types were not as expected.
+    """
+    if a.column_type == "timespan" and b.column_type == "datetime":
+        return TimespanAndDatetime(a, b)
+    elif a.column_type == "datetime" and b.column_type == "timespan":
+        return TimespanAndDatetime(b, a)
+    else:
+        return None

--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -61,6 +61,10 @@ from ._structs import OrderByClause
 
 
 class QueryResultsBase:
+    """Abstract base class defining functions used by several of the other
+    QueryResults classes.
+    """
+
     @abstractmethod
     def count(self, *, exact: bool = True, discard: bool = False) -> int:
         """Count the number of rows this query would return.
@@ -137,6 +141,7 @@ class QueryResultsBase:
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def order_by(self, *args: str) -> Self:
         """Make the iterator return ordered results.
 
@@ -159,6 +164,7 @@ class QueryResultsBase:
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def limit(self, limit: int, offset: int | None = 0) -> Self:
         """Make the iterator return limited number of records.
 

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2283,7 +2283,7 @@ class SqlRegistry:
             builder.joinDataset(datasetType, collection_wildcard, isResult=False)
         query = builder.finish()
 
-        return queries.DataCoordinateQueryResults(query)
+        return queries.DatabaseDataCoordinateQueryResults(query)
 
     def queryDimensionRecords(
         self,

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -2868,7 +2868,8 @@ class RegistryTests(ABC):
         self.assertFalse(query2.any(execute=True, exact=True))
         self.assertEqual(query2.count(exact=False), 0)
         self.assertEqual(query2.count(exact=True), 0)
-        self.assertTrue(list(query2.explain_no_results()))
+        if self.supportsDetailedQueryExplain:
+            self.assertTrue(list(query2.explain_no_results()))
         # These queries yield no results due to various problems that can be
         # spotted prior to execution, yielding helpful diagnostics.
         base_query = registry.queryDataIds(["detector", "physical_filter"])
@@ -2986,7 +2987,7 @@ class RegistryTests(ABC):
         self.assertTrue(query3.any(execute=False, exact=False))
         self.assertTrue(query3.any(execute=True, exact=False))
         self.assertTrue(query3.any(execute=True, exact=True))
-        self.assertGreaterEqual(query3.count(exact=False), 4)
+        self.assertGreaterEqual(query3.count(exact=False), 3)
         self.assertGreaterEqual(query3.count(exact=True, discard=True), 3)
         self.assertFalse(list(query3.explain_no_results()))
         # This query yields overlaps in the database, but all are filtered
@@ -3007,9 +3008,10 @@ class RegistryTests(ABC):
         self.assertFalse(query4.any(execute=True, exact=True))
         self.assertGreaterEqual(query4.count(exact=False), 1)
         self.assertEqual(query4.count(exact=True, discard=True), 0)
-        messages = query4.explain_no_results()
-        self.assertTrue(messages)
-        self.assertTrue(any("overlap" in message for message in messages))
+        if self.supportsDetailedQueryExplain:
+            messages = query4.explain_no_results()
+            self.assertTrue(messages)
+            self.assertTrue(any("overlap" in message for message in messages))
         # This query should yield results from one dataset type but not the
         # other, which is not registered.
         query5 = registry.queryDatasets(["bias", "nonexistent"], collections=["biases"])

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -388,8 +388,7 @@ class RemoteButlerRegistry(Registry):
         check: bool = True,
         **kwargs: Any,
     ) -> DataCoordinateQueryResults:
-        if dimensions is not None:
-            dimensions = self.dimensions.conform(dimensions)
+        dimensions = self.dimensions.conform(dimensions)
         args = self._convert_common_query_arguments(
             dataId=dataId, where=where, bind=bind, kwargs=kwargs, datasets=datasets, collections=collections
         )

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -68,10 +68,8 @@ from ._collection_args import (
     convert_dataset_type_arg_to_glob_string_list,
 )
 from ._http_connection import RemoteButlerHttpConnection, parse_model
-from .registry._query_dimension_records import (
-    DimensionRecordsQueryArguments,
-    QueryDriverDimensionRecordQueryResults,
-)
+from .registry._query_common import CommonQueryArguments
+from .registry._query_dimension_records import QueryDriverDimensionRecordQueryResults
 from .server_models import (
     ExpandDataIdRequestModel,
     ExpandDataIdResponseModel,
@@ -407,11 +405,26 @@ class RemoteButlerRegistry(Registry):
         if not isinstance(element, DimensionElement):
             element = self.dimensions.elements[element]
 
+        args = self._convert_common_query_arguments(
+            dataId=dataId, where=where, bind=bind, kwargs=kwargs, datasets=datasets, collections=collections
+        )
+
+        return QueryDriverDimensionRecordQueryResults(self._butler._query, element, args)
+
+    def _convert_common_query_arguments(
+        self,
+        *,
+        dataId: DataId | None = None,
+        datasets: object | None = None,
+        collections: CollectionArgType | None = None,
+        where: str = "",
+        bind: Mapping[str, Any] | None = None,
+        kwargs: dict[str, int | str],
+    ) -> CommonQueryArguments:
         dataset_types = self._resolve_dataset_types(datasets)
         if dataset_types and collections is None and not self.defaults.collections:
             raise NoDefaultCollectionError("'collections' must be provided if 'datasets' is provided")
-        args = DimensionRecordsQueryArguments(
-            element=element,
+        return CommonQueryArguments(
             dataId=dataId,
             where=where,
             bind=dict(bind) if bind else None,
@@ -419,8 +432,6 @@ class RemoteButlerRegistry(Registry):
             dataset_types=dataset_types,
             collections=self._resolve_collections(collections),
         )
-
-        return QueryDriverDimensionRecordQueryResults(self._butler._query, args)
 
     def queryDatasetAssociations(
         self,

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -69,6 +69,7 @@ from ._collection_args import (
 )
 from ._http_connection import RemoteButlerHttpConnection, parse_model
 from .registry._query_common import CommonQueryArguments
+from .registry._query_data_coordinates import QueryDriverDataCoordinateQueryResults
 from .registry._query_dimension_records import QueryDriverDimensionRecordQueryResults
 from .server_models import (
     ExpandDataIdRequestModel,
@@ -387,7 +388,12 @@ class RemoteButlerRegistry(Registry):
         check: bool = True,
         **kwargs: Any,
     ) -> DataCoordinateQueryResults:
-        raise NotImplementedError()
+        if dimensions is not None:
+            dimensions = self.dimensions.conform(dimensions)
+        args = self._convert_common_query_arguments(
+            dataId=dataId, where=where, bind=bind, kwargs=kwargs, datasets=datasets, collections=collections
+        )
+        return QueryDriverDataCoordinateQueryResults(self._butler._query, dimensions, args)
 
     def queryDimensionRecords(
         self,

--- a/python/lsst/daf/butler/remote_butler/registry/_query_common.py
+++ b/python/lsst/daf/butler/remote_butler/registry/_query_common.py
@@ -1,0 +1,138 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any, Generic, TypeAlias, TypeVar, cast
+
+from ...dimensions import DataId
+from ...queries import Query, QueryResultsBase
+
+QueryFactory: TypeAlias = Callable[[], AbstractContextManager[Query]]
+"""Function signature matching the interface of ``Butler._query``.  Returns a
+context manager that can be used to obtain a `Query` instance.
+"""
+
+
+@dataclasses.dataclass(frozen=True)
+class CommonQueryArguments:
+    """Simplified version of the arguments passed to many ``Registry.query*``
+    methods.
+    """
+
+    dataId: DataId | None
+    dataset_types: list[str]
+    collections: list[str] | None
+    where: str
+    bind: dict[str, Any] | None
+    kwargs: dict[str, int | str]
+
+
+_NewQueryT = TypeVar("_NewQueryT", bound=QueryResultsBase)
+"""The result type in the new query system equivalent to the legacy result
+class being implemented.
+"""
+_LegacyQueryT = TypeVar("_LegacyQueryT")
+"""The result class in the old query system that we are being mixed in to.
+Used for typing return values that are notionally `typing.Self`.
+"""
+
+
+class LegacyQueryResultsMixin(Generic[_NewQueryT, _LegacyQueryT]):
+    """Implements common methods for the various ``QueryResults`` classes in
+    the legacy query system by forwarding to the new query system.
+
+    Parameters
+    ----------
+    query_factory : `QueryFactory`
+        Function that can be called to access the new query system.
+    args : `CommonQueryArguments`
+        User-facing arguments forwarded from the original ``registry.query*``
+        method.
+    """
+
+    def __init__(
+        self,
+        query_factory: QueryFactory,
+        args: CommonQueryArguments,
+    ) -> None:
+        self._query_factory = query_factory
+        self._args = args
+        self._limit: int | None = None
+        self._order_by: list[str] = []
+
+    def count(self, *, exact: bool = True, discard: bool = False) -> int:
+        with self._build_query() as result:
+            return result.count(exact=exact, discard=discard)
+
+    def any(self, *, execute: bool = True, exact: bool = True) -> bool:
+        with self._build_query() as result:
+            return result.any(execute=execute, exact=exact)
+
+    def order_by(self, *args: str) -> _LegacyQueryT:
+        self._order_by.extend(args)
+        return cast(_LegacyQueryT, self)
+
+    def limit(self, limit: int, offset: int | None = 0) -> _LegacyQueryT:
+        if offset is not None and offset != 0:
+            raise NotImplementedError("Offset is no longer supported.")
+
+        self._limit = limit
+
+        return cast(_LegacyQueryT, self)
+
+    def explain_no_results(self, execute: bool = True) -> Iterable[str]:
+        with self._build_query() as result:
+            return result.explain_no_results(execute=execute)
+
+    @contextmanager
+    def _build_query(self) -> Iterator[_NewQueryT]:
+        with self._query_factory() as query:
+            a = self._args
+            for dataset_type in a.dataset_types:
+                query = query.join_dataset_search(dataset_type, a.collections)
+
+            result = self._build_result(query)
+            result = result.limit(self._limit)
+            if self._order_by:
+                result = result.order_by(*self._order_by)
+
+            if a.where:
+                result = result.where(a.where, bind=a.bind)
+            if a.dataId or a.kwargs:
+                id_list = [a.dataId] if a.dataId else []
+                # dataId and kwargs have to be sent together as part of the
+                # same call to where() so that the kwargs can override values
+                # in the data ID.
+                result = result.where(*id_list, **a.kwargs, bind=None)
+            yield result
+
+    def _build_result(self, query: Query) -> _NewQueryT:
+        raise NotImplementedError("Subclasses must implement _build_result")

--- a/python/lsst/daf/butler/remote_butler/registry/_query_data_coordinates.py
+++ b/python/lsst/daf/butler/remote_butler/registry/_query_data_coordinates.py
@@ -1,0 +1,126 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from ..._dataset_ref import DatasetRef
+from ..._dataset_type import DatasetType
+from ...dimensions import DataCoordinate, DimensionGraph, DimensionGroup
+from ...queries import DataCoordinateQueryResults, Query
+from ...registry.queries import DataCoordinateQueryResults as LegacyDataCoordinateQueryResults
+from ...registry.queries import ParentDatasetQueryResults
+from ._query_common import CommonQueryArguments, LegacyQueryResultsMixin, QueryFactory
+
+
+class QueryDriverDataCoordinateQueryResults(
+    LegacyQueryResultsMixin[DataCoordinateQueryResults],
+    LegacyDataCoordinateQueryResults,
+):
+    """Implementation of the legacy ``DimensionRecordQueryResults`` interface
+    using the new query system.
+
+    Parameters
+    ----------
+    query_factory : `QueryFactory`
+        Function that can be called to access the new query system.
+    dimensions : `DimensionGroup` | `None`
+        Dimensions of the data IDs to yield from the query.
+    args : `CommonQueryArguments`
+        User-facing arguments forwarded from
+        ``registry.queryDimensionRecords``.
+    """
+
+    def __init__(
+        self, query_factory: QueryFactory, dimensions: DimensionGroup | None, args: CommonQueryArguments
+    ) -> None:
+        LegacyQueryResultsMixin.__init__(self, query_factory, args)
+        LegacyDataCoordinateQueryResults.__init__(self)
+        self._dimensions = dimensions
+
+    def _build_result(self, query: Query) -> DataCoordinateQueryResults:
+        return query.data_ids(self._dimensions)
+
+    @property
+    def dimensions(self) -> DimensionGroup:
+        """The dimensions of the data IDs returned by this query."""
+        if self._dimensions is not None:
+            return self._dimensions
+
+        with self._build_query() as results:
+            return results.dimensions
+
+    def hasFull(self) -> bool:
+        return True
+
+    def hasRecords(self) -> bool:
+        return False
+
+    def __iter__(self) -> Iterator[DataCoordinate]:
+        with self._build_query() as result:
+            # We have to eagerly fetch the results to prevent
+            # leaking the resources associated with QueryDriver.
+            records = list(result)
+        return iter(records)
+
+    @contextmanager
+    def materialize(self) -> Iterator[LegacyDataCoordinateQueryResults]:
+        raise NotImplementedError()
+
+    def expanded(self) -> LegacyDataCoordinateQueryResults:
+        raise NotImplementedError()
+
+    def subset(
+        self,
+        dimensions: DimensionGroup | DimensionGraph | Iterable[str] | None = None,
+        *,
+        unique: bool = False,
+    ) -> LegacyDataCoordinateQueryResults:
+        raise NotImplementedError()
+
+    def findDatasets(
+        self,
+        datasetType: DatasetType | str,
+        collections: Any,
+        *,
+        findFirst: bool = True,
+        components: bool = False,
+    ) -> ParentDatasetQueryResults:
+        raise NotImplementedError()
+
+    def findRelatedDatasets(
+        self,
+        datasetType: DatasetType | str,
+        collections: Any,
+        *,
+        findFirst: bool = True,
+        dimensions: DimensionGroup | DimensionGraph | Iterable[str] | None = None,
+    ) -> Iterable[tuple[DataCoordinate, DatasetRef]]:
+        raise NotImplementedError()

--- a/python/lsst/daf/butler/remote_butler/registry/_query_data_coordinates.py
+++ b/python/lsst/daf/butler/remote_butler/registry/_query_data_coordinates.py
@@ -59,7 +59,7 @@ class QueryDriverDataCoordinateQueryResults(
     """
 
     def __init__(
-        self, query_factory: QueryFactory, dimensions: DimensionGroup | None, args: CommonQueryArguments
+        self, query_factory: QueryFactory, dimensions: DimensionGroup, args: CommonQueryArguments
     ) -> None:
         LegacyQueryResultsMixin.__init__(self, query_factory, args)
         LegacyDataCoordinateQueryResults.__init__(self)
@@ -70,11 +70,6 @@ class QueryDriverDataCoordinateQueryResults(
 
     @property
     def dimensions(self) -> DimensionGroup:
-        """The dimensions of the data IDs returned by this query."""
-        if self._dimensions is None:
-            with self._build_query() as results:
-                self._dimensions = results.dimensions
-
         return self._dimensions
 
     def hasFull(self) -> bool:

--- a/python/lsst/daf/butler/remote_butler/registry/_query_dimension_records.py
+++ b/python/lsst/daf/butler/remote_butler/registry/_query_dimension_records.py
@@ -36,7 +36,7 @@ from ._query_common import CommonQueryArguments, LegacyQueryResultsMixin, QueryF
 
 
 class QueryDriverDimensionRecordQueryResults(
-    LegacyQueryResultsMixin[DimensionRecordQueryResults, LegacyDimensionRecordQueryResults],
+    LegacyQueryResultsMixin[DimensionRecordQueryResults],
     LegacyDimensionRecordQueryResults,
 ):
     """Implementation of the legacy ``DimensionRecordQueryResults`` interface

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
@@ -1,0 +1,69 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from ....queries.driver import DataCoordinateResultPage, DimensionRecordResultPage, ResultPage, ResultSpec
+from ...server_models import DataCoordinateResultModel, DimensionRecordsResultModel, QueryExecuteResultData
+
+
+def convert_query_pages(spec: ResultSpec, pages: Iterator[ResultPage]) -> QueryExecuteResultData:
+    """Convert pages of result data from the query system to a serializable
+    format.
+
+    Parameters
+    ----------
+    spec : `ResultSpec`
+        Definition of the output format for the results.
+    pages : `~collections.abc.Iterator` [ `ResultPage` ]
+        Raw pages of data from the query driver.
+    """
+    match spec.result_type:
+        case "dimension_record":
+            return _convert_dimension_record_pages(pages)
+        case "data_coordinate":
+            return _convert_data_coordinate_pages(pages)
+        case _:
+            raise NotImplementedError(f"Unhandled query result type {spec.result_type}")
+
+
+def _convert_dimension_record_pages(pages: Iterator[ResultPage]) -> DimensionRecordsResultModel:
+    response = DimensionRecordsResultModel(rows=[])
+    for page in pages:
+        assert isinstance(page, DimensionRecordResultPage)
+        response.rows.extend(record.to_simple() for record in page.rows)
+    return response
+
+
+def _convert_data_coordinate_pages(pages: Iterator[ResultPage]) -> DataCoordinateResultModel:
+    response = DataCoordinateResultModel(rows=[])
+    for page in pages:
+        assert isinstance(page, DataCoordinateResultPage)
+        response.rows.extend(coordinate.to_simple() for coordinate in page.rows)
+    return response

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -236,10 +236,33 @@ class QueryExecuteRequestModel(pydantic.BaseModel):
     result_spec: SerializedResultSpec
 
 
-class QueryExecuteResponseModel(pydantic.BaseModel):
-    """Response model for /query/execute/."""
+class DataCoordinateResultModel(pydantic.BaseModel):
+    """Result model for /query/execute/ when user requested DataCoordinate
+    results.
+    """
 
+    type: Literal["data_coordinate"] = "data_coordinate"
+    rows: list[SerializedDataCoordinate]
+
+
+class DimensionRecordsResultModel(pydantic.BaseModel):
+    """Result model for /query/execute/ when user requested DimensionRecord
+    results.
+    """
+
+    type: Literal["dimension_record"] = "dimension_record"
     rows: list[SerializedDimensionRecord]
+
+
+QueryExecuteResultData: TypeAlias = DataCoordinateResultModel | DimensionRecordsResultModel
+
+
+class QueryExecuteResponseModel(pydantic.BaseModel):
+    """Response model for /query/execute/. Results may be in several different
+    formats depending what the user requested.
+    """
+
+    result: QueryExecuteResultData
 
 
 class QueryCountRequestModel(pydantic.BaseModel):

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -179,8 +179,6 @@ class ButlerQueryTests(ABC, TestCaseMixin):
     def test_simple_data_coordinate_query(self) -> None:
         butler = self.make_butler("base.yaml")
         with butler._query() as query:
-            _x = query.expression_factory
-
             # Test empty query
             self.assertCountEqual(query.data_ids([]), [DataCoordinate.makeEmpty(butler.dimensions)])
 

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -747,6 +747,45 @@ class ButlerQueryTests(ABC, TestCaseMixin):
                 [
                     record.id
                     for record in query.where(
+                        # Datetime equal to the "begin" of the timespan.
+                        _x.visit.timespan.overlaps(
+                            astropy.time.Time("2021-09-09T03:00:00", format="isot", scale="tai")
+                        )
+                    ).dimension_records("visit")
+                ],
+                # Timespan begin bound is inclusive, so the record should
+                # match.
+                [1],
+            )
+            self.assertCountEqual(
+                [
+                    record.id
+                    for record in query.where(
+                        # Datetime equal to the "end" of the timespan.
+                        _x.visit.timespan.overlaps(
+                            astropy.time.Time("2021-09-09T03:01:00", format="isot", scale="tai")
+                        )
+                    ).dimension_records("visit")
+                ],
+                # Timespan end bound is exclusive, so we should get no records.
+                [],
+            )
+            self.assertCountEqual(
+                [
+                    record.id
+                    for record in query.where(
+                        # In the middle of the timespan.
+                        _x.visit.timespan.overlaps(
+                            astropy.time.Time("2021-09-09T03:02:30", format="isot", scale="tai")
+                        )
+                    ).dimension_records("visit")
+                ],
+                [2],
+            )
+            self.assertCountEqual(
+                [
+                    record.id
+                    for record in query.where(
                         _x.visit.timespan.overlaps(
                             Timespan(
                                 begin=astropy.time.Time("2021-09-09T03:02:30", format="isot", scale="tai"),

--- a/python/lsst/daf/butler/tests/hybrid_butler_registry.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_registry.py
@@ -422,8 +422,11 @@ class _HybridDataCoordinateQueryResults:
         dimensions: DimensionGroup | DimensionGraph | Iterable[str] | None = None,
         *,
         unique: bool = False,
-    ) -> DataCoordinateQueryResults:
-        return self._direct.subset(dimensions, unique=unique)
+    ) -> _HybridDataCoordinateQueryResults:
+        return _HybridDataCoordinateQueryResults(
+            direct=self._direct.subset(dimensions, unique=unique),
+            remote=self._remote.subset(dimensions, unique=unique),
+        )
 
     def findDatasets(
         self,

--- a/python/lsst/daf/butler/tests/hybrid_butler_registry.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_registry.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
 from .._dataset_association import DatasetAssociation
 from .._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef
@@ -48,7 +48,12 @@ from ..dimensions import (
     DimensionUniverse,
 )
 from ..registry import CollectionArgType, CollectionSummary, CollectionType, Registry, RegistryDefaults
-from ..registry.queries import DataCoordinateQueryResults, DatasetQueryResults, DimensionRecordQueryResults
+from ..registry.queries import (
+    DataCoordinateQueryResults,
+    DatasetQueryResults,
+    DimensionRecordQueryResults,
+    ParentDatasetQueryResults,
+)
 from ..registry.sql_registry import SqlRegistry
 
 
@@ -309,7 +314,7 @@ class HybridButlerRegistry(Registry):
         check: bool = True,
         **kwargs: Any,
     ) -> DataCoordinateQueryResults:
-        return self._direct.queryDataIds(
+        direct = self._direct.queryDataIds(
             dimensions,
             dataId=dataId,
             datasets=datasets,
@@ -318,6 +323,21 @@ class HybridButlerRegistry(Registry):
             bind=bind,
             check=check,
             **kwargs,
+        )
+
+        remote = self._remote.queryDataIds(
+            dimensions,
+            dataId=dataId,
+            datasets=datasets,
+            collections=collections,
+            where=where,
+            bind=bind,
+            check=check,
+            **kwargs,
+        )
+
+        return cast(
+            DataCoordinateQueryResults, _HybridDataCoordinateQueryResults(direct=direct, remote=remote)
         )
 
     def queryDimensionRecords(
@@ -363,3 +383,66 @@ class HybridButlerRegistry(Registry):
     @storageClasses.setter
     def storageClasses(self, value: StorageClassFactory) -> None:
         raise NotImplementedError()
+
+
+class _HybridDataCoordinateQueryResults:
+    """Shim DataCoordinateQueryResults so that DirectButler can
+    provide a few methods that aren't implemented yet.
+    """
+
+    def __init__(self, *, direct: DataCoordinateQueryResults, remote: DataCoordinateQueryResults) -> None:
+        self._direct = direct
+        self._remote = remote
+
+    def __getattr__(self, name: str) -> Any:
+        # Send any methods not explicitly handled here to RemoteButler.
+        return getattr(self._remote, name)
+
+    def __iter__(self) -> Iterator[DataCoordinate]:
+        return iter(self._remote)
+
+    def order_by(self, *args: str) -> _HybridDataCoordinateQueryResults:
+        return _HybridDataCoordinateQueryResults(
+            direct=self._direct.order_by(*args), remote=self._remote.order_by(*args)
+        )
+
+    def limit(self, limit: int, offset: int | None = 0) -> _HybridDataCoordinateQueryResults:
+        return _HybridDataCoordinateQueryResults(
+            direct=self._direct.limit(limit, offset), remote=self._remote.limit(limit, offset)
+        )
+
+    def materialize(self) -> contextlib.AbstractContextManager[DataCoordinateQueryResults]:
+        return self._direct.materialize()
+
+    def expanded(self) -> DataCoordinateQueryResults:
+        return self._direct.expanded()
+
+    def subset(
+        self,
+        dimensions: DimensionGroup | DimensionGraph | Iterable[str] | None = None,
+        *,
+        unique: bool = False,
+    ) -> DataCoordinateQueryResults:
+        return self._direct.subset(dimensions, unique=unique)
+
+    def findDatasets(
+        self,
+        datasetType: DatasetType | str,
+        collections: Any,
+        *,
+        findFirst: bool = True,
+        components: bool = False,
+    ) -> ParentDatasetQueryResults:
+        return self._direct.findDatasets(datasetType, collections, findFirst=findFirst, components=components)
+
+    def findRelatedDatasets(
+        self,
+        datasetType: DatasetType | str,
+        collections: Any,
+        *,
+        findFirst: bool = True,
+        dimensions: DimensionGroup | DimensionGraph | Iterable[str] | None = None,
+    ) -> Iterable[tuple[DataCoordinate, DatasetRef]]:
+        return self._direct.findRelatedDatasets(
+            datasetType, collections, findFirst=findFirst, dimensions=dimensions
+        )

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -232,6 +232,8 @@ class PostgresqlRegistryTests(RegistryTests):
     work subclasses have to have this class first in the bases list.
     """
 
+    sometimesHasDuplicateQueryRows = True
+
     @classmethod
     def setUpClass(cls):
         cls.root = makeTestTempDir(TESTDIR)

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -141,6 +141,11 @@ class RemoteButlerRegistryTests(RegistryTests, unittest.TestCase):
     supportsQueryOffset = False
     supportsQueryGovernorValidation = False
 
+    # Jim decided to drop these expressions from the new query system -- they
+    # can be written less ambiguously by writing e.g. ``time <
+    # timespan.begin`` instead of ``time < timespan``.
+    supportsExtendedTimeQueryOperators = False
+
     def setUp(self):
         self.server_instance = self.enterContext(create_test_server(TESTDIR))
 

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -186,6 +186,22 @@ class RemoteButlerRegistryTests(RegistryTests, unittest.TestCase):
         # Tests a non-public API that isn't relevant on the client side.
         pass
 
+    def testQueryDataIdsGovernorExceptions(self):
+        # The new query system doesn't throw exceptions for invalid governor
+        # data IDs in queries -- instead it returns zero rows.  So this set of
+        # tests is not applicable to RemoteButler.
+        pass
+
+    def test_query_projection_drop_postprocessing(self):
+        # Tests a query system implementation detail that isn't relevant to
+        # RemoteButler.
+        pass
+
+    @unittest.expectedFailure
+    def test_skypix_constraint_queries(self) -> None:
+        # TODO DM-44362
+        return super().test_skypix_constraint_queries()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -193,6 +193,8 @@ class SqliteFileRegistryTests(RegistryTests):
     work sublasses have to have this class first in the bases list.
     """
 
+    sometimesHasDuplicateQueryRows = True
+
     def setUp(self):
         self.root = makeTestTempDir(TESTDIR)
 
@@ -254,6 +256,8 @@ class SqliteFileRegistrySynthIntKeyCollMgrUUIDTestCase(SqliteFileRegistryTests, 
 
 class SqliteMemoryRegistryTests(RegistryTests):
     """Tests for `Registry` backed by a SQLite in-memory database."""
+
+    sometimesHasDuplicateQueryRows = True
 
     @classmethod
     def getDataDir(cls) -> str:


### PR DESCRIPTION
Add minimal support for DataCoordinate result type for the new query system, and shim RemoteButler.registry.queryIds to use it.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
