### PR TITLE
DM-44280: Allow transfers with compatible dataset type definitions

### DIFF
--- a/doc/changes/DM-44280.misc.rst
+++ b/doc/changes/DM-44280.misc.rst
@@ -1,0 +1,3 @@
+``Butler.transfer_from()`` has been modified to allow there to be a dataset type mismatch between the source butler and the target butler.
+For this to work it is required that converters are registered for both directions such that the source python type can be converted to the target python type and the target python type can be converted to the source python type.
+Without supporting bidirectional conversions there will be problems with inconsistencies in the behavior of ``butler.get()`` for transferred datasets and those that were stored natively.

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -274,6 +274,22 @@ class MetricsExample:
         assert isinstance(exportDict["output"], dict | types.NoneType)
         return cls(exportDict["summary"], exportDict["output"], data)
 
+    @classmethod
+    def from_model(cls, model: MetricsExampleModel) -> MetricsExample:
+        """Create metrics from Pydantic model.
+
+        Parameters
+        ----------
+        model : `MetricsExampleModel`
+            Source model.
+
+        Returns
+        -------
+        newobject : `MetricsExample`
+            New `MetricsExample` object.
+        """
+        return cls(model.summary, model.output, model.data)
+
 
 class MetricsExampleModel(BaseModel):
     """A variant of `MetricsExample` based on model."""

--- a/tests/config/basic/formatters.yaml
+++ b/tests/config/basic/formatters.yaml
@@ -46,3 +46,4 @@ MetricsExampleModelA: lsst.daf.butler.formatters.json.JsonFormatter
 MetricsExampleModelB: lsst.daf.butler.formatters.yaml.YamlFormatter
 TupleExampleA: lsst.daf.butler.formatters.json.JsonFormatter
 TupleExampleB: lsst.daf.butler.formatters.yaml.YamlFormatter
+MetricsConversion: lsst.daf.butler.formatters.json.JsonFormatter

--- a/tests/config/basic/posixDatastore2.yaml
+++ b/tests/config/basic/posixDatastore2.yaml
@@ -22,3 +22,4 @@ datastore:
     StructuredDataJson: lsst.daf.butler.formatters.json.JsonFormatter
     StructuredDataPickle: lsst.daf.butler.formatters.pickle.PickleFormatter
     ThingOne: lsst.daf.butler.formatters.pickle.PickleFormatter
+    MetricsConversion: lsst.daf.butler.formatters.json.JsonFormatter

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -35,6 +35,8 @@ storageClasses:
       summary: StructuredDataDictYaml
       output: StructuredDataDictYaml
       data: StructuredDataListYaml
+    converters:
+      lsst.daf.butler.tests.MetricsExampleModel: lsst.daf.butler.tests.MetricsExample.from_model
   StructuredDataJson:
     inheritsFrom: StructuredData
   StructuredDataPickle:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2450,6 +2450,25 @@ class PosixDatastoreTransfers(unittest.TestCase):
         # Test disassembly.
         self.assertButlerTransfers(purge=True, storageClassName="StructuredComposite")
 
+    def testTransferDifferingStorageClasses(self) -> None:
+        """Test transfers when the source butler dataset type has a different
+        but compatible storage class.
+        """
+        self.create_butlers()
+
+        self.assertButlerTransfers(storageClassNameTarget="MetricsConversion")
+
+    def testTransferDifferingStorageClassesDisassembly(self) -> None:
+        """Test transfers when the source butler dataset type has a different
+        but compatible storage class and where the source butler has
+        disassembled.
+        """
+        self.create_butlers()
+
+        self.assertButlerTransfers(
+            storageClassName="StructuredComposite", storageClassNameTarget="MetricsConversion"
+        )
+
     def testAbsoluteURITransferDirect(self) -> None:
         """Test transfer using an absolute URI."""
         self._absolute_transfer("auto")
@@ -2489,9 +2508,19 @@ class PosixDatastoreTransfers(unittest.TestCase):
             else:
                 self.assertNotEqual(uri, temp)
 
-    def assertButlerTransfers(self, purge: bool = False, storageClassName: str = "StructuredData") -> None:
+    def assertButlerTransfers(
+        self,
+        purge: bool = False,
+        storageClassName: str = "StructuredData",
+        storageClassNameTarget: str | None = None,
+    ) -> None:
         """Test that a run can be transferred to another butler."""
         storageClass = self.storageClassFactory.getStorageClass(storageClassName)
+        if storageClassNameTarget is not None:
+            storageClassTarget = self.storageClassFactory.getStorageClass(storageClassNameTarget)
+        else:
+            storageClassTarget = storageClass
+
         datasetTypeName = "random_data"
 
         # Test will create 3 collections and we will want to transfer
@@ -2645,6 +2674,14 @@ class PosixDatastoreTransfers(unittest.TestCase):
             self.target_butler.transfer_from(self.source_butler, source_refs, register_dataset_types=True)
         self.assertIn("dimension", str(cm.exception))
 
+        # The dry run test requires dataset types to exist. If we have
+        # been given distinct storage classes for the target we have
+        # to redefine at least one of the dataset types in the target butler.
+        if storageClass != storageClassTarget:
+            self.target_butler.registry.removeDatasetType(datasetTypeNames[0])
+            datasetType = DatasetType(datasetTypeNames[0], dimensions, storageClassTarget)
+            self.target_butler.registry.registerDatasetType(datasetType)
+
         # The failed transfer above leaves registry in an inconsistent
         # state because the run is created but then rolled back without
         # the collection cache being cleared. For now force a refresh.
@@ -2704,6 +2741,13 @@ class PosixDatastoreTransfers(unittest.TestCase):
                 new_metric = self.target_butler.get(ref)
                 old_metric = self.source_butler.get(ref)
                 self.assertEqual(new_metric, old_metric)
+
+                # Try again without implicit storage class conversion
+                # triggered by using the source ref.
+                target_ref = self.target_butler.get_dataset(ref.id)
+                if target_ref.datasetType.storageClass != ref.datasetType.storageClass:
+                    new_metric = self.target_butler.get(target_ref)
+                    self.assertNotEqual(type(new_metric), type(old_metric))
 
         # Now prune run2 collection and create instead a CHAINED collection.
         # This should block the transfer.


### PR DESCRIPTION
Previously, the dataset types had to match exactly. Now the transfer is allowed even if the storage classes differ so long as the storage classes are compatible.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
