### PR TITLE
DM-44399: Add more helpful exception notes to parquet serializer when it fails.

### DIFF
--- a/doc/changes/DM-44399.misc.md
+++ b/doc/changes/DM-44399.misc.md
@@ -1,0 +1,1 @@
+Add helpful exception notes when Parquet serialization fails.


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`

Further checking of the exception notes will happen after "formatter v2".