### PR TITLE
Stop using VIRTUAL_ENV for uv pip install and use --system

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -25,10 +25,6 @@ jobs:
       - name: Install sqlite
         run: sudo apt-get install sqlite libyaml-dev
 
-      - name: Set the VIRTUAL_ENV variable for uv to work
-        run: |
-          echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
-
       - name: Install uv
         run: |
           python -m pip install --upgrade pip
@@ -36,7 +32,7 @@ jobs:
 
       - name: Update wheel infrastructure
         run: |
-          uv pip install wheel
+          uv pip install --system wheel
 
       - name: Install postgresql (server)
         run: |
@@ -45,16 +41,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
 
       - name: Build and install
-        run: uv pip install --no-deps -v -e .
+        run: uv pip install --system --no-deps -v -e .
 
       - name: Install graphviz
         run: sudo apt-get install graphviz
 
       - name: Install documenteer
-        run: uv pip install 'documenteer[pipelines]==0.8.2'
+        run: uv pip install --system 'documenteer[pipelines]==0.8.2'
 
       - name: Build documentation
         working-directory: ./doc

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -69,11 +69,6 @@ jobs:
         with:
           python-version: "3.11"
 
-
-      - name: Set the VIRTUAL_ENV variable for uv to work
-        run: |
-          echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
-
       - name: Install uv
         run: |
           python -m pip install --upgrade pip
@@ -81,13 +76,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --upgrade setuptools wheel build
-          uv pip install -r requirements.txt
-          uv pip install testcontainers
+          uv pip install --system --upgrade setuptools wheel build
+          uv pip install --system -r requirements.txt
+          uv pip install --system testcontainers
 
       - name: Install Butler client
         run: |
-          uv pip install -v --no-deps -e .
+          uv pip install --system -v --no-deps -e .
 
       - name: Run smoke test
         run: |


### PR DESCRIPTION
VIRTUAL_ENV is no longer supported in uv 0.2.0

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
