### PR TITLE
DM-43697: Fix server-side cursor lifetime issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
         args:
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,10 +23,10 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.3
+    rev: v0.4.5
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc
-    rev: "v1.6.0"
+    rev: "v1.7.0"
     hooks:
       - id: numpydoc-validation

--- a/python/lsst/daf/butler/column_spec.py
+++ b/python/lsst/daf/butler/column_spec.py
@@ -44,7 +44,7 @@ __all__ = (
 import textwrap
 import uuid
 from abc import ABC, abstractmethod
-from typing import Annotated, Any, ClassVar, Literal, TypeAlias, Union, final
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, TypeAlias, Union, final
 
 import astropy.time
 import pyarrow as pa
@@ -53,7 +53,9 @@ from lsst.sphgeom import Region
 
 from . import arrow_utils, ddl
 from ._timespan import Timespan
-from .name_shrinker import NameShrinker
+
+if TYPE_CHECKING:
+    from .name_shrinker import NameShrinker
 
 ColumnType: TypeAlias = Literal[
     "int",

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -241,7 +241,10 @@ class DirectQueryDriver(QueryDriver):
                 return DataCoordinateResultPageConverter(spec, builder.columns.get_column_order())
             case DatasetRefResultSpec():
                 return DatasetRefResultPageConverter(
-                    spec, self.get_dataset_type(spec.dataset_type_name), builder.columns.get_column_order()
+                    spec,
+                    self.get_dataset_type(spec.dataset_type_name),
+                    builder.columns.get_column_order(),
+                    name_shrinker=self.db.name_shrinker,
                 )
             case _:
                 raise NotImplementedError(f"Result type '{spec.result_type}' not yet implemented")

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -44,7 +44,6 @@ from sqlalchemy import sql
 
 from ..._named import NamedValueAbstractSet
 from ..._timespan import Timespan
-from ...name_shrinker import NameShrinker
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from ..interfaces import Database
 
@@ -138,7 +137,6 @@ class PostgresqlDatabase(Database):
         self._writeable = writeable
         self.dbname = dbname
         self._pg_version = pg_version
-        self._shrinker = NameShrinker(self.dialect.max_identifier_length)
 
     def clone(self) -> PostgresqlDatabase:
         clone = self.__new__(type(self))
@@ -294,10 +292,10 @@ class PostgresqlDatabase(Database):
         return f"PostgreSQL@{self.dbname}:{self.namespace}"
 
     def shrinkDatabaseEntityName(self, original: str) -> str:
-        return self._shrinker.shrink(original)
+        return self.name_shrinker.shrink(original)
 
     def expandDatabaseEntityName(self, shrunk: str) -> str:
-        return self._shrinker.expand(shrunk)
+        return self.name_shrinker.expand(shrunk)
 
     def _convertExclusionConstraintSpec(
         self,

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -50,6 +50,7 @@ import astropy.time
 import sqlalchemy
 
 from ..._named import NamedValueAbstractSet
+from ...name_shrinker import NameShrinker
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from .._exceptions import ConflictingDefinitionError
 
@@ -272,6 +273,7 @@ class Database(ABC):
         metadata: sqlalchemy.schema.MetaData | None = None,
     ):
         self.origin = origin
+        self.name_shrinker = NameShrinker(engine.dialect.max_identifier_length)
         self.namespace = namespace
         self._engine = engine
         self._session_connection: sqlalchemy.engine.Connection | None = None
@@ -1979,4 +1981,9 @@ class Database(ABC):
     namespace: str | None
     """The schema or namespace this database instance is associated with
     (`str` or `None`).
+    """
+
+    name_shrinker: NameShrinker
+    """An object that can be used to shrink field names to fit within the
+    identifier limit of the database engine (`NameShrinker`).
     """

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1861,11 +1861,14 @@ class Database(ABC):
             connection = self._engine.connect()
         else:
             connection = self._session_connection
-        # TODO: SelectBase is not good for execute(), but it used everywhere,
-        # e.g. in daf_relation. We should switch to Executable at some point.
-        result = connection.execute(cast(sqlalchemy.sql.expression.Executable, sql), *args, **kwargs)
         try:
-            yield result
+            # TODO: SelectBase is not good for execute(), but it used
+            # everywhere, e.g. in daf_relation. We should switch to Executable
+            # at some point.
+            with connection.execute(
+                cast(sqlalchemy.sql.expression.Executable, sql), *args, **kwargs
+            ) as result:
+                yield result
         finally:
             if connection is not self._session_connection:
                 connection.close()

--- a/python/lsst/daf/butler/registry/queries/_sql_query_context.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_context.py
@@ -55,7 +55,6 @@ from lsst.daf.relation import (
 
 from ..._column_tags import is_timespan_column
 from ..._column_type_info import ColumnTypeInfo, LogicalColumn
-from ...name_shrinker import NameShrinker
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from ._query_context import QueryContext
 from .butler_sql_engine import ButlerSqlEngine
@@ -86,9 +85,7 @@ class SqlQueryContext(QueryContext):
         row_chunk_size: int = 1000,
     ):
         super().__init__()
-        self.sql_engine = ButlerSqlEngine(
-            column_types=column_types, name_shrinker=NameShrinker(db.dialect.max_identifier_length)
-        )
+        self.sql_engine = ButlerSqlEngine(column_types=column_types, name_shrinker=db.name_shrinker)
         self._row_chunk_size = max(row_chunk_size, db.get_constant_rows_max())
         self._db = db
         self._exit_stack: ExitStack | None = None

--- a/python/lsst/daf/butler/registry/queries/butler_sql_engine.py
+++ b/python/lsst/daf/butler/registry/queries/butler_sql_engine.py
@@ -32,7 +32,7 @@ __all__ = ("ButlerSqlEngine",)
 
 import dataclasses
 from collections.abc import Iterable, Set
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import astropy.time
 import sqlalchemy
@@ -41,9 +41,11 @@ from lsst.daf.relation import ColumnTag, Relation, Sort, UnaryOperation, UnaryOp
 from ..._column_tags import is_timespan_column
 from ..._column_type_info import ColumnTypeInfo, LogicalColumn
 from ..._timespan import Timespan
-from ...name_shrinker import NameShrinker
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from .find_first_dataset import FindFirstDataset
+
+if TYPE_CHECKING:
+    from ...name_shrinker import NameShrinker
 
 
 @dataclasses.dataclass(repr=False, eq=False, kw_only=True)

--- a/tests/test_query_direct_postgresql.py
+++ b/tests/test_query_direct_postgresql.py
@@ -98,20 +98,6 @@ class DirectButlerPostgreSQLTests(ButlerQueryTests, unittest.TestCase):
             storageClasses=StorageClassFactory(),
         )
 
-    # TODO (DM-43697): these tests fail due to something going awry with cursor
-    # and temporary table lifetime management; PostgreSQL says we can't drop
-    # temp tables because there are still active queries against them.  The
-    # logic looks fine but is obfuscated by the many levels of competing
-    # context managers in the Database class, so we'll punt this to DM-43697.
-
-    @unittest.expectedFailure
-    def test_data_coordinate_upload_force_temp_table(self) -> None:
-        super().test_data_coordinate_upload_force_temp_table()
-
-    @unittest.expectedFailure
-    def test_materialization(self) -> None:
-        return super().test_materialization()
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A couple of other small improvements:
- better protection against exception in DirectQueryDriver context exit
- NameShrinker is now a Database property used by all other clients that need to shrink something.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
