### PR TITLE
DM-44502: Stream query results from Butler server

### DIFF
--- a/python/lsst/daf/butler/queries/_data_coordinate_query_results.py
+++ b/python/lsst/daf/butler/queries/_data_coordinate_query_results.py
@@ -69,10 +69,7 @@ class DataCoordinateQueryResults(QueryResultsBase):
         self._spec = spec
 
     def __iter__(self) -> Iterator[DataCoordinate]:
-        page = self._driver.execute(self._spec, self._tree)
-        yield from page.rows
-        while page.next_key is not None:
-            page = self._driver.fetch_next_page(self._spec, page.next_key)
+        for page in self._driver.execute(self._spec, self._tree):
             yield from page.rows
 
     @property

--- a/python/lsst/daf/butler/queries/_dataset_query_results.py
+++ b/python/lsst/daf/butler/queries/_dataset_query_results.py
@@ -72,10 +72,7 @@ class DatasetRefQueryResults(QueryResultsBase):
         self._spec = spec
 
     def __iter__(self) -> Iterator[DatasetRef]:
-        page = self._driver.execute(self._spec, self._tree)
-        yield from page.rows
-        while page.next_key is not None:
-            page = self._driver.fetch_next_page(self._spec, page.next_key)
+        for page in self._driver.execute(self._spec, self._tree):
             yield from page.rows
 
     @property

--- a/python/lsst/daf/butler/queries/_dimension_record_query_results.py
+++ b/python/lsst/daf/butler/queries/_dimension_record_query_results.py
@@ -73,10 +73,7 @@ class DimensionRecordQueryResults(QueryResultsBase):
         self._spec = spec
 
     def __iter__(self) -> Iterator[DimensionRecord]:
-        page = self._driver.execute(self._spec, self._tree)
-        yield from page.rows
-        while page.next_key is not None:
-            page = self._driver.fetch_next_page(self._spec, page.next_key)
+        for page in self._driver.execute(self._spec, self._tree):
             yield from page.rows
 
     def iter_table_pages(self) -> Iterator[DimensionRecordTable]:
@@ -88,10 +85,7 @@ class DimensionRecordQueryResults(QueryResultsBase):
         table : `DimensionRecordTable`
             A table-backed collection of dimension records.
         """
-        page = self._driver.execute(self._spec, self._tree)
-        yield page.as_table()
-        while page.next_key is not None:
-            page = self._driver.fetch_next_page(self._spec, page.next_key)
+        for page in self._driver.execute(self._spec, self._tree):
             yield page.as_table()
 
     def iter_set_pages(self) -> Iterator[DimensionRecordSet]:
@@ -103,10 +97,7 @@ class DimensionRecordQueryResults(QueryResultsBase):
         table : `DimensionRecordSet`
             A set-backed collection of dimension records.
         """
-        page = self._driver.execute(self._spec, self._tree)
-        yield page.as_set()
-        while page.next_key is not None:
-            page = self._driver.fetch_next_page(self._spec, page.next_key)
+        for page in self._driver.execute(self._spec, self._tree):
             yield page.as_set()
 
     @property

--- a/python/lsst/daf/butler/remote_butler/_errors.py
+++ b/python/lsst/daf/butler/remote_butler/_errors.py
@@ -1,0 +1,45 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from .._exceptions import ButlerUserError, create_butler_user_error
+from .server_models import ErrorResponseModel
+
+
+def serialize_butler_user_error(exc: ButlerUserError) -> ErrorResponseModel:  # numpydoc ignore=PR01
+    """Convert an exception to a format that can be transmitted to the
+    client.
+    """
+    return ErrorResponseModel(error_type=exc.error_type, detail=str(exc))
+
+
+def deserialize_butler_user_error(model: ErrorResponseModel) -> ButlerUserError:  # numpydoc ignore=PR01
+    """Convert a serialized exception into a ButlerUserError instance that can
+    be raised.
+    """
+    return create_butler_user_error(model.error_type, model.detail)

--- a/python/lsst/daf/butler/remote_butler/_http_connection.py
+++ b/python/lsst/daf/butler/remote_butler/_http_connection.py
@@ -39,8 +39,8 @@ import httpx
 from lsst.daf.butler import __version__
 from pydantic import BaseModel, ValidationError
 
-from .._exceptions import create_butler_user_error
 from ._authentication import get_authentication_headers
+from ._errors import deserialize_butler_user_error
 from .server_models import CLIENT_REQUEST_ID_HEADER_NAME, ERROR_STATUS_CODE, ErrorResponseModel
 
 _AnyPydanticModel = TypeVar("_AnyPydanticModel", bound=BaseModel)
@@ -233,7 +233,7 @@ class RemoteButlerHttpConnection:
             # client.
             model = _try_to_parse_model(response, ErrorResponseModel)
             if model is not None:
-                exc = create_butler_user_error(model.error_type, model.detail)
+                exc = deserialize_butler_user_error(model)
                 exc.add_note(f"Client request ID: {request_id}")
                 raise exc
             # If model is None, server sent an expected error code, but

--- a/python/lsst/daf/butler/remote_butler/_http_connection.py
+++ b/python/lsst/daf/butler/remote_butler/_http_connection.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 
 __all__ = ("RemoteButlerHttpConnection", "parse_model")
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TypeVar
 from uuid import uuid4
 
@@ -92,8 +94,40 @@ class RemoteButlerHttpConnection:
         ButlerServerError
             If there is an issue communicating with the server.
         """
+        request = self._build_post_request(path, model)
+        return self._send_request(request)
+
+    @contextmanager
+    def post_with_stream_response(self, path: str, model: BaseModel) -> Iterator[httpx.Response]:
+        """Send a POST request to the Butler server.
+
+        Parameters
+        ----------
+        path : `str`
+            A relative path to an endpoint.
+        model : `pydantic.BaseModel`
+            Pydantic model containing the request body to be sent to the
+            server.
+
+        Returns
+        -------
+        response: `~httpx.Response`
+            The response from the server.
+
+        Raises
+        ------
+        ButlerUserError
+            If the server explicitly returned a user-facing error response.
+        ButlerServerError
+            If there is an issue communicating with the server.
+        """
+        request = self._build_post_request(path, model)
+        with self._send_request_with_stream_response(request) as response:
+            yield response
+
+    def _build_post_request(self, path: str, model: BaseModel) -> _Request:
         json = model.model_dump_json().encode("utf-8")
-        return self._send_request(
+        return self._build_request(
             "POST",
             path,
             content=json,
@@ -122,7 +156,8 @@ class RemoteButlerHttpConnection:
         ButlerServerError
             If there is an issue communicating with the server.
         """
-        return self._send_request("GET", path, params=params)
+        request = self._build_request("GET", path, params=params)
+        return self._send_request(request)
 
     def _get_url(self, path: str, version: str = "v1") -> str:
         """Form the complete path to an endpoint on the server.
@@ -142,7 +177,7 @@ class RemoteButlerHttpConnection:
         slash = "" if self.server_url.endswith("/") else "/"
         return f"{self.server_url}{slash}{version}/{path}"
 
-    def _send_request(
+    def _build_request(
         self,
         method: str,
         path: str,
@@ -150,13 +185,7 @@ class RemoteButlerHttpConnection:
         content: bytes | None = None,
         params: Mapping[str, str | bool] | None = None,
         headers: Mapping[str, str] | None = None,
-    ) -> httpx.Response:
-        """Send an HTTP request to the Butler server with authentication
-        headers and a request ID.
-
-        If the server returns a user-facing error detail, raises an exception
-        with the message as a subclass of ButlerUserError.
-        """
+    ) -> _Request:
         url = self._get_url(path)
 
         request_id = str(uuid4())
@@ -165,27 +194,54 @@ class RemoteButlerHttpConnection:
         if headers is not None:
             request_headers.update(headers)
 
-        try:
-            response = self._client.request(
+        return _Request(
+            request=self._client.build_request(
                 method, url, content=content, params=params, headers=request_headers
-            )
+            ),
+            request_id=request_id,
+        )
 
-            if response.status_code == ERROR_STATUS_CODE:
-                # Raise an exception that the server has forwarded to the
-                # client.
-                model = _try_to_parse_model(response, ErrorResponseModel)
-                if model is not None:
-                    exc = create_butler_user_error(model.error_type, model.detail)
-                    exc.add_note(f"Client request ID: {request_id}")
-                    raise exc
-                # If model is None, server sent an expected error code, but the
-                # body wasn't in the expected JSON format.  This likely means
-                # some HTTP thing between us and the server is misbehaving.
+    def _send_request(self, request: _Request) -> httpx.Response:
+        """Send an HTTP request to the Butler server with authentication
+        headers and a request ID.
 
-            response.raise_for_status()
+        If the server returns a user-facing error detail, raises an exception
+        with the message as a subclass of ButlerUserError.
+        """
+        try:
+            response = self._client.send(request.request)
+            self._handle_http_status(response, request.request_id)
             return response
         except httpx.HTTPError as e:
-            raise ButlerServerError(request_id) from e
+            raise ButlerServerError(request.request_id) from e
+
+    @contextmanager
+    def _send_request_with_stream_response(self, request: _Request) -> Iterator[httpx.Response]:
+        try:
+            response = self._client.send(request.request, stream=True)
+            try:
+                self._handle_http_status(response, request.request_id)
+                yield response
+            finally:
+                response.close()
+        except httpx.HTTPError as e:
+            raise ButlerServerError(request.request_id) from e
+
+    def _handle_http_status(self, response: httpx.Response, request_id: str) -> None:
+        if response.status_code == ERROR_STATUS_CODE:
+            # Raise an exception that the server has forwarded to the
+            # client.
+            model = _try_to_parse_model(response, ErrorResponseModel)
+            if model is not None:
+                exc = create_butler_user_error(model.error_type, model.detail)
+                exc.add_note(f"Client request ID: {request_id}")
+                raise exc
+            # If model is None, server sent an expected error code, but
+            # the body wasn't in the expected JSON format.  This likely
+            # means some HTTP thing between us and the server is
+            # misbehaving.
+
+        response.raise_for_status()
 
 
 def parse_model(response: httpx.Response, model: type[_AnyPydanticModel]) -> _AnyPydanticModel:
@@ -203,7 +259,7 @@ def parse_model(response: httpx.Response, model: type[_AnyPydanticModel]) -> _An
     response_model : ``pydantic.BaseModel``
         An instance of the Pydantic model class loaded from the response body.
     """
-    return model.model_validate_json(response.content)
+    return model.model_validate_json(response.read())
 
 
 def _try_to_parse_model(response: httpx.Response, model: type[_AnyPydanticModel]) -> _AnyPydanticModel | None:
@@ -229,3 +285,9 @@ class ButlerServerError(RuntimeError):
 
     def __init__(self, client_request_id: str):
         super().__init__(f"Error while communicating with Butler server.  Request ID: {client_request_id}")
+
+
+@dataclass(frozen=True)
+class _Request:
+    request: httpx.Request
+    request_id: str

--- a/python/lsst/daf/butler/remote_butler/server/_server.py
+++ b/python/lsst/daf/butler/remote_butler/server/_server.py
@@ -37,6 +37,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 from safir.logging import configure_logging, configure_uvicorn_logging
 
 from ..._exceptions import ButlerUserError
+from .._errors import serialize_butler_user_error
 from ..server_models import CLIENT_REQUEST_ID_HEADER_NAME, ERROR_STATUS_CODE, ErrorResponseModel
 from .handlers._external import external_router
 from .handlers._external_query import query_router
@@ -94,7 +95,7 @@ def create_app() -> FastAPI:
     # user-facing Butler errors.
     @app.exception_handler(ButlerUserError)
     async def butler_exception_handler(request: Request, exc: ButlerUserError) -> Response:
-        error = ErrorResponseModel(error_type=exc.error_type, detail=str(exc))
+        error = serialize_butler_user_error(exc)
         return Response(
             media_type="application/json",
             status_code=ERROR_STATUS_CODE,

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -29,11 +29,13 @@ from __future__ import annotations
 
 __all__ = ("query_router",)
 
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator, Iterable, Iterator
+from contextlib import ExitStack, contextmanager
 from typing import NamedTuple
 
 from fastapi import APIRouter, Depends
+from fastapi.concurrency import contextmanager_in_threadpool, iterate_in_threadpool
+from fastapi.responses import StreamingResponse
 from lsst.daf.butler import DataCoordinate, DimensionGroup
 from lsst.daf.butler.remote_butler.server_models import (
     QueryAnyRequestModel,
@@ -41,16 +43,15 @@ from lsst.daf.butler.remote_butler.server_models import (
     QueryCountRequestModel,
     QueryCountResponseModel,
     QueryExecuteRequestModel,
-    QueryExecuteResponseModel,
     QueryExplainRequestModel,
     QueryExplainResponseModel,
     QueryInputs,
 )
 
-from ....queries.driver import QueryDriver, QueryTree
+from ....queries.driver import QueryDriver, QueryTree, ResultPage, ResultSpec
 from .._dependencies import factory_dependency
 from .._factory import Factory
-from ._query_serialization import convert_query_pages
+from ._query_serialization import serialize_query_pages
 
 query_router = APIRouter()
 
@@ -58,11 +59,55 @@ query_router = APIRouter()
 @query_router.post("/v1/query/execute", summary="Query the Butler database and return full results")
 def query_execute(
     request: QueryExecuteRequestModel, factory: Factory = Depends(factory_dependency)
-) -> QueryExecuteResponseModel:
-    with _get_query_context(factory, request.query) as ctx:
+) -> StreamingResponse:
+    # Managing the lifetime of the query context object is a little tricky.  We
+    # need to enter the context here, so that we can immediately deal with any
+    # exceptions raised by query set-up.  We eventually transfer control to an
+    # iterator consumed by FastAPI's StreamingResponse handler, which will
+    # start iterating after this function returns.  So we use this ExitStack
+    # instance to hand over the context manager to the iterator.
+    with ExitStack() as exit_stack:
+        ctx = exit_stack.enter_context(_get_query_context(factory, request.query))
         spec = request.result_spec.to_result_spec(ctx.driver.universe)
-        pages = ctx.driver.execute(spec, ctx.tree)
-        return QueryExecuteResponseModel(result=convert_query_pages(spec, pages))
+        response_pages = ctx.driver.execute(spec, ctx.tree)
+
+        # We write the response incrementally, one page at a time, as
+        # newline-separated chunks of JSON.  This allows clients to start
+        # reading results earlier and prevents the server from exhausting
+        # all its memory buffering rows from large queries.
+        output_generator = _stream_query_pages(
+            # Transfer control of the context manager to
+            # _stream_query_pages.
+            exit_stack.pop_all(),
+            spec,
+            response_pages,
+        )
+        return StreamingResponse(output_generator, media_type="application/jsonlines")
+
+    # Mypy thinks that ExitStack might swallow an exception.
+    assert False, "This line is unreachable."
+
+
+async def _stream_query_pages(
+    exit_stack: ExitStack, spec: ResultSpec, pages: Iterable[ResultPage]
+) -> AsyncIterator[str]:
+    # Instead of declaring this as a sync generator with 'def', it's async to
+    # give us more control over the lifetime of exit_stack.  StreamingResponse
+    # ensures that this async generator is cancelled if the client
+    # disconnects or another error occurs, ensuring that clean-up logic runs.
+    #
+    # If it was sync, it would get wrapped in an async function internal to
+    # FastAPI that does not guarantee that the generator is fully iterated or
+    # closed.
+    # (There is an example in the FastAPI docs showing StreamingResponse with a
+    # sync generator with a context manager, but after reading the FastAPI
+    # source code I believe that for sync generators it will leak the context
+    # manager if the client disconnects, and that it would be
+    # difficult/impossible for them to fix this in the general case within
+    # FastAPI.)
+    async with contextmanager_in_threadpool(exit_stack):
+        async for chunk in iterate_in_threadpool(serialize_query_pages(spec, pages)):
+            yield chunk
 
 
 @query_router.post(

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -70,7 +70,7 @@ class RemoteButlerErrorHandlingTests(unittest.TestCase):
     def setUp(self):
         server_instance = self.enterContext(create_test_server(TESTDIR))
         self.butler = server_instance.remote_butler
-        self.mock = self.enterContext(patch.object(self.butler._connection._client, "request"))
+        self.mock = self.enterContext(patch.object(self.butler._connection._client, "send"))
 
     def _mock_error_response(self, content: str) -> None:
         self.mock.return_value = httpx.Response(


### PR DESCRIPTION
Modified Butler server query responses so that they write the response incrementally, one page at a time, as newline-separated chunks of JSON.  This allows clients to start reading results earlier and prevents the server from exhausting all its memory buffering rows from large queries.

To simplify the implementation of this, reworked the structure of row fetching in the QueryDriver interface.  It previously had a `fetch_next_page` method that required passing a UUID for each page of data to be read.  For both QueryDriver implementations there has never been a natural source of those UUID page keys and it was just getting in the way.  So  instead we now return an iterator from QueryDriver.execute().

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
