### PR TITLE
DM-44311: Fix collection summary updates on associate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.5
+    rev: v0.4.7
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/python/lsst/daf/butler/_registry_shim.py
+++ b/python/lsst/daf/butler/_registry_shim.py
@@ -104,6 +104,10 @@ class RegistryShim(Registry):
         # Docstring inherited from a base class.
         self._registry.refresh()
 
+    def refresh_collection_summaries(self) -> None:
+        # Docstring inherited from a base class.
+        self._registry.refresh_collection_summaries()
+
     def caching_context(self) -> contextlib.AbstractContextManager[None]:
         # Docstring inherited from a base class.
         return self._butler._caching_context()

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -124,6 +124,15 @@ class Registry(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def refresh_collection_summaries(self) -> None:
+        """Refresh content of the collection summary tables in the database.
+
+        This method can be run to cleanup the contents of the summary tables
+        after removing datasets from collections.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def caching_context(self) -> contextlib.AbstractContextManager[None]:
         """Context manager that enables caching."""
         raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -344,6 +344,12 @@ class DatasetRecordStorage(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def refresh_collection_summaries(self) -> None:
+        """Make sure that collection summaries for this dataset type are
+        consistent with the contents of the dataset tables.
+        """
+
     datasetType: DatasetType
     """Dataset type whose records this object manages (`DatasetType`).
     """

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -339,6 +339,16 @@ class SqlRegistry:
         with self._db.transaction():
             self._managers.refresh()
 
+    def refresh_collection_summaries(self) -> None:
+        """Refresh content of the collection summary tables in the database.
+
+        This only cleans dataset type summaries, we may want to add cleanup of
+        governor summaries later.
+        """
+        for dataset_type in self.queryDatasetTypes():
+            if storage := self._managers.datasets.find(dataset_type.name):
+                storage.refresh_collection_summaries()
+
     def caching_context(self) -> contextlib.AbstractContextManager[None]:
         """Return context manager that enables caching.
 

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -4069,7 +4069,7 @@ class RegistryTests(ABC):
         registry.refresh_collection_summaries()
         summary = registry.getCollectionSummary(tagged_coll)
         self.assertFalse(summary.dataset_types.names)
-        # We do not clean governor summaries yet, but beacuse how the query is
+        # We do not clean governor summaries yet, but because how the query is
         # run, it returns empty governors when collection is missing from
         # summaries.
         self.assertFalse(summary.governors)

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -125,6 +125,10 @@ class RemoteButlerRegistry(Registry):
         # state.
         pass
 
+    def refresh_collection_summaries(self) -> None:
+        # Docstring inherited from a base class.
+        raise NotImplementedError()
+
     def caching_context(self) -> contextlib.AbstractContextManager[None]:
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/tests/hybrid_butler_registry.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_registry.py
@@ -101,6 +101,9 @@ class HybridButlerRegistry(Registry):
     def refresh(self) -> None:
         self._direct.refresh()
 
+    def refresh_collection_summaries(self) -> None:
+        self._direct.refresh_collection_summaries()
+
     def caching_context(self) -> contextlib.AbstractContextManager[None]:
         return self._direct.caching_context()
 


### PR DESCRIPTION
Datasets manager always updated collection summaries even if datasets
list was empty which resulted in many false positives in summaries.
One-line fix to skip empty datasets lists. Other methods get similar
protection for the case of empty input set of datasets.

Add registry method to cleanup collection summaries.
For now only the dataset type summaries are refreshed, governor
summaries cleanup may be added later.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
