### PR TITLE
DM-44842: Fix query crashes on postgres

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -39,6 +39,9 @@ ignore_missing_imports = True
 [mypy-httpx.*]
 ignore_missing_imports = True
 
+[mypy-testing.postgresql]
+ignore_missing_imports = True
+
 # Don't check LSST packages generally or even try to import them, since most
 # don't have type annotations.
 

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -539,16 +539,6 @@ class DirectQueryDriver(QueryDriver):
         for dataset_type, fields_for_dataset in projection_plan.columns.dataset_fields.items():
             if len(joins_plan.datasets[dataset_type].collection_records) > 1:
                 fields_for_dataset.add("collection_key")
-        if projection_plan:
-            # If there's a projection and we're doing postprocessing, we might
-            # be collapsing the dimensions of the postprocessing regions.  When
-            # that happens, we want to apply an aggregate function to them that
-            # computes the union of the regions that are grouped together.
-            for element in builder.postprocessing.iter_missing(projection_plan.columns):
-                if element.name in projection_plan.columns.dimensions.elements:
-                    projection_plan.region_non_aggregates.append(element)
-                else:
-                    projection_plan.region_aggregates.append(element)
 
         # The joins-stage query also needs to include all columns needed by the
         # downstream projection query.  Note that this:
@@ -663,6 +653,13 @@ class DirectQueryDriver(QueryDriver):
         unique_keys: list[sqlalchemy.ColumnElement[Any]] = [
             builder.joiner.dimension_keys[k][0] for k in plan.columns.dimensions.data_coordinate_keys
         ]
+
+        # Many of our fields derive their uniqueness from the unique_key
+        # fields: if rows are uniqe over the 'unique_key' fields, then they're
+        # automatically unique over these 'derived_fields'.  We just remember
+        # these as pairs of (logical_table, field) for now.
+        derived_fields: list[tuple[str, str]] = []
+
         # There are two reasons we might need an aggregate function:
         # - to make sure temporal constraints and joins have resulted in at
         #   most one validity range match for each data ID and collection,
@@ -678,21 +675,24 @@ class DirectQueryDriver(QueryDriver):
                 sqlalchemy.func.count().label(builder.postprocessing.VALIDITY_MATCH_COUNT)
             )
             have_aggregates = True
-        for element in plan.region_aggregates:
-            builder.joiner.fields[element.name]["region"] = ddl.Base64Region.union_aggregate(
-                builder.joiner.fields[element.name]["region"]
-            )
-            have_aggregates = True
-        # Many of our fields derive their uniqueness from the unique_key
-        # fields: if rows are uniqe over the 'unique_key' fields, then they're
-        # automatically unique over these 'derived_fields'.  We just remember
-        # these as pairs of (logical_table, field) for now.
-        derived_fields: list[tuple[str, str]] = []
-        # The region associated with dimension keys returned by the query are
-        # derived fields, since there is only one region associated with each
-        # dimension key value.
-        for element in plan.region_non_aggregates:
-            derived_fields.append((element.name, "region"))
+
+        for element in builder.postprocessing.iter_missing(plan.columns):
+            if element.name in plan.columns.dimensions.elements:
+                # The region associated with dimension keys returned by the
+                # query are derived fields, since there is only one region
+                # associated with each dimension key value.
+                derived_fields.append((element.name, "region"))
+            else:
+                # If there's a projection and we're doing postprocessing, we
+                # might be collapsing the dimensions of the postprocessing
+                # regions.  When that happens, we want to apply an aggregate
+                # function to them that computes the union of the regions that
+                # are grouped together.
+                builder.joiner.fields[element.name]["region"] = ddl.Base64Region.union_aggregate(
+                    builder.joiner.fields[element.name]["region"]
+                )
+                have_aggregates = True
+
         # All dimension record fields are derived fields.
         for element_name, fields_for_element in plan.columns.dimension_fields.items():
             for element_field in fields_for_element:

--- a/python/lsst/daf/butler/direct_query_driver/_query_plan.py
+++ b/python/lsst/daf/butler/direct_query_driver/_query_plan.py
@@ -207,21 +207,6 @@ class QueryProjectionPlan:
     one resolved collection.
     """
 
-    region_aggregates: list[DimensionElement] = dataclasses.field(default_factory=list)
-    """Dimension elements with spatial regions that must be aggregated by the
-    projection, since their dimension keys are being dropped.
-
-    This can only be non-empty if `needs_dimension_distinct` is `True`.
-    """
-
-    region_non_aggregates: list[DimensionElement] = dataclasses.field(default_factory=list)
-    """Dimension elements with spatial regions whose dimension keys are
-    included in the projection.  There is exactly one region corresponding to
-    each dimension key value, so these do not need to be aggregated.
-
-    This can only be non-empty if `needs_dimension_distinct` is `True`.
-    """
-
 
 @dataclasses.dataclass
 class QueryFindFirstPlan:

--- a/python/lsst/daf/butler/direct_query_driver/_query_plan.py
+++ b/python/lsst/daf/butler/direct_query_driver/_query_plan.py
@@ -214,6 +214,14 @@ class QueryProjectionPlan:
     This can only be non-empty if `needs_dimension_distinct` is `True`.
     """
 
+    region_non_aggregates: list[DimensionElement] = dataclasses.field(default_factory=list)
+    """Dimension elements with spatial regions whose dimension keys are
+    included in the projection.  There is exactly one region corresponding to
+    each dimension key value, so these do not need to be aggregated.
+
+    This can only be non-empty if `needs_dimension_distinct` is `True`.
+    """
+
 
 @dataclasses.dataclass
 class QueryFindFirstPlan:

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -394,8 +394,12 @@ class PostgresqlDatabase(Database):
         return self._pg_version >= (16, 0)
 
     def apply_any_aggregate(self, column: sqlalchemy.ColumnElement[Any]) -> sqlalchemy.ColumnElement[Any]:
-        # Docstring inherited.x
-        return sqlalchemy.func.any_value(column)
+        # Docstring inherited
+
+        # The cast is required to prevent sqlalchemy from forgetting the type
+        # of the initial column. Without the cast, for example, Base64Region
+        # would become a String column in the output.
+        return sqlalchemy.cast(sqlalchemy.func.any_value(column), column.type)
 
 
 class _RangeTimespanType(sqlalchemy.TypeDecorator):

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -47,8 +47,6 @@ from ..._timespan import Timespan
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from ..interfaces import Database
 
-_SERVER_VERSION_REGEX = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)")
-
 
 class PostgresqlDatabase(Database):
     """An implementation of the `Database` interface for PostgreSQL.
@@ -106,11 +104,8 @@ class PostgresqlDatabase(Database):
                     "`CREATE EXTENSION btree_gist;` in a database before a butler client for it is "
                     " initialized."
                 )
-            raw_pg_version = connection.execute(sqlalchemy.text("SHOW server_version")).scalar()
-            if raw_pg_version is not None and (m := _SERVER_VERSION_REGEX.search(raw_pg_version)):
-                pg_version = (int(m.group("major")), int(m.group("minor")))
-            else:
-                raise RuntimeError("Failed to get PostgreSQL server version.")
+
+            pg_version = get_postgres_server_version(connection)
         self._init(
             engine=engine,
             origin=origin,
@@ -606,3 +601,15 @@ class _RangeTimespanRepresentation(TimespanDatabaseRepresentation):
     ) -> TimespanDatabaseRepresentation:
         # Docstring inherited.
         return _RangeTimespanRepresentation(func(self.column), self.name)
+
+
+def get_postgres_server_version(connection: sqlalchemy.Connection) -> tuple[int, int]:  # numpydoc ignore=PR01
+    """Return the postgres DB server version as a tuple
+    (major version, minor version).
+    """
+    raw_pg_version = connection.execute(sqlalchemy.text("SHOW server_version")).scalar()
+    _SERVER_VERSION_REGEX = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)")
+    if raw_pg_version is not None and (m := _SERVER_VERSION_REGEX.search(raw_pg_version)):
+        return (int(m.group("major")), int(m.group("minor")))
+    else:
+        raise RuntimeError("Failed to get PostgreSQL server version.")

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -467,6 +467,21 @@ class ButlerQueryTests(ABC, TestCaseMixin):
                 [253954, 253955],
             )
 
+    def test_spatial_constraint_queries(self) -> None:
+        """Test queries in which one spatial dimension in the constraint (data
+        ID or ``where`` string) constrains a different spatial dimension in the
+        query result columns.
+        """
+        butler = self.make_butler("hsc-rc2-subset.yaml")
+        with butler._query() as query:
+            self.assertEqual(
+                [(9813, 72)],
+                [
+                    (data_id["tract"], data_id["patch"])
+                    for data_id in query.data_ids(["patch"]).where({"instrument": "HSC", "visit": 318})
+                ],
+            )
+
     def test_data_coordinate_upload(self) -> None:
         """Test queries for dimension records with a data coordinate upload."""
         butler = self.make_butler("base.yaml", "spatial.yaml")

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -474,11 +474,29 @@ class ButlerQueryTests(ABC, TestCaseMixin):
         """
         butler = self.make_butler("hsc-rc2-subset.yaml")
         with butler._query() as query:
+            # This tests the case where the 'patch' region is needed for
+            # postprocessing, to compare against the visit region, but is not
+            # needed in the resulting data ID.
             self.assertEqual(
                 [(9813, 72)],
                 [
                     (data_id["tract"], data_id["patch"])
                     for data_id in query.data_ids(["patch"]).where({"instrument": "HSC", "visit": 318})
+                ],
+            )
+
+            # This tests the case where the 'patch' region is needed in
+            # postprocessing AND is also returned in the result rows.
+            region_hex = (
+                "70cc2b4a68b7ecebbf32d931ecb816df3fffe573df5ab9a93f6d2ac3c7faf9ebbf39dad585e2e6de3fa"
+                "88934c311b9a93f55833497bef8ebbf15b3fe207ce5de3fae43c0300f6eab3f3e8709597bebebbf77d66"
+                "efa5115df3f05874a255d6eab3f"
+            )
+            self.assertEqual(
+                [(9813, 72, region_hex)],
+                [
+                    (record.tract, record.id, record.region.encode().hex())
+                    for record in query.dimension_records("patch").where({"instrument": "HSC", "visit": 318})
                 ],
             )
 

--- a/python/lsst/daf/butler/tests/postgresql.py
+++ b/python/lsst/daf/butler/tests/postgresql.py
@@ -105,3 +105,12 @@ class TemporaryPostgresInstance:  # numpydoc ignore=PR01
         from multiple tests.
         """
         return f"namespace_{secrets.token_hex(8).lower()}"
+
+    def server_major_version(self) -> int:
+        """Return the major version number of the Postgres server (e.g. 13 or
+        16).
+        """
+        from ..registry.databases.postgresql import get_postgres_server_version
+
+        with self.begin() as connection:
+            return get_postgres_server_version(connection)[0]

--- a/python/lsst/daf/butler/tests/postgresql.py
+++ b/python/lsst/daf/butler/tests/postgresql.py
@@ -1,0 +1,107 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import gc
+import secrets
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import sqlalchemy
+
+from .._butler_config import ButlerConfig
+from .._config import Config
+
+try:
+    from testing.postgresql import Postgresql
+except ImportError:
+    Postgresql = None
+
+
+@contextmanager
+def setup_postgres_test_db() -> Iterator[TemporaryPostgresInstance]:
+    """Set up a temporary postgres instance that can be used for testing the
+    Butler.
+    """
+    if Postgresql is None:
+        raise unittest.SkipTest("testing.postgresql module not available.")
+
+    with Postgresql() as server:
+        engine = sqlalchemy.engine.create_engine(server.url())
+        instance = TemporaryPostgresInstance(server, engine)
+        with instance.begin() as connection:
+            connection.execute(sqlalchemy.text("CREATE EXTENSION btree_gist;"))
+
+        yield instance
+
+        # Clean up any lingering SQLAlchemy engines/connections
+        # so they're closed before we shut down the server.
+        gc.collect()
+        engine.dispose()
+
+
+class TemporaryPostgresInstance:  # numpydoc ignore=PR01
+    """Wrapper for a temporary postgres database with utilities for connecting
+    a Butler to it.
+    """
+
+    def __init__(self, server: Postgresql, engine: sqlalchemy.Engine) -> None:
+        self._server = server
+        self._engine = engine
+
+    @property
+    def url(self) -> str:
+        """Return connection URL for the temporary database server."""
+        return self._server.url()
+
+    @contextmanager
+    def begin(self) -> Iterator[sqlalchemy.Connection]:
+        """Return a SQLAlchemy connection to the test database."""
+        with self._engine.begin() as connection:
+            yield connection
+
+    def patch_butler_config(self, config: ButlerConfig | Config) -> None:  # numpydoc ignore=PR01
+        """Modify a butler configuration in-place to point the registry to the
+        temporary database in a new empty namespace.
+        """
+        config["registry", "db"] = self.url
+        config["registry", "namespace"] = self.generate_namespace_name()
+
+    def patch_registry_config(self, config: Config) -> None:  # numpydoc ignore=PR01
+        """Modify a registry configuration in-place to point the database
+        connection to the temporary database in a new empty namespace.
+        """
+        config["db"] = self.url
+        config["namespace"] = self.generate_namespace_name()
+
+    def generate_namespace_name(self) -> str:
+        """Return a unique namespace name that can be used to separate the data
+        from multiple tests.
+        """
+        return f"namespace_{secrets.token_hex(8).lower()}"

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,5 @@
 matplotlib >= 3.0.3
 moto >= 1.3
-numpy >= 1.17
+numpy >= 1.17, <2
 pandas >= 1.0
 testing.postgresql


### PR DESCRIPTION
Fixed two issues where invalid SQL statements were being generated for Postgres by the new query system.  (See individual commit messages for details.)  

We now also run the Butler server tests using Postgres for the registry, since this is the configuration being used in production.  In the process, deduplicated the logic for setting up a postgres instance for testing -- it had been copy/pasted five places.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
