### PR TITLE
DM-44868: Fix order_by with dataID/dataset queries on postgres

### DIFF
--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -225,11 +225,6 @@ class RemoteButlerPostgresRegistryTests(RemoteButlerRegistryTests, unittest.Test
         cls.postgres = cls.enterClassContext(setup_postgres_test_db())
         super().setUpClass()
 
-    @unittest.expectedFailure
-    def testQueryDataIdsOrderBy(self):
-        # TODO DM-44868: order_by sometimes causes invalid SQL to be generated
-        return super().testQueryDataIdsOrderBy()
-
     def testSkipCalibs(self):
         if self.postgres.server_major_version() < 16:
             # TODO DM-44875: This test currently fails for older Postgres.


### PR DESCRIPTION
Fix an issue where using order_by in the new query system for a data ID query or dataset query would sometimes fail with the postgres error "SELECT DISTINCT ON expressions must match initial ORDER BY expressions".

This was occurring because the data ID de-duplication logic sometimes uses DISTINCT ON.  Postgres requires that the leftmost ORDER BY expressions match the DISTINCT ON clause, and we were not enforcing that.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
