### PR TITLE
DM-44875: Handle ambiguous calibration lookups on older postgres

### DIFF
--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -161,6 +161,14 @@ class MissingDatasetTypeError(DatasetTypeError, KeyError, ButlerUserError):
     error_type = "missing_dataset_type"
 
 
+class UnimplementedQueryError(NotImplementedError, ButlerUserError):
+    """Exception raised when the query system does not support the query
+    specified by the user.
+    """
+
+    error_type = "unimplemented_query"
+
+
 class DatasetTypeNotSupportedError(RuntimeError):
     """A `DatasetType` is not handled by this routine.
 
@@ -216,6 +224,7 @@ _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     InvalidQueryError,
     MissingCollectionError,
     MissingDatasetTypeError,
+    UnimplementedQueryError,
     UnknownButlerUserError,
 )
 _USER_ERROR_MAPPING = {e.error_type: e for e in _USER_ERROR_TYPES}

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -220,16 +220,19 @@ class RemoteButlerPostgresRegistryTests(RemoteButlerRegistryTests, unittest.Test
     server.
     """
 
+    postgres: TemporaryPostgresInstance
+
     @classmethod
     def setUpClass(cls):
         cls.postgres = cls.enterClassContext(setup_postgres_test_db())
         super().setUpClass()
 
-    def testSkipCalibs(self):
-        if self.postgres.server_major_version() < 16:
-            # TODO DM-44875: This test currently fails for older Postgres.
-            self.skipTest("TODO DM-44875")
-        return super().testSkipCalibs()
+    @property
+    def supportsCalibrationCollectionInFindFirst(self) -> bool:
+        # Find-first searches in calibration collections require the ANY_VALUE
+        # aggregate function, which is only supported starting from Postgres
+        # 16.
+        return self.postgres.server_major_version() >= 16
 
 
 if __name__ == "__main__":

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -225,11 +225,6 @@ class RemoteButlerPostgresRegistryTests(RemoteButlerRegistryTests, unittest.Test
         cls.postgres = cls.enterClassContext(setup_postgres_test_db())
         super().setUpClass()
 
-    @unittest.expectedFailure
-    def testQueryDataIdsOrderBy(self):
-        # TODO DM-44868: order_by sometimes causes invalid SQL to be generated
-        return super().testQueryDataIdsOrderBy()
-
     def testSkipCalibs(self):
         if self.postgres.server_major_version() < 16:
             # TODO DM-44875: This test currently fails for older Postgres.


### PR DESCRIPTION
For Postgres older than version 16, we now throw an error for find-first calibration searches instead of silently returning a potentially-incorrect result.   This is similar to the behavior of the old query system.

The query requires the ANY_VALUE aggregate function to generate the validity match count column used by postprocessing to check for ambiguous results.  This function is not available on older Postgres.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
