### PR TITLE
DM-44931: Define the dataset type override method for chained datastore

### DIFF
--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -35,7 +35,7 @@ import itertools
 import logging
 import time
 import warnings
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import DatasetRef, DatasetTypeNotSupportedError, FileDataset
@@ -1229,3 +1229,8 @@ class ChainedDatastore(Datastore):
         for datastore in self.datastores:
             tables.update(datastore.get_opaque_table_definitions())
         return tables
+
+    def set_retrieve_dataset_type_method(self, method: Callable[[str], DatasetType | None] | None) -> None:
+        # Docstring inherited from the base class.
+        for datastore in self.datastores:
+            datastore.set_retrieve_dataset_type_method(method)

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -78,7 +78,7 @@ from .server_models import (
     QueryInputs,
 )
 
-_QueryResultTypeAdapter = TypeAdapter(QueryExecuteResultData)
+_QueryResultTypeAdapter = TypeAdapter[QueryExecuteResultData](QueryExecuteResultData)
 
 
 class RemoteQueryDriver(QueryDriver):


### PR DESCRIPTION
Previously it was a no-op but this left any file datastores inside the chained datastore without the necessary mapping to allow them to cast to the registry dataset type.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
