### PR TITLE
DM-45045: Preserve the order of the keys in YAML

### DIFF
--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -180,7 +180,7 @@ class YamlFormatter(FileFormatter):
 
         unsafe_dump = self.writeParameters.get("unsafe_dump", False)
         if unsafe_dump:
-            serialized = yaml.dump(inMemoryDataset)
+            serialized = yaml.dump(inMemoryDataset, sort_keys=False)
         else:
-            serialized = yaml.safe_dump(inMemoryDataset)
+            serialized = yaml.safe_dump(inMemoryDataset, sort_keys=False)
         return serialized.encode()


### PR DESCRIPTION
Currently, YamlFormatter always sorts keys in alphabetical order. The reason is that we do not pass any keyword parameters to yaml's `dump` or `safe_dump`, and by default `sort_keys` is True. Added `sort_keys=False` to preserve the order of the keys in the Pydantic model.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
