### PR TITLE
DM-44362: Fix unit test for spatial overlaps

### DIFF
--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -155,6 +155,14 @@ class MissingCollectionError(CollectionError, ButlerUserError):
     error_type = "missing_collection"
 
 
+class UnimplementedQueryError(NotImplementedError, ButlerUserError):
+    """Exception raised when the query system does not support the query
+    specified by the user.
+    """
+
+    error_type = "unimplemented_query"
+
+
 class MissingDatasetTypeError(DatasetTypeError, KeyError, ButlerUserError):
     """Exception raised when a dataset type does not exist."""
 
@@ -216,6 +224,7 @@ _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     InvalidQueryError,
     MissingCollectionError,
     MissingDatasetTypeError,
+    UnimplementedQueryError,
     UnknownButlerUserError,
 )
 _USER_ERROR_MAPPING = {e.error_type: e for e in _USER_ERROR_TYPES}

--- a/python/lsst/daf/butler/dimensions/_group.py
+++ b/python/lsst/daf/butler/dimensions/_group.py
@@ -497,7 +497,7 @@ class DimensionGroup:  # numpydoc ignore=PR02
     """
 
     skypix: SortedSequenceSet
-    """A true `~collections.abc.Set` of all skypix dimension names in the "
+    """A true `~collections.abc.Set` of all skypix dimension names in the
     group.
     """
 

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -484,7 +484,7 @@ class DirectQueryDriver(QueryDriver):
             Column expressions to sort by.
         find_first_dataset : `str` or `None`, optional
             Name of a dataset type for which only one result row for each data
-            ID should be returned, with the colletions searched in order.
+            ID should be returned, with the collections searched in order.
 
         Returns
         -------

--- a/python/lsst/daf/butler/direct_query_driver/_query_plan.py
+++ b/python/lsst/daf/butler/direct_query_driver/_query_plan.py
@@ -168,9 +168,9 @@ class QueryProjectionPlan:
     """A struct describing the "projection" stage of a butler query.
 
     This struct evaluates to `True` in boolean contexts if either
-    `needs_dimension_distinct` or `needs_dataset_distict` are `True`.  In other
-    cases the projection is effectively a no-op, because the "joins"-stage rows
-    are already unique.
+    `needs_dimension_distinct` or `needs_dataset_distinct` are `True`.  In
+    other cases the projection is effectively a no-op, because the
+    "joins"-stage rows are already unique.
 
     See `QueryPlan` and `QueryPlan.projection` for additional information.
     """
@@ -237,19 +237,19 @@ class QueryPlan:
     postprocessing in three stages, with each corresponding to an attributes of
     this class and a method of `DirectQueryDriver`
 
-    - In the `joins` stage (`~DirectQueryButler.apply_query_joins`), we define
+    - In the `joins` stage (`~DirectQueryDriver.apply_query_joins`), we define
       the main SQL FROM and WHERE clauses, by joining all tables needed to
       bring in any columns, or constrain the keys of its rows.
 
-    - In the `projection` stage (`~DirectQueryButler.apply_query_projection`),
+    - In the `projection` stage (`~DirectQueryDriver.apply_query_projection`),
       we select only the columns needed for the query's result rows (including
-      columns needed only postprocessing and ORDER BY, as well those needed by
-      the objects returned to users).  If the result rows are not naturally
+      columns needed only by postprocessing and ORDER BY, as well those needed
+      by the objects returned to users).  If the result rows are not naturally
       unique given what went into the query in the "joins" stage, the
       projection involves a SELECT DISTINCT [ON] or GROUP BY to make them
       unique, and in a few rare cases uses aggregate functions with GROUP BY.
 
-    - In the `find_first` stage (`~DirectQueryButler.apply_query_find_first`),
+    - In the `find_first` stage (`~DirectQueryDriver.apply_query_find_first`),
       we use a window function (PARTITION BY) subquery to find only the first
       dataset in the collection search path for each data ID.  This stage does
       nothing if there is no find-first dataset search, or if the search is
@@ -259,8 +259,9 @@ class QueryPlan:
     via `DirectQueryDriver.analyze_query`, which also returns an initial
     `QueryBuilder`.  After this point the plans are considered frozen, and the
     nested plan attributes are then passed to each of the corresponding
-    `DirectQuery` along with the builder, which is mutated (and occasionally
-    replaced) into the complete SQL/postprocessing form of the query.
+    `DirectQueryDriver` methods along with the builder, which is mutated (and
+    occasionally replaced) into the complete SQL/postprocessing form of the
+    query.
     """
 
     joins: QueryJoinsPlan

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -40,6 +40,7 @@ from lsst.sphgeom import Region
 from ... import ddl
 from ..._column_tags import DimensionKeyColumnTag, DimensionRecordColumnTag
 from ..._column_type_info import LogicalColumn
+from ..._exceptions import UnimplementedQueryError
 from ..._named import NamedKeyDict
 from ...dimensions import (
     DatabaseDimensionElement,
@@ -1100,7 +1101,7 @@ class _CommonSkyPixMediatedOverlapsVisitor(OverlapsVisitor):
         # Reject spatial joins that are nested inside OR or NOT, because the
         # postprocessing needed for those would be a lot harder.
         if flags & PredicateVisitFlags.INVERTED or flags & PredicateVisitFlags.HAS_OR_SIBLINGS:
-            raise NotImplementedError("Spatial overlap joins nested inside OR or NOT are not supported.")
+            raise UnimplementedQueryError("Spatial overlap joins nested inside OR or NOT are not supported.")
         # Delegate to super to check for invalid joins and record this
         # "connection" for use when seeing whether to add an automatic join
         # later.
@@ -1137,7 +1138,7 @@ class _CommonSkyPixMediatedOverlapsVisitor(OverlapsVisitor):
                 # tile is necessary but not sufficient for that.
                 self.builder.postprocessing.spatial_join_filtering.append((a, b))
             case _:
-                raise NotImplementedError(f"Unsupported combination for spatial join: {a, b}.")
+                raise UnimplementedQueryError(f"Unsupported combination for spatial join: {a, b}.")
         return qt.Predicate.from_bool(True)
 
     def _join_common_skypix_overlap(self, element: DatabaseDimensionElement) -> None:

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -199,11 +199,6 @@ class RemoteButlerRegistryTests(RegistryTests):
         # RemoteButler.
         pass
 
-    @unittest.expectedFailure
-    def test_skypix_constraint_queries(self) -> None:
-        # TODO DM-44362
-        return super().test_skypix_constraint_queries()
-
 
 @unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
 class RemoteButlerSqliteRegistryTests(RemoteButlerRegistryTests, unittest.TestCase):


### PR DESCRIPTION
Using non-common skypix is going to be deprecated in favor of a
direct use of regions. New query system raises NotImplementedError
for non-common skypix, this patch replaces that exception with
a new exception class to support exception propagation from remote
butler to client.

`test_skypix_constraint_queries` unit test is updated to handle
exceptions from the new query system. When direct butler switches
to the new query system, that test can be removed or changed to
always expect the exceptions.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
