### PR TITLE
DM-45088: Fix deserialization of DimensionUniverse configuration

### DIFF
--- a/python/lsst/daf/butler/dimensions/_config.py
+++ b/python/lsst/daf/butler/dimensions/_config.py
@@ -180,7 +180,15 @@ class DimensionConfig(ConfigSubset):
         config : `DimensionConfig`
             Dimension configuration.
         """
-        return DimensionConfig(simple.model_dump())
+        return DimensionConfig(
+            simple.model_dump(
+                # Some of the fields in Pydantic model config have aliases
+                # (e.g. remapping 'class_' to 'class').  Pydantic ignores these
+                # in model_dump() by default, so we have to add by_alias to
+                # make sure that we end up with the right names in the dict.
+                by_alias=True
+            )
+        )
 
     def makeBuilder(self) -> DimensionConstructionBuilder:
         """Construct a `DimensionConstructionBuilder`.

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -158,7 +158,14 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         model = parse_model(response, GetUniverseResponseModel)
 
         config = DimensionConfig.from_simple(model.universe)
-        universe = DimensionUniverse(config)
+        universe = DimensionUniverse(
+            config,
+            # The process-global cache internal to DimensionUniverse can mask
+            # problems in unit tests, since client and server live in the same
+            # process for these tests.  We are doing our own caching, so we
+            # don't benefit from it.  So just disable it.
+            use_cache=False,
+        )
         with self._cache.access() as cache:
             if cache.dimensions is None:
                 cache.dimensions = universe


### PR DESCRIPTION
Fix an issue where DimensionConfig.from_simple() was not creating a valid DimensionConfig instance, due to some dict keys being serialized as "class_" instead of being renamed to "class".  This was causing RemoteButler to fail when deserializing the DimensionUniverse from the server.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
