### PR TITLE
DM-45140: Skip datastore root check for non-POSIX filesystems

### DIFF
--- a/doc/changes/DM-45140.bugfix.md
+++ b/doc/changes/DM-45140.bugfix.md
@@ -1,0 +1,3 @@
+We no longer try to create the datastore root at startup for non-POSIX
+filesystems, to fix an issue where this would fail on read-only repositories
+stored on S3/HTTP/GS.


### PR DESCRIPTION
We now skip existence checks for the datastore root for non-POSIX root paths.  This fixes an issue where FileDatastore was throwing a permissions-related exception on startup when trying to use a read-only S3 bucket via either `s3://` or `https://`.

This was occurring because on S3 there is no concept of a directory, so even though files exist in the datastore, the root directory does not.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
