### PR TITLE
DM-45237: Add ability to disable file validation info on ingest-files and import

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install -y -q \
-            pytest pytest-xdist pytest-openfiles pytest-cov
+            pytest pytest-xdist pytest-cov
 
       - name: List installed packages
         shell: bash -l {0}
@@ -90,7 +90,7 @@ jobs:
         env:
           SQLALCHEMY_WARN_20: 1
         run: |
-          pytest -r a -v -n 3 --open-files --cov=lsst.daf.butler --cov=tests --cov-report=xml --cov-report=term --cov-branch
+          pytest -r a -v -n 3 --cov=lsst.daf.butler --cov=tests --cov-report=xml --cov-report=term --cov-branch
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v4
         with:

--- a/doc/changes/DM-45237.feature.rst
+++ b/doc/changes/DM-45237.feature.rst
@@ -1,0 +1,2 @@
+Added ``--no-track-file-attrs`` to ``butler import`` (and associated import API) and ``butler ingest-files`` commands to allow an import/ingest to disable the calculation of file sizes on ingest.
+This can be useful if you are importing thousands of files from an object store where the file size determination can take a significant amount of time.

--- a/doc/changes/DM-45237.misc.rst
+++ b/doc/changes/DM-45237.misc.rst
@@ -1,0 +1,5 @@
+File ingest no longer checks that every file exists.
+This can take a very long time if thousands of files are being ingested from an object store.
+Now at most 200 files will be checked.
+Whether all files are subsequently checked depends on the transfer mode and whether ``--no-track-file-attrs`` is enabled.
+For ``direct`` or in-place ingest coupled with ``--no-track-file-attrs`` the file existence might never be verified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ server = [
 ]
 test = [
     "pytest >= 3.2",
-    "pytest-openfiles >= 0.5.0",
     "numpy >= 1.17",
     "matplotlib >= 3.0.3",
     "pandas >= 1.0",

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1260,6 +1260,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         format: str | None = None,
         transfer: str | None = None,
         skip_dimensions: set | None = None,
+        record_validation_info: bool = True,
     ) -> None:
         """Import datasets into this repository that were exported from a
         different butler repository via `~lsst.daf.butler.Butler.export`.
@@ -1285,6 +1286,13 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             Transfer mode passed to `~lsst.daf.butler.Datastore.ingest`.
         skip_dimensions : `set`, optional
             Names of dimensions that should be skipped and not imported.
+        record_validation_info : `bool`, optional
+            If `True`, the default, the datastore can record validation
+            information associated with the file. If `False` the datastore
+            will not attempt to track any information such as checksums
+            or file sizes. This can be useful if such information is tracked
+            in an external system or if the file is to be compressed in place.
+            It is up to the datastore whether this parameter is relevant.
 
         Raises
         ------

--- a/python/lsst/daf/butler/cli/cliLog.py
+++ b/python/lsst/daf/butler/cli/cliLog.py
@@ -317,7 +317,7 @@ class CliLog:
         Parameters
         ----------
         component : `str` or None
-            The name of the log component or None for the default logger.
+            The name of the log component or `None` for the default logger.
             The root logger can be specified either by an empty string or
             with the special name ``.``.
         level : `str`

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -54,6 +54,7 @@ from ..opt import (
     query_datasets_options,
     register_dataset_types_option,
     repo_argument,
+    track_file_attrs_option,
     transfer_dimensions_option,
     transfer_option,
     verbose_option,
@@ -725,6 +726,7 @@ def collection_chain(**kwargs: Any) -> None:
     help="For relative paths in the table file, specify a prefix to use. The default is to"
     " use the current working directory.",
 )
+@track_file_attrs_option()
 @transfer_option()
 def ingest_files(**kwargs: Any) -> None:
     """Ingest files from table file.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -114,6 +114,7 @@ def associate(**kwargs: Any) -> None:
     metavar=typeStrAcceptsMultiple,
     help="Dimensions that should be skipped during import",
 )
+@track_file_attrs_option()
 @options_file_option()
 def butler_import(*args: Any, **kwargs: Any) -> None:
     """Import data into a butler repository."""

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -122,7 +122,7 @@ components_option = MWOptionDecorator(
 )
 
 
-def _config_split(*args: Any) -> dict[str, str]:
+def _config_split(*args: Any) -> dict[str | None, str]:
     # Config values might include commas so disable comma-splitting.
     result = split_kv(*args, multiple=False)
     assert isinstance(result, dict), "For mypy check that we get the expected result"

--- a/python/lsst/daf/butler/cli/opt/options.py
+++ b/python/lsst/daf/butler/cli/opt/options.py
@@ -54,6 +54,7 @@ __all__ = (
     "order_by_option",
     "limit_option",
     "offset_option",
+    "track_file_attrs_option",
 )
 
 from functools import partial
@@ -312,4 +313,12 @@ offset_option = MWOptionDecorator(
     help=unwrap("Skip initial number of records, only used when --limit is specified."),
     type=int,
     default=0,
+)
+
+track_file_attrs_option = MWOptionDecorator(
+    "--track-file-attrs/--no-track-file-attrs",
+    default=True,
+    help="Indicate to the datastore whether file attributes such as file size"
+    " or checksum should be tracked or not. Whether this parameter is honored"
+    " depends on the specific datastore implementation.",
 )

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -352,10 +352,10 @@ def split_kv(
     separator: str = "=",
     unseparated_okay: bool = False,
     return_type: type[dict] | type[tuple] = dict,
-    default_key: str = "",
+    default_key: str | None = "",
     reverse_kv: bool = False,
     add_to_default: bool = False,
-) -> dict[str, str] | tuple[tuple[str, str], ...]:
+) -> dict[str | None, str] | tuple[tuple[str | None, str], ...]:
     """Process a tuple of values that are key-value pairs separated by a given
     separator. Multiple pairs may be comma separated. Return a dictionary of
     all the passed-in values.
@@ -401,8 +401,9 @@ def split_kv(
         tuple will be 2-item tuple, the first item will be the value to the
         left of the separator and the second item will be the value to the
         right. By default `dict`.
-    default_key : `Any`
+    default_key : `str` or `None`
         The key to use if a value is passed that is not a key-value pair.
+        `None` can imply no separator depending on how the results are handled.
         (Passing values that are not key-value pairs requires
         ``unseparated_okay`` to be `True`).
     reverse_kv : bool
@@ -453,26 +454,26 @@ def split_kv(
 
     class RetDict:
         def __init__(self) -> None:
-            self.ret: dict[str, str] = {}
+            self.ret: dict[str | None, str] = {}
 
-        def add(self, key: str, val: str) -> None:
+        def add(self, key: str | None, val: str) -> None:
             if reverse_kv:
                 key, val = val, key
             self.ret[key] = val
 
-        def get(self) -> dict[str, str]:
+        def get(self) -> dict[str | None, str]:
             return self.ret
 
     class RetTuple:
         def __init__(self) -> None:
-            self.ret: list[tuple[str, str]] = []
+            self.ret: list[tuple[str | None, str]] = []
 
-        def add(self, key: str, val: str) -> None:
+        def add(self, key: str | None, val: str) -> None:
             if reverse_kv:
                 key, val = val, key
             self.ret.append((key, val))
 
-        def get(self) -> tuple[tuple[str, str], ...]:
+        def get(self) -> tuple[tuple[str | None, str], ...]:
             return tuple(self.ret)
 
     if separator in (",", " "):

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -790,7 +790,7 @@ class MWOptionDecorator:
     """
 
     def __init__(self, *param_decls: Any, **kwargs: Any) -> None:
-        self.partialOpt = partial(click.option, *param_decls, cls=partial(MWOption), **kwargs)
+        self.partialOpt = partial(click.option, *param_decls, cls=partial(MWOption), **kwargs)  # type: ignore
         opt = click.Option(param_decls, **kwargs)
         self._name = opt.name
         self._opts = opt.opts

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -952,8 +952,6 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         NotImplementedError
             Raised if the datastore does not support the given transfer mode
             (including the case where ingest is not supported at all).
-        FileNotFoundError
-            Raised if one of the given files does not exist.
         """
         if transfer not in (None, "direct", "split") + self.root.transferModes:
             raise NotImplementedError(f"Transfer mode {transfer} not supported.")
@@ -962,12 +960,6 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         srcUri = ResourcePath(path, forceAbsolute=False, forceDirectory=False)
         if not srcUri.isabs():
             srcUri = self.root.join(path)
-
-        if not srcUri.exists():
-            raise FileNotFoundError(
-                f"Resource at {srcUri} does not exist; note that paths to ingest "
-                f"are assumed to be relative to {self.root} unless they are absolute."
-            )
 
         if transfer is None:
             relpath = srcUri.relative_to(self.root)

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1626,6 +1626,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         format: str | None = None,
         transfer: str | None = None,
         skip_dimensions: set | None = None,
+        record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited.
         if not self.isWriteable():
@@ -1679,6 +1680,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
                         directory=directory,
                         transfer=transfer,
                         skip_dimensions=skip_dimensions,
+                        record_validation_info=record_validation_info,
                     )
 
         if isinstance(filename, ResourcePath):

--- a/python/lsst/daf/butler/formatters/json.py
+++ b/python/lsst/daf/butler/formatters/json.py
@@ -135,7 +135,7 @@ class JsonFormatter(FileFormatter):
         # mypy needs the 'not a type' check because "is_dataclass" works
         # for both types and instances.
         if dataclasses.is_dataclass(inMemoryDataset) and not isinstance(inMemoryDataset, type):
-            inMemoryDataset = dataclasses.asdict(inMemoryDataset)
+            inMemoryDataset = dataclasses.asdict(inMemoryDataset)  # type: ignore[unreachable]
         elif hasattr(inMemoryDataset, "_asdict"):
             inMemoryDataset = inMemoryDataset._asdict()
         return json.dumps(inMemoryDataset, ensure_ascii=False).encode()

--- a/python/lsst/daf/butler/formatters/json.py
+++ b/python/lsst/daf/butler/formatters/json.py
@@ -132,7 +132,9 @@ class JsonFormatter(FileFormatter):
         with contextlib.suppress(AttributeError):
             return inMemoryDataset.json().encode()
 
-        if dataclasses.is_dataclass(inMemoryDataset):
+        # mypy needs the 'not a type' check because "is_dataclass" works
+        # for both types and instances.
+        if dataclasses.is_dataclass(inMemoryDataset) and not isinstance(inMemoryDataset, type):
             inMemoryDataset = dataclasses.asdict(inMemoryDataset)
         elif hasattr(inMemoryDataset, "_asdict"):
             inMemoryDataset = inMemoryDataset._asdict()

--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -173,7 +173,9 @@ class YamlFormatter(FileFormatter):
                 converted = True
 
         if not converted:
-            if dataclasses.is_dataclass(inMemoryDataset):
+            # mypy needs the 'not a type' check because "is_dataclass" works
+            # for both types and instances.
+            if dataclasses.is_dataclass(inMemoryDataset) and not isinstance(inMemoryDataset, type):
                 inMemoryDataset = dataclasses.asdict(inMemoryDataset)
             elif hasattr(inMemoryDataset, "_asdict"):
                 inMemoryDataset = inMemoryDataset._asdict()

--- a/python/lsst/daf/butler/formatters/yaml.py
+++ b/python/lsst/daf/butler/formatters/yaml.py
@@ -176,7 +176,7 @@ class YamlFormatter(FileFormatter):
             # mypy needs the 'not a type' check because "is_dataclass" works
             # for both types and instances.
             if dataclasses.is_dataclass(inMemoryDataset) and not isinstance(inMemoryDataset, type):
-                inMemoryDataset = dataclasses.asdict(inMemoryDataset)
+                inMemoryDataset = dataclasses.asdict(inMemoryDataset)  # type: ignore[unreachable]
             elif hasattr(inMemoryDataset, "_asdict"):
                 inMemoryDataset = inMemoryDataset._asdict()
 

--- a/python/lsst/daf/butler/registry/queries/_sql_query_context.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_context.py
@@ -96,7 +96,7 @@ class SqlQueryContext(QueryContext):
         self._exit_stack.enter_context(self._db.session())
         return self
 
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool | None:
         assert self._exit_stack is not None, "Context manager not yet entered."
         result = self._exit_stack.__exit__(exc_type, exc_value, traceback)
         self._exit_stack = None

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -477,6 +477,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         format: str | None = None,
         transfer: str | None = None,
         skip_dimensions: set | None = None,
+        record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited.
         raise NotImplementedError()

--- a/python/lsst/daf/butler/script/butlerImport.py
+++ b/python/lsst/daf/butler/script/butlerImport.py
@@ -38,6 +38,7 @@ def butlerImport(
     export_file: str | TextIO | None,
     transfer: str | None,
     skip_dimensions: Iterable[str] | None,
+    track_file_attrs: bool = True,
 ) -> None:
     """Import data into a butler repository.
 
@@ -58,6 +59,10 @@ def butlerImport(
         The external data transfer type.
     skip_dimensions : `list`, or `None`
         Dimensions that should be skipped.
+    track_file_attrs : `bool`, optional
+        Control whether file attributes such as the size or checksum should
+        be tracked by the datastore. Whether this parameter is honored
+        depends on the specific datastore implementation.
     """
     butler = Butler.from_config(repo, writeable=True)
 
@@ -70,4 +75,5 @@ def butlerImport(
         transfer=transfer,
         format="yaml",
         skip_dimensions=skip_dimensions,
+        record_validation_info=track_file_attrs,
     )

--- a/python/lsst/daf/butler/script/ingest_files.py
+++ b/python/lsst/daf/butler/script/ingest_files.py
@@ -57,6 +57,7 @@ def ingest_files(
     id_generation_mode: str = "UNIQUE",
     prefix: str | None = None,
     transfer: str = "auto",
+    track_file_attrs: bool = True,
 ) -> None:
     """Ingest files from a table.
 
@@ -89,6 +90,10 @@ def ingest_files(
         is to use the current working directory.
     transfer : `str`, optional
         Transfer mode to use for ingest.
+    track_file_attrs : `bool`, optional
+        Control whether file attributes such as the size or checksum should
+        be tracked by the datastore. Whether this parameter is honored
+        depends on the specific datastore implementation.
     """
     # Check that the formatter can be imported -- validate this as soon
     # as possible before we read a potentially large table file.
@@ -122,7 +127,7 @@ def ingest_files(
         table, common_data_id, datasetType, run, formatter, prefix, id_gen_mode
     )
 
-    butler.ingest(*datasets, transfer=transfer)
+    butler.ingest(*datasets, transfer=transfer, record_validation_info=track_file_attrs)
 
 
 def extract_datasets_from_table(

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -277,6 +277,7 @@ class HybridButler(Butler):
         format: str | None = None,
         transfer: str | None = None,
         skip_dimensions: set | None = None,
+        record_validation_info: bool = True,
     ) -> None:
         self._direct_butler.import_(
             directory=directory,
@@ -284,6 +285,7 @@ class HybridButler(Butler):
             format=format,
             transfer=transfer,
             skip_dimensions=skip_dimensions,
+            record_validation_info=record_validation_info,
         )
 
     def transfer_dimension_records_from(

--- a/python/lsst/daf/butler/transfers/_interfaces.py
+++ b/python/lsst/daf/butler/transfers/_interfaces.py
@@ -160,6 +160,7 @@ class RepoImportBackend(ABC):
         directory: ResourcePathExpression | None = None,
         transfer: str | None = None,
         skip_dimensions: set | None = None,
+        record_validation_info: bool = True,
     ) -> None:
         """Import information associated with the backend into the given
         registry and datastore.
@@ -180,5 +181,13 @@ class RepoImportBackend(ABC):
             Dimensions that should be skipped and not imported. This can
             be useful when importing into a registry that already knows
             about a specific instrument.
+        record_validation_info : `bool`, optional
+            If `True`, the default, the datastore can record validation
+            information associated with the file. If `False` the datastore
+            will not attempt to track any information such as checksums
+            or file sizes. This can be useful if such information is tracked
+            in an external system or if the file is to be compressed in place.
+            It is up to the underlying datastore whether this parameter is
+            relevant.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/transfers/_yaml.py
+++ b/python/lsst/daf/butler/transfers/_yaml.py
@@ -649,6 +649,7 @@ class YamlRepoImportBackend(RepoImportBackend):
         directory: ResourcePathExpression | None = None,
         transfer: str | None = None,
         skip_dimensions: set | None = None,
+        record_validation_info: bool = True,
     ) -> None:
         # Docstring inherited from RepoImportBackend.load.
         # Must ensure we insert in order supported by the universe.
@@ -696,7 +697,7 @@ class YamlRepoImportBackend(RepoImportBackend):
                 fileDatasets.append(fileDataset)
         # Ingest everything into the datastore at once.
         if datastore is not None and fileDatasets:
-            datastore.ingest(*fileDatasets, transfer=transfer)
+            datastore.ingest(*fileDatasets, transfer=transfer, record_validation_info=record_validation_info)
         # Associate datasets with tagged collections.
         for collection, dataset_ids in self.tagAssociations.items():
             self.registry.associate(collection, [self.refsByFileId[i] for i in dataset_ids])

--- a/tests/test_cliCmdImport.py
+++ b/tests/test_cliCmdImport.py
@@ -42,7 +42,14 @@ class ImportTestCase(CliCmdTestBase, unittest.TestCase):
 
     @staticmethod
     def defaultExpected():
-        return dict(repo=None, transfer="auto", directory=None, skip_dimensions=(), export_file=None)
+        return dict(
+            repo=None,
+            transfer="auto",
+            directory=None,
+            skip_dimensions=(),
+            export_file=None,
+            track_file_attrs=True,
+        )
 
     @staticmethod
     def command():


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
