### PR TITLE
DM-44843: Improve performance of collection resolution in the new query system

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,7 +35,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -348,26 +348,24 @@ class DefaultCollectionManager(CollectionManager[K]):
         wildcard: CollectionWildcard,
         *,
         collection_types: Set[CollectionType] = CollectionType.all(),
-        done: set[str] | None = None,
         flatten_chains: bool = True,
         include_chains: bool | None = None,
     ) -> list[CollectionRecord[K]]:
         # Docstring inherited
-        if done is None:
-            done = set()
+        done: set[K] = set()
         include_chains = include_chains if include_chains is not None else not flatten_chains
 
         def resolve_nested(
-            record: CollectionRecord, done: set[str], collection_cache: CollectionRecordCache | None
+            record: CollectionRecord, done: set[K], collection_cache: CollectionRecordCache | None
         ) -> Iterator[CollectionRecord[K]]:
-            if record.name in done:
+            if record.key in done:
                 return
             if record.type in collection_types:
-                done.add(record.name)
+                done.add(record.key)
                 if record.type is not CollectionType.CHAINED or include_chains:
                     yield record
             if flatten_chains and record.type is CollectionType.CHAINED:
-                done.add(record.name)
+                done.add(record.key)
                 children = cast(ChainedCollectionRecord[K], record).children
                 for child in self._find_many(children, flatten_chains, collection_cache):
                     # flake8 can't tell that we only delete this closure when

--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -31,7 +31,7 @@ from ... import ddl
 __all__ = ()
 
 from abc import abstractmethod
-from collections.abc import Callable, Iterable, Iterator, Set
+from collections.abc import Callable, Iterable, Iterator, Mapping, Set
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Generic, Literal, NamedTuple, TypeVar, cast
 
@@ -39,6 +39,7 @@ import sqlalchemy
 
 from ..._exceptions import CollectionCycleError, CollectionTypeError, MissingCollectionError
 from ...timespan_database_representation import TimespanDatabaseRepresentation
+from .._collection_record_cache import CollectionRecordCache
 from .._collection_type import CollectionType
 from ..interfaces import ChainedCollectionRecord, CollectionManager, CollectionRecord, RunRecord, VersionTuple
 from ..wildcards import CollectionWildcard
@@ -281,22 +282,47 @@ class DefaultCollectionManager(CollectionManager[K]):
             raise MissingCollectionError(f"No collection with name '{name}' found.")
         return result
 
-    def _find_many(self, names: Iterable[str]) -> list[CollectionRecord[K]]:
-        """Return multiple records given their names."""
+    def _find_many(
+        self, names: Iterable[str], flatten_chains: bool, collection_cache: CollectionRecordCache | None
+    ) -> list[CollectionRecord[K]]:
+        """Return multiple records given their names.
+
+        Parameters
+        ----------
+        names : `~collections.abc.Iterable` [`str`]
+            Collection names to search for.
+        flatten_chains : `bool`
+            If `True` then also retrieve recursively collection records for all
+            chained collections in the input list. Child collections are not
+            returned but are stored in collection cache.
+        collection_cache : `CollectionRecordCache`
+            If `None` then the cache from the caching context will be used if
+            that is not `None`. Collections are searched in the cache first,
+            collections that are missing from the cache are fetched from
+            database. All fetched collections are added to the cache.
+
+        Returns
+        -------
+        records : `list` [`CollectionRecord`]
+            Collection records. Only the records that match the input list are
+            returned in the same order.
+        """
         names = list(names)
+        if collection_cache is None:
+            collection_cache = self._caching_context.collection_records
         # To protect against potential races in cache updates.
         records: dict[str, CollectionRecord | None] = {}
-        if self._caching_context.collection_records is not None:
+        if collection_cache is not None:
             for name in names:
-                records[name] = self._caching_context.collection_records.get_by_name(name)
+                records[name] = collection_cache.get_by_name(name)
             fetch_names = [name for name, record in records.items() if record is None]
         else:
             fetch_names = list(names)
             records = {name: None for name in fetch_names}
         if fetch_names:
-            for record in self._fetch_by_name(fetch_names):
+            for record in self._fetch_by_name(fetch_names, flatten_chains):
                 records[record.name] = record
-                self._addCachedRecord(record)
+                self._addCachedRecord(record, collection_cache)
         missing_names = [name for name, record in records.items() if record is None]
         if len(missing_names) == 1:
             raise MissingCollectionError(f"No collection with name '{missing_names[0]}' found.")
@@ -331,7 +357,9 @@ class DefaultCollectionManager(CollectionManager[K]):
             done = set()
         include_chains = include_chains if include_chains is not None else not flatten_chains
 
-        def resolve_nested(record: CollectionRecord, done: set[str]) -> Iterator[CollectionRecord[K]]:
+        def resolve_nested(
+            record: CollectionRecord, done: set[str], collection_cache: CollectionRecordCache | None
+        ) -> Iterator[CollectionRecord[K]]:
             if record.name in done:
                 return
             if record.type in collection_types:
@@ -340,25 +368,36 @@ class DefaultCollectionManager(CollectionManager[K]):
                     yield record
             if flatten_chains and record.type is CollectionType.CHAINED:
                 done.add(record.name)
-                for child in self._find_many(cast(ChainedCollectionRecord[K], record).children):
+                children = cast(ChainedCollectionRecord[K], record).children
+                for child in self._find_many(children, flatten_chains, collection_cache):
                     # flake8 can't tell that we only delete this closure when
                     # we're totally done with it.
-                    yield from resolve_nested(child, done)  # noqa: F821
+                    yield from resolve_nested(child, done, collection_cache)  # noqa: F821
 
         result: list[CollectionRecord[K]] = []
 
         if wildcard.patterns is ...:
+            # As _fetch_all() returns all records we do not want to query
+            # for chain children just in case caching is disabled.
+            flatten_chains = False
             for record in self._fetch_all():
-                result.extend(resolve_nested(record, done))
+                result.extend(resolve_nested(record, done, self._caching_context.collection_records))
             del resolve_nested
             return result
+
         if wildcard.strings:
-            for record in self._find_many(wildcard.strings):
-                result.extend(resolve_nested(record, done))
+            # To be efficient we have to have caching enabled for at least the
+            # duration of this call.
+            cache = self._caching_context.collection_records or CollectionRecordCache()
+            for record in self._find_many(wildcard.strings, flatten_chains, cache):
+                result.extend(resolve_nested(record, done, cache))
         if wildcard.patterns:
+            # As _fetch_all() returns all records we do not want to query
+            # for chain children just in case caching is disabled.
+            flatten_chains = False
             for record in self._fetch_all():
                 if any(p.fullmatch(record.name) for p in wildcard.patterns):
-                    result.extend(resolve_nested(record, done))
+                    result.extend(resolve_nested(record, done, self._caching_context.collection_records))
         del resolve_nested
         return result
 
@@ -376,10 +415,14 @@ class DefaultCollectionManager(CollectionManager[K]):
         # Docstring inherited from CollectionManager.
         self._db.update(self._tables.collection, {self._collectionIdName: "key"}, {"key": key, "doc": doc})
 
-    def _addCachedRecord(self, record: CollectionRecord[K]) -> None:
+    def _addCachedRecord(
+        self, record: CollectionRecord[K], collection_cache: CollectionRecordCache | None = None
+    ) -> None:
         """Add single record to cache."""
-        if self._caching_context.collection_records is not None:
-            self._caching_context.collection_records.add(record)
+        if collection_cache is None:
+            collection_cache = self._caching_context.collection_records
+        if collection_cache is not None:
+            collection_cache.add(record)
 
     def _removeCachedRecord(self, record: CollectionRecord[K]) -> None:
         """Remove single record from cache."""
@@ -391,13 +434,13 @@ class DefaultCollectionManager(CollectionManager[K]):
         if self._caching_context.collection_records is not None:
             if (record := self._caching_context.collection_records.get_by_name(name)) is not None:
                 return record
-        records = self._fetch_by_name([name])
+        records = self._fetch_by_name([name], False)
         for record in records:
             self._addCachedRecord(record)
         return records[0] if records else None
 
     @abstractmethod
-    def _fetch_by_name(self, names: Iterable[str]) -> list[CollectionRecord[K]]:
+    def _fetch_by_name(self, names: Iterable[str], flatten_chains: bool) -> list[CollectionRecord[K]]:
         """Fetch collection record from database given its name."""
         raise NotImplementedError()
 
@@ -663,6 +706,116 @@ class DefaultCollectionManager(CollectionManager[K]):
         - ``type`` : the collection type
         """
         raise NotImplementedError()
+
+    def _query_recursive(
+        self,
+        collections: Iterable[str],
+        key_type: type,
+    ) -> list[Mapping]:
+        """Run the query that recursively finds collections and all their
+        child collections.
+
+        Parameters
+        ----------
+        collections : `~collections.abc.Iterable` [`str`]
+            List of collection names to retrieve.
+        key_type : `type`
+            Type of the key column, e.g. `sqlalchemy.BigInteger`.
+
+        Returns
+        -------
+        rows : `list` [`~collections.abc.Mapping`]
+            Database rows resulting from the query. Each row contains a
+            combination of columns from ``collections`` table and
+            ``collection_chain`` table joined on ``child`` column,
+            ``child`` column is not included into returned mappings.
+            For top-level collections both ``parent`` and ``position`` will
+            be `None`. Same collection can appear multiple times if it is a
+            child of multiple collections.
+        """
+        # Make recursive CTE to fetch everything in one query. There may be
+        # duplicate collection names in the result, but it should not affect
+        # performance too much for the limited number of input collections.
+        #
+        # The query will look like
+        #
+        # WITH RECURSIVE chains AS (
+        #     SELECT
+        #         coll_1.*,
+        #         cast(NULL as KEY_TYPE) parent,
+        #         cast(NULL as SMALLINT) position
+        #     FROM
+        #         collection coll_1
+        #     WHERE
+        #         coll_1.name IN (:collections)
+        #     UNION ALL
+        #     SELECT
+        #         coll_2.*,
+        #         chain_2.parent,
+        #         chain_2.position
+        #     FROM
+        #         collection coll_2
+        #         JOIN collection_chain chain_2
+        #             ON coll_2.key_column = chain_2.child
+        #         JOIN chains ON chain_2.parent = chains.key_column
+        # )
+        # SELECT
+        #     ch.*,
+        #     run.host,
+        #     run.timespan
+        # FROM
+        #     chains ch
+        #     LEFT OUTER JOIN run
+        #         ON ch.key_column = run.key_column;
+        #
+        chain_table = self._tables.collection_chain
+        collection_table = self._tables.collection
+        run_table = self._tables.run
+        key_column = self._collectionIdName
+
+        # First CTE select.
+        coll_1 = collection_table.alias("coll_1")
+        chains_cte = (
+            sqlalchemy.select(
+                *coll_1.columns,
+                sqlalchemy.cast(None, type_=key_type).label("parent"),
+                sqlalchemy.cast(None, type_=sqlalchemy.SmallInteger).label("position"),
+            )
+            .where(coll_1.columns["name"].in_(collections))
+            .cte("chains", recursive=True)
+        )
+
+        # Second CTE select.
+        cte_alias = chains_cte.alias()
+        coll_2 = collection_table.alias("coll_2")
+        chain_2 = chain_table.alias("chain_2")
+        chains_cte = chains_cte.union_all(
+            sqlalchemy.select(
+                *coll_2.columns, chain_2.columns["parent"], chain_2.columns["position"]
+            ).select_from(
+                coll_2.join(chain_2, onclause=(coll_2.columns[key_column] == chain_2.columns["child"])).join(
+                    cte_alias, onclause=(chain_2.columns["parent"] == cte_alias.columns[key_column])
+                )
+            )
+        )
+
+        # Outer select joining chains CTE with run table using LEFT OUTER JOIN.
+        TimespanReprClass = self._db.getTimespanRepresentation()
+        query = sqlalchemy.select(
+            *chains_cte.columns,
+            run_table.columns["host"],
+            *[run_table.columns[column] for column in TimespanReprClass.getFieldNames()],
+        ).select_from(
+            chains_cte.join(
+                run_table,
+                isouter=True,
+                onclause=(chains_cte.columns[key_column] == run_table.columns[key_column]),
+            )
+        )
+
+        with self._db.transaction():
+            with self._db.query(query) as sql_result:
+                return list(sql_result.mappings().fetchall())
 
 
 class _CollectionChainModificationContext(NamedTuple, Generic[K]):

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -527,7 +527,6 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         wildcard: CollectionWildcard,
         *,
         collection_types: Set[CollectionType] = CollectionType.all(),
-        done: set[str] | None = None,
         flatten_chains: bool = True,
         include_chains: bool | None = None,
     ) -> list[CollectionRecord[_Key]]:
@@ -539,11 +538,6 @@ class CollectionManager(Generic[_Key], VersionedExtension):
             Names and/or patterns for collections.
         collection_types : `collections.abc.Set` [ `CollectionType` ], optional
             If provided, only yield collections of these types.
-        done : `set` [ `str` ], optional
-            A `set` of collection names that will not be returned (presumably
-            because they have already been returned in some higher-level logic)
-            that will also be updated with the names of the collections
-            returned.
         flatten_chains : `bool`, optional
             If `True` (default) recursively yield the child collections of
             `~CollectionType.CHAINED` collections.

--- a/python/lsst/daf/butler/registry/queries/_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_query_backend.py
@@ -123,7 +123,6 @@ class QueryBackend(Generic[_C]):
         expression: Any,
         *,
         collection_types: Set[CollectionType] = CollectionType.all(),
-        done: set[str] | None = None,
         flatten_chains: bool = True,
         include_chains: bool | None = None,
     ) -> list[CollectionRecord]:
@@ -136,9 +135,6 @@ class QueryBackend(Generic[_C]):
             `CollectionWildcard.from_expression`.
         collection_types : `collections.abc.Set` [ `CollectionType` ], optional
             If provided, only yield collections of these types.
-        done : `set` [ `str` ], optional
-            A set of collection names that should be skipped, updated to
-            include all processed collection names on return.
         flatten_chains : `bool`, optional
             If `True` (default) recursively yield the child collections of
             `~CollectionType.CHAINED` collections.

--- a/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
@@ -94,7 +94,6 @@ class SqlQueryBackend(QueryBackend[SqlQueryContext]):
         expression: Any,
         *,
         collection_types: Set[CollectionType] = CollectionType.all(),
-        done: set[str] | None = None,
         flatten_chains: bool = True,
         include_chains: bool | None = None,
     ) -> list[CollectionRecord]:
@@ -102,7 +101,6 @@ class SqlQueryBackend(QueryBackend[SqlQueryContext]):
         return self._managers.collections.resolve_wildcard(
             expression,
             collection_types=collection_types,
-            done=done,
             flatten_chains=flatten_chains,
             include_chains=include_chains,
         )


### PR DESCRIPTION
This replaces Python-side recursive collection search, which caused
database query per collection with a call to collection manager
`resolve_wildcard` which is more efficient.

The code now uses recursive CTE in some cases to query collections
and their children. This results in reduced number of queries when
querying complex collection chains.

Small refactoring of collections manager, trying to simplify `resolve_wildcard`
method and possibly improve its performance.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
