### PR TITLE
DM-45386: Fix serialization of datetime64 to parquet via numpy and astropy.

### DIFF
--- a/doc/changes/DM-45386.bugfix.md
+++ b/doc/changes/DM-45386.bugfix.md
@@ -1,0 +1,2 @@
+Fix bug where datetime columns would serialize to parquet from pandas but not
+from astropy or numpy.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1248,6 +1248,11 @@ def _numpy_dtype_to_arrow_types(dtype: np.dtype) -> list[Any]:
                 pa.from_numpy_dtype(cast(tuple[np.dtype, tuple[int, ...]], dt.subdtype)[0].type),
                 prod(dt.shape),
             )
+        elif dt.type == np.datetime64:
+            time_unit = "ns" if "ns" in dt.str else "us"
+            # The pa.timestamp() is the correct datatype to round-trip
+            # a numpy datetime64[ns] or datetime[us] array.
+            arrow_type = pa.timestamp(time_unit)
         else:
             try:
                 arrow_type = pa.from_numpy_dtype(dt.type)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -30,6 +30,7 @@
 Tests in this module are disabled unless pandas and pyarrow are importable.
 """
 
+import datetime
 import os
 import unittest
 
@@ -138,6 +139,8 @@ def _makeSimpleNumpyTable(include_multidim=False, include_bigendian=False):
         ("f", "i8"),
         ("strcol", "U10"),
         ("bytecol", "a10"),
+        ("dtn", "datetime64[ns]"),
+        ("dtu", "datetime64[us]"),
     ]
 
     if include_multidim:
@@ -161,6 +164,8 @@ def _makeSimpleNumpyTable(include_multidim=False, include_bigendian=False):
     data["f"] = np.arange(nrow) * 10
     data["strcol"][:] = "teststring"
     data["bytecol"][:] = "teststring"
+    data["dtn"] = datetime.datetime.fromisoformat("2024-07-23")
+    data["dtu"] = datetime.datetime.fromisoformat("2024-07-23")
 
     if include_multidim:
         data["d1"] = np.random.randn(data["d1"].size).reshape(data["d1"].shape)
@@ -900,6 +905,10 @@ class ParquetFormatterArrowAstropyTestCase(unittest.TestCase):
 
     def testAstropyParquet(self):
         tab1 = _makeSimpleAstropyTable()
+
+        # Remove datetime column which doesn't work with astropy currently.
+        del tab1["dtn"]
+        del tab1["dtu"]
 
         fname = os.path.join(self.root, "test_astropy.parq")
         tab1.write(fname)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
