### PR TITLE
DM-45489: Add more test cover for RemoteButler queries

### DIFF
--- a/python/lsst/daf/butler/queries/convert_args.py
+++ b/python/lsst/daf/butler/queries/convert_args.py
@@ -35,6 +35,7 @@ __all__ = (
 from collections.abc import Mapping, Set
 from typing import Any
 
+from .._exceptions import InvalidQueryError
 from ..dimensions import DataCoordinate, DataId, DimensionGroup
 from ._expression_strings import convert_expression_string_to_predicate
 from ._identifiers import IdentifierContext, interpret_identifier
@@ -147,6 +148,8 @@ def convert_order_by_args(
                 if arg.startswith("-"):
                     reverse = True
                     arg = arg[1:]
+                if len(arg) == 0:
+                    raise InvalidQueryError("Empty dimension name in ORDER BY")
                 arg = interpret_identifier(context, arg)
                 if reverse:
                     arg = Reversed(operand=arg)

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -3231,7 +3231,7 @@ class RegistryTests(ABC):
 
         # errors in a name
         for order_by in ("", "-"):
-            with self.assertRaisesRegex(ValueError, "Empty dimension name in ORDER BY"):
+            with self.assertRaisesRegex((ValueError, InvalidQueryError), "Empty dimension name in ORDER BY"):
                 list(do_query().order_by(order_by))
 
         for order_by in ("undimension.name", "-undimension.name"):

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -3008,7 +3008,7 @@ class RegistryTests(ABC):
         ]
         with self.assertRaises(MissingDatasetTypeError):
             # Dataset type name doesn't match any existing dataset types.
-            registry.queryDataIds(["detector"], datasets=["nonexistent"], collections=...)
+            list(registry.queryDataIds(["detector"], datasets=["nonexistent"], collections=...))
         with self.assertRaises(MissingDatasetTypeError):
             # Dataset type name doesn't match any existing dataset types.
             registry.queryDimensionRecords("detector", datasets=["nonexistent"], collections=...).any()

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -57,6 +57,7 @@ from ..registry import (
     Registry,
     RegistryDefaults,
 )
+from ..registry._exceptions import ArgumentError
 from ..registry.queries import (
     ChainedDatasetQueryResults,
     DataCoordinateQueryResults,
@@ -448,6 +449,9 @@ class RemoteButlerRegistry(Registry):
         check: bool = True,
         **kwargs: Any,
     ) -> DataCoordinateQueryResults:
+        if collections is not None and datasets is None:
+            raise ArgumentError(f"Cannot pass 'collections' (='{collections}') without 'datasets'.")
+
         dimensions = self.dimensions.conform(dimensions)
         args = self._convert_common_query_arguments(
             dataId=dataId, where=where, bind=bind, kwargs=kwargs, datasets=datasets, collections=collections


### PR DESCRIPTION
Fixed an issue where the "Hybrid" query results object for queryDataIds was testing the DirectButler implementation in some cases where it should have been testing the RemoteButler implementation.  This revealed some small missing exception handling and minor discrepancies between the two implementations, which are now fixed.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
