### PR TITLE
DM-45119: Update logic for checking overlap dimensions in relations

### DIFF
--- a/doc/changes/DM-45119.bugfix.md
+++ b/doc/changes/DM-45119.bugfix.md
@@ -1,0 +1,1 @@
+Fix for handling of dataset types that use `healpix11` dimensions, previously they caused exception in many query operations.

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -385,9 +385,9 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
     ) -> tuple[Relation, bool]:
         # Docstring inherited.
         overlap_relationship = frozenset(
-            self.universe[element1].dimensions.names | self.universe[element2].dimensions.names
+            self.universe[element1].required.names | self.universe[element2].required.names
         )
-        if overlap_relationship in existing_relationships:
+        if any(overlap_relationship.issubset(rel) for rel in existing_relationships):
             return context.preferred_engine.make_join_identity_relation(), False
         overlaps: Relation | None = None
         needs_refinement: bool = False

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -384,11 +384,18 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
         existing_relationships: Set[frozenset[str]] = frozenset(),
     ) -> tuple[Relation, bool]:
         # Docstring inherited.
-        overlap_relationship = frozenset(
-            self.universe[element1].required.names | self.universe[element2].required.names
-        )
-        if any(overlap_relationship.issubset(rel) for rel in existing_relationships):
+        group1 = self.universe[element1].minimal_group
+        group2 = self.universe[element2].minimal_group
+        overlap_relationships = {
+            frozenset(a | b)
+            for a, b in itertools.product(
+                [group1.names, group1.required],
+                [group2.names, group2.required],
+            )
+        }
+        if not overlap_relationships.isdisjoint(existing_relationships):
             return context.preferred_engine.make_join_identity_relation(), False
+
         overlaps: Relation | None = None
         needs_refinement: bool = False
         if element1 == self.universe.commonSkyPix.name:


### PR DESCRIPTION
New logic only checks for required elements instead of full set of
dimensions. This fixes special case of `healpix11` dataset types
in dc2 repo. There is no unit test for this special case, but I verified
that query-datasets and query-data-ids now work correctly.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
