### PR TITLE
DM-45616: Add a way for Butler server to serve static files

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/_config.py
+++ b/python/lsst/daf/butler/remote_butler/server/_config.py
@@ -1,0 +1,54 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import dataclasses
+import os
+
+
+@dataclasses.dataclass(frozen=True)
+class ButlerServerConfig:
+    """Butler server configuration loaded from environment variables.
+
+    Notes
+    -----
+    Besides these variables, there is one critical environment variable.  The
+    list of repositories to be hosted must be defined using
+     ``DAF_BUTLER_REPOSITORIES`` or ``DAF_BUTLER_REPOSITORY_INDEX`` -- see
+     `ButlerRepoIndex`.
+    """
+
+    static_files_path: str | None
+    """Absolute path to a directory of files that will be served to end-users
+    as static files from the `configs/` HTTP route.
+    """
+
+
+def load_config() -> ButlerServerConfig:
+    """Read the Butler server configuration from the environment."""
+    return ButlerServerConfig(static_files_path=os.environ.get("DAF_BUTLER_SERVER_STATIC_FILES_PATH"))

--- a/python/lsst/daf/butler/tests/server_utils.py
+++ b/python/lsst/daf/butler/tests/server_utils.py
@@ -70,5 +70,7 @@ def _is_authenticated_endpoint(path: str) -> bool:
         return False
     if path.endswith("/butler.json"):
         return False
+    if path.startswith("/api/butler/configs"):
+        return False
 
     return True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os.path
+import tempfile
 import unittest
 import uuid
 
@@ -105,6 +106,17 @@ class ButlerClientServerTestCase(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["name"], "butler")
+
+    def test_static_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "temp.txt"), "w") as fh:
+                fh.write("test data 123")
+
+            with mock_env({"DAF_BUTLER_SERVER_STATIC_FILES_PATH": tmpdir}):
+                with create_test_server(TESTDIR) as server:
+                    response = server.client.get("/api/butler/configs/temp.txt")
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response.text, "test data 123")
 
     def test_dimension_universe(self):
         universe = self.butler.dimensions


### PR DESCRIPTION
You can now set the environment variable DAF_BUTLER_SERVER_STATIC_FILES_PATH to point to a directory of static files to be served by Butler server from its `/configs/` HTTP path.

There isn't currently a good place for the DirectButler configuration files used in the RSP lab containers to live.  These need to be controlled by Phalanx so we can update them as part of the IDF deployment process, but Phalanx doesn't provide a convenient way of deploying static files.  Much of this configuration is shared with Butler server or updated at the same time that Butler server is updated.  So it is convenient for the moment to just serve these files from Butler server rather than standing up additional infrastructure to host them.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
