### PR TITLE
DM-45429: Initial implementation of a general query result

### DIFF
--- a/python/lsst/daf/butler/column_spec.py
+++ b/python/lsst/daf/butler/column_spec.py
@@ -53,6 +53,7 @@ from lsst.sphgeom import Region
 
 from . import arrow_utils, ddl
 from ._timespan import Timespan
+from .pydantic_utils import SerializableRegion, SerializableTime
 
 if TYPE_CHECKING:
     from .name_shrinker import NameShrinker
@@ -134,6 +135,18 @@ class _BaseColumnSpec(pydantic.BaseModel, ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        """Return pydantic type adapter that converts values of this column to
+        or from serializable format.
+
+        Returns
+        -------
+        type_adapter : `pydantic.TypeAdapter`
+            A converter instance.
+        """
+        raise NotImplementedError()
+
     def display(self, level: int = 0, tab: str = "  ") -> list[str]:
         """Return a human-reader-focused string description of this column as
         a list of lines.
@@ -178,6 +191,10 @@ class IntColumnSpec(_BaseColumnSpec):
         # Docstring inherited.
         return arrow_utils.ToArrow.for_primitive(self.name, pa.uint64(), nullable=self.nullable)
 
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
+
 
 @final
 class StringColumnSpec(_BaseColumnSpec):
@@ -197,6 +214,10 @@ class StringColumnSpec(_BaseColumnSpec):
     def to_arrow(self) -> arrow_utils.ToArrow:
         # Docstring inherited.
         return arrow_utils.ToArrow.for_primitive(self.name, pa.string(), nullable=self.nullable)
+
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
 
 
 @final
@@ -224,6 +245,10 @@ class HashColumnSpec(_BaseColumnSpec):
             nullable=self.nullable,
         )
 
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
+
 
 @final
 class FloatColumnSpec(_BaseColumnSpec):
@@ -238,6 +263,10 @@ class FloatColumnSpec(_BaseColumnSpec):
         assert self.nullable is not None, "nullable=None should be resolved by validators"
         return arrow_utils.ToArrow.for_primitive(self.name, pa.float64(), nullable=self.nullable)
 
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
+
 
 @final
 class BoolColumnSpec(_BaseColumnSpec):
@@ -250,6 +279,10 @@ class BoolColumnSpec(_BaseColumnSpec):
     def to_arrow(self) -> arrow_utils.ToArrow:
         # Docstring inherited.
         return arrow_utils.ToArrow.for_primitive(self.name, pa.bool_(), nullable=self.nullable)
+
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
 
 
 @final
@@ -264,6 +297,10 @@ class UUIDColumnSpec(_BaseColumnSpec):
         # Docstring inherited.
         assert self.nullable is not None, "nullable=None should be resolved by validators"
         return arrow_utils.ToArrow.for_uuid(self.name, nullable=self.nullable)
+
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
 
 
 @final
@@ -284,6 +321,10 @@ class RegionColumnSpec(_BaseColumnSpec):
         assert self.nullable is not None, "nullable=None should be resolved by validators"
         return arrow_utils.ToArrow.for_region(self.name, nullable=self.nullable)
 
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(SerializableRegion)
+
 
 @final
 class TimespanColumnSpec(_BaseColumnSpec):
@@ -298,6 +339,10 @@ class TimespanColumnSpec(_BaseColumnSpec):
     def to_arrow(self) -> arrow_utils.ToArrow:
         # Docstring inherited.
         return arrow_utils.ToArrow.for_timespan(self.name, nullable=self.nullable)
+
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(self.pytype)
 
 
 @final
@@ -314,6 +359,10 @@ class DateTimeColumnSpec(_BaseColumnSpec):
         # Docstring inherited.
         assert self.nullable is not None, "nullable=None should be resolved by validators"
         return arrow_utils.ToArrow.for_datetime(self.name, nullable=self.nullable)
+
+    def type_adapter(self) -> pydantic.TypeAdapter:
+        # Docstring inherited.
+        return pydantic.TypeAdapter(SerializableTime)
 
 
 ColumnSpec = Annotated[

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -2193,32 +2193,19 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # Docstring inherited.
         return self._registry.dimensions
 
-    @contextlib.contextmanager
-    def _query(self) -> Iterator[Query]:
+    def _query(self) -> contextlib.AbstractContextManager[Query]:
         # Docstring inherited.
-        with self._query_driver(self._registry.defaults.collections, self.registry.defaults.dataId) as driver:
-            yield Query(driver)
+        return self._registry._query()
 
-    @contextlib.contextmanager
     def _query_driver(
         self,
         default_collections: Iterable[str],
         default_data_id: DataCoordinate,
-    ) -> Iterator[DirectQueryDriver]:
+    ) -> contextlib.AbstractContextManager[DirectQueryDriver]:
         """Set up a QueryDriver instance for use with this Butler.  Although
         this is marked as a private method, it is also used by Butler server.
         """
-        with self._caching_context():
-            driver = DirectQueryDriver(
-                self._registry._db,
-                self.dimensions,
-                self._registry._managers,
-                self._registry.dimension_record_cache,
-                default_collections=default_collections,
-                default_data_id=default_data_id,
-            )
-            with driver:
-                yield driver
+        return self._registry._query_driver(default_collections, default_data_id)
 
     def _preload_cache(self) -> None:
         """Immediately load caches that are used for common operations."""

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -79,6 +79,7 @@ from ._result_page_converter import (
     DataCoordinateResultPageConverter,
     DatasetRefResultPageConverter,
     DimensionRecordResultPageConverter,
+    GeneralResultPageConverter,
     ResultPageConverter,
     ResultPageConverterContext,
 )
@@ -271,6 +272,8 @@ class DirectQueryDriver(QueryDriver):
                 return DatasetRefResultPageConverter(
                     spec, self.get_dataset_type(spec.dataset_type_name), context
                 )
+            case GeneralResultSpec():
+                return GeneralResultPageConverter(spec, context)
             case _:
                 raise NotImplementedError(f"Result type '{spec.result_type}' not yet implemented")
 

--- a/python/lsst/daf/butler/queries/__init__.py
+++ b/python/lsst/daf/butler/queries/__init__.py
@@ -29,4 +29,5 @@ from ._base import *
 from ._data_coordinate_query_results import *
 from ._dataset_query_results import *
 from ._dimension_record_query_results import *
+from ._general_query_results import *
 from ._query import *

--- a/python/lsst/daf/butler/queries/_general_query_results.py
+++ b/python/lsst/daf/butler/queries/_general_query_results.py
@@ -1,0 +1,125 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("GeneralQueryResults",)
+
+from collections.abc import Iterator
+from typing import Any, final
+
+from .._dataset_ref import DatasetRef
+from .._dataset_type import DatasetType
+from ..dimensions import DataCoordinate, DimensionGroup
+from ._base import QueryResultsBase
+from .driver import QueryDriver
+from .result_specs import GeneralResultSpec
+from .tree import QueryTree, ResultColumn
+
+
+@final
+class GeneralQueryResults(QueryResultsBase):
+    """A query for `DatasetRef` results with a single dataset type.
+
+    Parameters
+    ----------
+    driver : `QueryDriver`
+        Implementation object that knows how to actually execute queries.
+    tree : `QueryTree`
+        Description of the query as a tree of joins and column expressions. The
+        instance returned directly by the `Butler._query` entry point should be
+        constructed via `make_unit_query_tree`.
+    spec : `GeneralResultSpec`
+        Specification of the query result rows, including output columns,
+        ordering, and slicing.
+
+    Notes
+    -----
+    This class should never be constructed directly by users; use `Query`
+    methods instead.
+    """
+
+    def __init__(self, driver: QueryDriver, tree: QueryTree, spec: GeneralResultSpec):
+        spec.validate_tree(tree)
+        super().__init__(driver, tree)
+        self._spec = spec
+
+    def __iter__(self) -> Iterator[dict[ResultColumn, Any]]:
+        """Iterate over result rows.
+
+        Yields
+        ------
+        row_dict : `dict` [`ResultColumn`, `Any`]
+            Result row as dictionary, the keys are `ResultColumn` instances.
+        """
+        for page in self._driver.execute(self._spec, self._tree):
+            columns = tuple(page.spec.get_result_columns())
+            for row in page.rows:
+                yield dict(zip(columns, row))
+
+    def iter_refs(self, dataset_type: DatasetType) -> Iterator[tuple[DatasetRef, dict[ResultColumn, Any]]]:
+        """Iterate over result rows and return DatasetRef constructed from each
+        row and an original row.
+
+        Parameters
+        ----------
+        dataset_type : `DatasetType`
+            Type of the dataset to return.
+
+        Yields
+        ------
+        dataset_ref : `DatasetRef`
+            Dataset reference.
+        row_dict : `dict` [`ResultColumn`, `Any`]
+            Result row as dictionary, the keys are `ResultColumn` instances.
+        """
+        dimensions = dataset_type.dimensions
+        id_key = ResultColumn(logical_table=dataset_type.name, field="dataset_id")
+        run_key = ResultColumn(logical_table=dataset_type.name, field="run")
+        data_id_keys = [ResultColumn(logical_table=element, field=None) for element in dimensions.required]
+        for row in self:
+            values = tuple(row[key] for key in data_id_keys)
+            data_id = DataCoordinate.from_required_values(dimensions, values)
+            ref = DatasetRef(dataset_type, data_id, row[run_key], id=row[id_key])
+            yield ref, row
+
+    @property
+    def dimensions(self) -> DimensionGroup:
+        # Docstring inherited
+        return self._spec.dimensions
+
+    def count(self, *, exact: bool = True, discard: bool = False) -> int:
+        # Docstring inherited.
+        return self._driver.count(self._tree, self._spec, exact=exact, discard=discard)
+
+    def _copy(self, tree: QueryTree, **kwargs: Any) -> GeneralQueryResults:
+        # Docstring inherited.
+        return GeneralQueryResults(self._driver, tree, self._spec.model_copy(update=kwargs))
+
+    def _get_datasets(self) -> frozenset[str]:
+        # Docstring inherited.
+        return frozenset(self._spec.dataset_fields)

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 __all__ = ("Query",)
 
 from collections.abc import Iterable, Mapping, Set
+from types import EllipsisType
 from typing import Any, final
 
 from lsst.utils.iteration import ensure_iterable
@@ -44,6 +45,7 @@ from ._data_coordinate_query_results import DataCoordinateQueryResults
 from ._dataset_query_results import DatasetRefQueryResults
 from ._dimension_record_query_results import DimensionRecordQueryResults
 from ._general_query_results import GeneralQueryResults
+from ._identifiers import IdentifierContext, interpret_identifier
 from .convert_args import convert_where_args
 from .driver import QueryDriver
 from .expression_factory import ExpressionFactory
@@ -53,7 +55,17 @@ from .result_specs import (
     DimensionRecordResultSpec,
     GeneralResultSpec,
 )
-from .tree import DatasetFieldName, DatasetSearch, Predicate, QueryTree, make_identity_query_tree
+from .tree import (
+    DATASET_FIELD_NAMES,
+    DatasetFieldName,
+    DatasetFieldReference,
+    DatasetSearch,
+    DimensionFieldReference,
+    DimensionKeyReference,
+    Predicate,
+    QueryTree,
+    make_identity_query_tree,
+)
 
 
 @final
@@ -301,8 +313,9 @@ class Query(QueryBase):
     def general(
         self,
         dimensions: DimensionGroup,
-        dimension_fields: Mapping[str, set[str]] = {},
-        dataset_fields: Mapping[str, set[DatasetFieldName]] = {},
+        *names: str,
+        dimension_fields: Mapping[str, Set[str]] = {},
+        dataset_fields: Mapping[str, Set[DatasetFieldName] | EllipsisType] = {},
         find_first: bool = False,
     ) -> GeneralQueryResults:
         """Execute query returning general result.
@@ -311,14 +324,18 @@ class Query(QueryBase):
         ----------
         dimensions : `DimensionGroup`
             The dimensions that span all fields returned by this query.
-        dimension_fields : `~collections.abc.Mapping` [`str`, `set`[`str`]], \
-                optional
+        *names : `str`
+            Names of dimensions fields (in  "dimension.field" format), dataset
+            fields (in  "dataset_type.field" format) to include in this query.
+        dimension_fields : `~collections.abc.Mapping` [`str`, \
+                `~collections.abc.Set`[`str`]], optional
             Dimension record fields included in this query, the key in the
             mapping is dimension name.
-        dataset_fields : `~collections.abc.Mapping` \
-                [`str`, `set`[`DatasetFieldName`]], optional
+        dataset_fields : `~collections.abc.Mapping` [`str`, \
+            `~collections.abc.Set`[`DatasetFieldName`] | ...], optional
             Dataset fields included in this query, the key in the mapping is
-            dataset type name.
+            dataset type name. Ellipsis (``...``) can be used for value
+            to include all dataset fields.
         find_first : bool, optional
             Whether this query requires find-first resolution for a dataset.
             This can only be `True` if exactly one dataset type's fields are
@@ -329,13 +346,42 @@ class Query(QueryBase):
         result : `GeneralQueryResults`
             Query result that can be iterated over.
         """
+        dimension_fields_dict = {name: set(fields) for name, fields in dimension_fields.items()}
+        dataset_fields_dict = {
+            name: set(DATASET_FIELD_NAMES) if fields is ... else set(fields)
+            for name, fields in dataset_fields.items()
+        }
+        # Parse all names.
+        context = IdentifierContext(dimensions, set(self._tree.datasets))
+        extra_dimension_names: set[str] = set()
+        for name in names:
+            identifier = interpret_identifier(context, name)
+            match identifier:
+                case DimensionKeyReference(dimension=dimension):
+                    # Could be because someone asked for the key field.
+                    extra_dimension_names.add(dimension.name)
+                case DimensionFieldReference(element=element, field=field):
+                    extra_dimension_names.add(element.name)
+                    dimension_fields_dict.setdefault(element.name, set()).add(field)
+                case DatasetFieldReference(dataset_type=dataset_type, field=dataset_field):
+                    dataset_fields_dict.setdefault(dataset_type, set()).add(dataset_field)
+                case _:
+                    raise TypeError(f"Unexpected type of identifier ({name}): {identifier}")
+
+        extra_dimensions = dimensions.universe.conform(extra_dimension_names)
+
+        # Merge missing dimensions into the tree.
+        tree = self._tree
+        if not extra_dimensions <= tree.dimensions:
+            tree = tree.join_dimensions(extra_dimensions)
+
         result_spec = GeneralResultSpec(
-            dimensions=dimensions,
-            dimension_fields=dimension_fields,
-            dataset_fields=dataset_fields,
+            dimensions=dimensions.union(extra_dimensions),
+            dimension_fields=dimension_fields_dict,
+            dataset_fields=dataset_fields_dict,
             find_first=find_first,
         )
-        return GeneralQueryResults(self._driver, tree=self._tree, spec=result_spec)
+        return GeneralQueryResults(self._driver, tree=tree, spec=result_spec)
 
     def materialize(
         self,

--- a/python/lsst/daf/butler/queries/driver.py
+++ b/python/lsst/daf/butler/queries/driver.py
@@ -116,7 +116,8 @@ class GeneralResultPage:
 
     spec: GeneralResultSpec
 
-    # Raw tabular data, with columns in the same order as spec.columns.
+    # Raw tabular data, with columns in the same order as
+    # spec.get_result_columns().
     rows: list[tuple[Any, ...]]
 
 

--- a/python/lsst/daf/butler/queries/tree/_column_set.py
+++ b/python/lsst/daf/butler/queries/tree/_column_set.py
@@ -376,6 +376,9 @@ class ResultColumn(NamedTuple):
     """Column associated with the dimension element or dataset type, or `None`
     if it is a dimension key column."""
 
+    def __str__(self) -> str:
+        return self.logical_table if self.field is None else f"{self.logical_table}.{self.field}"
+
 
 class ColumnOrder:
     """Defines the position of columns within a result row and provides helper

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -504,7 +504,11 @@ class _RangeTimespanRepresentation(TimespanDatabaseRepresentation):
     def fromLiteral(cls, timespan: Timespan | None) -> _RangeTimespanRepresentation:
         # Docstring inherited.
         if timespan is None:
-            return cls(column=sqlalchemy.sql.null(), name=cls.NAME)
+            # Cast NULL to an expected type, helps Postgres to figure out
+            # column type when doing UNION.
+            return cls(
+                column=sqlalchemy.func.cast(sqlalchemy.sql.null(), type_=_RangeTimespanType), name=cls.NAME
+            )
         return cls(
             column=sqlalchemy.sql.cast(
                 sqlalchemy.sql.literal(timespan, type_=_RangeTimespanType), type_=_RangeTimespanType

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -612,7 +612,7 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
             )
             if "timespan" in fields:
                 tags_builder.joiner.timespans[self.datasetType.name] = (
-                    self._db.getTimespanRepresentation().fromLiteral(Timespan(None, None))
+                    self._db.getTimespanRepresentation().fromLiteral(None)
                 )
         calibs_builder: QueryBuilder | None = None
         if CollectionType.CALIBRATION in collection_types:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_storage.py
@@ -622,16 +622,15 @@ class ByDimensionsDatasetRecordStorage(DatasetRecordStorage):
             assert (
                 self._calibs is not None
             ), "DatasetTypes with isCalibration() == False can never be found in a CALIBRATION collection."
+            calibs_table = self._calibs.alias(f"{self.datasetType.name}_calibs")
             calibs_builder = self._finish_query_builder(
-                QueryJoiner(self._db, self._calibs.alias(f"{self.datasetType.name}_calibs")).to_builder(
-                    columns
-                ),
+                QueryJoiner(self._db, calibs_table).to_builder(columns),
                 [record for record in collections if record.type is CollectionType.CALIBRATION],
                 fields,
             )
             if "timespan" in fields:
                 calibs_builder.joiner.timespans[self.datasetType.name] = (
-                    self._db.getTimespanRepresentation().from_columns(self._calibs.columns)
+                    self._db.getTimespanRepresentation().from_columns(calibs_table.columns)
                 )
 
             # In calibration collections, we need timespan as well as data ID

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2434,9 +2434,8 @@ class SqlRegistry:
             )
             timespan_key = f"{datasetType.name}.timespan"
             collection_key = f"{datasetType.name}.collection"
-            for ref, row_dict in result.iter_refs(datasetType):
-                _LOG.debug("row_dict: %s", row_dict)
-                yield DatasetAssociation(ref, row_dict[collection_key], row_dict[timespan_key])
+            for _, refs, row_dict in result.iter_tuples(datasetType):
+                yield DatasetAssociation(refs[0], row_dict[collection_key], row_dict[timespan_key])
 
     def get_datastore_records(self, ref: DatasetRef) -> DatasetRef:
         """Retrieve datastore records for given ref.

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2432,10 +2432,7 @@ class SqlRegistry:
                 datasetType.dimensions,
                 dataset_fields={datasetType.name: {"dataset_id", "run", "collection", "timespan"}},
             )
-            timespan_key = f"{datasetType.name}.timespan"
-            collection_key = f"{datasetType.name}.collection"
-            for _, refs, row_dict in result.iter_tuples(datasetType):
-                yield DatasetAssociation(refs[0], row_dict[collection_key], row_dict[timespan_key])
+            yield from DatasetAssociation.from_query_result(result, datasetType)
 
     def get_datastore_records(self, ref: DatasetRef) -> DatasetRef:
         """Retrieve datastore records for given ref.

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -271,14 +271,11 @@ def _convert_query_result_page(
 def _convert_general_result(spec: GeneralResultSpec, model: GeneralResultModel) -> GeneralResultPage:
     """Convert GeneralResultModel to a general result page."""
     columns = spec.get_result_columns()
-    type_adapters = [
-        columns.get_column_spec(column.logical_table, column.field).type_adapter() for column in columns
+    serializers = [
+        columns.get_column_spec(column.logical_table, column.field).serializer() for column in columns
     ]
     rows = [
-        tuple(
-            value if value is None else type_adapter.validate_python(value)
-            for value, type_adapter in zip(row, type_adapters)
-        )
+        tuple(serializer.deserialize(value) for value, serializer in zip(row, serializers))
         for row in model.rows
     ]
     return GeneralResultPage(spec=spec, rows=rows)

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -66,6 +66,7 @@ from ._http_connection import RemoteButlerHttpConnection, parse_model
 from .server_models import (
     AdditionalQueryInput,
     DataCoordinateUpload,
+    GeneralResultModel,
     MaterializedQuery,
     QueryAnyRequestModel,
     QueryAnyResponseModel,
@@ -260,5 +261,24 @@ def _convert_query_result_page(
             spec=result_spec,
             rows=[DatasetRef.from_simple(r, universe) for r in result.rows],
         )
+    elif result_spec.result_type == "general":
+        assert result.type == "general"
+        return _convert_general_result(result_spec, result)
     else:
         raise NotImplementedError(f"Unhandled result type {result_spec.result_type}")
+
+
+def _convert_general_result(spec: GeneralResultSpec, model: GeneralResultModel) -> GeneralResultPage:
+    """Convert GeneralResultModel to a general result page."""
+    columns = spec.get_result_columns()
+    type_adapters = [
+        columns.get_column_spec(column.logical_table, column.field).type_adapter() for column in columns
+    ]
+    rows = [
+        tuple(
+            value if value is None else type_adapter.validate_python(value)
+            for value, type_adapter in zip(row, type_adapters)
+        )
+        for row in model.rows
+    ]
+    return GeneralResultPage(spec=spec, rows=rows)

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -527,8 +527,8 @@ class RemoteButlerRegistry(Registry):
             )
             timespan_key = f"{datasetType.name}.timespan"
             collection_key = f"{datasetType.name}.collection"
-            for ref, row_dict in result.iter_refs(datasetType):
-                yield DatasetAssociation(ref, row_dict[collection_key], row_dict[timespan_key])
+            for _, refs, row_dict in result.iter_tuples(datasetType):
+                yield DatasetAssociation(refs[0], row_dict[collection_key], row_dict[timespan_key])
 
     @property
     def storageClasses(self) -> StorageClassFactory:

--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -525,10 +525,7 @@ class RemoteButlerRegistry(Registry):
                 datasetType.dimensions,
                 dataset_fields={datasetType.name: {"dataset_id", "run", "collection", "timespan"}},
             )
-            timespan_key = f"{datasetType.name}.timespan"
-            collection_key = f"{datasetType.name}.collection"
-            for _, refs, row_dict in result.iter_tuples(datasetType):
-                yield DatasetAssociation(refs[0], row_dict[collection_key], row_dict[timespan_key])
+            yield from DatasetAssociation.from_query_result(result, datasetType)
 
     @property
     def storageClasses(self) -> StorageClassFactory:

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
@@ -98,14 +98,10 @@ def _convert_query_page(spec: ResultSpec, page: ResultPage) -> QueryExecuteResul
 def _convert_general_result(page: GeneralResultPage) -> GeneralResultModel:
     """Convert GeneralResultPage to a serializable model."""
     columns = page.spec.get_result_columns()
-    type_adapters = [
-        columns.get_column_spec(column.logical_table, column.field).type_adapter() for column in columns
+    serializers = [
+        columns.get_column_spec(column.logical_table, column.field).serializer() for column in columns
     ]
     rows = [
-        tuple(
-            value if value is None else type_adapter.dump_python(value)
-            for value, type_adapter in zip(row, type_adapters)
-        )
-        for row in page.rows
+        tuple(serializer.serialize(value) for value, serializer in zip(row, serializers)) for row in page.rows
     ]
     return GeneralResultModel(rows=rows)

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -37,7 +37,7 @@ __all__ = [
     "GetCollectionSummaryResponseModel",
 ]
 
-from typing import Annotated, Literal, NewType, TypeAlias
+from typing import Annotated, Any, Literal, NewType, TypeAlias
 from uuid import UUID
 
 import pydantic
@@ -276,6 +276,13 @@ class DatasetRefResultModel(pydantic.BaseModel):
     rows: list[SerializedDatasetRef]
 
 
+class GeneralResultModel(pydantic.BaseModel):
+    """Result model for /query/execute/ when user requested general results."""
+
+    type: Literal["general"] = "general"
+    rows: list[tuple[Any, ...]]
+
+
 class QueryErrorResultModel(pydantic.BaseModel):
     """Result model for /query/execute when an error occurs part-way through
     returning rows.
@@ -293,7 +300,11 @@ class QueryErrorResultModel(pydantic.BaseModel):
 
 
 QueryExecuteResultData: TypeAlias = Annotated[
-    DataCoordinateResultModel | DimensionRecordsResultModel | DatasetRefResultModel | QueryErrorResultModel,
+    DataCoordinateResultModel
+    | DimensionRecordsResultModel
+    | DatasetRefResultModel
+    | GeneralResultModel
+    | QueryErrorResultModel,
     pydantic.Field(discriminator="type"),
 ]
 

--- a/python/lsst/daf/butler/tests/hybrid_butler_registry.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_registry.py
@@ -372,7 +372,7 @@ class HybridButlerRegistry(Registry):
         collectionTypes: Iterable[CollectionType] = CollectionType.all(),
         flattenChains: bool = False,
     ) -> Iterator[DatasetAssociation]:
-        return self._direct.queryDatasetAssociations(
+        return self._remote.queryDatasetAssociations(
             datasetType, collections, collectionTypes=collectionTypes, flattenChains=flattenChains
         )
 


### PR DESCRIPTION
Registry method `queryDatasetAssociations` is reimplemented (for both
direct and remote butler) to use new query system and new general query
result class.


## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
