### PR TITLE
DM-45726: Pass Butler to RepoExportContext rather than Registry

### DIFF
--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1607,9 +1607,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         with open(filename, "w") as stream:
             backend = BackendClass(stream, universe=self.dimensions)
             try:
-                helper = RepoExportContext(
-                    self._registry, self._datastore, backend=backend, directory=directory, transfer=transfer
-                )
+                helper = RepoExportContext(self, backend=backend, directory=directory, transfer=transfer)
                 with self._caching_context():
                     yield helper
             except BaseException:


### PR DESCRIPTION
Registry is being deprecated.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
