### PR TITLE
DM-45752: Support region overlap against points

### DIFF
--- a/doc/changes/DM-45752.feature.md
+++ b/doc/changes/DM-45752.feature.md
@@ -1,0 +1,4 @@
+Region overlap queries can now use points as regions.  Points can be specified
+as `region OVERLAPS POINT(ra, dec)`, or by binding an `lsst.sphgeom.LonLat` or
+`astropy.coordinates.SkyCoord` value.  (At the moment, this feature is only
+available when using client/server Butler.)

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -292,29 +292,16 @@ Here are few examples for checking containment in a time range:
     timestamp_id IN (interval.begin, interval.end)
     range_id NOT IN (interval_id)
 
-The same ``IN`` operator can be used for checking containment of a point or
-region inside other region. Presently there are no special literal type for
-regions, so this can only be done with regions represented by identifiers. Few
-examples of region containment:
-
-.. code-block:: sql
-
-    POINT(ra, dec) IN (region1)
-    region2 NOT IN (region1)
-
-
 OVERLAPS operator
 ^^^^^^^^^^^^^^^^^
 
 The ``OVERLAPS`` operator checks for overlapping time ranges or regions, its
 arguments have to have consistent types. Like with ``IN`` operator time ranges
 can be represented with a tuple of two timestamps (literals or identifiers) or
-with a single identifier. Regions can only be used as identifiers.
-``OVERLAPS`` syntax is similar to ``IN`` but it does not require  parentheses
-on right hand side when there is a single identifier representing a time range
-or a region.
+with a single identifier.
 
-Few examples of the syntax:
+
+Examples of the syntax for time ranges:
 
 .. code-block:: sql
 
@@ -322,8 +309,24 @@ Few examples of the syntax:
     (interval.begin, interval.end) OVERLAPS interval_2
     interval_1 OVERLAPS interval_2
 
-    NOT (region_1 OVERLAPS region_2)
+You can check for overlap of a region with a point using the ``POINT(ra, dec)`` syntax,
+where ``ra`` and ``dec`` are specified as an ICRS sky position in degrees.
 
+.. code-block:: sql
+
+    visit.region OVERLAPS POINT(53.6, -32.7)
+
+You can check overlaps with arbitrary sky regions by binding values (see
+:ref:`_daf_butler_dimension_expressions_identifiers`).  Bound region values may
+be specified as the following object types:
+
+-  ``lsst.sphgeom.Region``
+-  ``lsst.sphgeom.LonLat``
+-  ``astropy.coordinates.SkyCoord``
+
+.. code-block:: sql
+
+    visit.region OVERLAPS my_region
 
 Boolean operators
 ^^^^^^^^^^^^^^^^^

--- a/python/lsst/daf/butler/queries/tree/_column_literal.py
+++ b/python/lsst/daf/butler/queries/tree/_column_literal.py
@@ -390,6 +390,12 @@ def make_column_literal(value: LiteralValue) -> ColumnLiteral:
             return _make_region_literal_from_lonlat(value)
         case astropy.coordinates.SkyCoord():
             icrs = value.transform_to("icrs")
+            if not icrs.isscalar:
+                raise ValueError(
+                    "Astropy SkyCoord contained an array of points,"
+                    f" but it should be only a single point: {value}"
+                )
+
             ra = icrs.ra.degree
             dec = icrs.dec.degree
             lon_lat = lsst.sphgeom.LonLat.fromDegrees(ra, dec)

--- a/python/lsst/daf/butler/queries/tree/_column_literal.py
+++ b/python/lsst/daf/butler/queries/tree/_column_literal.py
@@ -42,14 +42,23 @@ from typing import Literal, TypeAlias, Union, final
 
 import astropy.time
 import erfa
-from lsst.sphgeom import Region
+import lsst.sphgeom
 
 from ..._timespan import Timespan
 from ...time_utils import TimeConverter
 from ._base import ColumnLiteralBase
 
 LiteralValue: TypeAlias = (
-    int | str | float | bytes | uuid.UUID | astropy.time.Time | datetime.datetime | Timespan | Region
+    int
+    | str
+    | float
+    | bytes
+    | uuid.UUID
+    | astropy.time.Time
+    | datetime.datetime
+    | Timespan
+    | lsst.sphgeom.Region
+    | lsst.sphgeom.LonLat
 )
 
 
@@ -310,10 +319,10 @@ class RegionColumnLiteral(ColumnLiteralBase):
     @cached_property
     def value(self) -> bytes:
         """The wrapped value."""
-        return Region.decode(b64decode(self.encoded))
+        return lsst.sphgeom.Region.decode(b64decode(self.encoded))
 
     @classmethod
-    def from_value(cls, value: Region) -> RegionColumnLiteral:
+    def from_value(cls, value: lsst.sphgeom.Region) -> RegionColumnLiteral:
         """Construct from the wrapped value.
 
         Parameters
@@ -374,6 +383,12 @@ def make_column_literal(value: LiteralValue) -> ColumnLiteral:
             return DateTimeColumnLiteral.from_value(astropy.time.Time(value))
         case Timespan():
             return TimespanColumnLiteral.from_value(value)
-        case Region():
+        case lsst.sphgeom.Region():
             return RegionColumnLiteral.from_value(value)
+        case lsst.sphgeom.LonLat():
+            vec = lsst.sphgeom.UnitVector3d(value)
+            # Convert the point to a Region by representing it as a zero-radius
+            # Circle.
+            region = lsst.sphgeom.Circle(vec)
+            return RegionColumnLiteral.from_value(region)
     raise TypeError(f"Invalid type {type(value).__name__!r} of value {value!r} for column literal.")

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
@@ -45,6 +45,7 @@ __all__ = [
     "IsIn",
     "NumericLiteral",
     "Parens",
+    "PointNode",
     "RangeLiteral",
     "StringLiteral",
     "TimeLiteral",

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 if TYPE_CHECKING:
     import astropy.time
 
-    from .exprTree import Node, RangeLiteral
+    from .exprTree import Node, PointNode, RangeLiteral
 
 
 T = TypeVar("T")
@@ -228,7 +228,7 @@ class TreeVisitor(Generic[T]):
         raise ValueError(f"Unknown function '{name}' in expression")
 
     @abstractmethod
-    def visitPointNode(self, ra: T, dec: T, node: Node) -> T:
+    def visitPointNode(self, ra: T, dec: T, node: PointNode) -> T:
         """Visit PointNode node.
 
         Parameters

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -676,6 +676,17 @@ class ButlerQueryTests(ABC, TestCaseMixin):
             ):
                 query.where(f"visit_detector_region.region OVERLAPS POINT({ra}, 'not-a-number')")
 
+            # astropy's SkyCoord can be array-valued, but we expect only a
+            # single point.
+            array_point = astropy.coordinates.SkyCoord(
+                ra=[10, 11, 12, 13], dec=[41, -5, 42, 0], unit="deg", frame="icrs"
+            )
+            with self.assertRaisesRegex(ValueError, "Astropy SkyCoord contained an array of points"):
+                query.where(
+                    "visit_detector_region.region OVERLAPS my_point",
+                    bind={"my_point": array_point},
+                )
+
     def test_common_skypix_overlaps(self) -> None:
         """Test spatial overlap queries that return htm7 records."""
         butler = self.make_butler("base.yaml", "spatial.yaml")


### PR DESCRIPTION
Region overlap queries can now use points as regions.  Points can be specified
as `region OVERLAPS POINT(ra, dec)`, or by binding an `lsst.sphgeom.LonLat` or
`astropy.coordinates.SkyCoord` value.  (At the moment, this feature is only
available when using client/server Butler.)

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
