### PR TITLE
DM-45775: Enable datastore cache for client/server butler

### DIFF
--- a/doc/changes/DM-45775.api.rst
+++ b/doc/changes/DM-45775.api.rst
@@ -1,0 +1,1 @@
+Added ``DatastoreCacheManager.create_disabled()`` to create a cache manager which is disabled by default but can be enabled via the environment.

--- a/doc/changes/DM-45775.feature.rst
+++ b/doc/changes/DM-45775.feature.rst
@@ -1,0 +1,2 @@
+Added an expiration mode of "disabled" to the datastore cache manager.
+This allows an environment variable to be used to disable caching completely, or allows for a default configuration to be disabled and for environment variables to enable caching.

--- a/doc/changes/DM-45775.misc.rst
+++ b/doc/changes/DM-45775.misc.rst
@@ -1,0 +1,2 @@
+Enabled remote butler to utilize a datastore cache.
+By default clients created using a factory method will use a disabled cache that can be enabled by an environment variable and clients created from ``Butler()`` will use a default cache configuration.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -309,8 +309,12 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             case ButlerType.REMOTE:
                 from .remote_butler import RemoteButlerFactory
 
+                # Assume this is being created by a client who would like
+                # default caching of remote datasets.
                 factory = RemoteButlerFactory.create_factory_from_config(butler_config)
-                return factory.create_butler_with_credentials_from_environment(butler_options=options)
+                return factory.create_butler_with_credentials_from_environment(
+                    butler_options=options, use_disabled_datastore_cache=False
+                )
             case _:
                 raise TypeError(f"Unknown Butler type '{butler_type}'")
 

--- a/python/lsst/daf/butler/configs/datastores/fileDatastore.yaml
+++ b/python/lsst/daf/butler/configs/datastores/fileDatastore.yaml
@@ -23,6 +23,7 @@ datastore:
       # Expiry mode and associated threshold.
       # Options are:
       # - null (no expiry)
+      # - disabled (no caching)
       # - files (threshold is number of files)
       # - datasets (threshold is number of datasets)
       # - size (threshold is size in bytes)

--- a/python/lsst/daf/butler/datastores/fileDatastoreClient.py
+++ b/python/lsst/daf/butler/datastores/fileDatastoreClient.py
@@ -4,7 +4,10 @@ from typing import Any, Literal
 
 import pydantic
 from lsst.daf.butler import DatasetRef, Location
-from lsst.daf.butler.datastore.cache_manager import DatastoreDisabledCacheManager
+from lsst.daf.butler.datastore.cache_manager import (
+    AbstractDatastoreCacheManager,
+    DatastoreDisabledCacheManager,
+)
 from lsst.daf.butler.datastore.stored_file_info import SerializedStoredFileInfo, StoredFileInfo
 from lsst.daf.butler.datastores.file_datastore.get import (
     DatasetLocationInformation,
@@ -47,6 +50,7 @@ def get_dataset_as_python_object(
     payload: FileDatastoreGetPayload,
     *,
     parameters: Mapping[str, Any] | None,
+    cache_manager: AbstractDatastoreCacheManager | None = None,
 ) -> Any:
     """Retrieve an artifact from storage and return it as a Python object.
 
@@ -60,6 +64,8 @@ def get_dataset_as_python_object(
     parameters : `Mapping`[`str`, `typing.Any`]
         `StorageClass` and `Formatter` parameters to be used when converting
         the artifact to a Python object.
+    cache_manager : `AbstractDatastoreCacheManager` or `None`, optional
+        Cache manager to use. If `None` the cache is disabled.
 
     Returns
     -------
@@ -76,6 +82,8 @@ def get_dataset_as_python_object(
         ref=ref,
         parameters=parameters,
     )
+    if cache_manager is None:
+        cache_manager = DatastoreDisabledCacheManager()
     return get_dataset_as_python_object_from_get_info(
-        datastore_file_info, ref=ref, parameters=parameters, cache_manager=DatastoreDisabledCacheManager()
+        datastore_file_info, ref=ref, parameters=parameters, cache_manager=cache_manager
     )

--- a/python/lsst/daf/butler/remote_butler/_factory.py
+++ b/python/lsst/daf/butler/remote_butler/_factory.py
@@ -87,7 +87,11 @@ class RemoteButlerFactory:
         return RemoteButlerFactory(server_url)
 
     def create_butler_for_access_token(
-        self, access_token: str, *, butler_options: ButlerInstanceOptions | None = None
+        self,
+        access_token: str,
+        *,
+        butler_options: ButlerInstanceOptions | None = None,
+        use_disabled_datastore_cache: bool = True,
     ) -> RemoteButler:
         if butler_options is None:
             butler_options = ButlerInstanceOptions()
@@ -97,10 +101,14 @@ class RemoteButlerFactory:
             ),
             options=butler_options,
             cache=self._cache,
+            use_disabled_datastore_cache=use_disabled_datastore_cache,
         )
 
     def create_butler_with_credentials_from_environment(
-        self, *, butler_options: ButlerInstanceOptions | None = None
+        self,
+        *,
+        butler_options: ButlerInstanceOptions | None = None,
+        use_disabled_datastore_cache: bool = True,
     ) -> RemoteButler:
         token = get_authentication_token_from_environment(self.server_url)
         if token is None:
@@ -108,4 +116,6 @@ class RemoteButlerFactory:
                 "Attempting to connect to Butler server,"
                 " but no access credentials were found in the environment."
             )
-        return self.create_butler_for_access_token(token, butler_options=butler_options)
+        return self.create_butler_for_access_token(
+            token, butler_options=butler_options, use_disabled_datastore_cache=use_disabled_datastore_cache
+        )

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -195,7 +195,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             return cache.dimensions
 
     @property
-    def datastore_cache_manager(self) -> AbstractDatastoreCacheManager:
+    def _cache_manager(self) -> AbstractDatastoreCacheManager:
         """Cache manager to use when reading files from the butler."""
         # RemoteButler does not get any cache configuration from the server.
         # Read the Datastore default config (which is a FileDatastore)
@@ -204,7 +204,6 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         # defaults for DatastoreConfig no longer include the cache.
         if self._datastore_cache_manager is None:
             datastore_config = DatastoreConfig()
-            self._datastore_cache_manager: AbstractDatastoreCacheManager
             if "cached" in datastore_config:
                 self._datastore_cache_manager = DatastoreCacheManager(
                     datastore_config["cached"], universe=self.dimensions
@@ -295,7 +294,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             ref,
             _to_file_payload(model),
             parameters=parameters,
-            cache_manager=self.datastore_cache_manager,
+            cache_manager=self._cache_manager,
         )
 
     def _get_file_info(

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -350,7 +350,7 @@ class ButlerPutGetTests(TestCaseMixin):
                         for preserve_path in (True, False):
                             destination = root_uri.join(f"{preserve_path}_{counter}/")
                             log = logging.getLogger("lsst.x")
-                            log.warning("Using destination %s for args %s", destination, args)
+                            log.debug("Using destination %s for args %s", destination, args)
                             # Use copy so that we can test that overwrite
                             # protection works (using "auto" for File URIs
                             # would use hard links and subsequent transfer

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1896,6 +1896,18 @@ cached:
         self.assertExpiration(cache_manager, 10, 6)
         self.assertIn(f"{mode}={threshold}", str(cache_manager))
 
+    def testDisabledCache(self) -> None:
+        threshold = 0
+        mode = "disabled"
+        config_str = self._expiration_config(mode, threshold)
+        cache_manager = self._make_cache_manager(config_str)
+        for uri, ref in zip(self.files, self.refs, strict=True):
+            self.assertFalse(cache_manager.should_be_cached(ref))
+            self.assertIsNone(cache_manager.move_to_cache(uri, ref))
+            self.assertFalse(cache_manager.known_to_cache(ref))
+            with cache_manager.find_in_cache(ref, ".txt") as found:
+                self.assertIsNone(found, msg=f"{cache_manager}")
+
     def assertExpiration(
         self, cache_manager: DatastoreCacheManager, n_datasets: int, n_retained: int
     ) -> None:

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1877,6 +1877,47 @@ cached:
             self.assertExpiration(cache_manager, 5, threshold + 1)
             self.assertIn(f"{mode}={threshold}", str(cache_manager))
 
+    def testExpirationModeOverride(self) -> None:
+        threshold = 2  # Keep 2 datasets.
+        mode = "datasets"
+        config_str = self._expiration_config(mode, threshold)
+
+        mode = "size"
+        threshold = 55
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"DAF_BUTLER_CACHE_EXPIRATION_MODE": f"{mode}={threshold}"},
+        ):
+            cache_manager = self._make_cache_manager(config_str)
+            self.assertExpiration(cache_manager, 10, 6)
+            self.assertIn(f"{mode}={threshold}", str(cache_manager))
+
+        # Check we get a warning with unrecognized form.
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"DAF_BUTLER_CACHE_EXPIRATION_MODE": "something"},
+        ):
+            with self.assertLogs(level="WARNING") as cm:
+                self._make_cache_manager(config_str)
+            self.assertIn("Unrecognized form (something)", cm.output[0])
+
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"DAF_BUTLER_CACHE_EXPIRATION_MODE": "something=5"},
+        ):
+            with self.assertRaises(ValueError) as cm:
+                self._make_cache_manager(config_str)
+            self.assertIn("Unrecognized value", str(cm.exception))
+
+    def testMissingThreshold(self) -> None:
+        threshold = ""
+        mode = "datasets"
+        config_str = self._expiration_config(mode, threshold)
+
+        with self.assertRaises(ValueError) as cm:
+            self._make_cache_manager(config_str)
+        self.assertIn("Cache expiration threshold", str(cm.exception))
+
     def testCacheExpiryDatasetsComposite(self) -> None:
         threshold = 2  # Keep 2 datasets.
         mode = "datasets"
@@ -1908,13 +1949,26 @@ cached:
         self.assertIn(f"{mode}={threshold}", str(cache_manager))
 
     def testDisabledCache(self) -> None:
+        # Configure an active cache but disable via environment.
+        threshold = 2
+        mode = "datasets"
+        config_str = self._expiration_config(mode, threshold)
+
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"DAF_BUTLER_CACHE_EXPIRATION_MODE": "disabled"},
+        ):
+            env_cache_manager = self._make_cache_manager(config_str)
+
+        # Configure to be disabled
         threshold = 0
         mode = "disabled"
         config_str = self._expiration_config(mode, threshold)
-        cache_manager = self._make_cache_manager(config_str)
+        cfg_cache_manager = self._make_cache_manager(config_str)
 
         for cache_manager in (
-            self._make_cache_manager(config_str),
+            cfg_cache_manager,
+            env_cache_manager,
             DatastoreCacheManager.create_disabled(universe=DimensionUniverse()),
         ):
             for uri, ref in zip(self.files, self.refs, strict=True):
@@ -1923,6 +1977,7 @@ cached:
                 self.assertFalse(cache_manager.known_to_cache(ref))
                 with cache_manager.find_in_cache(ref, ".txt") as found:
                     self.assertIsNone(found, msg=f"{cache_manager}")
+                self.assertIn("disabled", str(cache_manager))
 
     def assertExpiration(
         self, cache_manager: DatastoreCacheManager, n_datasets: int, n_retained: int

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1558,6 +1558,7 @@ class ChainedDatastorePerStoreConstraintsTests(DatastoreTestsBase, unittest.Test
                     self.assertFalse(datastore.exists(ref))
 
 
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
 class DatastoreCacheTestCase(DatasetTestHelper, unittest.TestCase):
     """Tests for datastore caching infrastructure."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -224,10 +224,13 @@ class ButlerClientServerTestCase(unittest.TestCase):
                     self.assertEqual(butler._connection.server_url, server_url)
                     self.assertEqual(butler.collections.defaults, ("collection1", "collection2"))
                     self.assertEqual(butler.run, "collection2")
+                    # A butler created this way uses the default cache config.
+                    self.assertFalse(butler._use_disabled_datastore_cache)
 
                 butler_factory = LabeledButlerFactory({"server": server_url})
                 factory_created_butler = butler_factory.create_butler(label="server", access_token="token")
                 self.assertIsInstance(factory_created_butler, RemoteButler)
+                self.assertTrue(factory_created_butler._use_disabled_datastore_cache)
                 self.assertEqual(factory_created_butler._connection.server_url, server_url)
 
     def test_get(self):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
