### PR TITLE
DM-45907: Decrease page size for queries

### DIFF
--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -134,7 +134,10 @@ class DirectQueryDriver(QueryDriver):
         dimension_record_cache: DimensionRecordCache,
         default_collections: Iterable[str],
         default_data_id: DataCoordinate,
-        raw_page_size: int = 10000,
+        # Increasing raw_page_size increases memory usage for queries on
+        # Butler server, so if you increase this you may need to increase the
+        # memory allocation for the server in Phalanx as well.
+        raw_page_size: int = 2000,
         constant_rows_limit: int = 1000,
         postprocessing_filter_factor: int = 10,
     ):


### PR DESCRIPTION
Decrease query driver's default page size.  Queries were consuming excessive memory on Butler server, and lowering this value does not seem to make queries any slower.  This reduces memory consumption for a dataset query with dimension records from ~120MB to ~30MB per in-flight query.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
