### PR TITLE
DM-45908: Fix client-side HTTP timeouts when communicating with Butler server

### DIFF
--- a/python/lsst/daf/butler/remote_butler/_factory.py
+++ b/python/lsst/daf/butler/remote_butler/_factory.py
@@ -66,7 +66,18 @@ class RemoteButlerFactory:
         if http_client is not None:
             self.http_client = http_client
         else:
-            self.http_client = httpx.Client()
+            self.http_client = httpx.Client(
+                # This timeout is fairly conservative.  This value isn't the
+                # maximum amount of time the request can take -- it's the
+                # maximum amount of time to wait after receiving the last chunk
+                # of data from the server.
+                #
+                # Long-running, streamed queries send a keep-alive every 15
+                # seconds.  However, unstreamed operations like
+                # queryCollections can potentially take a while if the database
+                # is under duress.
+                timeout=120  # seconds
+            )
         self._cache = RemoteButlerCache()
 
     @staticmethod

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -147,8 +147,9 @@ class RemoteQueryDriver(QueryDriver):
                 # There is one result page JSON object per line of the
                 # response.
                 for line in response.iter_lines():
-                    result_chunk = _QueryResultTypeAdapter.validate_json(line)
-                    yield _convert_query_result_page(result_spec, result_chunk, universe)
+                    result_chunk: QueryExecuteResultData = _QueryResultTypeAdapter.validate_json(line)
+                    if result_chunk.type != "keep-alive":
+                        yield _convert_query_result_page(result_spec, result_chunk, universe)
                     if self._closed:
                         raise RuntimeError(
                             "Cannot continue query result iteration: query context has been closed"

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -148,7 +148,9 @@ class RemoteQueryDriver(QueryDriver):
                 # response.
                 for line in response.iter_lines():
                     result_chunk: QueryExecuteResultData = _QueryResultTypeAdapter.validate_json(line)
-                    if result_chunk.type != "keep-alive":
+                    if result_chunk.type == "keep-alive":
+                        _received_keep_alive()
+                    else:
                         yield _convert_query_result_page(result_spec, result_chunk, universe)
                     if self._closed:
                         raise RuntimeError(
@@ -280,3 +282,10 @@ def _convert_general_result(spec: GeneralResultSpec, model: GeneralResultModel) 
         for row in model.rows
     ]
     return GeneralResultPage(spec=spec, rows=rows)
+
+
+def _received_keep_alive() -> None:
+    """Do nothing.  Gives a place for unit tests to hook in for testing
+    keepalive behavior.
+    """
+    pass

--- a/python/lsst/daf/butler/remote_butler/server/_server.py
+++ b/python/lsst/daf/butler/remote_butler/server/_server.py
@@ -33,7 +33,6 @@ from collections.abc import Awaitable, Callable
 
 import safir.dependencies.logger
 from fastapi import FastAPI, Request, Response
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from safir.logging import configure_logging, configure_uvicorn_logging
 
@@ -54,7 +53,6 @@ def create_app() -> FastAPI:
     config = load_config()
 
     app = FastAPI()
-    app.add_middleware(GZipMiddleware, minimum_size=1000)
 
     # A single instance of the server can serve data from multiple Butler
     # repositories.  This 'repository' path placeholder is consumed by

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -31,7 +31,7 @@ __all__ = ("query_router",)
 
 import asyncio
 from collections.abc import AsyncIterator, Iterator
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from typing import NamedTuple
 
 from fastapi import APIRouter, Depends
@@ -63,61 +63,26 @@ query_router = APIRouter()
 
 
 @query_router.post("/v1/query/execute", summary="Query the Butler database and return full results")
-def query_execute(
+async def query_execute(
     request: QueryExecuteRequestModel, factory: Factory = Depends(factory_dependency)
 ) -> StreamingResponse:
-    # Managing the lifetime of the query context object is a little tricky.  We
-    # need to enter the context here, so that we can immediately deal with any
-    # exceptions raised by query set-up.  We eventually transfer control to an
-    # iterator consumed by FastAPI's StreamingResponse handler, which will
-    # start iterating after this function returns.  So we use this ExitStack
-    # instance to hand over the context manager to the iterator.
-    with ExitStack() as exit_stack:
-        ctx = exit_stack.enter_context(_get_query_context(factory, request.query))
-        spec = request.result_spec.to_result_spec(ctx.driver.universe)
-
-        # We write the response incrementally, one page at a time, as
-        # newline-separated chunks of JSON.  This allows clients to start
-        # reading results earlier and prevents the server from exhausting
-        # all its memory buffering rows from large queries.
-        output_generator = _stream_query_pages(
-            # Transfer control of the context manager to
-            # _stream_query_pages.
-            exit_stack.pop_all(),
-            ctx,
-            spec,
-        )
-        return StreamingResponse(
-            output_generator,
-            media_type="application/jsonlines",
-            headers={
-                # Instruct the Kubernetes ingress to not buffer the response,
-                # so that keep-alives reach the client promptly.
-                "X-Accel-Buffering": "no"
-            },
-        )
-
-    # Mypy thinks that ExitStack might swallow an exception.
-    assert False, "This line is unreachable."
+    # We write the response incrementally, one page at a time, as
+    # newline-separated chunks of JSON.  This allows clients to start
+    # reading results earlier and prevents the server from exhausting
+    # all its memory buffering rows from large queries.
+    output_generator = _stream_query_pages(request, factory)
+    return StreamingResponse(
+        output_generator,
+        media_type="application/jsonlines",
+        headers={
+            # Instruct the Kubernetes ingress to not buffer the response,
+            # so that keep-alives reach the client promptly.
+            "X-Accel-Buffering": "no"
+        },
+    )
 
 
-# Instead of declaring this as a sync generator with 'def', it's async to
-# give us more control over the lifetime of exit_stack.  StreamingResponse
-# ensures that this async generator is cancelled if the client
-# disconnects or another error occurs, ensuring that clean-up logic runs.
-#
-# If it was sync, it would get wrapped in an async function internal to
-# FastAPI that does not guarantee that the generator is fully iterated or
-# closed.
-# (There is an example in the FastAPI docs showing StreamingResponse with a
-# sync generator with a context manager, but after reading the FastAPI
-# source code I believe that for sync generators it will leak the context
-# manager if the client disconnects, and that it would be
-# difficult/impossible for them to fix this in the general case within
-# FastAPI.)
-async def _stream_query_pages(
-    exit_stack: ExitStack, ctx: _QueryContext, spec: ResultSpec
-) -> AsyncIterator[str]:
+async def _stream_query_pages(request: QueryExecuteRequestModel, factory: Factory) -> AsyncIterator[str]:
     """Stream the query output with one page object per line, as
     newline-delimited JSON records in the "JSON Lines" format
     (https://jsonlines.org/).
@@ -125,23 +90,44 @@ async def _stream_query_pages(
     When it takes longer than 15 seconds to get a response from the DB,
     sends a keep-alive message to prevent clients from timing out.
     """
-    # Ensure that the database connection is cleaned up by taking control of
-    # exit_stack.
-    async with contextmanager_in_threadpool(exit_stack):
-        # `None` signals that there is no more data to send.
-        queue = asyncio.Queue[QueryExecuteResultData | None](1)
-        async with asyncio.TaskGroup() as tg:
-            tg.create_task(_enqueue_query_pages(ctx, spec, queue))
-            async for message in _dequeue_query_pages_with_keepalive(queue):
-                yield message.model_dump_json() + "\n"
+    # `None` signals that there is no more data to send.
+    queue = asyncio.Queue[QueryExecuteResultData | None](1)
+    async with asyncio.TaskGroup() as tg:
+        # Run a background task to read from the DB and insert the result pages
+        # into a queue.
+        tg.create_task(_enqueue_query_pages(queue, request, factory))
+        # Read the result pages from the queue and send them to the client,
+        # inserting a keep-alive message every 15 seconds if we are waiting a
+        # long time for the database.
+        async for message in _dequeue_query_pages_with_keepalive(queue):
+            yield message.model_dump_json() + "\n"
 
 
-async def _enqueue_query_pages(ctx: _QueryContext, spec: ResultSpec, queue: asyncio.Queue) -> None:
-    async for page in iterate_in_threadpool(_retrieve_query_pages(ctx, spec)):
-        await queue.put(page)
+async def _enqueue_query_pages(
+    queue: asyncio.Queue[QueryExecuteResultData | None], request: QueryExecuteRequestModel, factory: Factory
+) -> None:
+    """Set up a QueryDriver to run the query, and copy the results into a
+    queue.  Send `None` to the queue when there is no more data to read.
+    """
+    try:
+        async with contextmanager_in_threadpool(_get_query_context(factory, request.query)) as ctx:
+            spec = request.result_spec.to_result_spec(ctx.driver.universe)
+            async for page in iterate_in_threadpool(_retrieve_query_pages(ctx, spec)):
+                await queue.put(page)
+    except ButlerUserError as e:
+        # If a user-facing error occurs, serialize it and send it to the
+        # client.
+        await queue.put(QueryErrorResultModel(error=serialize_butler_user_error(e)))
 
     # Signal that there is no more data to read.
     await queue.put(None)
+
+
+def _retrieve_query_pages(ctx: _QueryContext, spec: ResultSpec) -> Iterator[QueryExecuteResultData]:
+    """Execute the database query and and return pages of results."""
+    pages = ctx.driver.execute(spec, ctx.tree)
+    for page in pages:
+        yield convert_query_page(spec, page)
 
 
 async def _dequeue_query_pages_with_keepalive(
@@ -160,18 +146,6 @@ async def _dequeue_query_pages_with_keepalive(
                 yield message
         except TimeoutError:
             yield QueryKeepAliveModel()
-
-
-def _retrieve_query_pages(ctx: _QueryContext, spec: ResultSpec) -> Iterator[QueryExecuteResultData]:
-    """Execute the database query and and return pages of results."""
-    try:
-        pages = ctx.driver.execute(spec, ctx.tree)
-        for page in pages:
-            yield convert_query_page(spec, page)
-    except ButlerUserError as e:
-        # If a user-facing error occurs, serialize it and send it to the
-        # client.
-        yield QueryErrorResultModel(error=serialize_butler_user_error(e))
 
 
 @query_router.post(

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -61,6 +61,9 @@ from ._query_serialization import convert_query_page
 
 query_router = APIRouter()
 
+# Alias this function so we can mock it during unit tests.
+_timeout = asyncio.timeout
+
 
 @query_router.post("/v1/query/execute", summary="Query the Butler database and return full results")
 async def query_execute(
@@ -139,7 +142,7 @@ async def _dequeue_query_pages_with_keepalive(
     """
     while True:
         try:
-            async with asyncio.timeout(15):
+            async with _timeout(15):
                 message = await queue.get()
                 if message is None:
                     return

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -299,12 +299,24 @@ class QueryErrorResultModel(pydantic.BaseModel):
     error: ErrorResponseModel
 
 
+class QueryKeepAliveModel(pydantic.BaseModel):
+    """Result model for /query/execute used to keep connection alive.
+
+    Some queries require a significant start-up time before they can start
+    returning results, or a long processing time for each chunk of rows.  This
+    message signals that the server is still fetching the data.
+    """
+
+    type: Literal["keep-alive"] = "keep-alive"
+
+
 QueryExecuteResultData: TypeAlias = Annotated[
     DataCoordinateResultModel
     | DimensionRecordsResultModel
     | DatasetRefResultModel
     | GeneralResultModel
-    | QueryErrorResultModel,
+    | QueryErrorResultModel
+    | QueryKeepAliveModel,
     pydantic.Field(discriminator="type"),
 ]
 


### PR DESCRIPTION
Fixed an issue where slow queries would result in `httpx` timeouts on the client side.  The server now sends keep-alives from slow-running queries to prevent a timeout.  The timeout duration has been increased to 2 minutes on the client side -- previously it was 5 seconds.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
