### PR TITLE
DM-45791: Put ingest reference time back in the correct place in test

### DIFF
--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -2722,8 +2722,8 @@ class RegistryTests(ABC):
     def testIngestTimeQuery(self):
         butler = self.make_butler()
         registry = butler._registry
-        self.load_data(butler, "base.yaml", "datasets.yaml")
         dt0 = datetime.datetime.now(datetime.UTC)
+        self.load_data(butler, "base.yaml", "datasets.yaml")
         dt1 = datetime.datetime.now(datetime.UTC)
 
         datasets = list(registry.queryDatasets(..., collections=...))


### PR DESCRIPTION
Commit 4dbfaa989 moved the reference time calculation to after the ingest.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
