### PR TITLE
DM-46173: Allow negative values for ra and dec

### DIFF
--- a/python/lsst/daf/butler/queries/_expression_strings.py
+++ b/python/lsst/daf/butler/queries/_expression_strings.py
@@ -365,5 +365,7 @@ def _get_float_literal_value(value: _VisitorResult, node: Node) -> float:
             return expr.value
         elif expr.expression_type == "int":
             return float(expr.value)
+        elif expr.expression_type == "unary" and expr.operator == "-":
+            return -1 * _get_float_literal_value(_ColExpr(expr.operand), node)
 
     raise InvalidQueryError(f"Expression '{node}' in POINT() is not a literal number.")


### PR DESCRIPTION
Fix an issue where ra and dec values in POINT() query expressions could not be negative.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
