### PR TITLE
DM-46129: Make collections.query_info a single HTTP call

### DIFF
--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -45,6 +45,9 @@ if TYPE_CHECKING:
 class CollectionInfo(BaseModel):
     """Information about a single Butler collection."""
 
+    # This class is serialized for the server API -- any new properties you add
+    # must have default values provided to preserve backwards compatibility.
+
     name: str
     """Name of the collection."""
     type: CollectionType

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -283,7 +283,7 @@ class ButlerCollections(ABC, Sequence):
         include_parents: bool = False,
         include_summary: bool = False,
         include_doc: bool = False,
-        summary_datasets: Iterable[DatasetType] | None = None,
+        summary_datasets: Iterable[DatasetType] | Iterable[str] | None = None,
     ) -> Sequence[CollectionInfo]:
         """Query the butler for collections matching an expression and
         return detailed information about those collections.
@@ -310,8 +310,8 @@ class ButlerCollections(ABC, Sequence):
         include_doc : `bool`, optional
             Whether the returned information includes collection documentation
             string.
-        summary_datasets : `~collections.abc.Iterable` [ `DatasetType` ], \
-                optional
+        summary_datasets : `~collections.abc.Iterable` [ `DatasetType` ] or \
+            `~collections.abc.Iterable` [ `str` ], optional
             Dataset types to include in returned summaries. Only used if
             ``include_summary`` is `True`. If not specified then all dataset
             types will be included.

--- a/python/lsst/daf/butler/_dataset_type.py
+++ b/python/lsst/daf/butler/_dataset_type.py
@@ -805,8 +805,12 @@ def get_dataset_type_name(datasetTypeOrName: DatasetType | str) -> str:
     Parameters
     ----------
     datasetTypeOrName : `DatasetType` | `str`
-        A DatasetType, or the name of a DatasetType. This union is a common
-        parameter in many `Butler` methods.
+        A DatasetType, or the name of a DatasetType.
+
+    Returns
+    -------
+    name
+        The name associated with the given DatasetType, or the given string.
     """
     if isinstance(datasetTypeOrName, DatasetType):
         return datasetTypeOrName.name

--- a/python/lsst/daf/butler/_dataset_type.py
+++ b/python/lsst/daf/butler/_dataset_type.py
@@ -796,3 +796,21 @@ def _unpickle_via_factory(factory: Callable, args: Any, kwargs: Any) -> DatasetT
     arguments as well as positional arguments.
     """
     return factory(*args, **kwargs)
+
+
+def get_dataset_type_name(datasetTypeOrName: DatasetType | str) -> str:
+    """Given a `DatasetType` object or a dataset type name, return a dataset
+    type name.
+
+    Parameters
+    ----------
+    datasetTypeOrName : `DatasetType` | `str`
+        A DatasetType, or the name of a DatasetType. This union is a common
+        parameter in many `Butler` methods.
+    """
+    if isinstance(datasetTypeOrName, DatasetType):
+        return datasetTypeOrName.name
+    elif isinstance(datasetTypeOrName, str):
+        return datasetTypeOrName
+    else:
+        raise TypeError(f"Expected DatasetType or str, got unexpected object: {datasetTypeOrName}")

--- a/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
@@ -114,7 +114,7 @@ class DirectButlerCollections(ButlerCollections):
         include_parents: bool = False,
         include_summary: bool = False,
         include_doc: bool = False,
-        summary_datasets: Iterable[DatasetType] | None = None,
+        summary_datasets: Iterable[DatasetType] | Iterable[str] | None = None,
     ) -> Sequence[CollectionInfo]:
         info = []
         with self._registry.caching_context():

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 import sqlalchemy
 
 from ...._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef, DatasetType
+from ...._dataset_type import get_dataset_type_name
 from ...._exceptions_legacy import DatasetTypeError
 from ....dimensions import DimensionUniverse
 from ..._collection_summary import CollectionSummary
@@ -511,12 +512,14 @@ class ByDimensionsDatasetRecordStorageManagerBase(DatasetRecordStorageManager):
         return summaries[collection.key]
 
     def fetch_summaries(
-        self, collections: Iterable[CollectionRecord], dataset_types: Iterable[DatasetType] | None = None
+        self,
+        collections: Iterable[CollectionRecord],
+        dataset_types: Iterable[DatasetType] | Iterable[str] | None = None,
     ) -> Mapping[Any, CollectionSummary]:
         # Docstring inherited from DatasetRecordStorageManager.
         dataset_type_names: Iterable[str] | None = None
         if dataset_types is not None:
-            dataset_type_names = set(dataset_type.name for dataset_type in dataset_types)
+            dataset_type_names = set(get_dataset_type_name(dt) for dt in dataset_types)
         return self._summaries.fetch_summaries(collections, dataset_type_names, self._dataset_type_from_row)
 
     _versions: list[VersionTuple]

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -11,8 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 
-from ...._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef, DatasetType
-from ...._dataset_type import get_dataset_type_name
+from ...._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef
+from ...._dataset_type import DatasetType, get_dataset_type_name
 from ...._exceptions_legacy import DatasetTypeError
 from ....dimensions import DimensionUniverse
 from ..._collection_summary import CollectionSummary

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -674,7 +674,9 @@ class DatasetRecordStorageManager(VersionedExtension):
 
     @abstractmethod
     def fetch_summaries(
-        self, collections: Iterable[CollectionRecord], dataset_types: Iterable[DatasetType] | None = None
+        self,
+        collections: Iterable[CollectionRecord],
+        dataset_types: Iterable[DatasetType] | Iterable[str] | None = None,
     ) -> Mapping[Any, CollectionSummary]:
         """Fetch collection summaries given their names and dataset types.
 

--- a/python/lsst/daf/butler/remote_butler/_defaults.py
+++ b/python/lsst/daf/butler/remote_butler/_defaults.py
@@ -1,0 +1,60 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ..registry import RegistryDefaults
+
+
+class DefaultsHolder:
+    """Holds a `RegistryDefaults` object and allows it to be set.
+
+    Parameters
+    ----------
+    defaults : `RegistryDefaults`
+        Initial value for the defaults object.
+
+    Notes
+    -----
+    This exists to work around circular dependency issues (RemoteButler,
+    ButlerCollections, and Registry all need to know/modify the defaults.)
+    """
+
+    def __init__(self, defaults: RegistryDefaults) -> None:
+        self._defaults = defaults
+
+    def get(self) -> RegistryDefaults:
+        """Retrieve the current registry defaults."""
+        return self._defaults
+
+    def set(self, defaults: RegistryDefaults) -> None:
+        """Set a new value for the registry defaults.
+
+        Parameters
+        ----------
+        defaults : `RegistryDefaults`
+            New value for defaults object.
+        """
+        self._defaults = defaults

--- a/python/lsst/daf/butler/remote_butler/_ref_utils.py
+++ b/python/lsst/daf/butler/remote_butler/_ref_utils.py
@@ -36,7 +36,7 @@ __all__ = (
 from pydantic import TypeAdapter
 
 from .._dataset_ref import DatasetRef
-from .._dataset_type import DatasetType
+from .._dataset_type import DatasetType, get_dataset_type_name
 from .._storage_class import StorageClass
 from ..dimensions import DataCoordinate, DataId, DataIdValue, SerializedDataId
 from .server_models import DatasetTypeName
@@ -85,12 +85,7 @@ def normalize_dataset_type_name(datasetTypeOrName: DatasetType | str) -> Dataset
         A DatasetType, or the name of a DatasetType. This union is a common
         parameter in many `Butler` methods.
     """
-    if isinstance(datasetTypeOrName, DatasetType):
-        return DatasetTypeName(datasetTypeOrName.name)
-    elif isinstance(datasetTypeOrName, str):
-        return DatasetTypeName(datasetTypeOrName)
-    else:
-        raise TypeError(f"Got unexpected object for DatasetType: {datasetTypeOrName}")
+    return DatasetTypeName(get_dataset_type_name(datasetTypeOrName))
 
 
 def simplify_dataId(dataId: DataId | None, kwargs: dict[str, DataIdValue]) -> SerializedDataId:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -61,8 +61,11 @@ from ..dimensions import DataIdValue, DimensionConfig, DimensionUniverse, Serial
 from ..queries import Query
 from ..registry import CollectionArgType, NoDefaultCollectionError, Registry, RegistryDefaults
 from ._collection_args import convert_collection_arg_to_glob_string_list
+from ._defaults import DefaultsHolder
+from ._http_connection import RemoteButlerHttpConnection, parse_model, quote_path_variable
 from ._query_driver import RemoteQueryDriver
 from ._ref_utils import apply_storage_class_override, normalize_dataset_type_name, simplify_dataId
+from ._registry import RemoteButlerRegistry
 from ._remote_butler_collections import RemoteButlerCollections
 from .server_models import (
     CollectionList,
@@ -80,8 +83,6 @@ if TYPE_CHECKING:
     from .._timespan import Timespan
     from ..dimensions import DataId
     from ..transfers import RepoExportContext
-
-from ._http_connection import RemoteButlerHttpConnection, parse_model, quote_path_variable
 
 
 class RemoteButler(Butler):  # numpydoc ignore=PR02
@@ -109,10 +110,10 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     `Butler.from_config` or `RemoteButlerFactory`.
     """
 
-    _registry_defaults: RegistryDefaults
+    _registry_defaults: DefaultsHolder
     _connection: RemoteButlerHttpConnection
     _cache: RemoteButlerCache
-    _registry: Registry
+    _registry: RemoteButlerRegistry
     _datastore_cache_manager: AbstractDatastoreCacheManager | None
     _use_disabled_datastore_cache: bool
 
@@ -140,15 +141,10 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         self._datastore_cache_manager = None
         self._use_disabled_datastore_cache = use_disabled_datastore_cache
 
-        # Avoid a circular import by deferring this import.
-        from ._registry import RemoteButlerRegistry
-
-        self._registry = RemoteButlerRegistry(self, self._connection)
-
-        self._registry_defaults = RegistryDefaults(
-            options.collections, options.run, options.inferDefaults, **options.kwargs
-        )
-        self._registry_defaults.finish(self._registry)
+        defaults = RegistryDefaults(options.collections, options.run, options.inferDefaults, **options.kwargs)
+        self._registry_defaults = DefaultsHolder(defaults)
+        self._registry = RemoteButlerRegistry(self, self._registry_defaults, self._connection)
+        defaults.finish(self._registry)
 
         return self
 
@@ -164,16 +160,12 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     )
     def collection_chains(self) -> ButlerCollections:
         """Object with methods for modifying collection chains."""
-        from ._registry import RemoteButlerRegistry
-
-        return RemoteButlerCollections(cast(RemoteButlerRegistry, self._registry), self._connection)
+        return self.collections
 
     @property
     def collections(self) -> ButlerCollections:
         """Object with methods for modifying and querying collections."""
-        from ._registry import RemoteButlerRegistry
-
-        return RemoteButlerCollections(cast(RemoteButlerRegistry, self._registry), self._connection)
+        return RemoteButlerCollections(self._registry_defaults, self._connection)
 
     @property
     def dimensions(self) -> DimensionUniverse:
@@ -563,7 +555,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     @property
     def run(self) -> str | None:
         # Docstring inherited.
-        return self._registry_defaults.run
+        return self._registry_defaults.get().run
 
     @property
     def registry(self) -> Registry:
@@ -633,7 +625,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         # dimensions, but knowing what things are implied depends on what the
         # required dimensions are.
 
-        return self._registry_defaults.dataId.to_simple(minimal=True).dataId
+        return self._registry_defaults.get().dataId.to_simple(minimal=True).dataId
 
 
 def _to_file_payload(get_file_response: GetFileResponseModel) -> FileDatastoreGetPayload:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -166,14 +166,14 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         """Object with methods for modifying collection chains."""
         from ._registry import RemoteButlerRegistry
 
-        return RemoteButlerCollections(cast(RemoteButlerRegistry, self._registry))
+        return RemoteButlerCollections(cast(RemoteButlerRegistry, self._registry), self._connection)
 
     @property
     def collections(self) -> ButlerCollections:
         """Object with methods for modifying and querying collections."""
         from ._registry import RemoteButlerRegistry
 
-        return RemoteButlerCollections(cast(RemoteButlerRegistry, self._registry))
+        return RemoteButlerCollections(cast(RemoteButlerRegistry, self._registry), self._connection)
 
     @property
     def dimensions(self) -> DimensionUniverse:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler_collections.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler_collections.py
@@ -30,20 +30,17 @@ from __future__ import annotations
 __all__ = ("RemoteButlerCollections",)
 
 from collections.abc import Iterable, Sequence, Set
-from typing import TYPE_CHECKING
 
 from lsst.utils.iteration import ensure_iterable
 
 from .._butler_collections import ButlerCollections, CollectionInfo
 from .._collection_type import CollectionType
+from .._dataset_type import DatasetType
 from ..utils import has_globs
 from ._collection_args import convert_collection_arg_to_glob_string_list
+from ._defaults import DefaultsHolder
 from ._http_connection import RemoteButlerHttpConnection, parse_model
 from .server_models import QueryCollectionInfoRequestModel, QueryCollectionInfoResponseModel
-
-if TYPE_CHECKING:
-    from .._dataset_type import DatasetType
-    from ._registry import RemoteButlerRegistry
 
 
 class RemoteButlerCollections(ButlerCollections):
@@ -51,19 +48,19 @@ class RemoteButlerCollections(ButlerCollections):
 
     Parameters
     ----------
-    registry : `~lsst.daf.butler.registry.sql_registry.SqlRegistry`
-        Registry object used to work with the collections database.
+    defaults : `DefaultsHolder`
+        Registry object used to look up default collections.
     connection : `RemoteButlerHttpConnection`
         HTTP connection to Butler server.
     """
 
-    def __init__(self, registry: RemoteButlerRegistry, connection: RemoteButlerHttpConnection):
-        self._registry = registry
+    def __init__(self, defaults: DefaultsHolder, connection: RemoteButlerHttpConnection):
+        self._defaults = defaults
         self._connection = connection
 
     @property
     def defaults(self) -> Sequence[str]:
-        return self._registry.defaults.collections
+        return self._defaults.get().collections
 
     def extend_chain(self, parent_collection_name: str, child_collection_names: str | Iterable[str]) -> None:
         raise NotImplementedError("Not yet available")

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -199,6 +199,8 @@ def _get_file_by_ref(butler: Butler, ref: DatasetRef) -> GetFileResponseModel:
     return GetFileResponseModel(dataset_ref=ref.to_simple(), artifact=payload)
 
 
+# TODO DM-46204: This can be removed once the RSP recommended image has been
+# upgraded to a version that contains DM-46129.
 @external_router.get(
     "/v1/collection_info", summary="Get information about a collection", response_model_exclude_unset=True
 )
@@ -233,6 +235,8 @@ def get_collection_summary(
     return GetCollectionSummaryResponseModel(summary=butler.registry.getCollectionSummary(name).to_simple())
 
 
+# TODO DM-46204: This can be removed once the RSP recommended image has been
+# upgraded to a version that contains DM-46129.
 @external_router.post(
     "/v1/query_collections", summary="Search for collections with names that match an expression"
 )

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -267,6 +267,8 @@ def query_collection_info(
         include_chains=request.include_chains,
         include_parents=request.include_parents,
         include_summary=request.include_summary,
+        include_doc=request.include_doc,
+        summary_datasets=request.summary_datasets,
     )
     return QueryCollectionInfoResponseModel(collections=list(collections))
 

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -46,6 +46,8 @@ from lsst.daf.butler.remote_butler.server_models import (
     GetFileByDataIdRequestModel,
     GetFileResponseModel,
     GetUniverseResponseModel,
+    QueryCollectionInfoRequestModel,
+    QueryCollectionInfoResponseModel,
     QueryCollectionsRequestModel,
     QueryCollectionsResponseModel,
     QueryDatasetTypesRequestModel,
@@ -245,6 +247,24 @@ def query_collections(
         includeChains=request.include_chains,
     )
     return QueryCollectionsResponseModel(collections=collections)
+
+
+@external_router.post(
+    "/v1/query_collection_info", summary="Search for collections with names that match an expression"
+)
+def query_collection_info(
+    request: QueryCollectionInfoRequestModel, factory: Factory = Depends(factory_dependency)
+) -> QueryCollectionInfoResponseModel:
+    butler = factory.create_butler()
+    collections = butler.collections.query_info(
+        expression=request.expression,
+        collection_types=set(request.collection_types),
+        flatten_chains=request.flatten_chains,
+        include_chains=request.include_chains,
+        include_parents=request.include_parents,
+        include_summary=request.include_summary,
+    )
+    return QueryCollectionInfoResponseModel(collections=list(collections))
 
 
 @external_router.post(

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -205,6 +205,8 @@ class QueryCollectionInfoRequestModel(pydantic.BaseModel):
     include_chains: bool
     include_parents: bool
     include_summary: bool
+    include_doc: bool
+    summary_datasets: list[DatasetTypeName] | None
 
 
 class QueryCollectionInfoResponseModel(pydantic.BaseModel):

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -142,6 +142,8 @@ class ErrorResponseModel(pydantic.BaseModel):
     """Detailed explanation of the error that will be sent to the client."""
 
 
+# TODO DM-46204: This can be removed once the RSP recommended image has been
+# upgraded to a version that contains DM-46129.
 class GetCollectionInfoResponseModel(pydantic.BaseModel):
     """Response model for get_collection_info."""
 
@@ -174,6 +176,8 @@ class ExpandDataIdResponseModel(pydantic.BaseModel):
     data_coordinate: SerializedDataCoordinate
 
 
+# TODO DM-46204: This can be removed once the RSP recommended image has been
+# upgraded to a version that contains DM-46129.
 class QueryCollectionsRequestModel(pydantic.BaseModel):
     """Request model for query_collections."""
 
@@ -183,6 +187,8 @@ class QueryCollectionsRequestModel(pydantic.BaseModel):
     include_chains: bool
 
 
+# TODO DM-46204: This can be removed once the RSP recommended image has been
+# upgraded to a version that contains DM-46129.
 class QueryCollectionsResponseModel(pydantic.BaseModel):
     """Response model for query_collections."""
 

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -42,6 +42,7 @@ from uuid import UUID
 
 import pydantic
 from lsst.daf.butler import (
+    CollectionInfo,
     CollectionType,
     DataIdValue,
     SerializedDataCoordinate,
@@ -187,6 +188,23 @@ class QueryCollectionsResponseModel(pydantic.BaseModel):
 
     collections: list[str]
     """Collection names that match the search."""
+
+
+class QueryCollectionInfoRequestModel(pydantic.BaseModel):
+    """Request model for query_collection_info."""
+
+    expression: CollectionList
+    collection_types: list[CollectionType]
+    flatten_chains: bool
+    include_chains: bool
+    include_parents: bool
+    include_summary: bool
+
+
+class QueryCollectionInfoResponseModel(pydantic.BaseModel):
+    """Response model for query_collection_info."""
+
+    collections: list[CollectionInfo]
 
 
 class QueryDatasetTypesRequestModel(pydantic.BaseModel):

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -1804,6 +1804,21 @@ class ButlerQueryTests(ABC, TestCaseMixin):
                 ],
             )
 
+    def test_collection_query_info(self) -> None:
+        butler = self.make_butler("base.yaml", "datasets.yaml")
+
+        info = butler.collections.query_info("imported_g", include_summary=True)
+        self.assertEqual(len(info), 1)
+        dataset_types = info[0].dataset_types
+        assert dataset_types is not None
+        self.assertCountEqual(dataset_types, ["flat", "bias"])
+
+        info = butler.collections.query_info("imported_g", include_summary=True, summary_datasets=["flat"])
+        self.assertEqual(len(info), 1)
+        dataset_types = info[0].dataset_types
+        assert dataset_types is not None
+        self.assertCountEqual(dataset_types, ["flat"])
+
 
 def _get_exposure_ids_from_dimension_records(dimension_records: Iterable[DimensionRecord]) -> list[int]:
     output = []

--- a/python/lsst/daf/butler/tests/hybrid_butler_collections.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_collections.py
@@ -87,7 +87,7 @@ class HybridButlerCollections(ButlerCollections):
         include_parents: bool = False,
         include_summary: bool = False,
         include_doc: bool = False,
-        summary_datasets: Iterable[DatasetType] | None = None,
+        summary_datasets: Iterable[DatasetType] | Iterable[str] | None = None,
     ) -> Sequence[CollectionInfo]:
         return self._hybrid._remote_butler.collections.query_info(
             expression,


### PR DESCRIPTION
Previously `RemoteButlerCollections.query_info` would make an HTTP call for each resolved collection.  It now does everything in a single call to the server instead.

`RemoteButlerCollections.get_info` and other collection methods in `RemoteButlerRegistry` have also been updated to re-use the new endpoint.

Also fixed an issue where the `summary_datasets` parameter to `DirectButlerCollections.query_info` was not doing anything.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
