### PR TITLE
DM-45993: Optimize DirectButlerCollections.query_info to avoid too many queries

### DIFF
--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -31,11 +31,14 @@ __all__ = ("ButlerCollections", "CollectionInfo")
 
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence, Set
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from pydantic import BaseModel
 
 from ._collection_type import CollectionType
+
+if TYPE_CHECKING:
+    from ._dataset_type import DatasetType
 
 
 class CollectionInfo(BaseModel):
@@ -275,6 +278,7 @@ class ButlerCollections(ABC, Sequence):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         """Query the butler for collections matching an expression and
         return detailed information about those collections.
@@ -298,6 +302,11 @@ class ButlerCollections(ABC, Sequence):
         include_summary : `bool`, optional
             Whether the returned information includes dataset type and
             governor information for the collections.
+        summary_datasets : `~collections.abc.Iterable` [ `DatasetType` ], \
+                optional
+            Dataset types to include in returned summaries. Only used if
+            ``include_summary`` is `True`. If not specified then all dataset
+            types will be included.
 
         Returns
         -------

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -437,7 +437,7 @@ class ButlerCollections(ABC, Sequence):
         dataset_types : `~collections.abc.Set` [`str`]
             Set of dataset type names to extract.
         collection_infos : `~collections.abc.Iterable` [`CollectionInfo`]
-            Colelction infos, must contain dataset type summary.
+            Collection infos, must contain dataset type summary.
 
         Returns
         -------

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -278,6 +278,7 @@ class ButlerCollections(ABC, Sequence):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        include_doc: bool = False,
         summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         """Query the butler for collections matching an expression and
@@ -302,6 +303,9 @@ class ButlerCollections(ABC, Sequence):
         include_summary : `bool`, optional
             Whether the returned information includes dataset type and
             governor information for the collections.
+        include_doc : `bool`, optional
+            Whether the returned information includes collection documentation
+            string.
         summary_datasets : `~collections.abc.Iterable` [ `DatasetType` ], \
                 optional
             Dataset types to include in returned summaries. Only used if

--- a/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler_collections.py
@@ -29,7 +29,8 @@ from __future__ import annotations
 
 __all__ = ("DirectButlerCollections",)
 
-from collections.abc import Iterable, Sequence, Set
+from collections.abc import Iterable, Mapping, Sequence, Set
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
 from lsst.utils.iteration import ensure_iterable
@@ -39,6 +40,11 @@ from .._collection_type import CollectionType
 from ..registry._exceptions import OrphanedRecordError
 from ..registry.interfaces import ChainedCollectionRecord
 from ..registry.sql_registry import SqlRegistry
+from ..registry.wildcards import CollectionWildcard
+
+if TYPE_CHECKING:
+    from .._dataset_type import DatasetType
+    from ..registry._collection_summary import CollectionSummary
 
 
 class DirectButlerCollections(ButlerCollections):
@@ -107,20 +113,55 @@ class DirectButlerCollections(ButlerCollections):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         info = []
         with self._registry.caching_context():
             if collection_types is None:
                 collection_types = CollectionType.all()
-            for name in self._registry.queryCollections(
-                expression,
-                collectionTypes=collection_types,
-                flattenChains=flatten_chains,
-                includeChains=include_chains,
-            ):
+            elif isinstance(collection_types, CollectionType):
+                collection_types = {collection_types}
+
+            records = self._registry._managers.collections.resolve_wildcard(
+                CollectionWildcard.from_expression(expression),
+                collection_types=collection_types,
+                flatten_chains=flatten_chains,
+                include_chains=include_chains,
+            )
+
+            summaries: Mapping[Any, CollectionSummary] = {}
+            if include_summary:
+                summaries = self._registry._managers.datasets.fetch_summaries(records, summary_datasets)
+
+            for record in records:
+                # TODO: getDocumentation method is not vectorized, we want to
+                # avoid thousands of queries to just fetch documentation that
+                # is not needed in many cases.
+                doc = ""
+                children: tuple[str, ...] = tuple()
+                if record.type == CollectionType.CHAINED:
+                    assert isinstance(record, ChainedCollectionRecord)
+                    children = tuple(record.children)
+                parents: frozenset[str] | None = None
+                if include_parents:
+                    # TODO: This is non-vectorized as well, so expensive to do
+                    # in a loop.
+                    parents = frozenset(self._registry.getCollectionParentChains(record.name))
+                dataset_types: Set[str] | None = None
+                if summary := summaries.get(record.key):
+                    dataset_types = frozenset([dt.name for dt in summary.dataset_types])
+
                 info.append(
-                    self.get_info(name, include_parents=include_parents, include_summary=include_summary)
+                    CollectionInfo(
+                        name=record.name,
+                        type=record.type,
+                        doc=doc,
+                        parents=parents,
+                        children=children,
+                        dataset_types=dataset_types,
+                    )
                 )
+
         return info
 
     def get_info(

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 from abc import abstractmethod
-from collections.abc import Iterable, Set
+from collections.abc import Iterable, Mapping, Set
 from typing import TYPE_CHECKING, Any, Generic, Self, TypeVar
 
 import sqlalchemy
@@ -567,6 +567,23 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         -------
         docs : `str` or `None`
             Docstring for the collection with the given key.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_docs(self, key: Iterable[_Key]) -> Mapping[_Key, str]:
+        """Retrieve the documentation string for multiple collections.
+
+        Parameters
+        ----------
+        key : `~collections.abc.Iterable` [ _Key ]
+            Internal primary key value for the collection.
+
+        Returns
+        -------
+        docs : `~collections.abc.Mapping` [ _Key, `str`]
+            Documentation strings indexed by collection key. Only collections
+            with non-empty documentation strings are returned.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/remote_butler/_remote_butler_collections.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler_collections.py
@@ -36,6 +36,7 @@ from .._butler_collections import ButlerCollections, CollectionInfo
 from .._collection_type import CollectionType
 
 if TYPE_CHECKING:
+    from .._dataset_type import DatasetType
     from ._registry import RemoteButlerRegistry
 
 
@@ -79,6 +80,7 @@ class RemoteButlerCollections(ButlerCollections):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         # This should become a single call on the server in the future.
         if collection_types is None:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler_collections.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler_collections.py
@@ -80,6 +80,7 @@ class RemoteButlerCollections(ButlerCollections):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        include_doc: bool = False,
         summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         # This should become a single call on the server in the future.

--- a/python/lsst/daf/butler/script/exportCalibs.py
+++ b/python/lsst/daf/butler/script/exportCalibs.py
@@ -138,6 +138,7 @@ def exportCalibs(
         collections_query,
         flatten_chains=True,
         include_chains=True,
+        include_doc=True,
         collection_types={CollectionType.CALIBRATION, CollectionType.CHAINED},
     ):
         log.info("Checking collection: %s", collection.name)

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -35,7 +35,6 @@ import numpy as np
 from astropy.table import Table as AstropyTable
 
 from .._butler import Butler
-from .._collection_type import CollectionType
 from ..cli.utils import sortAstropyTable
 
 if TYPE_CHECKING:
@@ -268,13 +267,9 @@ class QueryDatasets:
 
         # Only iterate over dataset types that are relevant for the query.
         dataset_type_names = {dataset_type.name for dataset_type in dataset_types}
-        dataset_type_collections: dict[str, list[str]] = defaultdict(list)
-        for coll_info in query_collections_info:
-            # Only care about non-chained collections.
-            if coll_info.type != CollectionType.CHAINED:
-                assert coll_info.dataset_types is not None, "collection summary is missing"
-                for dataset_type in coll_info.dataset_types & dataset_type_names:
-                    dataset_type_collections[dataset_type].append(coll_info.name)
+        dataset_type_collections = self.butler.collections._group_by_dataset_type(
+            dataset_type_names, query_collections_info
+        )
 
         if (n_filtered := len(dataset_type_collections)) != n_dataset_types:
             _LOG.info("Filtered %d dataset types down to %d", n_dataset_types, n_filtered)

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -272,6 +272,7 @@ class QueryDatasets:
         for coll_info in query_collections_info:
             # Only care about non-chained collections.
             if coll_info.type != CollectionType.CHAINED:
+                assert coll_info.dataset_types is not None, "collection summary is missing"
                 for dataset_type in coll_info.dataset_types & dataset_type_names:
                     dataset_type_collections[dataset_type].append(coll_info.name)
 

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -83,21 +83,21 @@ def queryDimensionRecords(
 
         if datasets:
             query_collections = collections or "*"
-            collections_info = butler.collections.query_info(query_collections, include_summary=True)
-            expanded_collections = [info.name for info in collections_info]
-            dataset_types = [dt.name for dt in butler.registry.queryDatasetTypes(datasets)]
-            dataset_types = list(butler.collections._filter_dataset_types(dataset_types, collections_info))
+            dataset_types = butler.registry.queryDatasetTypes(datasets)
+            collections_info = butler.collections.query_info(
+                query_collections, include_summary=True, summary_datasets=dataset_types
+            )
+            dataset_type_collections = butler.collections._group_by_dataset_type(
+                {dt.name for dt in dataset_types}, collections_info
+            )
 
-            if not dataset_types:
+            if not dataset_type_collections:
                 return None
 
-            sub_query = query.join_dataset_search(dataset_types.pop(0), collections=expanded_collections)
-            for dt in dataset_types:
-                sub_query = sub_query.join_dataset_search(dt, collections=expanded_collections)
+            for dt, dt_collections in dataset_type_collections.items():
+                query = query.join_dataset_search(dt, collections=dt_collections)
 
-            query_results = sub_query.dimension_records(element)
-        else:
-            query_results = query.dimension_records(element)
+        query_results = query.dimension_records(element)
 
         if where:
             query_results = query_results.where(where)

--- a/python/lsst/daf/butler/tests/hybrid_butler_collections.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_collections.py
@@ -36,6 +36,7 @@ from .._butler_collections import ButlerCollections, CollectionInfo
 from .._collection_type import CollectionType
 
 if TYPE_CHECKING:
+    from .._dataset_type import DatasetType
     from .hybrid_butler import HybridButler
 
 
@@ -85,6 +86,7 @@ class HybridButlerCollections(ButlerCollections):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         return self._hybrid._remote_butler.collections.query_info(
             expression,
@@ -93,6 +95,7 @@ class HybridButlerCollections(ButlerCollections):
             include_chains=include_chains,
             include_parents=include_parents,
             include_summary=include_summary,
+            summary_datasets=summary_datasets,
         )
 
     def get_info(

--- a/python/lsst/daf/butler/tests/hybrid_butler_collections.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_collections.py
@@ -86,6 +86,7 @@ class HybridButlerCollections(ButlerCollections):
         include_chains: bool | None = None,
         include_parents: bool = False,
         include_summary: bool = False,
+        include_doc: bool = False,
         summary_datasets: Iterable[DatasetType] | None = None,
     ) -> Sequence[CollectionInfo]:
         return self._hybrid._remote_butler.collections.query_info(
@@ -95,6 +96,7 @@ class HybridButlerCollections(ButlerCollections):
             include_chains=include_chains,
             include_parents=include_parents,
             include_summary=include_summary,
+            include_doc=include_doc,
             summary_datasets=summary_datasets,
         )
 


### PR DESCRIPTION
Direct butler reimplements `query_info` method to avoid multiple queries, which makes it significantly faster. This patch also adds two optional parameters to `query_info` to allow further optimizations. There is still an inefficiency in `fetch_summaries` method when the number of potential collections is very large (when collections are `*`). Further optimization would probably need more work (and I think that we'll have to optimize it as the number of collections grows every day).

@dhirving, I added the same parameters to remote butler interface, but they are not used for now. I know you are working on DM-46129, maybe you can add forwarding of those parameters to remote server?

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
