### PR TITLE
DM-46339: fix regression in glob detection in query-datasets

### DIFF
--- a/doc/changes/DM-46339.bugfix.md
+++ b/doc/changes/DM-46339.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug in `butler query-datasets` that incorrectly rejected a find-first query against a chain collection as having a glob.

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -36,6 +36,7 @@ from astropy.table import Table as AstropyTable
 
 from .._butler import Butler
 from ..cli.utils import sortAstropyTable
+from ..utils import has_globs
 
 if TYPE_CHECKING:
     from lsst.daf.butler import DatasetRef
@@ -261,7 +262,7 @@ class QueryDatasets:
             summary_datasets=dataset_types,
         )
         expanded_query_collections = [c.name for c in query_collections_info]
-        if self._find_first and set(query_collections) != set(expanded_query_collections):
+        if self._find_first and has_globs(query_collections):
             raise RuntimeError("Can not use wildcards in collections when find_first=True")
         query_collections = expanded_query_collections
 


### PR DESCRIPTION
CHAINED collections could masquerade as globs with the previous logic. With the new logic, we're probably trying to turn each string into a regex more than one time, but that shouldn't be very expensive.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
