### PR TITLE
DM-46363: Inject SqlQueryContext into ObsCoreManager at top level

### DIFF
--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -44,9 +44,9 @@ from ._versioning import VersionedExtension, VersionTuple
 if TYPE_CHECKING:
     from lsst.sphgeom import Region
 
+    from ..._column_type_info import ColumnTypeInfo
     from ..._dataset_ref import DatasetRef
     from ...dimensions import DimensionUniverse
-    from ..queries import SqlQueryContext
     from ._collections import CollectionRecord
     from ._database import Database, StaticTablesContext
     from ._datasets import DatasetRecordStorageManager
@@ -103,6 +103,7 @@ class ObsCoreTableManager(VersionedExtension):
         datasets: type[DatasetRecordStorageManager],
         dimensions: DimensionRecordStorageManager,
         registry_schema_version: VersionTuple | None = None,
+        column_type_info: ColumnTypeInfo,
     ) -> ObsCoreTableManager:
         """Construct an instance of the manager.
 
@@ -124,6 +125,9 @@ class ObsCoreTableManager(VersionedExtension):
             Manager for Registry dimensions.
         registry_schema_version : `VersionTuple` or `None`
             Schema version of this extension as defined in registry.
+        column_type_info : `ColumnTypeInfo`
+            Information about column types that can differ between data
+            repositories and registry instances.
 
         Returns
         -------
@@ -144,7 +148,7 @@ class ObsCoreTableManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def add_datasets(self, refs: Iterable[DatasetRef], context: SqlQueryContext) -> int:
+    def add_datasets(self, refs: Iterable[DatasetRef]) -> int:
         """Possibly add datasets to the obscore table.
 
         This method should be called when new datasets are added to a RUN
@@ -156,8 +160,6 @@ class ObsCoreTableManager(VersionedExtension):
             Dataset refs to add. Dataset refs have to be completely expanded.
             If a record with the same dataset ID is already in obscore table,
             the dataset is ignored.
-        context : `SqlQueryContext`
-            Context used to execute queries for additional dimension metadata.
 
         Returns
         -------
@@ -180,9 +182,7 @@ class ObsCoreTableManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def associate(
-        self, refs: Iterable[DatasetRef], collection: CollectionRecord, context: SqlQueryContext
-    ) -> int:
+    def associate(self, refs: Iterable[DatasetRef], collection: CollectionRecord) -> int:
         """Possibly add datasets to the obscore table.
 
         This method should be called when existing datasets are associated with
@@ -196,8 +196,6 @@ class ObsCoreTableManager(VersionedExtension):
             the dataset is ignored.
         collection : `CollectionRecord`
             Collection record for a TAGGED collection.
-        context : `SqlQueryContext`
-            Context used to execute queries for additional dimension metadata.
 
         Returns
         -------

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -444,18 +444,6 @@ class RegistryManagerInstances(
             universe=universe,
             registry_schema_version=schema_versions.get("datastores"),
         )
-        if types.obscore is not None and "obscore" in types.manager_configs:
-            kwargs["obscore"] = types.obscore.initialize(
-                database,
-                context,
-                universe=universe,
-                config=types.manager_configs["obscore"],
-                datasets=types.datasets,
-                dimensions=kwargs["dimensions"],
-                registry_schema_version=schema_versions.get("obscore"),
-            )
-        else:
-            kwargs["obscore"] = None
         kwargs["column_types"] = ColumnTypeInfo(
             database.getTimespanRepresentation(),
             universe,
@@ -467,6 +455,19 @@ class RegistryManagerInstances(
             run_key_spec=types.collections.addRunForeignKey(dummy_table, primaryKey=False, nullable=False),
             ingest_date_dtype=datasets.ingest_date_dtype(),
         )
+        if types.obscore is not None and "obscore" in types.manager_configs:
+            kwargs["obscore"] = types.obscore.initialize(
+                database,
+                context,
+                universe=universe,
+                config=types.manager_configs["obscore"],
+                datasets=types.datasets,
+                dimensions=kwargs["dimensions"],
+                registry_schema_version=schema_versions.get("obscore"),
+                column_type_info=kwargs["column_types"],
+            )
+        else:
+            kwargs["obscore"] = None
         kwargs["caching_context"] = caching_context
         return cls(**kwargs)
 

--- a/python/lsst/daf/butler/registry/obscore/_records.py
+++ b/python/lsst/daf/butler/registry/obscore/_records.py
@@ -49,9 +49,6 @@ if TYPE_CHECKING:
     from ._schema import ObsCoreSchema
     from ._spatial import SpatialObsCorePlugin
 
-if TYPE_CHECKING:
-    from ..queries import SqlQueryContext
-
 _LOG = logging.getLogger(__name__)
 
 # Map extra column type to a conversion method that takes string.
@@ -67,15 +64,13 @@ class ExposureRegionFactory:
     """Abstract interface for a class that returns a Region for an exposure."""
 
     @abstractmethod
-    def exposure_region(self, dataId: DataCoordinate, context: SqlQueryContext) -> Region | None:
+    def exposure_region(self, dataId: DataCoordinate) -> Region | None:
         """Return a region for a given DataId that corresponds to an exposure.
 
         Parameters
         ----------
         dataId : `DataCoordinate`
             Data ID for an exposure dataset.
-        context : `SqlQueryContext`
-            Context used to execute queries for additional dimension metadata.
 
         Returns
         -------
@@ -125,7 +120,7 @@ class RecordFactory:
         self.visit = universe["visit"]
         self.physical_filter = cast(Dimension, universe["physical_filter"])
 
-    def __call__(self, ref: DatasetRef, context: SqlQueryContext) -> Record | None:
+    def __call__(self, ref: DatasetRef) -> Record | None:
         """Make an ObsCore record from a dataset.
 
         Parameters
@@ -194,7 +189,7 @@ class RecordFactory:
             if (dimension_record := dataId.records[self.exposure.name]) is not None:
                 self._exposure_records(dimension_record, record)
                 if self.exposure_region_factory is not None:
-                    region = self.exposure_region_factory.exposure_region(dataId, context)
+                    region = self.exposure_region_factory.exposure_region(dataId)
         elif self.visit.name in dataId and (dimension_record := dataId.records[self.visit.name]) is not None:
             self._visit_records(dimension_record, record)
 

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -1078,8 +1078,7 @@ class SqlRegistry:
         try:
             refs = list(storage.insert(runRecord, expandedDataIds, idGenerationMode))
             if self._managers.obscore:
-                context = queries.SqlQueryContext(self._db, self._managers.column_types)
-                self._managers.obscore.add_datasets(refs, context)
+                self._managers.obscore.add_datasets(refs)
         except sqlalchemy.exc.IntegrityError as err:
             raise ConflictingDefinitionError(
                 "A database constraint failure was triggered by inserting "
@@ -1193,8 +1192,7 @@ class SqlRegistry:
         try:
             refs = list(storage.import_(runRecord, expandedDatasets))
             if self._managers.obscore:
-                context = queries.SqlQueryContext(self._db, self._managers.column_types)
-                self._managers.obscore.add_datasets(refs, context)
+                self._managers.obscore.add_datasets(refs)
         except sqlalchemy.exc.IntegrityError as err:
             raise ConflictingDefinitionError(
                 "A database constraint failure was triggered by inserting "
@@ -1307,8 +1305,7 @@ class SqlRegistry:
                 if self._managers.obscore:
                     # If a TAGGED collection is being monitored by ObsCore
                     # manager then we may need to save the dataset.
-                    context = queries.SqlQueryContext(self._db, self._managers.column_types)
-                    self._managers.obscore.associate(refsForType, collectionRecord, context)
+                    self._managers.obscore.associate(refsForType, collectionRecord)
             except sqlalchemy.exc.IntegrityError as err:
                 raise ConflictingDefinitionError(
                     f"Constraint violation while associating dataset of type {datasetType.name} with "


### PR DESCRIPTION
Modified the ExposureRegionFactory interface to no longer expose SqlQueryContext outside daf_butler.

The ExposureRegionFactory interface has one internal implementation and one external implementation in the dax_obscore package.  The internal implementation needs privileged access to SqlRegistry internals, but the external one does not.  The external one now needs to support RemoteButler and can no longer provide a SqlRegistry object.

In order to make this change, the SqlQueryContext is now created once when ObscoreLiveTableManager is created and passed to the internal ExposureRegionFactory's constructor, instead of being part of the ExposureRegionFactory method call interface.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
