### PR TITLE
DM-45844: Avoid creating identical parsers

### DIFF
--- a/python/lsst/daf/butler/registry/queries/expressions/parser/parser.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/parser.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 
 from .exprTree import Node
-from .parserYacc import ParserYacc  # type: ignore
+from .parserYacc import ParserYacc
 
 
 def parse_expression(expression: str) -> Node | None:

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -437,45 +437,6 @@ class ParserLexTestCase(unittest.TestCase):
         self.assertIsInstance(tree.rhs.rhs, exprTree.StringLiteral)
         self.assertEqual(tree.rhs.rhs.value, "i")
 
-    def testSubstitution(self):
-        """Test for identifier substitution"""
-        # substitution is not recursive, so we can swap id2/id3
-        idMap = {
-            "id1": exprTree.StringLiteral("id1 value"),
-            "id2": exprTree.Identifier("id3"),
-            "id3": exprTree.Identifier("id2"),
-            "POINT": exprTree.StringLiteral("not used"),
-            "OR": exprTree.StringLiteral("not used"),
-        }
-        parser = ParserYacc(idMap=idMap)
-
-        expression = "id1 = 'v'"
-        tree = parser.parse(expression)
-        self.assertIsInstance(tree, exprTree.BinaryOp)
-        self.assertEqual(tree.op, "=")
-        self.assertIsInstance(tree.lhs, exprTree.StringLiteral)
-        self.assertEqual(tree.lhs.value, "id1 value")
-
-        expression = "id2 - id3"
-        tree = parser.parse(expression)
-        self.assertIsInstance(tree, exprTree.BinaryOp)
-        self.assertEqual(tree.op, "-")
-        self.assertIsInstance(tree.lhs, exprTree.Identifier)
-        self.assertEqual(tree.lhs.name, "id3")
-        self.assertIsInstance(tree.rhs, exprTree.Identifier)
-        self.assertEqual(tree.rhs.name, "id2")
-
-        # reserved words are not substituted
-        expression = "id2 OR id3"
-        tree = parser.parse(expression)
-        self.assertIsInstance(tree, exprTree.BinaryOp)
-        self.assertEqual(tree.op, "OR")
-
-        # function names are not substituted
-        expression = "POINT(1, 2)"
-        tree = parser.parse(expression)
-        self.assertIsInstance(tree, exprTree.PointNode)
-
     def testException(self):
         """Test for exceptional cases"""
 


### PR DESCRIPTION
Building parsers is expensive, now `ParserYacc` keeps a cache of parsers,
there is one parser created per combination of keyword parameters. In
reality there will be just one parser because we do not pass any non-default
parameters to constructor. This makes repeated construction or `ParserYacc`
significantly faster, timing shows reduction from 6.6 sec to 0.3 msec per
1000 instantiations.

This commit removes option for identifier substitution at parser level (`idMap`
parameter for `ParserYacc`). We never used that option, its presence made
reusable parsers hard to implement. We handle identifiers in our visitor classes,
so there is no impact on our code. The only use of that option in the unit tests
was also removed.

Also added type annotations to parserLex and parserYacc modules.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
