### PR TITLE
DM-46563: Ensure that arrow tables with null values return masked numpy array

### DIFF
--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -231,12 +231,14 @@ def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray:
     -------
     array : `numpy.ndarray` (N,)
         Numpy array table with N rows and the same column names
-        as the input arrow table.
+        as the input arrow table. Will be masked records if any values
+        in the table are null.
     """
     import numpy as np
 
     numpy_dict = arrow_to_numpy_dict(arrow_table)
 
+    has_mask = False
     dtype = []
     for name, col in numpy_dict.items():
         if len(shape := numpy_dict[name].shape) <= 1:
@@ -244,8 +246,13 @@ def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray:
         else:
             dtype.append((name, (col.dtype, shape[1:])))
 
-    array = np.rec.fromarrays(numpy_dict.values(), dtype=dtype)
+        if not has_mask and isinstance(col, np.ma.MaskedArray):
+            has_mask = True
 
+    if has_mask:
+        array = np.ma.mrecords.fromarrays(numpy_dict.values(), dtype=dtype)
+    else:
+        array = np.rec.fromarrays(numpy_dict.values(), dtype=dtype)
     return array
 
 

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1098,7 +1098,8 @@ def _arrow_string_to_numpy_dtype(
         # String/bytes length from header.
         strlen = int(schema.metadata[encoded])
     elif numpy_column is not None and len(numpy_column) > 0:
-        strlen = max([len(row) for row in numpy_column if row])
+        lengths = [len(row) for row in numpy_column if row]
+        strlen = max(lengths) if lengths else 0
 
     dtype = f"U{strlen}" if schema.field(name).type == pa.string() else f"|S{strlen}"
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -759,6 +759,20 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         _checkNumpyTableEquality(tab1, tab2)
 
     @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
+    def testMaskedNumpy(self):
+        tab1 = _makeSimpleArrowTable(include_multidim=False, include_masked=True)
+        tab1_np = arrow_to_numpy(tab1)
+        self.assertIsInstance(tab1_np, np.ma.MaskedArray)
+        # Stats on a masked column should ignore the nan in row 1.
+        col = tab1_np["m_f8"]
+        self.assertEqual(np.mean(col), 2.25, f"Column: {col}")
+
+        # Now without a mask.
+        tab1 = _makeSimpleArrowTable(include_multidim=False, include_masked=False)
+        tab1_np = arrow_to_numpy(tab1)
+        self.assertNotIsInstance(tab1_np, np.ma.MaskedArray)
+
+    @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
     def testWriteReadArrowTableLossless(self):
         tab1 = _makeSimpleArrowTable(include_multidim=False, include_masked=True)
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
