### PR TITLE
DM-46563: Use masked record arrays in arrow to numpy conversion

### DIFF
--- a/doc/changes/DM-46563.bugfix.rst
+++ b/doc/changes/DM-46563.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the return type of ``arrow_to_numpy`` so that a masked record array is returned if any of the columns in the arrow table includes nulls.
+Previously the masks were ignored and fill values were visible and used in calculations.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -219,7 +219,7 @@ def arrow_to_astropy(arrow_table: pa.Table) -> atable.Table:
     return astropy_table
 
 
-def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray:
+def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray | np.ma.MaskedArray:
     """Convert a pyarrow table to a structured numpy array.
 
     Parameters
@@ -229,14 +229,16 @@ def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray:
 
     Returns
     -------
-    array : `numpy.ndarray` (N,)
+    array : `numpy.ndarray` or `numpy.ma.MaskedArray` (N,)
         Numpy array table with N rows and the same column names
-        as the input arrow table.
+        as the input arrow table. Will be masked records if any values
+        in the table are null.
     """
     import numpy as np
 
     numpy_dict = arrow_to_numpy_dict(arrow_table)
 
+    has_mask = False
     dtype = []
     for name, col in numpy_dict.items():
         if len(shape := numpy_dict[name].shape) <= 1:
@@ -244,8 +246,13 @@ def arrow_to_numpy(arrow_table: pa.Table) -> np.ndarray:
         else:
             dtype.append((name, (col.dtype, shape[1:])))
 
-    array = np.rec.fromarrays(numpy_dict.values(), dtype=dtype)
+        if not has_mask and isinstance(col, np.ma.MaskedArray):
+            has_mask = True
 
+    if has_mask:
+        array = np.ma.mrecords.fromarrays(numpy_dict.values(), dtype=dtype)
+    else:
+        array = np.rec.fromarrays(numpy_dict.values(), dtype=dtype)
     return array
 
 

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1098,7 +1098,8 @@ def _arrow_string_to_numpy_dtype(
         # String/bytes length from header.
         strlen = int(schema.metadata[encoded])
     elif numpy_column is not None and len(numpy_column) > 0:
-        strlen = max([len(row) for row in numpy_column if row])
+        lengths = [len(row) for row in numpy_column if row]
+        strlen = max(lengths) if lengths else 0
 
     dtype = f"U{strlen}" if schema.field(name).type == pa.string() else f"|S{strlen}"
 

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -759,6 +759,20 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         _checkNumpyTableEquality(tab1, tab2)
 
     @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
+    def testMaskedNumpy(self):
+        tab1 = _makeSimpleArrowTable(include_multidim=False, include_masked=True)
+        tab1_np = arrow_to_numpy(tab1)
+        self.assertIsInstance(tab1_np, np.ma.MaskedArray)
+        # Stats on a masked column should ignore the nan in row 1.
+        col = tab1_np["m_f8"]
+        self.assertEqual(np.mean(col), 2.25, f"Column: {col}")
+
+        # Now without a mask.
+        tab1 = _makeSimpleArrowTable(include_multidim=False, include_masked=False)
+        tab1_np = arrow_to_numpy(tab1)
+        self.assertNotIsInstance(tab1_np, np.ma.MaskedArray)
+
+    @unittest.skipUnless(pa is not None, "Cannot test reading as arrow without pyarrow.")
     def testWriteReadArrowTableLossless(self):
         tab1 = _makeSimpleArrowTable(include_multidim=False, include_masked=True)
 


### PR DESCRIPTION
This is #1086 with the right branch name. 

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
