### PR TITLE
DM-46575: Update parquet formatter to use fsspec.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,7 @@ jobs:
         run: |
           pip install uv
           uv pip install -r requirements.txt
+          uv pip install fsspec s3fs
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages

--- a/doc/changes/DM-46575.feature.md
+++ b/doc/changes/DM-46575.feature.md
@@ -1,0 +1,1 @@
+Update parquet formatter to use fsspec, which allows direct access to columns in S3, WebDAV, etc.

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,6 +30,9 @@ ignore_missing_imports = True
 [mypy-botocore.*]
 ignore_missing_imports = True
 
+[mypy-fsspec.*]
+ignore_missing_imports = True
+
 [mypy-urllib3.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
