### PR TITLE
DM-46601: Use nanoseconds for ingest_date for new repos 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,10 +23,10 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.5
+    rev: v0.6.8
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc
-    rev: "v1.8.0rc2"
+    rev: "v1.8.0"
     hooks:
       - id: numpydoc-validation

--- a/doc/changes/DM-46601.misc.md
+++ b/doc/changes/DM-46601.misc.md
@@ -1,0 +1,1 @@
+Update default version of `datasets` manager; new Butler repositories will use TAI nanoseconds for `ingest_date` column instead of database-native timestamps.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
 
 # This has to be updated on every schema change
+# TODO: 1.0.0 can be removed once all repos were migrated to 2.0.0.
 _VERSION_UUID = VersionTuple(1, 0, 0)
 # Starting with 2.0.0 the `ingest_date` column type uses nanoseconds instead
 # of TIMESTAMP. The code supports both 1.0.0 and 2.0.0 for the duration of
@@ -572,9 +573,9 @@ class ByDimensionsDatasetRecordStorageManagerUUID(ByDimensionsDatasetRecordStora
     def _newDefaultSchemaVersion(cls) -> VersionTuple:
         # Docstring inherited from VersionedExtension.
 
-        # By default return 1.0.0 so that older clients can still access new
-        # registries created with a default config.
-        return _VERSION_UUID
+        # By default return latest version so that new repos are created with
+        # nanoseconds ingest_date.
+        return _VERSION_UUID_NS
 
     def ingest_date_dtype(self) -> type:
         """Return type of the ``ingest_date`` column."""


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
