### PR TITLE
DM-46259: Prevent confusing error when deriving dataId from bad exposure/detector combination

### DIFF
--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -751,10 +751,9 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
                                         # Use bind to allow zero results.
                                         # This is a fully-specified query.
                                         "visit_system_membership",
-                                        where="instrument = inst AND visit_system = system AND visit = v",
-                                        bind=dict(
-                                            inst=instrument_records[0].name, system=visit_system, v=rec.id
-                                        ),
+                                        instrument=instrument_records[0].name,
+                                        visit_system=visit_system,
+                                        visit=rec.id,
                                         explain=False,
                                     )
                                     if membership:


### PR DESCRIPTION
* Use new query system in direct butler for dimension records.
* When querying for a detector, say, do not include the exposure in the query (if the exposure is bad the detector query will fail with a confusing error message).
* Improve some other error messages if you have "detector=16, raft='0'" and the raft is inconsistent with the detector or the detector is not known at all.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
