### PR TITLE
DM-46781: Allow no matching results in a query datasets call on command line

### DIFF
--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -301,6 +301,7 @@ class QueryDatasets:
                 find_first=self._find_first,
                 with_dimension_records=True,
                 order_by=self._order_by,
+                explain=False,
                 **kwargs,
             )
             if not unlimited:


### PR DESCRIPTION
Generally this hasn't been a problem because each matching collection is only querying dataset types where there are non-zero datasets.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
