### PR TITLE
DM-46794: Fix problem with data ID rewriting

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Copyright 2016-2021 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
-Copyright 2018-2021 Association of Universities for Research in Astronomy
-Copyright 2015, 2018-2021 The Trustees of Princeton University
+Copyright 2016-2024 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+Copyright 2018-2024 Association of Universities for Research in Astronomy
+Copyright 2015, 2018-2024 The Trustees of Princeton University
 Copyright 2020, 2024 University of Washington

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -708,21 +708,23 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
                     for k, v in newDataId.items()
                     if k in self.dimensions[dimensionName].minimal_group.names
                 }
-                # Build up a WHERE expression
-                bind = dict(values.items())
-                where = " AND ".join(f"{dimensionName}.{k} = {k}" for k in bind)
 
-                # Hopefully we get a single record that matches
-                records = set(
-                    self.query_dimension_records(
-                        dimensionName,
-                        data_id=filtered_data_id,
-                        where=where,
-                        bind=bind,
-                        explain=False,
-                        **kwargs,
-                    )
-                )
+                def _get_attr(obj: Any, attr: str) -> Any:
+                    # Used to implement x.exposure.seq_num when given
+                    # x and "exposure.seq_num".
+                    for component in attr.split("."):
+                        obj = getattr(obj, component)
+                    return obj
+
+                with self.query() as q:
+                    x = q.expression_factory
+                    # Build up a WHERE expression.
+                    predicates = tuple(_get_attr(x, f"{dimensionName}.{k}") == v for k, v in values.items())
+                    extra_args: dict[str, Any] = {}  # For mypy.
+                    extra_args.update(filtered_data_id)
+                    extra_args.update(kwargs)
+                    q = q.where(x.all(*predicates), **extra_args)
+                    records = set(q.dimension_records(dimensionName))
 
                 if len(records) != 1:
                     if len(records) > 1:

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -704,7 +704,9 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
                 # by an exposure ID that doesn't exist and return no matches
                 # for a detector even though it's a good detector name.
                 filtered_data_id = {
-                    k: v for k, v in newDataId.items() if k in self.dimensions[dimensionName].required
+                    k: v
+                    for k, v in newDataId.items()
+                    if k in self.dimensions[dimensionName].minimal_group.names
                 }
                 # Build up a WHERE expression
                 bind = dict(values.items())


### PR DESCRIPTION
Fixes bug introduced in #1092. Now uses the implied and required dimensions for filtering out unnecessary dimensions rather than just required dimensions. This was preventing the standard day_obs+seq_num queries from working.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
