### PR TITLE
DM-46599: Deprecate old query system behavior

### DIFF
--- a/doc/changes/DM-46599.removal.md
+++ b/doc/changes/DM-46599.removal.md
@@ -1,0 +1,19 @@
+Regular expressions in collection and dataset type patterns are now deprecated. (Shell-like globs will continue to be supported.)
+
+Materializing dataset queries into temporary tables is now deprecated.  (Materializing data ID queries will continue to be supported.)
+
+The `datasetTypes` argument to `Registry.queryCollections` is now deprecated. (This parameter has never had any effect.)
+
+We will soon stop raising `DataIdValueError` exceptions for typos and other bad values in query expressions like `instrument='HsC'` for typos and other bad values in query expressions.  Instead, these queries will return an empty iterable of results.
+
+Using HTM and HEALPix spatial dimensions like `htm11` or `healpix10` in data ID constraints passed to queries is now deprecated. The exception is `htm7`, which will continue to work.
+
+The `--no-check` parameter to `butler query-dimension-records` is now deprecated.
+
+The `offset` argument to `limit()` for `Registry.queryDataIds` and `Registry.queryDimensionRecords` result objects is now deprecated.
+
+The `--offset` option for `butler query-data-ids` and `butler-query-datasets` is now deprecated.
+
+It will soon become mandatory to explicitly provide `--collections` and a dataset type search when calling `butler query-datasets`.
+
+Using `Butler.collections` to get the list of default collections is now deprecated.  Use `Butler.collections.defaults` instead.

--- a/doc/changes/DM-46599.removal.md
+++ b/doc/changes/DM-46599.removal.md
@@ -12,7 +12,7 @@ The `--no-check` parameter to `butler query-dimension-records` is now deprecated
 
 The `offset` argument to `limit()` for `Registry.queryDataIds` and `Registry.queryDimensionRecords` result objects is now deprecated.
 
-The `--offset` option for `butler query-data-ids` and `butler-query-datasets` is now deprecated.
+The `--offset` option for `butler query-data-ids` and `butler-query-datasets` is no longer supported, and will raise on exception if you attempt to use it.
 
 It will soon become mandatory to explicitly provide `--collections` and a dataset type search when calling `butler query-datasets`.
 

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -85,8 +85,8 @@ class ButlerCollections(ABC, Sequence):
     def __getitem__(self, index: slice) -> Sequence[str]: ...
 
     @deprecated(
-        "'Butler.collections' will no longer directly contain the list of default collections"
-        " after v28. Use 'Butler.collections.defaults' instead.",
+        "‘Butler.collections’ should no longer be used to get the list of default collections."
+        " Use ‘Butler.collections.default’ instead. Will be removed after v28.",
         version="v28",
         category=FutureWarning,
     )
@@ -94,8 +94,8 @@ class ButlerCollections(ABC, Sequence):
         return self.defaults[index]
 
     @deprecated(
-        "'Butler.collections' will no longer directly contain the list of default collections"
-        " after v28. Use 'Butler.collections.defaults' instead.",
+        "‘Butler.collections’ should no longer be used to get the list of default collections."
+        " Use ‘Butler.collections.default’ instead. Will be removed after v28.",
         version="v28",
         category=FutureWarning,
     )

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -34,6 +34,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence, Set
 from typing import TYPE_CHECKING, Any, overload
 
+from deprecated.sphinx import deprecated
 from pydantic import BaseModel
 
 from ._collection_type import CollectionType
@@ -83,9 +84,21 @@ class ButlerCollections(ABC, Sequence):
     @overload
     def __getitem__(self, index: slice) -> Sequence[str]: ...
 
+    @deprecated(
+        "'Butler.collections' will no longer directly contain the list of default collections"
+        " after v28. Use 'Butler.collections.defaults' instead.",
+        version="v28",
+        category=FutureWarning,
+    )
     def __getitem__(self, index: int | slice) -> str | Sequence[str]:
         return self.defaults[index]
 
+    @deprecated(
+        "'Butler.collections' will no longer directly contain the list of default collections"
+        " after v28. Use 'Butler.collections.defaults' instead.",
+        version="v28",
+        category=FutureWarning,
+    )
     def __len__(self) -> int:
         return len(self.defaults)
 

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -576,7 +576,7 @@ def query_data_ids(**kwargs: Any) -> None:
 def query_dimension_records(**kwargs: Any) -> None:
     """Query for dimension information."""
     if kwargs.pop("no_check") is not None:
-        click.echo("WARNING: --no-check option now has no effect and is ignored.")
+        click.echo("WARNING: --no-check option has no effect and will be removed after v28.")
     table = script.queryDimensionRecords(**kwargs)
     if table:
         table.pprint_all()

--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -534,7 +534,8 @@ class DatabaseDataCoordinateQueryResults(DataCoordinateQueryResults):
     def limit(self, limit: int, offset: int | None | EllipsisType = ...) -> Self:
         if offset is not ...:
             warnings.warn(
-                "offset parameter is not supported in new query system and will be removed after v28.",
+                "'offset' parameter should no longer be used. It is not supported by the new query system."
+                " Will be removed after v28.",
                 FutureWarning,
             )
         if offset is None or offset is ...:
@@ -675,7 +676,7 @@ class DatabaseParentDatasetQueryResults(ParentDatasetQueryResults):
 
     @contextmanager
     @deprecated(
-        "This method is not supported by the new query system and will be removed after v28.",
+        "This method should no longer be used. Will be removed after v28.",
         version="v28",
         category=FutureWarning,
     )
@@ -835,7 +836,8 @@ class DatabaseDimensionRecordQueryResults(DimensionRecordQueryResults):
         # Docstring inherited from base class.
         if offset is not ...:
             warnings.warn(
-                "offset parameter is not supported in new query system and will be removed after v28.",
+                "'offset' parameter should no longer be used. It is not supported by the new query system."
+                " Will be removed after v28.",
                 FutureWarning,
             )
         if offset is None or offset is ...:

--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -44,6 +44,8 @@ from collections.abc import Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from typing import Any, Self
 
+from deprecated.sphinx import deprecated
+
 from ..._dataset_ref import DatasetRef
 from ..._dataset_type import DatasetType
 from ..._exceptions_legacy import DatasetTypeError
@@ -665,6 +667,11 @@ class DatabaseParentDatasetQueryResults(ParentDatasetQueryResults):
         yield self
 
     @contextmanager
+    @deprecated(
+        "This method is not supported by the new query system and will be removed after v28.",
+        version="v28",
+        category=FutureWarning,
+    )
     def materialize(self) -> Iterator[DatabaseParentDatasetQueryResults]:
         # Docstring inherited from DatasetQueryResults.
         with self._query.open_context():

--- a/python/lsst/daf/butler/registry/queries/_results.py
+++ b/python/lsst/daf/butler/registry/queries/_results.py
@@ -39,9 +39,11 @@ __all__ = (
 )
 
 import itertools
+import warnings
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, ExitStack, contextmanager
+from types import EllipsisType
 from typing import Any, Self
 
 from deprecated.sphinx import deprecated
@@ -529,8 +531,13 @@ class DatabaseDataCoordinateQueryResults(DataCoordinateQueryResults):
         self._query = self._query.sorted(clause.terms, defer=True)
         return self
 
-    def limit(self, limit: int, offset: int | None = 0) -> Self:
-        if offset is None:
+    def limit(self, limit: int, offset: int | None | EllipsisType = ...) -> Self:
+        if offset is not ...:
+            warnings.warn(
+                "offset parameter is not supported in new query system and will be removed after v28.",
+                FutureWarning,
+            )
+        if offset is None or offset is ...:
             offset = 0
         self._query = self._query.sliced(offset, offset + limit, defer=True)
         return self
@@ -824,9 +831,14 @@ class DatabaseDimensionRecordQueryResults(DimensionRecordQueryResults):
         self._query = self._query.sorted(clause.terms, defer=True)
         return self
 
-    def limit(self, limit: int, offset: int | None = 0) -> Self:
+    def limit(self, limit: int, offset: int | None | EllipsisType = ...) -> Self:
         # Docstring inherited from base class.
-        if offset is None:
+        if offset is not ...:
+            warnings.warn(
+                "offset parameter is not supported in new query system and will be removed after v28.",
+                FutureWarning,
+            )
+        if offset is None or offset is ...:
             offset = 0
         self._query = self._query.sliced(offset, offset + limit, defer=True)
         return self

--- a/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
@@ -339,8 +339,8 @@ class SqlQueryBackend(QueryBackend[SqlQueryContext]):
             if (constraint_values := constraints.get(dimension_name)) is not None:
                 if not (constraint_values <= all_values):
                     warnings.warn(
-                        "DataIdValueError will no longer be raised for invalid governor dimension"
-                        " values after v28.",
+                        "DataIdValueError will no longer be raised for invalid governor dimension values."
+                        " Instead, an empty list will be returned.  Will be changed after v28.",
                         FutureWarning,
                     )
                     raise DataIdValueError(

--- a/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 __all__ = ("SqlQueryBackend",)
 
+import warnings
 from collections.abc import Iterable, Mapping, Sequence, Set
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, cast
@@ -337,6 +338,11 @@ class SqlQueryBackend(QueryBackend[SqlQueryContext]):
             }
             if (constraint_values := constraints.get(dimension_name)) is not None:
                 if not (constraint_values <= all_values):
+                    warnings.warn(
+                        "DataIdValueError will no longer be raised for invalid governor dimension"
+                        " values after v28.",
+                        FutureWarning,
+                    )
                     raise DataIdValueError(
                         f"Unknown values specified for governor dimension {dimension_name}: "
                         f"{constraint_values - all_values}."

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -399,9 +399,9 @@ class QuerySummary:
                 dimension.startswith("htm") or dimension.startswith("healpix")
             ) and not dimension == self.universe.commonSkyPix.name:
                 warnings.warn(
-                    f"Queries using dimension '{dimension}' are deprecated."
+                    f"Dimension '{dimension}' should no longer be used in data IDs."
                     " Use the region 'OVERLAPS' operator in the where clause instead."
-                    "  Will be removed after v28.",
+                    " Will be removed after v28.",
                     FutureWarning,
                 )
 

--- a/python/lsst/daf/butler/registry/queries/_structs.py
+++ b/python/lsst/daf/butler/registry/queries/_structs.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 __all__ = ["QuerySummary"]  # other classes here are local to subpackage
 
 import dataclasses
+import warnings
 from collections.abc import Iterable, Mapping, Set
 from typing import Any
 
@@ -393,6 +394,16 @@ class QuerySummary:
         self.order_by = None if order_by is None else OrderByClause.parse_general(order_by, requested)
         self.limit = limit
         self.columns_required, self.dimensions, self.region = self._compute_columns_required()
+        for dimension in self.where.data_id.dimensions.names:
+            if (
+                dimension.startswith("htm") or dimension.startswith("healpix")
+            ) and not dimension == self.universe.commonSkyPix.name:
+                warnings.warn(
+                    f"Queries using dimension '{dimension}' are deprecated."
+                    " Use the region 'OVERLAPS' operator in the where clause instead."
+                    "  Will be removed after v28.",
+                    FutureWarning,
+                )
 
     requested: DimensionGroup
     """Dimensions whose primary keys should be included in the result rows of

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -1789,6 +1789,11 @@ class SqlRegistry:
         # Right now the datasetTypes argument is completely ignored, but that
         # is consistent with its [lack of] guarantees.  DM-24939 or a follow-up
         # ticket will take care of that.
+        if datasetType is not None:
+            warnings.warn(
+                "The datasetType parameter has never done anything and will be removed after v28",
+                FutureWarning,
+            )
         try:
             wildcard = CollectionWildcard.from_expression(expression)
         except TypeError as exc:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2426,7 +2426,7 @@ class SqlRegistry:
         if isinstance(datasetType, str):
             datasetType = self.getDatasetType(datasetType)
         resolved_collections = self.queryCollections(
-            collections, datasetType, collectionTypes=collectionTypes, flattenChains=flattenChains
+            collections, collectionTypes=collectionTypes, flattenChains=flattenChains
         )
         with self._query() as query:
             query = query.join_dataset_search(datasetType, resolved_collections)

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -1791,7 +1791,8 @@ class SqlRegistry:
         # ticket will take care of that.
         if datasetType is not None:
             warnings.warn(
-                "The datasetType parameter has never done anything and will be removed after v28",
+                "The datasetType parameter should no longer be used. It has"
+                " never had any effect. Will be removed after v28",
                 FutureWarning,
             )
         try:

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -42,6 +42,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
 from collections.abc import Callable, Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from datetime import timedelta
 from threading import Barrier
 from typing import TypeVar
@@ -835,15 +836,19 @@ class RegistryTests(ABC):
 
         if self.supportsCollectionRegex:
             # Query for collections matching a regex.
-            self.assertCountEqual(
-                list(registry.queryCollections(re.compile("imported_."), flattenChains=False)),
-                ["imported_r", "imported_g"],
-            )
+            with self.assertWarns(FutureWarning):
+                self.assertCountEqual(
+                    list(registry.queryCollections(re.compile("imported_."), flattenChains=False)),
+                    ["imported_r", "imported_g"],
+                )
             # Query for collections matching a regex or an explicit str.
-            self.assertCountEqual(
-                list(registry.queryCollections([re.compile("imported_."), "chain1"], flattenChains=False)),
-                ["imported_r", "imported_g", "chain1"],
-            )
+            with self.assertWarns(FutureWarning):
+                self.assertCountEqual(
+                    list(
+                        registry.queryCollections([re.compile("imported_."), "chain1"], flattenChains=False)
+                    ),
+                    ["imported_r", "imported_g", "chain1"],
+                )
         # Same queries as the regex ones above, but using globs instead of
         # regex.
         self.assertCountEqual(
@@ -1388,7 +1393,8 @@ class RegistryTests(ABC):
         if self.supportsQueryGovernorValidation:
             # Specifying non-existing skymap is an exception
             with self.assertRaisesRegex(DataIdValueError, "Unknown values specified for governor dimension"):
-                do_query()
+                with self.assertWarns(FutureWarning):
+                    do_query()
         else:
             # New query system returns zero rows instead of raising an
             # exception.
@@ -1726,14 +1732,15 @@ class RegistryTests(ABC):
 
         # Materialize the bias dataset queries (only) by putting the results
         # into temporary tables, then repeat those tests.
-        with subsetDataIds.findDatasets(
-            bias, collections=["imported_r", "imported_g"], findFirst=False
-        ).materialize() as biases:
-            self.assertCountEqual(list(biases), expectedAllBiases)
-        with subsetDataIds.findDatasets(
-            bias, collections=["imported_r", "imported_g"], findFirst=True
-        ).materialize() as biases:
-            self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
+        with self.assertWarns(FutureWarning):
+            with subsetDataIds.findDatasets(
+                bias, collections=["imported_r", "imported_g"], findFirst=False
+            ).materialize() as biases:
+                self.assertCountEqual(list(biases), expectedAllBiases)
+            with subsetDataIds.findDatasets(
+                bias, collections=["imported_r", "imported_g"], findFirst=True
+            ).materialize() as biases:
+                self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
         # Materialize the data ID subset query, but not the dataset queries.
         with subsetDataIds.materialize() as subsetDataIds:
             self.assertEqual(subsetDataIds.dimensions, expected_subset_dimensions)
@@ -1753,14 +1760,15 @@ class RegistryTests(ABC):
                 expectedDeduplicatedBiases,
             )
             # Materialize the dataset queries, too.
-            with subsetDataIds.findDatasets(
-                bias, collections=["imported_r", "imported_g"], findFirst=False
-            ).materialize() as biases:
-                self.assertCountEqual(list(biases), expectedAllBiases)
-            with subsetDataIds.findDatasets(
-                bias, collections=["imported_r", "imported_g"], findFirst=True
-            ).materialize() as biases:
-                self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
+            with self.assertWarns(FutureWarning):
+                with subsetDataIds.findDatasets(
+                    bias, collections=["imported_r", "imported_g"], findFirst=False
+                ).materialize() as biases:
+                    self.assertCountEqual(list(biases), expectedAllBiases)
+                with subsetDataIds.findDatasets(
+                    bias, collections=["imported_r", "imported_g"], findFirst=True
+                ).materialize() as biases:
+                    self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
         # Materialize the original query, but none of the follow-up queries.
         with dataIds.materialize() as dataIds:
             self.assertEqual(dataIds.dimensions, expected_dimensions)
@@ -1792,14 +1800,15 @@ class RegistryTests(ABC):
                 expectedDeduplicatedBiases,
             )
             # Materialize just the bias dataset queries.
-            with subsetDataIds.findDatasets(
-                bias, collections=["imported_r", "imported_g"], findFirst=False
-            ).materialize() as biases:
-                self.assertCountEqual(list(biases), expectedAllBiases)
-            with subsetDataIds.findDatasets(
-                bias, collections=["imported_r", "imported_g"], findFirst=True
-            ).materialize() as biases:
-                self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
+            with self.assertWarns(FutureWarning):
+                with subsetDataIds.findDatasets(
+                    bias, collections=["imported_r", "imported_g"], findFirst=False
+                ).materialize() as biases:
+                    self.assertCountEqual(list(biases), expectedAllBiases)
+                with subsetDataIds.findDatasets(
+                    bias, collections=["imported_r", "imported_g"], findFirst=True
+                ).materialize() as biases:
+                    self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
             # Materialize the subset data ID query, but not the dataset
             # queries.
             with subsetDataIds.materialize() as subsetDataIds:
@@ -1823,14 +1832,15 @@ class RegistryTests(ABC):
                 )
                 # Materialize the bias dataset queries, too, so now we're
                 # materializing every single step.
-                with subsetDataIds.findDatasets(
-                    bias, collections=["imported_r", "imported_g"], findFirst=False
-                ).materialize() as biases:
-                    self.assertCountEqual(list(biases), expectedAllBiases)
-                with subsetDataIds.findDatasets(
-                    bias, collections=["imported_r", "imported_g"], findFirst=True
-                ).materialize() as biases:
-                    self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
+                with self.assertWarns(FutureWarning):
+                    with subsetDataIds.findDatasets(
+                        bias, collections=["imported_r", "imported_g"], findFirst=False
+                    ).materialize() as biases:
+                        self.assertCountEqual(list(biases), expectedAllBiases)
+                    with subsetDataIds.findDatasets(
+                        bias, collections=["imported_r", "imported_g"], findFirst=True
+                    ).materialize() as biases:
+                        self.assertCountEqual(list(biases), expectedDeduplicatedBiases)
 
     def testStorageClassPropagation(self):
         """Test that queries for datasets respect the storage class passed in
@@ -2700,7 +2710,8 @@ class RegistryTests(ABC):
         # regular expression will skip too
         if self.supportsCollectionRegex:
             pattern = re.compile(".*")
-            datasets = list(registry.queryDatasets("bias", collections=pattern))
+            with self.assertWarns(FutureWarning):
+                datasets = list(registry.queryDatasets("bias", collections=pattern))
             self.assertGreater(len(datasets), 0)
 
         # ellipsis should work as usual
@@ -3364,7 +3375,10 @@ class RegistryTests(ABC):
             dimensions = test.dimensions.split(",")
             if test.exception:
                 with self.assertRaises(test.exception):
-                    do_query(dimensions, test.dataId, test.where, bind=test.bind, **test.kwargs).count()
+                    with ExitStack() as stack:
+                        if test.exception == DataIdValueError:
+                            stack.enter_context(self.assertWarns(FutureWarning))
+                        do_query(dimensions, test.dataId, test.where, bind=test.bind, **test.kwargs).count()
             else:
                 query = do_query(dimensions, test.dataId, test.where, bind=test.bind, **test.kwargs)
                 self.assertEqual(query.count(discard=True), test.count)
@@ -3372,9 +3386,12 @@ class RegistryTests(ABC):
             # and materialize
             if test.exception:
                 with self.assertRaises(test.exception):
-                    query = do_query(dimensions, test.dataId, test.where, bind=test.bind, **test.kwargs)
-                    with query.materialize() as materialized:
-                        materialized.count(discard=True)
+                    with ExitStack() as stack:
+                        if test.exception == DataIdValueError:
+                            stack.enter_context(self.assertWarns(FutureWarning))
+                        query = do_query(dimensions, test.dataId, test.where, bind=test.bind, **test.kwargs)
+                        with query.materialize() as materialized:
+                            materialized.count(discard=True)
             else:
                 query = do_query(dimensions, test.dataId, test.where, bind=test.bind, **test.kwargs)
                 with query.materialize() as materialized:
@@ -3416,13 +3433,14 @@ class RegistryTests(ABC):
         if self.supportsQueryOffset:
             test_data.append(Test("detector", "-purpose,detector.raft,name_in_raft", (2, 3), limit=(2, 2)))
 
-        for test in test_data:
-            order_by = test.order_by.split(",")
-            query = do_query(test.element).order_by(*order_by)
-            if test.limit is not None:
-                query = query.limit(*test.limit)
-            dataIds = tuple(rec.id for rec in query)
-            self.assertEqual(dataIds, test.result)
+        with self.assertWarns(FutureWarning):
+            for test in test_data:
+                order_by = test.order_by.split(",")
+                query = do_query(test.element).order_by(*order_by)
+                if test.limit is not None:
+                    query = query.limit(*test.limit)
+                dataIds = tuple(rec.id for rec in query)
+                self.assertEqual(dataIds, test.result)
 
         # errors in a name
         for order_by in ("", "-"):
@@ -3482,23 +3500,31 @@ class RegistryTests(ABC):
         self.assertEqual(result.count(), 4)
 
         if self.supportsQueryGovernorValidation:
-            with self.assertRaisesRegex(DataIdValueError, "dimension instrument"):
-                result = registry.queryDimensionRecords("detector", instrument="NotCam1")
-                result.count()
+            with self.assertWarns(FutureWarning):
+                with self.assertRaisesRegex(DataIdValueError, "dimension instrument"):
+                    result = registry.queryDimensionRecords("detector", instrument="NotCam1")
+                    result.count()
 
-            with self.assertRaisesRegex(DataIdValueError, "dimension instrument"):
-                result = registry.queryDimensionRecords("detector", dataId={"instrument": "NotCam1"})
-                result.count()
+            with self.assertWarns(FutureWarning):
+                with self.assertRaisesRegex(DataIdValueError, "dimension instrument"):
+                    result = registry.queryDimensionRecords("detector", dataId={"instrument": "NotCam1"})
+                    result.count()
 
-            with self.assertRaisesRegex(DataIdValueError, "Unknown values specified for governor dimension"):
-                result = registry.queryDimensionRecords("detector", where="instrument='NotCam1'")
-                result.count()
+            with self.assertWarns(FutureWarning):
+                with self.assertRaisesRegex(
+                    DataIdValueError, "Unknown values specified for governor dimension"
+                ):
+                    result = registry.queryDimensionRecords("detector", where="instrument='NotCam1'")
+                    result.count()
 
-            with self.assertRaisesRegex(DataIdValueError, "Unknown values specified for governor dimension"):
-                result = registry.queryDimensionRecords(
-                    "detector", where="instrument=instr", bind={"instr": "NotCam1"}
-                )
-                result.count()
+            with self.assertWarns(FutureWarning):
+                with self.assertRaisesRegex(
+                    DataIdValueError, "Unknown values specified for governor dimension"
+                ):
+                    result = registry.queryDimensionRecords(
+                        "detector", where="instrument=instr", bind={"instr": "NotCam1"}
+                    )
+                    result.count()
 
     def testDatasetConstrainedDimensionRecordQueries(self):
         """Test that queryDimensionRecords works even when given a dataset
@@ -3697,17 +3723,18 @@ class RegistryTests(ABC):
         # New query system does not support non-common skypix constraints
         # and we are deprecating it to replace with region-based constraints.
         # TODO: Drop this tests once we remove support for non-common skypix.
-        with contextlib.suppress(NotImplementedError):
-            self.assertEqual(
-                {
-                    (data_id["tract"], data_id["patch"])
-                    for data_id in registry.queryDataIds(
-                        ["patch"],
-                        dataId={skypix_dimension.name: skypix_id},
-                    )
-                },
-                overlapping_patches,
-            )
+        with self.assertWarns(FutureWarning):
+            with contextlib.suppress(NotImplementedError):
+                self.assertEqual(
+                    {
+                        (data_id["tract"], data_id["patch"])
+                        for data_id in registry.queryDataIds(
+                            ["patch"],
+                            dataId={skypix_dimension.name: skypix_id},
+                        )
+                    },
+                    overlapping_patches,
+                )
         # Test that a three-way join that includes the common skypix system in
         # the dimensions doesn't generate redundant join terms in the query.
         # TODO: In the new query system this raises InvalidQueryError, change

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -35,6 +35,7 @@ __all__ = (
 import contextlib
 import dataclasses
 import re
+import warnings
 from collections.abc import Callable, Iterable, Mapping
 from types import EllipsisType
 from typing import Any
@@ -197,6 +198,11 @@ class CategorizedWildcard:
                         self.strings.append(element)
                         return None
             if allowPatterns and isinstance(element, re.Pattern):
+                warnings.warn(
+                    "Using regular expressions in collection or dataset type searches is deprecated"
+                    " and will be removed after v28. Use globs ('*' wildcards) instead.",
+                    FutureWarning,
+                )
                 self.patterns.append(element)
                 return None
             if alreadyCoerced:

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -202,8 +202,8 @@ class CategorizedWildcard:
             if allowPatterns and isinstance(element, re.Pattern):
                 if not was_string:
                     warnings.warn(
-                        "Using regular expressions in collection or dataset type searches is deprecated"
-                        " and will be removed after v28. Use globs ('*' wildcards) instead.",
+                        "Regular expressions should no longer be used in collection or dataset type searches."
+                        " Use globs ('*' wildcards) instead. Will be removed after v28.",
                         FutureWarning,
                     )
                 self.patterns.append(element)

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -182,7 +182,9 @@ class CategorizedWildcard:
         # a local function so we can recurse after coercion.
 
         def process(element: Any, alreadyCoerced: bool = False) -> EllipsisType | None:
+            was_string = False
             if isinstance(element, str):
+                was_string = True
                 if defaultItemValue is not None:
                     self.items.append((element, defaultItemValue))
                     return None
@@ -198,11 +200,12 @@ class CategorizedWildcard:
                         self.strings.append(element)
                         return None
             if allowPatterns and isinstance(element, re.Pattern):
-                warnings.warn(
-                    "Using regular expressions in collection or dataset type searches is deprecated"
-                    " and will be removed after v28. Use globs ('*' wildcards) instead.",
-                    FutureWarning,
-                )
+                if not was_string:
+                    warnings.warn(
+                        "Using regular expressions in collection or dataset type searches is deprecated"
+                        " and will be removed after v28. Use globs ('*' wildcards) instead.",
+                        FutureWarning,
+                    )
                 self.patterns.append(element)
                 return None
             if alreadyCoerced:

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -223,7 +223,7 @@ class RemoteQueryDriver(QueryDriver):
         return result.messages
 
     def get_default_collections(self) -> tuple[str, ...]:
-        collections = tuple(self._butler.collections)
+        collections = tuple(self._butler.collections.defaults)
         if not collections:
             raise NoDefaultCollectionError("No collections provided and no default collections.")
         return collections

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -584,11 +584,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         methods to a standardized format for the REST API.
         """
         if collections is None:
-            if not self.collections:
+            if not self.collections.defaults:
                 raise NoDefaultCollectionError(
                     "No collections provided, and no defaults from butler construction."
                 )
-            collections = self.collections
+            collections = self.collections.defaults
         return convert_collection_arg_to_glob_string_list(collections)
 
     def clone(

--- a/python/lsst/daf/butler/script/queryDataIds.py
+++ b/python/lsst/daf/butler/script/queryDataIds.py
@@ -139,7 +139,7 @@ def queryDataIds(
     `~lsst.daf.butler.Registry.queryDataIds`.
     """
     if offset:
-        raise RuntimeError("Offset is no longer supported by the query system.")
+        raise NotImplementedError("--offset is no longer supported.  It will be removed after v28.")
 
     butler = Butler.from_config(repo, without_datastore=True)
 

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -27,6 +27,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any
@@ -185,6 +186,20 @@ class QueryDatasets:
     ):
         if (repo and butler) or (not repo and not butler):
             raise RuntimeError("One of repo and butler must be provided and the other must be None.")
+        collections = list(collections)
+        if not collections:
+            warnings.warn(
+                "No --collections specified.  The --collections argument will become mandatory after v28.",
+                FutureWarning,
+            )
+        glob = list(glob)
+        if not glob:
+            warnings.warn(
+                "No dataset types specified.  Explicitly specifying dataset types will become mandatory"
+                " after v28. Specify '*' to match the current behavior of querying all dataset types.",
+                FutureWarning,
+            )
+
         # show_uri requires a datastore.
         without_datastore = not show_uri
         self.butler = butler or Butler.from_config(repo, without_datastore=without_datastore)

--- a/python/lsst/daf/butler/script/queryDimensionRecords.py
+++ b/python/lsst/daf/butler/script/queryDimensionRecords.py
@@ -77,6 +77,9 @@ def queryDimensionRecords(
     `~lsst.daf.butler.Registry.queryDimensionRecords` except for ``no_check``,
     which is the inverse of ``check``.
     """
+    if offset:
+        raise NotImplementedError("--offset is no longer supported.  It will be removed after v28.")
+
     butler = Butler.from_config(repo, without_datastore=True)
 
     with butler.query() as query:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -472,7 +472,7 @@ class ButlerPutGetTests(TestCaseMixin):
                 )
                 self.assertEqual(count, stop)
 
-            compRef = butler.find_dataset(compNameS, dataId, collections=butler.collections)
+            compRef = butler.find_dataset(compNameS, dataId, collections=butler.collections.defaults)
             assert compRef is not None
             summary = butler.get(compRef)
             self.assertEqual(summary, metric.summary)
@@ -1235,7 +1235,7 @@ class ButlerTests(ButlerPutGetTests):
         with self.assertRaises(LookupError, msg=f"Check can't get by {datasetTypeName} and {dataId}"):
             butler.get(datasetTypeName, dataId)
         # Also check explicitly if Dataset entry is missing
-        self.assertIsNone(butler.find_dataset(datasetType, dataId, collections=butler.collections))
+        self.assertIsNone(butler.find_dataset(datasetType, dataId, collections=butler.collections.defaults))
         # Direct retrieval should not find the file in the Datastore
         with self.assertRaises(FileNotFoundError, msg=f"Check {ref} can't be retrieved directly"):
             butler.get(ref)

--- a/tests/test_query_relations.py
+++ b/tests/test_query_relations.py
@@ -244,6 +244,8 @@ class TestQueryRelationsTests(unittest.TestCase):
         # could special-case skypix dimensions that are coarser than the common
         # dimension and part of the same system to simplify both the SQL query
         # and avoid post-query filtering, but we don't at present.
+        with self.assertWarns(FutureWarning):
+            relation_string = self.butler.registry.queryDataIds(["patch"], htm11=self.htm11)
         self.assert_relation_str(
             f"""
             Π[patch, skymap, tract](
@@ -265,7 +267,7 @@ class TestQueryRelationsTests(unittest.TestCase):
                 )
             )
             """,
-            self.butler.registry.queryDataIds(["patch"], htm11=self.htm11),
+            relation_string,
         )
         # Constrain a regular spatial dimension (patch) from the common
         # skypix dimension.  This does not require post-query filtering.
@@ -286,6 +288,10 @@ class TestQueryRelationsTests(unittest.TestCase):
         # and also constrain via a skypix dimension other than the common one.
         # Once again we could special-case this for skypix dimensions that are
         # coarser than the common dimension in the same syste, but we don't.
+        with self.assertWarns(FutureWarning):
+            relation_string = self.butler.registry.queryDataIds(
+                ["detector"], visit=self.visit, instrument=self.instrument, htm11=self.htm11
+            )
         self.assert_relation_str(
             # This query also doesn't need visit or physical_filter joined in,
             # but we can live with that.
@@ -319,9 +325,7 @@ class TestQueryRelationsTests(unittest.TestCase):
                 )
             )
             """,
-            self.butler.registry.queryDataIds(
-                ["detector"], visit=self.visit, instrument=self.instrument, htm11=self.htm11
-            ),
+            relation_string,
         )
         # Constrain a regular dimension (detector) via a different dimension
         # (visit) that combine together to define a more fine-grained region,

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -150,6 +150,7 @@ class RemoteButlerRegistryTests(RegistryTests):
     supportsDetailedQueryExplain = False
     supportsQueryOffset = False
     supportsQueryGovernorValidation = False
+    supportsNonCommonSkypixQueries = False
 
     # Jim decided to drop these expressions from the new query system -- they
     # can be written less ambiguously by writing e.g. ``time <

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -725,17 +725,20 @@ class SimpleButlerTests(TestCaseMixin):
             ("*oll*", {"collection", "coll3"}),
             ("*[0-9]", {"coll3"}),
         ]
-        if self.supportsCollectionRegex:
-            expressions.extend(
-                [
-                    (re.compile("u.*"), {"u/user/test"}),
-                    (re.compile(".*oll.*"), {"collection", "coll3"}),
-                    ((re.compile(r".*\d$"), "u/user/test"), {"coll3", "u/user/test"}),
-                ]
-            )
         for expression, expected in expressions:
             result = butler.registry.queryCollections(expression)
             self.assertEqual(set(result), expected)
+
+        if self.supportsCollectionRegex:
+            expressions = [
+                (re.compile("u.*"), {"u/user/test"}),
+                (re.compile(".*oll.*"), {"collection", "coll3"}),
+                ((re.compile(r".*\d$"), "u/user/test"), {"coll3", "u/user/test"}),
+            ]
+            for expression, expected in expressions:
+                with self.assertWarns(FutureWarning):
+                    result = butler.registry.queryCollections(expression)
+                    self.assertEqual(set(result), expected)
 
     def test_skypix_templates(self):
         """Test that skypix templates can work."""


### PR DESCRIPTION
Deprecate behavior from the old query system that will no longer be supported when we switch to the new implementation.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
