### PR TITLE
DM-46711: Allow numpy integers to be used as literals

### DIFF
--- a/doc/changes/DM-46711.bugfix.md
+++ b/doc/changes/DM-46711.bugfix.md
@@ -1,0 +1,1 @@
+Fix an issue where the new query system was rejecting numpy integers used in data IDs or bind values.

--- a/python/lsst/daf/butler/queries/tree/_column_literal.py
+++ b/python/lsst/daf/butler/queries/tree/_column_literal.py
@@ -34,6 +34,7 @@ __all__ = (
 )
 
 import datetime
+import numbers
 import uuid
 import warnings
 from base64 import b64decode, b64encode
@@ -400,6 +401,9 @@ def make_column_literal(value: LiteralValue) -> ColumnLiteral:
             dec = icrs.dec.degree
             lon_lat = lsst.sphgeom.LonLat.fromDegrees(ra, dec)
             return _make_region_literal_from_lonlat(lon_lat)
+        case numbers.Integral():
+            # numpy.int64 and other integer-like values.
+            return IntColumnLiteral.from_value(int(value))
 
     raise TypeError(f"Invalid type {type(value).__name__!r} of value {value!r} for column literal.")
 


### PR DESCRIPTION
Fix an issue where the new query system was rejecting numpy integers used in data IDs or bind values.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
