### PR TITLE
DM-46496: Include advanced query system objects in docs

### DIFF
--- a/doc/lsst.daf.butler/index.rst
+++ b/doc/lsst.daf.butler/index.rst
@@ -104,6 +104,17 @@ Python API reference
    :no-inherited-members:
    :skip: RegistryConfig
 
+Advanced query system
+---------------------
+
+.. automodapi:: lsst.daf.butler.queries
+   :headings: ^"
+   :no-main-docstr:
+
+.. automodapi:: lsst.daf.butler.queries.expression_factory
+   :headings: ^"
+   :no-main-docstr:
+
 Example datastores
 ------------------
 
@@ -172,6 +183,17 @@ Datastore utilities
    :no-inherited-members:
    :headings: ^"
    :skip: Datastore
+
+Advanced query system internals
+-------------------------------
+
+.. automodapi:: lsst.daf.butler.queries.tree
+   :no-main-docstr:
+   :no-inherited-members:
+   :headings: ^"
+   :include: Predicate
+   :skip: DataCoordinateUploadKey
+   :skip: MaterializationKey
 
 Registry utilities and interfaces
 ---------------------------------

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -82,7 +82,7 @@ class Query(QueryBase):
     Notes
     -----
     `Query` objects should never be constructed directly by users; use
-    `Butler._query` instead.
+    `Butler.query` instead.
 
     A `Query` object represents the first stage of query construction, in which
     constraints and joins are defined (roughly corresponding to the WHERE and
@@ -135,6 +135,7 @@ class Query(QueryBase):
     @property
     def expression_factory(self) -> ExpressionFactory:
         """A factory for column expressions using overloaded operators.
+        (`~lsst.daf.butler.queries.expression_factory.ExpressionFactory`).
 
         Notes
         -----

--- a/python/lsst/daf/butler/queries/tree/__init__.py
+++ b/python/lsst/daf/butler/queries/tree/__init__.py
@@ -35,6 +35,5 @@ from ._predicate import LogicalNot
 from ._query_tree import *
 
 LogicalNot.model_rebuild()
-del LogicalNot
 
 Predicate.model_rebuild()

--- a/python/lsst/daf/butler/queries/tree/__init__.py
+++ b/python/lsst/daf/butler/queries/tree/__init__.py
@@ -30,10 +30,10 @@ from ._column_expression import *
 from ._column_literal import *
 from ._column_reference import *
 from ._column_set import *
+from ._predicate import LogicalNot as _LogicalNot
 from ._predicate import *
-from ._predicate import LogicalNot
 from ._query_tree import *
 
-LogicalNot.model_rebuild()
+_LogicalNot.model_rebuild()
 
 Predicate.model_rebuild()


### PR DESCRIPTION
`Butler.query` has been public for a while, but the documentation for the `Query` object it returns was not included in the documentation.

This change pulls in the user-facing portions of the interface without any of the internal objects.  (The internal objects are sometimes referenced from constructors, but those constructors are documented as "do not use".)

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
