### PR TITLE
DM-47335: Fix dataset query missing implied dimensions

### DIFF
--- a/python/lsst/daf/butler/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/dimensions/_coordinate.py
@@ -709,7 +709,7 @@ class DataCoordinate:
         else:
             records = None
 
-        return SerializedDataCoordinate(dataId=dict(self.required), records=records)
+        return SerializedDataCoordinate(dataId=dict(self.mapping), records=records)
 
     @classmethod
     def from_simple(

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -42,6 +42,7 @@ from lsst.daf.butler import (
     DataCoordinate,
     DataCoordinateSequence,
     DataCoordinateSet,
+    DatasetType,
     Dimension,
     DimensionConfig,
     DimensionElement,
@@ -410,6 +411,19 @@ class DimensionTestCase(unittest.TestCase):
             group1 = element1.minimal_group
             group2 = pickle.loads(pickle.dumps(group1))
             self.assertIs(group1, group2)
+
+    def testSerialization(self):
+        # Check that dataset types round-trip correctly through serialization.
+        dataset_type = DatasetType(
+            "flat",
+            dimensions=["instrument", "detector", "physical_filter", "band"],
+            isCalibration=True,
+            universe=self.universe,
+            storageClass="int",
+        )
+        roundtripped = DatasetType.from_simple(dataset_type.to_simple(), universe=self.universe)
+
+        self.assertEqual(dataset_type, roundtripped)
 
 
 @dataclass


### PR DESCRIPTION
Revert serialization change from DM-46776 in SerializedDataCoordinate, which caused it to drop values for implied dimensions.

That change broke the transfer of DatasetRefs from server to client, since it drops the values for implied dimensions in the data ID.  Per the documented behavior of dataset queries, the returned refs will have `hasFull() = True` and this behavior is relied on in tutorial notebooks.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
