### PR TITLE
DM-47375: Run query_all_datasets in a single request for RemoteButler

### DIFF
--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -45,7 +45,7 @@ from ._butler_config import ButlerConfig, ButlerType
 from ._butler_instance_options import ButlerInstanceOptions
 from ._butler_repo_index import ButlerRepoIndex
 from ._config import Config, ConfigSubset
-from ._exceptions import EmptyQueryResultError
+from ._exceptions import EmptyQueryResultError, InvalidQueryError
 from ._limited_butler import LimitedButler
 from .datastore import Datastore
 from .dimensions import DataCoordinate, DimensionConfig
@@ -1741,7 +1741,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             # collections when we do not have wildcards is expensive so only
             # do it if we need it.
             if find_first:
-                raise RuntimeError(
+                raise InvalidQueryError(
                     f"Can not use wildcards in collections when find_first=True (given {collections})"
                 )
             collections = self.collections.query(collections)

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1972,6 +1972,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             limit=limit,
             bind=bind,
             kwargs=kwargs,
+            with_dimension_records=False,
         )
         with self._query_all_datasets_by_page(args) as pages:
             result = []

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1946,7 +1946,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             include dimension records (`DataCoordinate.hasRecords` will be
             `False`).
         """
-        from ._query_all_datasets import query_all_datasets
+        from ._query_all_datasets import QueryAllDatasetsParameters, query_all_datasets
 
         if collections is None:
             collections = list(self.collections.defaults)
@@ -1961,9 +1961,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
 
         result = []
         with self.query() as query:
-            for page in query_all_datasets(
-                self,
-                query,
+            args = QueryAllDatasetsParameters(
                 collections=collections,
                 name=name,
                 find_first=find_first,
@@ -1971,8 +1969,9 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
                 where=where,
                 limit=limit,
                 bind=bind,
-                **kwargs,
-            ):
+                kwargs=kwargs,
+            )
+            for page in query_all_datasets(self, query, args):
                 result.extend(page.data)
 
         if warn_limit and limit is not None and len(result) >= limit:

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1960,18 +1960,20 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             warn_limit = True
 
         result = []
-        for page in query_all_datasets(
-            self,
-            collections=collections,
-            name=name,
-            find_first=find_first,
-            data_id=data_id,
-            where=where,
-            limit=limit,
-            bind=bind,
-            **kwargs,
-        ):
-            result.extend(page.data)
+        with self.query() as query:
+            for page in query_all_datasets(
+                self,
+                query,
+                collections=collections,
+                name=name,
+                find_first=find_first,
+                data_id=data_id,
+                where=where,
+                limit=limit,
+                bind=bind,
+                **kwargs,
+            ):
+                result.extend(page.data)
 
         if warn_limit and limit is not None and len(result) >= limit:
             # Remove the extra dataset we added for the limit check.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 __all__ = ["Butler"]
 
 from abc import abstractmethod
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager
 from types import EllipsisType
 from typing import TYPE_CHECKING, Any, TextIO
@@ -47,6 +47,7 @@ from ._butler_repo_index import ButlerRepoIndex
 from ._config import Config, ConfigSubset
 from ._exceptions import EmptyQueryResultError, InvalidQueryError
 from ._limited_butler import LimitedButler
+from ._query_all_datasets import QueryAllDatasetsParameters
 from .datastore import Datastore
 from .dimensions import DataCoordinate, DimensionConfig
 from .registry import RegistryConfig, _RegistryFactory
@@ -1946,12 +1947,15 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             include dimension records (`DataCoordinate.hasRecords` will be
             `False`).
         """
-        from ._query_all_datasets import QueryAllDatasetsParameters, query_all_datasets
-
         if collections is None:
             collections = list(self.collections.defaults)
         else:
             collections = list(ensure_iterable(collections))
+
+        if bind is None:
+            bind = {}
+        if data_id is None:
+            data_id = {}
 
         warn_limit = False
         if limit is not None and limit < 0:
@@ -1959,20 +1963,20 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             limit = abs(limit) + 1
             warn_limit = True
 
-        result = []
-        with self.query() as query:
-            args = QueryAllDatasetsParameters(
-                collections=collections,
-                name=name,
-                find_first=find_first,
-                data_id=data_id,
-                where=where,
-                limit=limit,
-                bind=bind,
-                kwargs=kwargs,
-            )
-            for page in query_all_datasets(self, query, args):
-                result.extend(page.data)
+        args = QueryAllDatasetsParameters(
+            collections=collections,
+            name=list(ensure_iterable(name)),
+            find_first=find_first,
+            data_id=data_id,
+            where=where,
+            limit=limit,
+            bind=bind,
+            kwargs=kwargs,
+        )
+        with self._query_all_datasets_by_page(args) as pages:
+            result = []
+            for page in pages:
+                result.extend(page)
 
         if warn_limit and limit is not None and len(result) >= limit:
             # Remove the extra dataset we added for the limit check.
@@ -1980,6 +1984,12 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             _LOG.warning("More datasets are available than the requested limit of %d.", limit - 1)
 
         return result
+
+    @abstractmethod
+    def _query_all_datasets_by_page(
+        self, args: QueryAllDatasetsParameters
+    ) -> AbstractContextManager[Iterator[list[DatasetRef]]]:
+        raise NotImplementedError()
 
     def clone(
         self,

--- a/python/lsst/daf/butler/_query_all_datasets.py
+++ b/python/lsst/daf/butler/_query_all_datasets.py
@@ -75,6 +75,7 @@ class QueryAllDatasetsParameters:
     (This cannot be negative, contrary to the `Butler.query_all_datasets`
     equivalent.)
     """
+    with_dimension_records: bool
     kwargs: dict[str, DataIdValue] = dataclasses.field(default_factory=dict)
 
 
@@ -124,6 +125,8 @@ def query_all_datasets(
             .where(args.data_id, args.where, args.kwargs, bind=args.bind)
             .limit(limit)
         )
+        if args.with_dimension_records:
+            results = results.with_dimension_records()
 
         for page in results._iter_pages():
             if limit is not None:

--- a/python/lsst/daf/butler/_query_all_datasets.py
+++ b/python/lsst/daf/butler/_query_all_datasets.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping
 from typing import Any, NamedTuple
 
 from lsst.utils.iteration import ensure_iterable
@@ -61,7 +61,6 @@ def query_all_datasets(
     where: str = "",
     bind: Mapping[str, Any] | None = None,
     limit: int | None = None,
-    order_by: Sequence[str] | None = None,
     **kwargs: Any,
 ) -> Iterator[DatasetsPage]:
     """Query for dataset refs from multiple types simultaneously.
@@ -103,11 +102,6 @@ def query_all_datasets(
         Upper limit on the number of returned records. `None` can be used
         if no limit is wanted. A limit of ``0`` means that the query will
         be executed and validated but no results will be returned.
-    order_by : `~collections.abc.Iterable` [`str`] or `str`, optional
-        Names of the columns/dimensions to use for ordering returned data
-        IDs. Column name can be prefixed with minus (``-``) to use
-        descending ordering.  Results are ordered only within each dataset
-        type, they are not globally ordered across all results.
     **kwargs
         Additional keyword arguments are forwarded to
         `DataCoordinate.standardize` when processing the ``data_id``
@@ -130,8 +124,6 @@ def query_all_datasets(
     """
     if find_first and has_globs(collections):
         raise InvalidQueryError("Can not use wildcards in collections when find_first=True")
-    if order_by is None:
-        order_by = []
     if data_id is None:
         data_id = {}
 
@@ -144,7 +136,6 @@ def query_all_datasets(
             query.datasets(dt, filtered_collections, find_first=find_first)
             .where(data_id, where, kwargs, bind=bind)
             .limit(limit)
-            .order_by(*order_by)
         )
 
         for page in results._iter_pages():

--- a/python/lsst/daf/butler/_query_all_datasets.py
+++ b/python/lsst/daf/butler/_query_all_datasets.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections.abc import Iterable, Iterator, Mapping
 from typing import Any, NamedTuple
@@ -36,7 +37,7 @@ from lsst.utils.iteration import ensure_iterable
 from ._butler import Butler
 from ._dataset_ref import DatasetRef
 from ._exceptions import InvalidQueryError, MissingDatasetTypeError
-from .dimensions import DataId
+from .dimensions import DataId, DataIdValue
 from .queries import Query
 from .utils import has_globs
 
@@ -50,18 +51,32 @@ class DatasetsPage(NamedTuple):
     data: list[DatasetRef]
 
 
+@dataclasses.dataclass(frozen=True)
+class QueryAllDatasetsParameters:
+    """These are the parameters passed to `Butler.query_all_datasets` and have
+    the same meaning as that function unless noted below.
+    """
+
+    collections: list[str]
+    name: str | Iterable[str]
+    find_first: bool
+    data_id: DataId | None
+    where: str
+    bind: Mapping[str, Any] | None
+    limit: int | None
+    """
+    Upper limit on the number of returned records. `None` can be used
+    if no limit is wanted. A limit of ``0`` means that the query will
+    be executed and validated but no results will be returned.
+
+    (This cannot be negative, contrary to the `Butler.query_all_datasets`
+    equivalent.)
+    """
+    kwargs: dict[str, DataIdValue] = dataclasses.field(default_factory=dict)
+
+
 def query_all_datasets(
-    butler: Butler,
-    query: Query,
-    *,
-    collections: list[str],
-    name: str | Iterable[str] = "*",
-    find_first: bool = True,
-    data_id: DataId | None = None,
-    where: str = "",
-    bind: Mapping[str, Any] | None = None,
-    limit: int | None = None,
-    **kwargs: Any,
+    butler: Butler, query: Query, args: QueryAllDatasetsParameters
 ) -> Iterator[DatasetsPage]:
     """Query for dataset refs from multiple types simultaneously.
 
@@ -71,42 +86,8 @@ def query_all_datasets(
         Butler instance to use for executing queries.
     query : `Query`
         Query context object to use for executing queries.
-    collections :  `list` [ `str` ]
-        The collections to search, in order.  If not provided
-        or `None`, the default collection search path for this butler is
-        used.
-    name : `str` or `~collections.abc.Iterable` [ `str` ], optional
-        Names or name patterns (glob-style) that returned dataset type
-        names must match.  If an iterable, items are OR'd together.  The
-        default is to include all dataset types in the given collections.
-    find_first : `bool`, optional
-        If `True` (default), for each result data ID, only yield one
-        `DatasetRef` of each `DatasetType`, from the first collection in
-        which a dataset of that dataset type appears (according to the
-        order of ``collections`` passed in).
-    data_id : `dict` or `DataCoordinate`, optional
-        A data ID whose key-value pairs are used as equality constraints in
-        the query.
-    where : `str`, optional
-        A string expression similar to a SQL WHERE clause.  May involve any
-        column of a dimension table or (as a shortcut for the primary key
-        column of a dimension table) dimension name.  See
-        :ref:`daf_butler_dimension_expressions` for more information.
-    bind : `~collections.abc.Mapping`, optional
-        Mapping containing literal values that should be injected into the
-        ``where`` expression, keyed by the identifiers they replace. Values
-        of collection type can be expanded in some cases; see
-        :ref:`daf_butler_dimension_expressions_identifiers` for more
-        information.
-    limit : `int` or `None`, optional
-        Upper limit on the number of returned records. `None` can be used
-        if no limit is wanted. A limit of ``0`` means that the query will
-        be executed and validated but no results will be returned.
-    **kwargs
-        Additional keyword arguments are forwarded to
-        `DataCoordinate.standardize` when processing the ``data_id``
-        argument (and may be used to provide a constraining data ID even
-        when the ``data_id`` argument is `None`).
+    args : `QueryAllDatasetsParameters`
+        Arguments describing the query to be performed.
 
     Raises
     ------
@@ -115,6 +96,8 @@ def query_all_datasets(
         dataset type in ``name`` does not exist.
     InvalidQueryError
         If the parameters to the query are inconsistent or malformed.
+    MissingCollectionError
+        If a given collection is not found.
 
     Returns
     -------
@@ -122,19 +105,23 @@ def query_all_datasets(
         `DatasetRef` results matching the given query criteria, grouped by
         dataset type.
     """
-    if find_first and has_globs(collections):
+    if args.find_first and has_globs(args.collections):
         raise InvalidQueryError("Can not use wildcards in collections when find_first=True")
+    data_id = args.data_id
     if data_id is None:
         data_id = {}
 
-    dataset_type_query = list(ensure_iterable(name))
-    dataset_type_collections = _filter_collections_and_dataset_types(butler, collections, dataset_type_query)
+    dataset_type_query = list(ensure_iterable(args.name))
+    dataset_type_collections = _filter_collections_and_dataset_types(
+        butler, args.collections, dataset_type_query
+    )
 
+    limit = args.limit
     for dt, filtered_collections in sorted(dataset_type_collections.items()):
         _LOG.debug("Querying dataset type %s", dt)
         results = (
-            query.datasets(dt, filtered_collections, find_first=find_first)
-            .where(data_id, where, kwargs, bind=bind)
+            query.datasets(dt, filtered_collections, find_first=args.find_first)
+            .where(data_id, args.where, args.kwargs, bind=args.bind)
             .limit(limit)
         )
 

--- a/python/lsst/daf/butler/_query_all_datasets.py
+++ b/python/lsst/daf/butler/_query_all_datasets.py
@@ -60,7 +60,6 @@ def query_all_datasets(
     data_id: DataId | None = None,
     where: str = "",
     bind: Mapping[str, Any] | None = None,
-    with_dimension_records: bool = False,
     limit: int | None = None,
     order_by: Sequence[str] | None = None,
     **kwargs: Any,
@@ -100,9 +99,6 @@ def query_all_datasets(
         of collection type can be expanded in some cases; see
         :ref:`daf_butler_dimension_expressions_identifiers` for more
         information.
-    with_dimension_records : `bool`, optional
-        If `True` (default is `False`) then returned data IDs will have
-        dimension records.
     limit : `int` or `None`, optional
         Upper limit on the number of returned records. `None` can be used
         if no limit is wanted. A limit of ``0`` means that the query will
@@ -150,8 +146,6 @@ def query_all_datasets(
             .limit(limit)
             .order_by(*order_by)
         )
-        if with_dimension_records:
-            results = results.with_dimension_records()
 
         for page in results._iter_pages():
             if limit is not None:

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -65,6 +65,7 @@ from .._deferredDatasetHandle import DeferredDatasetHandle
 from .._exceptions import DatasetNotFoundError, DimensionValueError, EmptyQueryResultError, ValidationError
 from .._file_dataset import FileDataset
 from .._limited_butler import LimitedButler
+from .._query_all_datasets import QueryAllDatasetsParameters, query_all_datasets
 from .._registry_shim import RegistryShim
 from .._storage_class import StorageClass, StorageClassFactory
 from .._timespan import Timespan
@@ -2329,6 +2330,14 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         this is marked as a private method, it is also used by Butler server.
         """
         return self._registry._query_driver(default_collections, default_data_id)
+
+    @contextlib.contextmanager
+    def _query_all_datasets_by_page(
+        self, args: QueryAllDatasetsParameters
+    ) -> Iterator[Iterator[list[DatasetRef]]]:
+        with self.query() as query:
+            pages = query_all_datasets(self, query, args)
+            yield iter(page.data for page in pages)
 
     def _preload_cache(self) -> None:
         """Immediately load caches that are used for common operations."""

--- a/python/lsst/daf/butler/queries/_dataset_query_results.py
+++ b/python/lsst/daf/butler/queries/_dataset_query_results.py
@@ -72,8 +72,17 @@ class DatasetRefQueryResults(QueryResultsBase):
         self._spec = spec
 
     def __iter__(self) -> Iterator[DatasetRef]:
+        for page in self._iter_pages():
+            yield from page
+
+    def _iter_pages(self) -> Iterator[list[DatasetRef]]:
+        """Return the results from the query in batches as they are returned
+        from the database.
+        """
+        # This method is used outside this class in other daf_butler-internal
+        # functions.
         for page in self._driver.execute(self._spec, self._tree):
-            yield from page.rows
+            yield page.rows
 
     @property
     def dimensions(self) -> DimensionGroup:

--- a/python/lsst/daf/butler/remote_butler/_query_results.py
+++ b/python/lsst/daf/butler/remote_butler/_query_results.py
@@ -1,0 +1,91 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+from pydantic import TypeAdapter
+
+from .._dataset_ref import DatasetRef
+from ..dimensions import DimensionUniverse
+from ._errors import deserialize_butler_user_error
+from .server_models import QueryExecuteResultData
+
+_QueryResultTypeAdapter = TypeAdapter[QueryExecuteResultData](QueryExecuteResultData)
+
+
+def read_query_results(response: httpx.Response) -> Iterator[QueryExecuteResultData]:
+    """Read streaming query results from the server.
+
+    Parameters
+    ----------
+    response : `httpx.Response`
+        HTTPX response object from a request where ``stream=True`` was set.
+
+    Yields
+    ------
+    pages : `QueryExecuteResultData`
+        Pages of result data from the server, excluding out-of-band messages
+        like keep-alives and errors.
+
+    Raises
+    ------
+    ButlerUserError
+        Any subclass of ButlerUserError might be raised, to propagate
+        server-side exceptions to the client.
+    """
+    # There is one result page JSON object per line of the response.
+    for line in response.iter_lines():
+        result: QueryExecuteResultData = _QueryResultTypeAdapter.validate_json(line)
+        if result.type == "keep-alive":
+            # Server is still in the process of generating the response.
+            _received_keep_alive()
+        elif result.type == "error":
+            # A server-side exception occurred part-way through generating
+            # results.
+            raise deserialize_butler_user_error(result.error)
+        else:
+            yield result
+
+
+def convert_dataset_ref_results(
+    result: QueryExecuteResultData, universe: DimensionUniverse
+) -> list[DatasetRef]:  # numpydoc ignore=PR01
+    """Convert a serialized page of dataset results to `DatasetRef`
+    instances.
+    """
+    assert result.type == "dataset_ref"
+    return [DatasetRef.from_simple(r, universe) for r in result.rows]
+
+
+def _received_keep_alive() -> None:
+    """Do nothing.  Gives a place for unit tests to hook in for testing
+    keepalive behavior.
+    """
+    pass

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -647,6 +647,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             where=args.where,
             bind={k: make_column_literal(v) for k, v in args.bind.items()},
             limit=args.limit,
+            with_dimension_records=args.with_dimension_records,
         )
         with self._connection.post_with_stream_response("query/all_datasets", request) as response:
             pages = read_query_results(response)

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -57,17 +57,20 @@ from .._dataset_ref import DatasetId, DatasetRef
 from .._dataset_type import DatasetType
 from .._deferredDatasetHandle import DeferredDatasetHandle
 from .._exceptions import DatasetNotFoundError
+from .._query_all_datasets import QueryAllDatasetsParameters
 from .._storage_class import StorageClass, StorageClassFactory
 from .._utilities.locked_object import LockedObject
 from ..datastore import DatasetRefURIs, DatastoreConfig
 from ..datastore.cache_manager import AbstractDatastoreCacheManager, DatastoreCacheManager
 from ..dimensions import DataIdValue, DimensionConfig, DimensionUniverse, SerializedDataId
 from ..queries import Query
+from ..queries.tree import make_column_literal
 from ..registry import CollectionArgType, NoDefaultCollectionError, Registry, RegistryDefaults
 from ._collection_args import convert_collection_arg_to_glob_string_list
 from ._defaults import DefaultsHolder
 from ._http_connection import RemoteButlerHttpConnection, parse_model, quote_path_variable
 from ._query_driver import RemoteQueryDriver
+from ._query_results import convert_dataset_ref_results, read_query_results
 from ._ref_utils import apply_storage_class_override, normalize_dataset_type_name, simplify_dataId
 from ._registry import RemoteButlerRegistry
 from ._remote_butler_collections import RemoteButlerCollections
@@ -79,6 +82,7 @@ from .server_models import (
     GetFileByDataIdRequestModel,
     GetFileResponseModel,
     GetUniverseResponseModel,
+    QueryAllDatasetsRequestModel,
 )
 
 if TYPE_CHECKING:
@@ -627,6 +631,26 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         with driver:
             query = Query(driver)
             yield query
+
+    @contextmanager
+    def _query_all_datasets_by_page(
+        self, args: QueryAllDatasetsParameters
+    ) -> Iterator[Iterator[list[DatasetRef]]]:
+        universe = self.dimensions
+
+        request = QueryAllDatasetsRequestModel(
+            collections=self._normalize_collections(args.collections),
+            name=[normalize_dataset_type_name(name) for name in args.name],
+            find_first=args.find_first,
+            data_id=simplify_dataId(args.data_id, args.kwargs),
+            default_data_id=self._serialize_default_data_id(),
+            where=args.where,
+            bind={k: make_column_literal(v) for k, v in args.bind.items()},
+            limit=args.limit,
+        )
+        with self._connection.post_with_stream_response("query/all_datasets", request) as response:
+            pages = read_query_results(response)
+            yield (convert_dataset_ref_results(page, universe) for page in pages)
 
     def pruneDatasets(
         self,

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -27,17 +27,19 @@
 
 from __future__ import annotations
 
-from lsst.daf.butler.remote_butler.server.handlers._utils import set_default_data_id
-
 __all__ = ()
 
 import uuid
 from typing import Any
 
 from fastapi import APIRouter, Depends
-from lsst.daf.butler import Butler, CollectionType, DatasetRef
-from lsst.daf.butler.registry.interfaces import ChainedCollectionRecord
-from lsst.daf.butler.remote_butler.server_models import (
+
+from ...._butler import Butler
+from ...._collection_type import CollectionType
+from ...._dataset_ref import DatasetRef
+from ...._exceptions import DatasetNotFoundError
+from ....registry.interfaces import ChainedCollectionRecord
+from ...server_models import (
     ExpandDataIdRequestModel,
     ExpandDataIdResponseModel,
     FindDatasetRequestModel,
@@ -55,10 +57,9 @@ from lsst.daf.butler.remote_butler.server_models import (
     QueryDatasetTypesRequestModel,
     QueryDatasetTypesResponseModel,
 )
-
-from ...._exceptions import DatasetNotFoundError
 from .._dependencies import factory_dependency
 from .._factory import Factory
+from ._utils import set_default_data_id
 
 external_router = APIRouter()
 

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -62,7 +62,12 @@ from ._utils import set_default_data_id
 query_router = APIRouter()
 
 
-class _StreamQueryDriverExecute(StreamingQuery):
+class _QueryContext(NamedTuple):
+    driver: QueryDriver
+    tree: QueryTree
+
+
+class _StreamQueryDriverExecute(StreamingQuery[_QueryContext]):
     """Wrapper to call `QueryDriver.execute` from async stream handler."""
 
     def __init__(self, request: QueryExecuteRequestModel, factory: Factory) -> None:
@@ -94,7 +99,7 @@ class _QueryAllDatasetsContext(NamedTuple):
     query: Query
 
 
-class _StreamQueryAllDatasets(StreamingQuery):
+class _StreamQueryAllDatasets(StreamingQuery[_QueryAllDatasetsContext]):
     def __init__(self, request: QueryAllDatasetsRequestModel, factory: Factory) -> None:
         self._request = request
         self._factory = factory
@@ -199,8 +204,3 @@ def _get_query_context(factory: Factory, query: QueryInputs) -> Iterator[_QueryC
                 ),
 
         yield _QueryContext(driver=driver, tree=tree)
-
-
-class _QueryContext(NamedTuple):
-    driver: QueryDriver
-    tree: QueryTree

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -117,6 +117,7 @@ class _StreamQueryAllDatasets(StreamingQuery):
             where=request.where,
             bind=bind,
             limit=request.limit,
+            with_dimension_records=request.with_dimension_records,
         )
         pages = query_all_datasets(ctx.butler, ctx.query, args)
         for page in pages:

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
@@ -69,7 +69,7 @@ def convert_query_page(spec: ResultSpec, page: ResultPage) -> QueryExecuteResult
             return DataCoordinateResultModel(rows=[coordinate.to_simple() for coordinate in page.rows])
         case "dataset_ref":
             assert isinstance(page, DatasetRefResultPage)
-            return DatasetRefResultModel(rows=[ref.to_simple() for ref in page.rows])
+            return DatasetRefResultModel.from_refs(page.rows)
         case "general":
             assert isinstance(page, GeneralResultPage)
             return _convert_general_result(page)

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
@@ -1,0 +1,165 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from contextlib import AbstractContextManager
+from typing import Protocol, TypeVar
+
+from fastapi.concurrency import contextmanager_in_threadpool, iterate_in_threadpool
+from fastapi.responses import StreamingResponse
+from lsst.daf.butler.remote_butler.server_models import (
+    QueryErrorResultModel,
+    QueryExecuteResultData,
+    QueryKeepAliveModel,
+)
+
+from ...._exceptions import ButlerUserError
+from ..._errors import serialize_butler_user_error
+
+# Alias this function so we can mock it during unit tests.
+_timeout = asyncio.timeout
+
+_TContext = TypeVar("_TContext")
+
+
+class StreamingQuery(Protocol[_TContext]):
+    """Interface for queries that can return streaming results."""
+
+    def setup(self) -> AbstractContextManager[_TContext]:
+        """Context manager that sets up any resources used to execute the
+        query.
+        """
+
+    def execute(self, context: _TContext) -> Iterator[QueryExecuteResultData]:
+        """Execute the database query and and return pages of results.
+
+        Parameters
+        ----------
+        context : generic
+            Value returned by the call to ``setup()``.
+        """
+
+
+def execute_streaming_query(query: StreamingQuery) -> StreamingResponse:
+    """Run a query, streaming the response incrementally, one page at a time,
+    as newline-separated chunks of JSON.
+
+    Parameters
+    ----------
+    query : ``StreamingQuery``
+        Callers should define a class implementing the ``StreamingQuery``
+        protocol to specify the inner logic that will be called during
+        query execution.
+
+    Returns
+    -------
+    response : `fastapi.StreamingResponse`
+        FastAPI streaming response that can be returned by a route handler.
+
+    Notes
+    -----
+    - Streaming the response allows clients to start reading results earlier
+      and prevents the server from exhausting all its memory buffering rows
+      from large queries.
+    - If the query is taking a long time to execute, we insert a keepalive
+      message in the JSON stream every 15 seconds.
+    - If the caller closes the HTTP connection, async cancellation is
+      triggered by FastAPI. The query will be cancelled after the next page is
+      read -- ``StreamingQuery.execute()`` cannot be interrupted while it is
+      in the middle of reading a page.
+    """
+    output_generator = _stream_query_pages(query)
+    return StreamingResponse(
+        output_generator,
+        media_type="application/jsonlines",
+        headers={
+            # Instruct the Kubernetes ingress to not buffer the response,
+            # so that keep-alives reach the client promptly.
+            "X-Accel-Buffering": "no"
+        },
+    )
+
+
+async def _stream_query_pages(query: StreamingQuery) -> AsyncIterator[str]:
+    """Stream the query output with one page object per line, as
+    newline-delimited JSON records in the "JSON Lines" format
+    (https://jsonlines.org/).
+
+    When it takes longer than 15 seconds to get a response from the DB,
+    sends a keep-alive message to prevent clients from timing out.
+    """
+    # `None` signals that there is no more data to send.
+    queue = asyncio.Queue[QueryExecuteResultData | None](1)
+    async with asyncio.TaskGroup() as tg:
+        # Run a background task to read from the DB and insert the result pages
+        # into a queue.
+        tg.create_task(_enqueue_query_pages(queue, query))
+        # Read the result pages from the queue and send them to the client,
+        # inserting a keep-alive message every 15 seconds if we are waiting a
+        # long time for the database.
+        async for message in _dequeue_query_pages_with_keepalive(queue):
+            yield message.model_dump_json() + "\n"
+
+
+async def _enqueue_query_pages(
+    queue: asyncio.Queue[QueryExecuteResultData | None], query: StreamingQuery
+) -> None:
+    """Set up a QueryDriver to run the query, and copy the results into a
+    queue.  Send `None` to the queue when there is no more data to read.
+    """
+    try:
+        async with contextmanager_in_threadpool(query.setup()) as ctx:
+            async for page in iterate_in_threadpool(query.execute(ctx)):
+                await queue.put(page)
+    except ButlerUserError as e:
+        # If a user-facing error occurs, serialize it and send it to the
+        # client.
+        await queue.put(QueryErrorResultModel(error=serialize_butler_user_error(e)))
+
+    # Signal that there is no more data to read.
+    await queue.put(None)
+
+
+async def _dequeue_query_pages_with_keepalive(
+    queue: asyncio.Queue[QueryExecuteResultData | None],
+) -> AsyncIterator[QueryExecuteResultData]:
+    """Read and return messages from the given queue until the end-of-stream
+    message `None` is reached.  If the producer is taking a long time, returns
+    a keep-alive message every 15 seconds while we are waiting.
+    """
+    while True:
+        try:
+            async with _timeout(15):
+                message = await queue.get()
+                if message is None:
+                    return
+                yield message
+        except TimeoutError:
+            yield QueryKeepAliveModel()

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_utils.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_utils.py
@@ -1,0 +1,39 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from lsst.daf.butler import Butler
+from lsst.daf.butler.dimensions import DataCoordinate, SerializedDataId
+from lsst.daf.butler.registry import RegistryDefaults
+
+
+def set_default_data_id(butler: Butler, data_id: SerializedDataId) -> None:  # numpydoc ignore=PR01
+    """Set the default data ID values used for lookups in the given Butler."""
+    butler.registry.defaults = RegistryDefaults.from_data_id(
+        DataCoordinate.standardize(data_id, universe=butler.dimensions)
+    )

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -409,3 +409,4 @@ class QueryAllDatasetsRequestModel(pydantic.BaseModel):
     where: str
     bind: dict[str, ColumnLiteral]
     limit: int | None
+    with_dimension_records: bool

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -37,7 +37,8 @@ __all__ = [
     "GetCollectionSummaryResponseModel",
 ]
 
-from typing import Annotated, Any, Literal, NewType, TypeAlias
+from collections.abc import Iterable
+from typing import Annotated, Any, Literal, NewType, Self, TypeAlias
 from uuid import UUID
 
 import pydantic
@@ -45,6 +46,7 @@ from lsst.daf.butler import (
     CollectionInfo,
     CollectionType,
     DataIdValue,
+    DatasetRef,
     SerializedDataCoordinate,
     SerializedDataId,
     SerializedDatasetRef,
@@ -57,7 +59,7 @@ from lsst.daf.butler.registry import SerializedCollectionSummary
 
 from ..dimensions import SerializedDimensionConfig, SerializedDimensionRecord
 from ..queries.result_specs import SerializedResultSpec
-from ..queries.tree import SerializedQueryTree
+from ..queries.tree import ColumnLiteral, SerializedQueryTree
 
 CLIENT_REQUEST_ID_HEADER_NAME = "X-Butler-Client-Request-Id"
 ERROR_STATUS_CODE = 422
@@ -301,6 +303,10 @@ class DatasetRefResultModel(pydantic.BaseModel):
     type: Literal["dataset_ref"] = "dataset_ref"
     rows: list[SerializedDatasetRef]
 
+    @classmethod
+    def from_refs(cls, refs: Iterable[DatasetRef]) -> Self:
+        return cls(rows=[ref.to_simple() for ref in refs])
+
 
 class GeneralResultModel(pydantic.BaseModel):
     """Result model for /query/execute/ when user requested general results."""
@@ -387,3 +393,19 @@ class QueryExplainResponseModel(pydantic.BaseModel):
     """Response model for /query/explain/."""
 
     messages: list[str]
+
+
+class QueryAllDatasetsRequestModel(pydantic.BaseModel):
+    """Request model for /query/all_datasets/."""
+
+    collections: CollectionList
+    name: list[DatasetTypeName]
+    find_first: bool
+    data_id: SerializedDataId
+    default_data_id: SerializedDataId = pydantic.Field(default_factory=dict)
+    """Data ID values used as a fallback if required values are not specified
+    in ``data_id``.
+    """
+    where: str
+    bind: dict[str, ColumnLiteral]
+    limit: int | None

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -327,8 +327,8 @@ class QueryDatasets:
                 name=self._dataset_type_glob,
                 where=self._where,
                 limit=limit,
-                data_id=None,
-                bind=None,
+                data_id={},
+                bind={},
             )
             yield query_all_datasets(self.butler, query, args)
 

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -39,7 +39,7 @@ from astropy.table import Table as AstropyTable
 
 from .._butler import Butler
 from .._exceptions import MissingDatasetTypeError
-from .._query_all_datasets import DatasetsPage, query_all_datasets
+from .._query_all_datasets import DatasetsPage, QueryAllDatasetsParameters, query_all_datasets
 from ..cli.utils import sortAstropyTable
 from ..utils import has_globs
 
@@ -321,15 +321,16 @@ class QueryDatasets:
         self, collections: list[str], limit: int | None
     ) -> Iterator[Iterator[DatasetsPage]]:
         with self.butler.query() as query:
-            yield query_all_datasets(
-                self.butler,
-                query,
+            args = QueryAllDatasetsParameters(
                 collections=collections,
                 find_first=self._find_first,
                 name=self._dataset_type_glob,
                 where=self._where,
                 limit=limit,
+                data_id=None,
+                bind=None,
             )
+            yield query_all_datasets(self.butler, query, args)
 
     @contextmanager
     def _query_single_dataset_type(

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -40,6 +40,7 @@ from .._butler import Butler
 from .._exceptions import MissingDatasetTypeError
 from .._query_all_datasets import DatasetsPage, query_all_datasets
 from ..cli.utils import sortAstropyTable
+from ..utils import has_globs
 
 if TYPE_CHECKING:
     from lsst.daf.butler import DatasetRef
@@ -204,6 +205,9 @@ class QueryDatasets:
                 stacklevel=2,
             )
             glob = ["*"]
+
+        if order_by and (len(glob) > 1 or has_globs(glob)):
+            raise NotImplementedError("--order-by is only supported for queries with a single dataset type.")
 
         # show_uri requires a datastore.
         without_datastore = not show_uri

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -174,6 +174,9 @@ class QueryDatasets:
     butler : `lsst.daf.butler.Butler` or `None`
         The butler to use to query. One of `repo` and `butler` must be `None`
         and the other must not be `None`.
+    with_dimension_records : `bool`, optional
+        If `True` (default is `False`) then returned data IDs will have
+        dimension records.
     """
 
     def __init__(
@@ -187,6 +190,7 @@ class QueryDatasets:
         order_by: tuple[str, ...] = (),
         repo: str | None = None,
         butler: Butler | None = None,
+        with_dimension_records: bool = False,
     ):
         if (repo and butler) or (not repo and not butler):
             raise RuntimeError("One of repo and butler must be provided and the other must be None.")
@@ -222,6 +226,7 @@ class QueryDatasets:
         self._limit = limit
         self._order_by = order_by
         self._searches_multiple_dataset_types = searches_multiple_dataset_types
+        self._with_dimension_records = with_dimension_records
 
     def getTables(self) -> Iterator[AstropyTable]:
         """Get the datasets as a list of astropy tables.
@@ -329,6 +334,7 @@ class QueryDatasets:
                 limit=limit,
                 data_id={},
                 bind={},
+                with_dimension_records=self._with_dimension_records,
             )
             yield query_all_datasets(self.butler, query, args)
 
@@ -346,6 +352,7 @@ class QueryDatasets:
             where=self._where,
             limit=limit,
             order_by=self._order_by,
+            with_dimension_records=self._with_dimension_records,
         )
 
         yield iter([DatasetsPage(dataset_type=dataset_type, data=refs)])

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -283,7 +283,6 @@ class QueryDatasets:
                     collections=query_collections,
                     find_first=self._find_first,
                     name=self._dataset_type_glob,
-                    with_dimension_records=True,
                     where=self._where,
                     limit=limit,
                     order_by=self._order_by,

--- a/python/lsst/daf/butler/script/transferDatasets.py
+++ b/python/lsst/daf/butler/script/transferDatasets.py
@@ -100,6 +100,7 @@ def transferDatasets(
         limit=limit,
         order_by=order_by,
         show_uri=False,
+        with_dimension_records=True,
     )
     # Place results in a set to remove duplicates (which should not exist
     # in new query system)

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -302,7 +302,7 @@ class ButlerQueryTests(ABC, TestCaseMixin):
         self.assertEqual(len(refs_simple), 4)
         self.assertIn("More datasets are available", lcm.output[0])
 
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaises(InvalidQueryError) as cm:
             butler.query_datasets("bias", "*", detector=100, instrument="Unknown", find_first=True)
         self.assertIn("Can not use wildcards", str(cm.exception))
         with self.assertRaises(EmptyQueryResultError) as cm2:

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -27,7 +27,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager
 from types import EllipsisType
 from typing import Any, TextIO, cast
@@ -42,6 +42,7 @@ from .._dataset_type import DatasetType
 from .._deferredDatasetHandle import DeferredDatasetHandle
 from .._file_dataset import FileDataset
 from .._limited_butler import LimitedButler
+from .._query_all_datasets import QueryAllDatasetsParameters
 from .._storage_class import StorageClass
 from .._timespan import Timespan
 from ..datastore import DatasetRefURIs
@@ -391,3 +392,8 @@ class HybridButler(Butler):
     @property
     def collections(self) -> ButlerCollections:
         return HybridButlerCollections(self)
+
+    def _query_all_datasets_by_page(
+        self, args: QueryAllDatasetsParameters
+    ) -> AbstractContextManager[Iterator[list[DatasetRef]]]:
+        return self._remote_butler._query_all_datasets_by_page(args)

--- a/tests/test_cliCmdQueryDatasets.py
+++ b/tests/test_cliCmdQueryDatasets.py
@@ -344,7 +344,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
 
         with self.assertLogs("lsst.daf.butler.script.queryDatasets", level="WARNING") as cm:
             tables = self._queryDatasets(
-                repo=testRepo.butler, limit=-1, order_by=("visit"), collections="*", glob="*"
+                repo=testRepo.butler, limit=-1, order_by=("visit",), collections="*", glob="*"
             )
 
         self.assertIn("increase this limit", cm.output[0])
@@ -361,13 +361,13 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         # issued.
         with self.assertNoLogs("lsst.daf.butler.script.queryDatasets", level="WARNING"):
             tables = self._queryDatasets(
-                repo=testRepo.butler, limit=1, order_by=("visit"), collections="*", glob="*"
+                repo=testRepo.butler, limit=1, order_by=("visit",), collections="*", glob="*"
             )
         self.assertAstropyTablesEqual(tables, expectedTables, filterColumns=True)
 
         with self.assertLogs("lsst.daf.butler.script.queryDatasets", level="WARNING") as cm:
             tables = self._queryDatasets(
-                repo=testRepo.butler, limit=-1, order_by=("-visit"), collections="*", glob="*"
+                repo=testRepo.butler, limit=-1, order_by=("-visit",), collections="*", glob="*"
             )
         self.assertIn("increase this limit", cm.output[0])
 

--- a/tests/test_cliCmdQueryDatasets.py
+++ b/tests/test_cliCmdQueryDatasets.py
@@ -274,21 +274,26 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         """
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
 
-        tables = self._queryDatasets(
-            repo=testRepo.butler, where="instrument='DummyCamComp' AND visit=423", collections="*", glob="*"
-        )
+        for glob in (("*",), ("test_metric_comp",)):
+            with self.subTest(glob=glob):
+                tables = self._queryDatasets(
+                    repo=testRepo.butler,
+                    where="instrument='DummyCamComp' AND visit=423",
+                    collections="*",
+                    glob=glob,
+                )
 
-        expectedTables = (
-            AstropyTable(
-                array(("test_metric_comp", "ingest/run", "DummyCamComp", "423", "R", "d-r")),
-                names=("type", "run", "instrument", "visit", "band", "physical_filter"),
-            ),
-        )
+                expectedTables = (
+                    AstropyTable(
+                        array(("test_metric_comp", "ingest/run", "DummyCamComp", "423", "R", "d-r")),
+                        names=("type", "run", "instrument", "visit", "band", "physical_filter"),
+                    ),
+                )
 
-        self.assertAstropyTablesEqual(tables, expectedTables, filterColumns=True)
+                self.assertAstropyTablesEqual(tables, expectedTables, filterColumns=True)
 
-        with self.assertRaises(InvalidQueryError):
-            self._queryDatasets(repo=testRepo.butler, collections="*", find_first=True, glob="*")
+                with self.assertRaises(InvalidQueryError):
+                    self._queryDatasets(repo=testRepo.butler, collections="*", find_first=True, glob=glob)
 
     def testGlobDatasetType(self):
         """Test specifying dataset type."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,7 +35,7 @@ from lsst.daf.butler.tests.dict_convertible_model import DictConvertibleModel
 try:
     # Failing to import any of these should disable the tests.
     import lsst.daf.butler.remote_butler._query_driver
-    import lsst.daf.butler.remote_butler.server.handlers._external_query
+    import lsst.daf.butler.remote_butler.server.handlers._query_streaming
     import safir.dependencies.logger
     from fastapi.testclient import TestClient
     from lsst.daf.butler.remote_butler import RemoteButler
@@ -413,7 +413,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
         # Normally it takes 15 seconds for a timeout -- mock it to trigger
         # immediately instead.
         with patch.object(
-            lsst.daf.butler.remote_butler.server.handlers._external_query, "_timeout"
+            lsst.daf.butler.remote_butler.server.handlers._query_streaming, "_timeout"
         ) as mock_timeout:
             # Hook into QueryDriver to track the number of keep-alives we have
             # seen.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -34,7 +34,7 @@ from lsst.daf.butler.tests.dict_convertible_model import DictConvertibleModel
 
 try:
     # Failing to import any of these should disable the tests.
-    import lsst.daf.butler.remote_butler._query_driver
+    import lsst.daf.butler.remote_butler._query_results
     import lsst.daf.butler.remote_butler.server.handlers._query_streaming
     import safir.dependencies.logger
     from fastapi.testclient import TestClient
@@ -418,7 +418,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
             # Hook into QueryDriver to track the number of keep-alives we have
             # seen.
             with patch.object(
-                lsst.daf.butler.remote_butler._query_driver, "_received_keep_alive"
+                lsst.daf.butler.remote_butler._query_results, "_received_keep_alive"
             ) as mock_keep_alive:
                 mock_timeout.side_effect = _timeout_twice()
                 with self.butler.query() as query:


### PR DESCRIPTION
Added a server-side endpoint to handle `query_all_datasets` in a single request.  `query_all_datasets` can potentially involve hundreds or thousands of separate dataset queries, and we don't want clients slamming the server with that many HTTP requests.

The new endpoint streams results in the same manner as the existing query endpoints used by `QueryDriver`, but it is separate from the `Query`/`QueryDriver` framework.

This is not yet used in the CLI tools and `Butler._query_all_datasets` is still private -- we need to deploy an updated server with this change before we can release the client side.

`--order-by` in the CLI tools is now restricted to queries for a single dataset type -- future implementations of `query_all_datasets` may not support it.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
