### PR TITLE
DM-47475: Fix crash in some find_first queries in the new query system.

### DIFF
--- a/doc/changes/DM-47475.bugfix.md
+++ b/doc/changes/DM-47475.bugfix.md
@@ -1,0 +1,1 @@
+Fix a crash in the new Butler query system which happened in some conditions when using find-first option with multiple collections.

--- a/python/lsst/daf/butler/_topology.py
+++ b/python/lsst/daf/butler/_topology.py
@@ -76,7 +76,7 @@ class TopologicalFamily(ABC):
     another's in a predefined way.
 
     This hierarchy means that endpoints in the same family do not generally
-    have to be have to be related using (e.g.) overlaps; instead, the regions
+    have to be related using (e.g.) overlaps; instead, the regions
     from one "best" endpoint from each family are related to the best endpoint
     from each other family in a query.
 

--- a/python/lsst/daf/butler/direct_query_driver/_sql_builders.py
+++ b/python/lsst/daf/butler/direct_query_driver/_sql_builders.py
@@ -231,7 +231,7 @@ class SqlSelectBuilder:
                 self.select(postprocessing).cte() if cte else self.select(postprocessing).subquery()
             )
             return SqlJoinsBuilder(db=self.joins.db, from_clause=sql_from_clause).extract_columns(
-                self.columns, special=self.joins.special.keys()
+                self.columns, postprocessing, special=self.joins.special.keys()
             )
         return self.joins
 

--- a/tests/data/registry/ci_hsc-subset-skymap.yaml
+++ b/tests/data/registry/ci_hsc-subset-skymap.yaml
@@ -1,0 +1,45 @@
+# Skymap definition from ci_hsc_gen3, for our tests we only need tracts,
+# dimension records for patches are not included.
+description: Butler Data Repository Export
+version: 1.0.2
+universe_version: 7
+universe_namespace: daf_butler
+data:
+- type: dimension
+  element: skymap
+  records:
+  - name: discrete/ci_hsc
+    hash: !!binary |
+      Kt7swQ9e5zUif7fo1Onj3ezH+Ts=
+    tract_max: 1
+    patch_nx_max: 16
+    patch_ny_max: 16
+- type: dimension
+  element: tract
+  records:
+  - skymap: discrete/ci_hsc
+    id: 0
+    region: !<lsst.sphgeom.ConvexPolygon>
+      encoded: 70cb48dd838019e83fe79b0e4ace0ae5bfcae4291ac61395bf4884794db329e93f68b2ba9327c2e3bfa603a921c61395bf0e047a6ce727e93fc46da7b1aac0e3bf8779dd59c921a03f513c3fa3b417e83f6ffa86675109e5bf06a12054c921a03f
+- type: collection
+  collection_type: RUN
+  name: skymaps
+  host: null
+  timespan_begin: null
+  timespan_end: null
+- type: dataset_type
+  name: skyMap
+  dimensions:
+  - skymap
+  storage_class: SkyMap
+  is_calibration: false
+- type: dataset
+  dataset_type: skyMap
+  run: skymaps
+  records:
+  - dataset_id:
+    - !uuid '557e15c6-0529-4fc9-998b-b90a4750315e'
+    data_id:
+    - skymap: discrete/ci_hsc
+    path: skymaps/skyMap/skyMap_discrete_ci_hsc_skymaps.pickle
+    formatter: lsst.daf.butler.formatters.pickle.PickleFormatter


### PR DESCRIPTION
Find-first follow-up queries caused crash in some conditions in QG builder due to a missing postprocessing parameter. The fix is one-liner, and this patch adds a unit test which reproduces the crash with more than one run collection.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
