### PR TITLE
DM-47543: Reduce likelihood of collection deadlocks

### DIFF
--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -390,8 +390,11 @@ class ButlerCollections(ABC, Sequence):
 
         Notes
         -----
-        This method cannot be called within transactions, as it needs to be
-        able to perform its own transaction to be concurrent
+        Avoid calling this method multiple times within a `Butler.transaction`.
+        If concurrent processes register the same collection names, they may
+        block each other until the end of the transaction and in some cases the
+        database will be required to abort one of the transactions to prevent
+        deadlock.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
Fix an issue where concurrent calls to transfer_from() in Prompt Processing were causing Postgres to abort with a deadlock error.

We now register collection names in alphabetical order when multiple collections are registered inside a transaction in `transfer_from()`.  Because `ButlerCollections.register()` inserts rows into a table with a unique index, Postgres takes a lock when the row is inserted and holds it until the end of the transaction.  If there are two processes with concurrent transactions attempting to create the same collections, it is possible for the locks to be acquired in different orders, causing a deadlock.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
