### PR TITLE
DM-47768: Add "--chains NO-CHILDREN" to query-collections

### DIFF
--- a/doc/changes/DM-47768.feature.md
+++ b/doc/changes/DM-47768.feature.md
@@ -1,0 +1,2 @@
+Added a `--chains NO-CHILDREN` mode to the `butler query-collections` CLI,
+which returns results without recursing into `CHAINED` collections.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -394,20 +394,22 @@ def prune_datasets(**kwargs: Any) -> None:
     default="TREE",
     help="""Affects how results are presented:
 
-        TABLE lists each dataset in table form, with columns for dataset name
-        and type, and a column that lists children of CHAINED datasets (if any
-        CHAINED datasets are found).
+        TABLE lists each collection in table form, with columns for collection
+        name and type, and a column that lists children of CHAINED collections
+        (if any CHAINED collections are found).
 
         INVERSE-TABLE is like TABLE but instead of a column listing CHAINED
-        dataset children, it lists the parents of the dataset if it is contained
-        in any CHAINED collections.
+        collection children, it lists the parents of the collection if it is
+        contained in any CHAINED collections.
 
-        TREE recursively lists children below each CHAINED dataset in tree form.
+        TREE recursively lists children below each CHAINED collection in tree
+        form.
 
-        INVERSE-TREE recursively lists parent datasets below each dataset in
-        tree form.
+        INVERSE-TREE recursively lists parent collections below each collection
+        in tree form.
 
-        FLATTEN lists all datasets, including child datasets, in one list.
+        FLATTEN lists all collections, including children of CHAINED
+        collections, in one list.
 
         NO-CHILDREN lists all collections in one list.  CHAINED collections are
         included, but they are not expanded to include their children.

--- a/python/lsst/daf/butler/cli/cmd/commands.py
+++ b/python/lsst/daf/butler/cli/cmd/commands.py
@@ -409,13 +409,16 @@ def prune_datasets(**kwargs: Any) -> None:
 
         FLATTEN lists all datasets, including child datasets, in one list.
 
+        NO-CHILDREN lists all collections in one list.  CHAINED collections are
+        included, but they are not expanded to include their children.
+
         [default: TREE]""",
     # above, the default value is included, instead of using show_default, so
     # that the default is printed on its own line instead of coming right after
     # the FLATTEN text.
     callback=to_upper,
     type=click.Choice(
-        choices=("TABLE", "INVERSE-TABLE", "TREE", "INVERSE-TREE", "FLATTEN"),
+        choices=("TABLE", "INVERSE-TABLE", "TREE", "INVERSE-TREE", "FLATTEN", "NO-CHILDREN"),
         case_sensitive=False,
     ),
 )

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -277,6 +277,24 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
             )
             self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
 
+            result = self.runner.invoke(cli, ["query-collections", "here", "--chains", "NO-CHILDREN"])
+            self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+            expected = Table(
+                array(
+                    (
+                        ("calibration1", "CALIBRATION"),
+                        ("chain1", "CHAINED"),
+                        ("chain2", "CHAINED"),
+                        ("imported_g", "RUN"),
+                        ("imported_r", "RUN"),
+                        ("run1", "RUN"),
+                        ("tag1", "TAGGED"),
+                    )
+                ),
+                names=("Name", "Type"),
+            )
+            self.assertAstropyTablesEqual(readTable(result.output), expected, unorderedRows=True)
+
             # Add a couple more run collections for chain testing
             registry1.registerRun("run2")
             registry1.registerRun("run3")


### PR DESCRIPTION
Added a `--chains NO-CHILDREN` mode to the `butler query-collections` CLI,
which returns results without recursing into `CHAINED` collections.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
