### PR TITLE
DM-46914: Add ability for ObsCore record facility name to vary by instrument

### DIFF
--- a/doc/changes/DM-46914.misc.rst
+++ b/doc/changes/DM-46914.misc.rst
@@ -1,0 +1,2 @@
+Modified ObsCore configuration to support ``facility_map`` lookup table to allow the facility to be associated with a specific instrument.
+This is important for butler repositories containing data from multiple instruments and facilities.

--- a/python/lsst/daf/butler/registry/obscore/_config.py
+++ b/python/lsst/daf/butler/registry/obscore/_config.py
@@ -116,7 +116,7 @@ class SpatialPluginConfig(pydantic.BaseModel):
     cls: str
     """Name of the class implementing plugin methods."""
 
-    config: dict[str, Any] = {}
+    config: dict[str, Any] = pydantic.Field(default_factory=dict)
     """Configuration object passed to plugin ``initialize()`` method."""
 
 
@@ -144,7 +144,13 @@ class ObsCoreConfig(pydantic.BaseModel):
     """
 
     facility_name: str
-    """Value for the ``facility_name`` column."""
+    """Default value for the ``facility_name`` column. If an instrument
+    is listed in ``facility_map`` that will be used in preference but this
+    value must always be set as a fallback."""
+
+    facility_map: dict[str, str] = pydantic.Field(default_factory=dict)
+    """Mapping of instrument name to facility name. Takes precedence over
+    the ``facility_name``."""
 
     extra_columns: None | (
         dict[str, StrictFloat | StrictInt | StrictBool | StrictStr | ExtraColumnConfig]

--- a/python/lsst/daf/butler/registry/obscore/_records.py
+++ b/python/lsst/daf/butler/registry/obscore/_records.py
@@ -163,7 +163,6 @@ class RecordFactory:
         record["dataproduct_type"] = dataset_config.dataproduct_type
         record["dataproduct_subtype"] = dataset_config.dataproduct_subtype
         record["o_ucd"] = dataset_config.o_ucd
-        record["facility_name"] = self.config.facility_name
         record["calib_level"] = dataset_config.calib_level
         if dataset_config.obs_collection is not None:
             record["obs_collection"] = dataset_config.obs_collection
@@ -171,9 +170,12 @@ class RecordFactory:
             record["obs_collection"] = self.config.obs_collection
         record["access_format"] = dataset_config.access_format
 
-        record["instrument_name"] = dataId.get("instrument")
+        instrument_name = cast(str, dataId.get("instrument"))
+        record["instrument_name"] = instrument_name
         if self.schema.dataset_fk is not None:
             record[self.schema.dataset_fk.name] = ref.id
+
+        record["facility_name"] = self.config.facility_map.get(instrument_name, self.config.facility_name)
 
         timespan = dataId.timespan
         if timespan is not None:

--- a/tests/config/basic/obscore.yaml
+++ b/tests/config/basic/obscore.yaml
@@ -3,6 +3,8 @@ version: 0
 table_name: obscore
 collection_type: RUN
 facility_name: daf_butler_test
+facility_map:
+  DummyCam: derived_facility
 obs_collection: daf_butler_obs_collection
 collections: []
 use_butler_uri: false

--- a/tests/test_obscore.py
+++ b/tests/test_obscore.py
@@ -479,7 +479,7 @@ class ObsCoreTests(TestCaseMixin):
         )
         self.assertEqual(count, 2)
 
-        with obscore.query(["s_ra", "s_dec", "s_region", "lsst_detector"]) as result:
+        with obscore.query(["s_ra", "s_dec", "s_region", "lsst_detector", "facility_name"]) as result:
             rows = list(result)
             self.assertEqual(len(rows), 4)
             for row in rows:
@@ -491,6 +491,7 @@ class ObsCoreTests(TestCaseMixin):
                     self.assertIsNone(row.s_ra)
                     self.assertIsNone(row.s_dec)
                     self.assertIsNone(row.s_region)
+                self.assertEqual(row.facility_name, "derived_facility")
 
 
 class SQLiteObsCoreTest(ObsCoreTests, unittest.TestCase):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
