### PR TITLE
DM-47889: Prevent DB connection pool exhaustion in Butler server

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -91,7 +91,7 @@ async def query_execute(
     request: QueryExecuteRequestModel, factory: Factory = Depends(factory_dependency)
 ) -> StreamingResponse:
     query = _StreamQueryDriverExecute(request, factory)
-    return execute_streaming_query(query)
+    return await execute_streaming_query(query)
 
 
 class _QueryAllDatasetsContext(NamedTuple):
@@ -136,7 +136,7 @@ async def query_all_datasets_execute(
     request: QueryAllDatasetsRequestModel, factory: Factory = Depends(factory_dependency)
 ) -> StreamingResponse:
     query = _StreamQueryAllDatasets(request, factory)
-    return execute_streaming_query(query)
+    return await execute_streaming_query(query)
 
 
 @query_router.post(

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
@@ -123,8 +123,7 @@ async def execute_streaming_query(query: StreamingQuery) -> StreamingResponse:
         await _block_retry_for_unit_test()
         raise HTTPException(
             status_code=503,  # service temporarily unavailable
-            detail="The Butler Server is currently overloaded with requests."
-            f" Try again in {_QUERY_RETRY_SECONDS} seconds.",
+            detail="The Butler Server is currently overloaded with requests.",
             headers={"retry-after": str(_QUERY_RETRY_SECONDS)},
         )
 


### PR DESCRIPTION
Adjusted the database connection pool parameters and added a limit to the number of long-running queries that the server will execute simultaneously.

If a client tries to run a long-running query while the server is overloaded, the request will be rejected with an HTTP 503 and the client will retry later.  This also sets up the retry logic for HTTP 429, which will be used in the future for other kinds of rate limiting.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
