### PR TITLE
DM-47948: Preload dataset type cache for Butler server

### DIFF
--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -2339,9 +2339,9 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             pages = query_all_datasets(self, query, args)
             yield iter(page.data for page in pages)
 
-    def _preload_cache(self) -> None:
+    def _preload_cache(self, *, load_dimension_record_cache: bool = True) -> None:
         """Immediately load caches that are used for common operations."""
-        self._registry.preload_cache()
+        self._registry.preload_cache(load_dimension_record_cache=load_dimension_record_cache)
 
     _config: ButlerConfig
     """Configuration for this Butler instance."""

--- a/python/lsst/daf/butler/registry/_caching_context.py
+++ b/python/lsst/daf/butler/registry/_caching_context.py
@@ -31,7 +31,6 @@ __all__ = ["CachingContext"]
 
 from ._collection_record_cache import CollectionRecordCache
 from ._collection_summary_cache import CollectionSummaryCache
-from ._dataset_type_cache import DatasetTypeCache
 
 
 class CachingContext:
@@ -46,13 +45,9 @@ class CachingContext:
     instances which will be `None` when caching is disabled. Instance of this
     class is passed to the relevant managers that can use it to query or
     populate caches when caching is enabled.
-
-    Dataset type cache is always enabled for now, this avoids the need for
-    explicitly enabling caching in pipetask executors.
     """
 
     def __init__(self) -> None:
-        self._dataset_types: DatasetTypeCache = DatasetTypeCache()
         self._collection_records: CollectionRecordCache | None = None
         self._collection_summaries: CollectionSummaryCache | None = None
         self._depth = 0
@@ -96,8 +91,3 @@ class CachingContext:
     def collection_summaries(self) -> CollectionSummaryCache | None:
         """Cache for collection summary records (`CollectionSummaryCache`)."""
         return self._collection_summaries
-
-    @property
-    def dataset_types(self) -> DatasetTypeCache:
-        """Cache for dataset types, never disabled (`DatasetTypeCache`)."""
-        return self._dataset_types

--- a/python/lsst/daf/butler/registry/_caching_context.py
+++ b/python/lsst/daf/butler/registry/_caching_context.py
@@ -27,19 +27,14 @@
 
 from __future__ import annotations
 
-__all__ = ["CachingContext", "GenericCachingContext"]
-
-from typing import Generic, TypeAlias, TypeVar
+__all__ = ["CachingContext"]
 
 from ._collection_record_cache import CollectionRecordCache
 from ._collection_summary_cache import CollectionSummaryCache
 from ._dataset_type_cache import DatasetTypeCache
 
-_T = TypeVar("_T")
-_U = TypeVar("_U")
 
-
-class GenericCachingContext(Generic[_T, _U]):
+class CachingContext:
     """Collection of caches for various types of records retrieved from
     database.
 
@@ -54,16 +49,10 @@ class GenericCachingContext(Generic[_T, _U]):
 
     Dataset type cache is always enabled for now, this avoids the need for
     explicitly enabling caching in pipetask executors.
-
-    `GenericCachingContext` is generic over two kinds of opaque dataset type
-    data, with the expectation that most code will use the ``CachingContext``
-    type alias (which resolves to `GenericCachingContext[object, object]`);
-    the `DatasetRecordStorageManager` can then cast this to a
-    `GenericCachingContext` with the actual opaque data types it uses.
     """
 
     def __init__(self) -> None:
-        self._dataset_types: DatasetTypeCache[_T, _U] = DatasetTypeCache()
+        self._dataset_types: DatasetTypeCache = DatasetTypeCache()
         self._collection_records: CollectionRecordCache | None = None
         self._collection_summaries: CollectionSummaryCache | None = None
         self._depth = 0
@@ -109,9 +98,6 @@ class GenericCachingContext(Generic[_T, _U]):
         return self._collection_summaries
 
     @property
-    def dataset_types(self) -> DatasetTypeCache[_T, _U]:
+    def dataset_types(self) -> DatasetTypeCache:
         """Cache for dataset types, never disabled (`DatasetTypeCache`)."""
         return self._dataset_types
-
-
-CachingContext: TypeAlias = GenericCachingContext[object, object]

--- a/python/lsst/daf/butler/registry/_dataset_type_cache.py
+++ b/python/lsst/daf/butler/registry/_dataset_type_cache.py
@@ -57,6 +57,9 @@ class DatasetTypeCache:
     """
 
     def __init__(self) -> None:
+        from .datasets.byDimensions.tables import DynamicTablesCache
+
+        self.tables = DynamicTablesCache()
         self._by_name_cache: dict[str, tuple[DatasetType, int]] = {}
         self._by_dimensions_cache: dict[DimensionGroup, DynamicTables] = {}
         self._full = False

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
@@ -30,13 +30,10 @@ from __future__ import annotations
 __all__ = ("DatasetTypeCache",)
 
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING
 
-from .._dataset_type import DatasetType
-from ..dimensions import DimensionGroup
-
-if TYPE_CHECKING:
-    from .datasets.byDimensions.tables import DynamicTables
+from ...._dataset_type import DatasetType
+from ....dimensions import DimensionGroup
+from .tables import DynamicTables, DynamicTablesCache
 
 
 class DatasetTypeCache:
@@ -57,8 +54,6 @@ class DatasetTypeCache:
     """
 
     def __init__(self) -> None:
-        from .datasets.byDimensions.tables import DynamicTablesCache
-
         self.tables = DynamicTablesCache()
         self._by_name_cache: dict[str, tuple[DatasetType, int]] = {}
         self._by_dimensions_cache: dict[DimensionGroup, DynamicTables] = {}

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
@@ -33,7 +33,7 @@ from collections.abc import Iterable, Iterator
 
 from ...._dataset_type import DatasetType
 from ....dimensions import DimensionGroup
-from .tables import DynamicTables, DynamicTablesCache
+from .tables import DynamicTables, TableCache
 
 
 class DatasetTypeCache:
@@ -54,7 +54,7 @@ class DatasetTypeCache:
     """
 
     def __init__(self) -> None:
-        self.tables = DynamicTablesCache()
+        self.tables = TableCache()
         self._by_name_cache: dict[str, tuple[DatasetType, int]] = {}
         self._by_dimensions_cache: dict[DimensionGroup, DynamicTables] = {}
         self._full = False

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
@@ -108,7 +108,7 @@ class DatasetTypeCache:
             Dataset type, replaces any existing dataset type with the same
             name.
         id : `int`
-            The dataset type primary key
+            The dataset type primary key.
             Additional opaque object stored with this dataset type.
         """
         self._by_name_cache[dataset_type.name] = (dataset_type, id)

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -586,9 +586,9 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         record = self._fetch_dataset_type_record(name)
         if record is not None:
             self._cache.add(record.dataset_type, record.dataset_type_id)
-            return _DatasetRecordStorage(
-                record.dataset_type, record.dataset_type_id, record.make_dynamic_tables()
-            )
+            tables = record.make_dynamic_tables()
+            self._cache.add_by_dimensions(record.dataset_type.dimensions, tables)
+            return _DatasetRecordStorage(record.dataset_type, record.dataset_type_id, tables)
         raise MissingDatasetTypeError(f"Dataset type {name!r} does not exist.")
 
     def getCollectionSummary(self, collection: CollectionRecord) -> CollectionSummary:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -6,7 +6,7 @@ import dataclasses
 import datetime
 import logging
 from collections.abc import Iterable, Mapping, Sequence, Set
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import astropy.time
 import sqlalchemy
@@ -24,7 +24,7 @@ from ...._timespan import Timespan
 from ....dimensions import DataCoordinate, DimensionGroup, DimensionUniverse
 from ....direct_query_driver import SqlJoinsBuilder, SqlSelectBuilder  # new query system, server+direct only
 from ....queries import tree as qt  # new query system, both clients + server
-from ..._caching_context import CachingContext, GenericCachingContext
+from ..._caching_context import CachingContext
 from ..._collection_summary import CollectionSummary
 from ..._exceptions import ConflictingDefinitionError, DatasetTypeExpressionError, OrphanedRecordError
 from ...interfaces import DatasetRecordStorageManager, RunRecord, VersionTuple
@@ -155,7 +155,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         self._dimensions = dimensions
         self._static = static
         self._summaries = summaries
-        self._caching_context = cast(GenericCachingContext[int, DynamicTables], caching_context)
+        self._caching_context = caching_context
         self._use_astropy_ingest_date = self.ingest_date_dtype() is ddl.AstropyTimeNsecTai
         self._run_key_column = collections.getRunForeignKeyName()
 

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -432,7 +432,6 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
             return None
         run = row[self._run_key_column]
         record = self._record_from_row(row)
-        dynamic_tables: DynamicTables | None = None
         _, dataset_type_id = self._cache.get(record.dataset_type.name)
         if dataset_type_id is None:
             self._cache.add(record.dataset_type, record.dataset_type_id)

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
@@ -451,7 +451,7 @@ def makeCalibTableSpec(
     return tableSpec
 
 
-DynamicTablesCache: TypeAlias = ThreadSafeCache[str, sqlalchemy.Table]
+TableCache: TypeAlias = ThreadSafeCache[str, sqlalchemy.Table]
 
 
 @immutable
@@ -519,7 +519,7 @@ class DynamicTables:
             calibs_name=makeCalibTableName(dimensions_key) if is_calibration else None,
         )
 
-    def create(self, db: Database, collections: type[CollectionManager], cache: DynamicTablesCache) -> None:
+    def create(self, db: Database, collections: type[CollectionManager], cache: TableCache) -> None:
         """Create the tables if they don't already exist.
 
         Parameters
@@ -551,7 +551,7 @@ class DynamicTables:
             )
 
     def add_calibs(
-        self, db: Database, collections: type[CollectionManager], cache: DynamicTablesCache
+        self, db: Database, collections: type[CollectionManager], cache: TableCache
     ) -> DynamicTables:
         """Create a calibs table for a dataset type whose dimensions already
         have a tags table.
@@ -577,9 +577,7 @@ class DynamicTables:
 
         return self.copy(calibs_name=calibs_name)
 
-    def tags(
-        self, db: Database, collections: type[CollectionManager], cache: DynamicTablesCache
-    ) -> sqlalchemy.Table:
+    def tags(self, db: Database, collections: type[CollectionManager], cache: TableCache) -> sqlalchemy.Table:
         """Return the "tags" table that associates datasets with data IDs in
         TAGGED and RUN collections.
 
@@ -612,7 +610,7 @@ class DynamicTables:
         return cache.set_or_get(self.tags_name, table)
 
     def calibs(
-        self, db: Database, collections: type[CollectionManager], cache: DynamicTablesCache
+        self, db: Database, collections: type[CollectionManager], cache: TableCache
     ) -> sqlalchemy.Table:
         """Return the "calibs" table that associates datasets with data IDs and
         timespans in CALIBRATION collections.

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -103,6 +103,13 @@ class DatasetRecordStorageManager(VersionedExtension):
         """
         raise NotImplementedError()
 
+    @abstractmethod
+    def preload_cache(self) -> None:
+        """Fetch data from the database and use it to pre-populate caches to
+        speed up later operations.
+        """
+        raise NotImplementedError()
+
     @classmethod
     @abstractmethod
     def initialize(

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2482,10 +2482,20 @@ class SqlRegistry:
                 pass
         self._datastore_record_classes = datastore_record_classes
 
-    def preload_cache(self) -> None:
-        """Immediately load caches that are used for common operations."""
-        self.dimension_record_cache.preload_cache()
+    def preload_cache(self, *, load_dimension_record_cache: bool) -> None:
+        """Immediately load caches that are used for common operations.
+
+        Parameters
+        ----------
+        load_dimension_record_cache : `bool`
+            If True, preload the dimension record cache.  When this cache is
+            preloaded, subsequent external changes to governor dimension
+            records will not be visible to this Butler.
+        """
         self._managers.datasets.preload_cache()
+
+        if load_dimension_record_cache:
+            self.dimension_record_cache.preload_cache()
 
     @property
     def obsCoreTableManager(self) -> ObsCoreTableManager | None:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2485,6 +2485,7 @@ class SqlRegistry:
     def preload_cache(self) -> None:
         """Immediately load caches that are used for common operations."""
         self.dimension_record_cache.preload_cache()
+        self._managers.datasets.preload_cache()
 
     @property
     def obsCoreTableManager(self) -> ObsCoreTableManager | None:

--- a/python/lsst/daf/butler/remote_butler/server/README.md
+++ b/python/lsst/daf/butler/remote_butler/server/README.md
@@ -1,0 +1,57 @@
+# Butler server
+
+## Concurrency and caching
+
+The server internally uses `DirectButler` instances to retrieve data from the
+database.  `DirectButler` instances are not thread-safe, so we need a separate
+instance for each request.  It is expensive to create a `DirectButler` instance
+from scratch, so we create a "template" `DirectButler` the first a repository
+is accessed, and clone it for each request.  (The cloning process is managed by
+`LabeledButlerFactory`.)
+
+Within `DirectButler`, there are a number of internal caches.  Some of these
+caches assume that no external processes will be mutating the repository during
+the lifetime of the `DirectButler` instance, and lock in state at the first
+time the data is accessed.  This behavior is OK in the context of a single HTTP
+request in Butler server. However, it is problematic across requests if the
+repository can be changing in the background, because new requests wouldn't be
+able to see updated data.
+
+It is expected that the main data release repositories will be immutable,
+which would allow for more aggressive caching, but we don't yet have a way to
+configure "mutable" vs "immutable" repositories in the server.
+
+### Summary of caches that exist in `DirectButler`
+
+Caches that are shared globally between all Butler instances within a process:
+
+- `DimensionUniverse`
+- `DimensionGroup`
+- `StorageClassFactory`
+
+Caches shared between instances cloned from the same parent Butler instance:
+
+- Most SqlAlchemy `Table` objects created during managers' `initialize()` classmethods
+- Tables created by `register()` in `ByNameOpaqueTableStorageManager`
+- Dataset "tag" and "calib" tables created by
+  `ByDimensionsDatasetRecordStorageManagerUUID` and stored in `DatasetTypeCache`
+
+Caches copied between instances at the time of cloning:
+
+- `DimensionRecordCache`
+- `DatasetType` and `DynamicTables` instances in `DatasetTypeCache`
+
+Caches that start empty in a newly cloned instance:
+
+- Collection cache and collection summary cache in `CachingContext`
+- `DimensionGraph` cache in `_DimensionGroupStorage`
+- `DatastoreCacheManager` in `FileDatastore` (not relevant to Butler server,
+  since the server does not access files on the filesystem.)
+
+### Caching caveats
+
+There is not currently a way to detect all changes to a Butler repository and invalidate the caches.  The Butler server must be restarted if a repository is changed in any of the following ways:
+
+- Any additions/deletions/modifications to governor dimension records
+- Updating a dataset type (deleting it and re-registering the same name with different values)
+- Deleting a dataset type

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -119,7 +119,7 @@ def create_test_server(
                 # instrument records etc during setup.  So configure the
                 # factory to disable this preloading and re-fetch the records
                 # as needed.
-                server_butler_factory._preload_direct_butler_cache = False
+                server_butler_factory._preload_unsafe_direct_butler_caches = False
                 app.dependency_overrides[butler_factory_dependency] = lambda: server_butler_factory
 
                 # Using TestClient in a context manager ensures that it uses


### PR DESCRIPTION
We now preload the dataset type cache the first time a repository is accessed in Butler server.  This is an optimization to avoid needing to go to the database every time we need the definition of a dataset type.

In preparation for this change, `DatasetTypeCache` was tweaked to make it non-generic, and to make all inner cached values immutable.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
