### PR TITLE
DM-47976: Support conversion field in file template format strings

### DIFF
--- a/doc/changes/DM-47976.bugfix.md
+++ b/doc/changes/DM-47976.bugfix.md
@@ -1,0 +1,1 @@
+Support type conversion field in file template format strings.

--- a/python/lsst/daf/butler/datastore/file_templates.py
+++ b/python/lsst/daf/butler/datastore/file_templates.py
@@ -571,7 +571,7 @@ class FileTemplate:
         parts = fmt.parse(self.template)
         output = ""
 
-        for literal, field_name, format_spec, _ in parts:
+        for literal, field_name, format_spec, conversion in parts:
             if field_name and "|" in field_name:
                 alternates = field_name.split("|")
                 for alt in alternates:
@@ -677,6 +677,10 @@ class FileTemplate:
                 value = value.replace(" ", "_")
                 if replace_slash:
                     value = value.replace("/", "_")
+
+            # Apply conversion (e.g., integer to string)
+            if conversion:
+                value = fmt.convert_field(value, conversion)
 
             # Now use standard formatting
             output = output + literal + format(value, format_spec)

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -152,6 +152,15 @@ class TestFileTemplates(unittest.TestCase):
             self.makeDatasetRef("calexp", run="run.2", dataId=dataId),
         )
 
+        # Check that type conversion is applied
+        dataId = {"instrument": "dummy", "day_obs": 20250203}
+        tmplstr = "{run}/{datasetType}/{day_obs!s:.4s}"
+        self.assertTemplate(
+            tmplstr,
+            "run3/calexp/2025",
+            self.makeDatasetRef("calexp", run="run3", dataId=dataId),
+        )
+
         with self.assertRaises(FileTemplateValidationError):
             FileTemplate("no fields at all")
 


### PR DESCRIPTION
A fix to support type conversion in file template format strings. For example, the conversion specifier `!s` in a format string like `{healpix!s:.2s}` converts a numeric field healpix into a string before applying additional formatting.

The modified unit test, which previously produced a `ValueError: Unknown format code 's' for object of type 'int'`, now passes.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
