### PR TITLE
DM-48052: Fix intermittent failure in unit tests

### DIFF
--- a/tests/test_cliCmdRetrieveArtifacts.py
+++ b/tests/test_cliCmdRetrieveArtifacts.py
@@ -75,6 +75,7 @@ class CliRetrieveArtifactsTest(unittest.TestCase, ButlerTestHelper):
                 self.assertTrue(result.stdout.endswith(": 6\n"), f"Expected 6 got: {result.stdout}")
 
                 artifacts = self.find_files(destdir)
+                artifacts.sort()
                 self.assertEqual(len(artifacts), 7, f"Expected 7 artifacts including index: {artifacts}")
                 self.assertIn(f"{destdir}{prefix}", str(artifacts[1]))
 
@@ -95,6 +96,7 @@ class CliRetrieveArtifactsTest(unittest.TestCase, ButlerTestHelper):
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
             self.assertTrue(result.stdout.endswith(": 3\n"), f"Expected 3 got: {result.stdout}")
             artifacts = self.find_files(destdir)
+            artifacts.sort()
             self.assertEqual(len(artifacts), 4, f"Expected 4 artifacts including index: {artifacts}")
 
     def testRetrieveAsZip(self):


### PR DESCRIPTION
testRetrieveAll in test_cliCmdRetrieveArtifacts.py was failing intermittently, any time that the zip index happened to be the second file in the directory listing.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
