### PR TITLE
DM-48094: Fix dataset fields not working in Butler.query_datasets

### DIFF
--- a/doc/changes/DM-48094.bugfix.md
+++ b/doc/changes/DM-48094.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug where dataset fields like `ingest_date` were raising `InvalidQueryError: Unrecognized identifier` when used in `Butler.query_datasets` `where` clause.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1869,8 +1869,8 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             warn_limit = True
         with self.query() as query:
             result = (
-                query.where(data_id, where, bind=bind, **kwargs)
-                .datasets(dataset_type, collections=collections, find_first=find_first)
+                query.datasets(dataset_type, collections=collections, find_first=find_first)
+                .where(data_id, where, bind=bind, **kwargs)
                 .order_by(*ensure_iterable(order_by))
                 .limit(query_limit)
             )

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -1921,6 +1921,13 @@ class ButlerQueryTests(ABC, TestCaseMixin):
             self.assertEqual(rows[0]["visit"], 1)
             self.assertEqual(rows[0]["dt.collection"], "run1")
 
+        # Test that dataset fields like ingest_date can be used in the 'where'
+        # clause.
+        result = butler.query_datasets("dt", "run1", where="ingest_date > T'2000-01-01'")
+        self.assertEqual(len(result), 1)
+        result = butler.query_datasets("dt", "run1", where="ingest_date < T'2000-01-01'", explain=False)
+        self.assertEqual(len(result), 0)
+
     def test_multiple_instrument_queries(self) -> None:
         """Test that multiple-instrument queries are not rejected as having
         governor dimension ambiguities.


### PR DESCRIPTION
Fix an issue where dataset fields like `ingest_date` were raising `InvalidQueryError: Unrecognized identifier` because the where clause was being applied before query was known to be a dataset query.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
