### PR TITLE
DM-47980: Add an option to include dimension records into general query result

### DIFF
--- a/python/lsst/daf/butler/direct_query_driver/_result_page_converter.py
+++ b/python/lsst/daf/butler/direct_query_driver/_result_page_converter.py
@@ -326,17 +326,35 @@ class GeneralResultPageConverter(ResultPageConverter):  # numpydoc ignore=PR01
 
     def __init__(self, spec: GeneralResultSpec, ctx: ResultPageConverterContext) -> None:
         self.spec = spec
-
-        result_columns = spec.get_result_columns()
+        # In case `spec.include_dimension_records` is True then in addition to
+        # columns returned by the query we have to add columns from dimension
+        # records that are not returned by the query. These columns belong to
+        # either cached or skypix dimensions.
+        query_result_columns = set(spec.get_result_columns())
+        output_columns = spec.get_all_result_columns()
+        universe = spec.dimensions.universe
         self.converters: list[_GeneralColumnConverter] = []
-        for column in result_columns:
+        for column in output_columns:
             column_name = qt.ColumnSet.get_qualified_name(column.logical_table, column.field)
-            if column.field == TimespanDatabaseRepresentation.NAME:
-                self.converters.append(_TimespanGeneralColumnConverter(column_name, ctx.db))
+            converter: _GeneralColumnConverter
+            if column not in query_result_columns and column.field is not None:
+                # This must be a field from a cached dimension record or
+                # skypix record.
+                assert isinstance(column.logical_table, str), "Do not expect AnyDatasetType here"
+                element = universe[column.logical_table]
+                if isinstance(element, SkyPixDimension):
+                    converter = _SkypixRecordGeneralColumnConverter(element, column.field)
+                else:
+                    converter = _CachedRecordGeneralColumnConverter(
+                        element, column.field, ctx.dimension_record_cache
+                    )
+            elif column.field == TimespanDatabaseRepresentation.NAME:
+                converter = _TimespanGeneralColumnConverter(column_name, ctx.db)
             elif column.field == "ingest_date":
-                self.converters.append(_TimestampGeneralColumnConverter(column_name))
+                converter = _TimestampGeneralColumnConverter(column_name)
             else:
-                self.converters.append(_DefaultGeneralColumnConverter(column_name))
+                converter = _DefaultGeneralColumnConverter(column_name)
+            self.converters.append(converter)
 
     def convert(self, raw_rows: Iterable[sqlalchemy.Row]) -> GeneralResultPage:
         rows = [tuple(cvt.convert(row) for cvt in self.converters) for row in raw_rows]
@@ -422,3 +440,47 @@ class _TimespanGeneralColumnConverter(_GeneralColumnConverter):
     def convert(self, row: sqlalchemy.Row) -> Any:
         timespan = self.timespan_class.extract(row._mapping, self.name)
         return timespan
+
+
+class _CachedRecordGeneralColumnConverter(_GeneralColumnConverter):
+    """Helper for converting result row into a field value for cached
+    dimension records.
+
+    Parameters
+    ----------
+    element : `DimensionElement`
+        Dimension element, must be of cached type.
+    field : `str`
+        Name of the field to extract from the dimension record.
+    cache : `DimensionRecordCache`
+        Cache for dimension records.
+    """
+
+    def __init__(self, element: DimensionElement, field: str, cache: DimensionRecordCache) -> None:
+        self._record_converter = _CachedDimensionRecordRowConverter(element, cache)
+        self._field = field
+
+    def convert(self, row: sqlalchemy.Row) -> Any:
+        record = self._record_converter.convert(row)
+        return getattr(record, self._field)
+
+
+class _SkypixRecordGeneralColumnConverter(_GeneralColumnConverter):
+    """Helper for converting result row into a field value for skypix
+    dimension records.
+
+    Parameters
+    ----------
+    element : `SkyPixDimension`
+        Dimension element.
+    field : `str`
+        Name of the field to extract from the dimension record.
+    """
+
+    def __init__(self, element: SkyPixDimension, field: str) -> None:
+        self._record_converter = _SkypixDimensionRecordRowConverter(element)
+        self._field = field
+
+    def convert(self, row: sqlalchemy.Row) -> Any:
+        record = self._record_converter.convert(row)
+        return getattr(record, self._field)

--- a/python/lsst/daf/butler/queries/driver.py
+++ b/python/lsst/daf/butler/queries/driver.py
@@ -47,6 +47,7 @@ from .._dataset_type import DatasetType
 from ..dimensions import (
     DataCoordinate,
     DataIdValue,
+    DimensionElement,
     DimensionGroup,
     DimensionRecord,
     DimensionRecordSet,
@@ -117,8 +118,12 @@ class GeneralResultPage:
     spec: GeneralResultSpec
 
     # Raw tabular data, with columns in the same order as
-    # spec.get_all_result_columns().
+    # spec.get_result_columns().
     rows: list[tuple[Any, ...]]
+
+    # This map contains dimension records for cached and skypix elements,
+    # and only when spec.include_dimension_records is True.
+    dimension_records: dict[DimensionElement, DimensionRecordSet] | None
 
 
 ResultPage: TypeAlias = Union[

--- a/python/lsst/daf/butler/queries/driver.py
+++ b/python/lsst/daf/butler/queries/driver.py
@@ -117,7 +117,7 @@ class GeneralResultPage:
     spec: GeneralResultSpec
 
     # Raw tabular data, with columns in the same order as
-    # spec.get_result_columns().
+    # spec.get_all_result_columns().
     rows: list[tuple[Any, ...]]
 
 

--- a/python/lsst/daf/butler/queries/result_specs.py
+++ b/python/lsst/daf/butler/queries/result_specs.py
@@ -213,6 +213,11 @@ class GeneralResultSpec(ResultSpecBase):
     dataset_fields: Mapping[str, set[DatasetFieldName]]
     """Dataset fields included in this query."""
 
+    include_dimension_records: bool = False
+    """Whether to include fields for all dimension records, in addition to
+    explicitly specified in `dimension_fields`.
+    """
+
     find_first: bool
     """Whether this query requires find-first resolution for a dataset.
 
@@ -241,6 +246,33 @@ class GeneralResultSpec(ResultSpecBase):
             result.dimension_fields[element_name].update(fields_for_element)
         for dataset_type, fields_for_dataset in self.dataset_fields.items():
             result.dataset_fields[dataset_type].update(fields_for_dataset)
+        if self.include_dimension_records:
+            # This only adds record fields for non-cached and non-skypix
+            # elements, this is what we want when generating query. We could
+            # potentially add those too but it may make queries slower, so
+            # instead we query cached dimension records separately and add them
+            # to the result page in the page converter.
+            _add_dimension_records_to_column_set(self.dimensions, result)
+        return result
+
+    def get_all_result_columns(self) -> ColumnSet:
+        """Return all columns that have to appear in the result. This includes
+        columns for all dimension records for all dimensions if
+        ``include_dimension_records`` is `True`.
+
+        Returns
+        -------
+        columns : `ColumnSet`
+            Full column set.
+        """
+        dimensions = self.dimensions
+        result = self.get_result_columns()
+        if self.include_dimension_records:
+            for element_name in dimensions.elements:
+                element = dimensions.universe[element_name]
+                # Non-cached dimensions are already there, but it does not harm
+                # to add them again.
+                result.dimension_fields[element_name].update(element.schema.remainder.names)
         return result
 
     @pydantic.model_validator(mode="after")

--- a/python/lsst/daf/butler/queries/result_specs.py
+++ b/python/lsst/daf/butler/queries/result_specs.py
@@ -248,31 +248,10 @@ class GeneralResultSpec(ResultSpecBase):
             result.dataset_fields[dataset_type].update(fields_for_dataset)
         if self.include_dimension_records:
             # This only adds record fields for non-cached and non-skypix
-            # elements, this is what we want when generating query. We could
-            # potentially add those too but it may make queries slower, so
-            # instead we query cached dimension records separately and add them
-            # to the result page in the page converter.
+            # elements, this is what we want when generating query. When
+            # `include_dimension_records` is True, dimension records for cached
+            # and skypix elements are added to result pages by page converter.
             _add_dimension_records_to_column_set(self.dimensions, result)
-        return result
-
-    def get_all_result_columns(self) -> ColumnSet:
-        """Return all columns that have to appear in the result. This includes
-        columns for all dimension records for all dimensions if
-        ``include_dimension_records`` is `True`.
-
-        Returns
-        -------
-        columns : `ColumnSet`
-            Full column set.
-        """
-        dimensions = self.dimensions
-        result = self.get_result_columns()
-        if self.include_dimension_records:
-            for element_name in dimensions.elements:
-                element = dimensions.universe[element_name]
-                # Non-cached dimensions are already there, but it does not harm
-                # to add them again.
-                result.dimension_fields[element_name].update(element.schema.remainder.names)
         return result
 
     @pydantic.model_validator(mode="after")

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -257,12 +257,25 @@ def _convert_query_result_page(
 
 def _convert_general_result(spec: GeneralResultSpec, model: GeneralResultModel) -> GeneralResultPage:
     """Convert GeneralResultModel to a general result page."""
-    columns = spec.get_result_columns()
+    columns = spec.get_all_result_columns()
+    # Verify that column list that we received from server matches local
+    # expectations (mismatch could result from different versions). Older
+    # server may not know about `model.columns` in that case it will be empty.
+    # If `model.columns` is empty then `zip(strict=True)` below will fail if
+    # column count is different (column names are not checked in that case).
+    if model.columns:
+        expected_column_names = [str(column) for column in columns]
+        if expected_column_names != model.columns:
+            raise ValueError(
+                "Inconsistent columns in general result -- "
+                f"server columns: {model.columns}, expected: {expected_column_names}"
+            )
+
     serializers = [
         columns.get_column_spec(column.logical_table, column.field).serializer() for column in columns
     ]
     rows = [
-        tuple(serializer.deserialize(value) for value, serializer in zip(row, serializers))
+        tuple(serializer.deserialize(value) for value, serializer in zip(row, serializers, strict=True))
         for row in model.rows
     ]
     return GeneralResultPage(spec=spec, rows=rows)

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
@@ -79,11 +79,12 @@ def convert_query_page(spec: ResultSpec, page: ResultPage) -> QueryExecuteResult
 
 def _convert_general_result(page: GeneralResultPage) -> GeneralResultModel:
     """Convert GeneralResultPage to a serializable model."""
-    columns = page.spec.get_result_columns()
+    columns = page.spec.get_all_result_columns()
     serializers = [
         columns.get_column_spec(column.logical_table, column.field).serializer() for column in columns
     ]
     rows = [
-        tuple(serializer.serialize(value) for value, serializer in zip(row, serializers)) for row in page.rows
+        tuple(serializer.serialize(value) for value, serializer in zip(row, serializers, strict=True))
+        for row in page.rows
     ]
-    return GeneralResultModel(rows=rows)
+    return GeneralResultModel(rows=rows, columns=[str(column) for column in columns])

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_serialization.py
@@ -79,7 +79,7 @@ def convert_query_page(spec: ResultSpec, page: ResultPage) -> QueryExecuteResult
 
 def _convert_general_result(page: GeneralResultPage) -> GeneralResultModel:
     """Convert GeneralResultPage to a serializable model."""
-    columns = page.spec.get_all_result_columns()
+    columns = page.spec.get_result_columns()
     serializers = [
         columns.get_column_spec(column.logical_table, column.field).serializer() for column in columns
     ]
@@ -87,4 +87,10 @@ def _convert_general_result(page: GeneralResultPage) -> GeneralResultModel:
         tuple(serializer.serialize(value) for value, serializer in zip(row, serializers, strict=True))
         for row in page.rows
     ]
-    return GeneralResultModel(rows=rows, columns=[str(column) for column in columns])
+    dimension_records = None
+    if page.dimension_records is not None:
+        dimension_records = {
+            element.name: [record.to_simple() for record in records]
+            for element, records in page.dimension_records.items()
+        }
+    return GeneralResultModel(rows=rows, dimension_records=dimension_records)

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -313,6 +313,9 @@ class GeneralResultModel(pydantic.BaseModel):
 
     type: Literal["general"] = "general"
     rows: list[tuple[Any, ...]]
+    # List of column names, default is used for compatibility with older
+    # servers that do not set this field.
+    columns: list[str] = pydantic.Field(default_factory=list)
 
 
 class QueryErrorResultModel(pydantic.BaseModel):

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -313,9 +313,10 @@ class GeneralResultModel(pydantic.BaseModel):
 
     type: Literal["general"] = "general"
     rows: list[tuple[Any, ...]]
-    # List of column names, default is used for compatibility with older
+    # Dimension records indexed by element name, only cached and skypix
+    # elements are included. Default is used for compatibility with older
     # servers that do not set this field.
-    columns: list[str] = pydantic.Field(default_factory=list)
+    dimension_records: dict[str, list[SerializedDimensionRecord]] | None = None
 
 
 class QueryErrorResultModel(pydantic.BaseModel):


### PR DESCRIPTION
The `GeneralQueryResults.iter_tuples` method returned DataIds without dimension records. In some cases (e.g. for obscore export) it would be very useful to include records in the same result to avoid querying them separately. New method `with_dimension_records` is added to the class to trigger adding fields from all dimension records into returned page. This will produce many duplicates for some dimensions (e.g. `instrument`) but it keeps page structure simple.

This adds one attribute to the `GeneralResultSpec` class, will need some care with Butler server compatibility.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
