### PR TITLE
DM-48141: Add a simple way to represent a pandas index in astropy table parquet metadata.

### DIFF
--- a/doc/changes/DM-48141.feature.md
+++ b/doc/changes/DM-48141.feature.md
@@ -1,0 +1,1 @@
+Added `lsst.daf.butler.formatters.parquet.add_pandas_index_to_astropy()` function which stores special metadata that will be used to create a pandas DataFrame index if the table is read as a DataFrame.


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
