### PR TITLE
DM-48288: Do not cache collection summaries by default in queries

### DIFF
--- a/python/lsst/daf/butler/registry/collections/_base.py
+++ b/python/lsst/daf/butler/registry/collections/_base.py
@@ -581,7 +581,7 @@ class DefaultCollectionManager(CollectionManager[K]):
         skip_caching_check: bool = False,
         skip_cycle_check: bool = False,
     ) -> Iterator[_CollectionChainModificationContext[K]]:
-        if (not skip_caching_check) and self._caching_context.is_enabled:
+        if (not skip_caching_check) and self._caching_context.collection_records is not None:
             # Avoid having cache-maintenance code around that is unlikely to
             # ever be used.
             raise RuntimeError("Chained collection modification not permitted with active caching context.")

--- a/python/lsst/daf/butler/registry/managers.py
+++ b/python/lsst/daf/butler/registry/managers.py
@@ -362,11 +362,11 @@ class RegistryManagerInstances(
         may even be closed out of order, with only the context manager entered
         and the last context manager exited having any effect.
         """
-        self.caching_context._enable()
-        try:
+        with (
+            self.caching_context.enable_collection_record_cache(),
+            self.caching_context.enable_collection_summary_cache(),
+        ):
             yield
-        finally:
-            self.caching_context._disable()
 
     @classmethod
     def initialize(

--- a/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
@@ -86,7 +86,7 @@ class SqlQueryBackend(QueryBackend[SqlQueryContext]):
 
     def get_collection_name(self, key: Any) -> str:
         assert (
-            self._managers.caching_context.is_enabled
+            self._managers.caching_context.collection_records is not None
         ), "Collection-record caching should already been enabled any time this is called."
         return self._managers.collections[key].name
 

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -2332,7 +2332,9 @@ class SqlRegistry:
         default_data_id: DataCoordinate,
     ) -> Iterator[DirectQueryDriver]:
         """Set up a `QueryDriver` instance for query execution."""
-        with self.caching_context():
+        # Query internals do repeated lookups of the same collections, so it
+        # benefits from the collection record cache.
+        with self._managers.caching_context.enable_collection_record_cache():
             driver = DirectQueryDriver(
                 self._db,
                 self.dimensions,


### PR DESCRIPTION
We now enable the collection summary cache separately from the collection record cache.  In the Butler.query() context, only the collection record cache is now enabled by default.  When Butler.registry.caching_context() is called, both caches are enabled (as before.)

More often than not, the query context manager is used to execute one query and then exited.  The collection summary cache was often a pessimization in this case -- fetching tens of thousands of rows when only a few were needed.

Also added explicit caching context calls to a few places in the Butler internals where we are doing repeated dataset queries that will benefit from the cache.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
