### PR TITLE
DM-48452: Protect subcommand imports via entry points

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -22,9 +22,6 @@ jobs:
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 
-      - name: Install sqlite
-        run: sudo apt-get install sqlite libyaml-dev
-
       - name: Install uv
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.4
+    rev: v0.9.1
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -334,7 +334,16 @@ class LoaderCLI(click.MultiCommand, abc.ABC):
         if hasattr(cls, "entryPoint"):
             plugins = entry_points(group=cls.entryPoint)
             for p in plugins:
-                func = p.load()
+                try:
+                    func = p.load()
+                except Exception as err:
+                    log.warning("Could not import plugin from entry point %s, skipping.", p)
+                    log.debug(
+                        "Plugin import exception: %s\nTraceback:\n%s",
+                        err,
+                        "".join(traceback.format_tb(err.__traceback__)),
+                    )
+                    continue
                 func_name = get_full_type_name(func)
                 pluginCommands = {cmd.name: [PluginCommand(cmd, func_name)] for cmd in func()}
                 cls._mergeCommandLists(commands, defaultdict(list, pluginCommands))


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
