### PR TITLE
DM-48482 (hotfix): Add missing doc cross reference

### DIFF
--- a/doc/lsst.daf.butler/writing-subcommands.rst
+++ b/doc/lsst.daf.butler/writing-subcommands.rst
@@ -396,6 +396,8 @@ The following conventions are recommended but not required:
    │    └── sharedOptions.py
    └── utils.yaml
 
+.. _daf_butler_cli-entry-points:
+
 Entry Points
 ------------
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
