### PR TITLE
DM-35396: Add provenance hooks for datastore to use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -17,13 +17,13 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.1
+    rev: v0.9.3
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/doc/changes/DM-35396.feature.rst
+++ b/doc/changes/DM-35396.feature.rst
@@ -1,0 +1,4 @@
+* Added new class ``DatasetProvenance`` for tracking the provenance of an individual dataset.
+* Modified ``Butler.put()`` to accept an optional ``DatasetProvenance``.
+* Added ``add_provenance`` methods to ``FormatterV2`` and ``StorageClassDelegate``.
+  These methods will now be called with the provenance object during ``Butler.put()`` to allow the in-memory dataset to be updated prior to writing.

--- a/python/lsst/daf/butler/__init__.py
+++ b/python/lsst/daf/butler/__init__.py
@@ -47,6 +47,7 @@ from ._config import *
 from ._config_support import LookupKey
 from ._dataset_association import *
 from ._dataset_existence import *
+from ._dataset_provenance import *
 from ._dataset_ref import *
 from ._dataset_type import *
 from ._deferredDatasetHandle import *

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -59,6 +59,7 @@ from .utils import has_globs
 
 if TYPE_CHECKING:
     from ._dataset_existence import DatasetExistence
+    from ._dataset_provenance import DatasetProvenance
     from ._dataset_ref import DatasetId, DatasetRef
     from ._dataset_type import DatasetType
     from ._deferredDatasetHandle import DeferredDatasetHandle
@@ -664,6 +665,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         dataId: DataId | None = None,
         *,
         run: str | None = None,
+        provenance: DatasetProvenance | None = None,
         **kwargs: Any,
     ) -> DatasetRef:
         """Store and register a dataset.
@@ -683,6 +685,9 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         run : `str`, optional
             The name of the run the dataset should be added to, overriding
             ``self.run``. Not used if a resolved `DatasetRef` is provided.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Not supported by all serialization mechanisms.
         **kwargs
             Additional keyword arguments used to augment or construct a
             `DataCoordinate`.  See `DataCoordinate.standardize`

--- a/python/lsst/daf/butler/_dataset_provenance.py
+++ b/python/lsst/daf/butler/_dataset_provenance.py
@@ -1,0 +1,67 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("DatasetProvenance",)
+
+import typing
+import uuid
+
+import pydantic
+
+from ._dataset_ref import DatasetRef, SerializedDatasetRef
+
+
+class DatasetProvenance(pydantic.BaseModel):
+    """Provenance of a single `DatasetRef`."""
+
+    inputs: list[SerializedDatasetRef] = pydantic.Field(default_factory=list)
+    """The input datasets."""
+    quantum_id: uuid.UUID | None = None
+    """Identifier of the Quantum that was executed."""
+    _uuids: set[uuid.UUID] = pydantic.PrivateAttr(default_factory=set)
+
+    @pydantic.model_validator(mode="after")
+    def populate_cache(self) -> typing.Self:
+        for ref in self.inputs:
+            self._uuids.add(ref.id)
+        return self
+
+    def add_input(self, ref: DatasetRef) -> None:
+        """Add an input dataset to the provenance.
+
+        Parameters
+        ----------
+        ref : `DatasetRef`
+            A dataset to register as an input.
+        """
+        if ref.id in self._uuids:
+            # Already registered.
+            return
+        self._uuids.add(ref.id)
+        self.inputs.append(ref.to_simple())

--- a/python/lsst/daf/butler/_formatter.py
+++ b/python/lsst/daf/butler/_formatter.py
@@ -60,6 +60,7 @@ from .mapping_factory import MappingFactory
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ._dataset_provenance import DatasetProvenance
     from ._dataset_ref import DatasetRef
     from ._dataset_type import DatasetType
     from ._storage_class import StorageClass
@@ -98,6 +99,10 @@ class FormatterV2:
          Parameters to control how the dataset is serialized.
     write_recipes : `dict`, optional
         Detailed write recipes indexed by recipe name.
+    provenance : `DatasetProvenance` or `None`, optional
+        Any provenance that should be attached to the serialized dataset.
+        Can be ignored by a formatter.
+
     **kwargs
         Additional arguments that will be ignored but allow for
         `Formatter` V1 parameters to be given.
@@ -169,6 +174,7 @@ class FormatterV2:
         ref: DatasetRef,
         write_parameters: Mapping[str, Any] | None = None,
         write_recipes: Mapping[str, Any] | None = None,
+        provenance: DatasetProvenance | None = None,
         # Compatibility parameters. Unused in v2.
         **kwargs: Any,
     ):
@@ -198,6 +204,7 @@ class FormatterV2:
 
         self._write_parameters = write_parameters
         self._write_recipes = self.validate_write_recipes(write_recipes)
+        self._provenance = provenance
 
     def __str__(self) -> str:
         return f"{self.name()}@{self.file_descriptor.location.uri}"

--- a/python/lsst/daf/butler/_formatter.py
+++ b/python/lsst/daf/butler/_formatter.py
@@ -863,6 +863,26 @@ class FormatterV2:
         """
         return NotImplemented
 
+    def add_provenance(self, in_memory_dataset: Any) -> Any:
+        """Add provenance to the dataset.
+
+        Parameters
+        ----------
+        in_memory_dataset : `object`
+            The dataset to serialize.
+
+        Returns
+        -------
+        dataset_to_write : `object`
+            The dataset to use for serialization. Can be the same object as
+            given.
+
+        Notes
+        -----
+        The base class implementation returns the given object unchanged.
+        """
+        return in_memory_dataset
+
     @final
     def write(
         self,
@@ -894,6 +914,10 @@ class FormatterV2:
         """
         # Ensure we are using the correct file extension.
         uri = self.file_descriptor.location.uri.updatedExtension(self.get_write_extension())
+
+        # Attach any provenance to the dataset. This could involve returning
+        # a different object.
+        in_memory_dataset = self.add_provenance(in_memory_dataset)
 
         written = self.write_direct(in_memory_dataset, uri, cache_manager)
         if not written:

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -261,8 +261,7 @@ class LimitedButler(ABC):
 
         if primary is None or components:
             raise RuntimeError(
-                f"Dataset ({ref}) includes distinct URIs for components. "
-                "Use LimitedButler.getURIs() instead."
+                f"Dataset ({ref}) includes distinct URIs for components. Use LimitedButler.getURIs() instead."
             )
         return primary
 

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -36,6 +36,7 @@ from typing import Any, ClassVar
 
 from lsst.resources import ResourcePath
 
+from ._dataset_provenance import DatasetProvenance
 from ._dataset_ref import DatasetRef
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._storage_class import StorageClass, StorageClassFactory
@@ -64,7 +65,7 @@ class LimitedButler(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def put(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
+    def put(self, obj: Any, ref: DatasetRef, /, *, provenance: DatasetProvenance | None = None) -> DatasetRef:
         """Store a dataset that already has a UUID and ``RUN`` collection.
 
         Parameters
@@ -73,6 +74,9 @@ class LimitedButler(ABC):
             The dataset.
         ref : `DatasetRef`
             Resolved reference for a not-yet-stored dataset.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Not supported by all serialization mechanisms.
 
         Returns
         -------

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -43,6 +43,7 @@ from lsst.resources import ResourcePath, ResourcePathExpression
 
 from ._butler_config import ButlerConfig
 from ._config import Config
+from ._dataset_provenance import DatasetProvenance
 from ._dataset_ref import DatasetId, DatasetRef
 from ._dataset_type import DatasetType
 from ._deferredDatasetHandle import DeferredDatasetHandle
@@ -453,11 +454,11 @@ class QuantumBackedButler(LimitedButler):
         # Docstring inherited.
         return self._dimensions
 
-    def put(self, obj: Any, ref: DatasetRef, /) -> DatasetRef:
+    def put(self, obj: Any, ref: DatasetRef, /, *, provenance: DatasetProvenance | None = None) -> DatasetRef:
         # Docstring inherited.
         if ref.id not in self._predicted_outputs:
             raise RuntimeError("Cannot `put` dataset that was not predicted as an output.")
-        self._datastore.put(obj, ref)
+        self._datastore.put(obj, ref, provenance=provenance)
         self._actual_output_refs.add(ref)
         return ref
 

--- a/python/lsst/daf/butler/_storage_class_delegate.py
+++ b/python/lsst/daf/butler/_storage_class_delegate.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any
 from lsst.utils.introspection import get_full_type_name
 
 if TYPE_CHECKING:
-    from lsst.daf.butler import DatasetRef
+    from lsst.daf.butler import DatasetProvenance, DatasetRef
 
     from ._storage_class import StorageClass
 
@@ -335,7 +335,9 @@ class StorageClassDelegate:
 
         return components
 
-    def add_provenance(self, inMemoryDataset: Any, ref: DatasetRef) -> Any:
+    def add_provenance(
+        self, inMemoryDataset: Any, ref: DatasetRef, provenance: DatasetProvenance | None = None
+    ) -> Any:
         """Add provenance to the composite dataset.
 
         Parameters
@@ -344,6 +346,9 @@ class StorageClassDelegate:
             The composite dataset to serialize.
         ref : `DatasetRef`
             The dataset associated with this in-memory dataset.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Can be ignored by a delegate.
 
         Returns
         -------

--- a/python/lsst/daf/butler/_storage_class_delegate.py
+++ b/python/lsst/daf/butler/_storage_class_delegate.py
@@ -40,6 +40,8 @@ from typing import TYPE_CHECKING, Any
 from lsst.utils.introspection import get_full_type_name
 
 if TYPE_CHECKING:
+    from lsst.daf.butler import DatasetRef
+
     from ._storage_class import StorageClass
 
 log = logging.getLogger(__name__)
@@ -332,6 +334,28 @@ class StorageClassDelegate:
             raise ValueError(f"Unhandled components during disassembly ({requested})")
 
         return components
+
+    def add_provenance(self, inMemoryDataset: Any, ref: DatasetRef) -> Any:
+        """Add provenance to the composite dataset.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            The composite dataset to serialize.
+        ref : `DatasetRef`
+            The dataset associated with this in-memory dataset.
+
+        Returns
+        -------
+        dataset_to_disassemble : `object`
+            The dataset to use for serialization and disassembly.
+            Can be the same object as given.
+
+        Notes
+        -----
+        The base class implementation returns the given object unchanged.
+        """
+        return inMemoryDataset
 
     def handleParameters(self, inMemoryDataset: Any, parameters: Mapping[str, Any] | None = None) -> Any:
         """Modify the in-memory dataset using the supplied parameters.

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 
     from .. import ddl
     from .._config_support import LookupKey
+    from .._dataset_provenance import DatasetProvenance
     from .._dataset_ref import DatasetRef
     from .._dataset_type import DatasetType
     from .._storage_class import StorageClass
@@ -626,7 +627,9 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def put(self, inMemoryDataset: Any, datasetRef: DatasetRef) -> None:
+    def put(
+        self, inMemoryDataset: Any, datasetRef: DatasetRef, provenance: DatasetProvenance | None = None
+    ) -> None:
         """Write a `InMemoryDataset` with a given `DatasetRef` to the store.
 
         Parameters
@@ -635,6 +638,9 @@ class Datastore(metaclass=ABCMeta):
             The Dataset to store.
         datasetRef : `DatasetRef`
             Reference to the associated Dataset.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Not supported by all serialization mechanisms.
         """
         raise NotImplementedError("Must be implemented by subclass")
 
@@ -1449,7 +1455,9 @@ class NullDatastore(Datastore):
     ) -> Any:
         raise FileNotFoundError("This is a no-op datastore that can not access a real datastore")
 
-    def put(self, inMemoryDataset: Any, datasetRef: DatasetRef) -> None:
+    def put(
+        self, inMemoryDataset: Any, datasetRef: DatasetRef, provenance: DatasetProvenance | None = None
+    ) -> None:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
     def put_new(self, in_memory_dataset: Any, ref: DatasetRef) -> Mapping[str, DatasetRef]:

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -53,7 +53,7 @@ from lsst.resources import ResourcePath
 from lsst.utils import doImportType
 
 if TYPE_CHECKING:
-    from lsst.daf.butler import Config, DatasetType, LookupKey, StorageClass
+    from lsst.daf.butler import Config, DatasetProvenance, DatasetType, LookupKey, StorageClass
     from lsst.daf.butler.registry.interfaces import DatasetIdRef, DatastoreRegistryBridgeManager
     from lsst.resources import ResourcePathExpression
 
@@ -420,7 +420,7 @@ class ChainedDatastore(Datastore):
 
         return None
 
-    def put(self, inMemoryDataset: Any, ref: DatasetRef) -> None:
+    def put(self, inMemoryDataset: Any, ref: DatasetRef, provenance: DatasetProvenance | None = None) -> None:
         """Write a InMemoryDataset with a given `DatasetRef` to each
         datastore.
 
@@ -435,6 +435,9 @@ class ChainedDatastore(Datastore):
             The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Not supported by all serialization mechanisms.
 
         Raises
         ------
@@ -468,7 +471,7 @@ class ChainedDatastore(Datastore):
             else:
                 npermanent += 1
             try:
-                datastore.put(inMemoryDataset, ref)
+                datastore.put(inMemoryDataset, ref, provenance=provenance)
                 nsuccess += 1
                 if not datastore.isEphemeral:
                     isPermanent = True

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -108,7 +108,7 @@ from lsst.utils.timer import time_this
 from sqlalchemy import BigInteger, String
 
 if TYPE_CHECKING:
-    from lsst.daf.butler import LookupKey
+    from lsst.daf.butler import DatasetProvenance, LookupKey
     from lsst.daf.butler.registry.interfaces import DatasetIdRef, DatastoreRegistryBridgeManager
 
 log = getLogger(__name__)
@@ -830,13 +830,17 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             parameters=parameters,
         )
 
-    def _determine_put_formatter_location(self, ref: DatasetRef) -> tuple[Location, Formatter | FormatterV2]:
+    def _determine_put_formatter_location(
+        self, ref: DatasetRef, provenance: DatasetProvenance | None = None
+    ) -> tuple[Location, Formatter | FormatterV2]:
         """Calculate the formatter and output location to use for put.
 
         Parameters
         ----------
         ref : `DatasetRef`
             Reference to the associated Dataset.
+        provenance : `DatasetProvenance`
+            Any provenance that should be attached to the serialized dataset.
 
         Returns
         -------
@@ -865,6 +869,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                 FileDescriptor(location, storageClass=storageClass, component=ref.datasetType.component()),
                 dataId=ref.dataId,
                 ref=ref,
+                provenance=provenance,
             )
         except KeyError as e:
             raise DatasetTypeNotSupportedError(
@@ -1275,7 +1280,9 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         return location
 
-    def _write_in_memory_to_artifact(self, inMemoryDataset: Any, ref: DatasetRef) -> StoredFileInfo:
+    def _write_in_memory_to_artifact(
+        self, inMemoryDataset: Any, ref: DatasetRef, provenance: DatasetProvenance | None = None
+    ) -> StoredFileInfo:
         """Write out in memory dataset to datastore.
 
         Parameters
@@ -1284,6 +1291,9 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             Dataset to write to datastore.
         ref : `DatasetRef`
             Registry information associated with this dataset.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Not supported by all formatters.
 
         Returns
         -------
@@ -1302,7 +1312,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                 f"Dataset {ref} has been rejected by this datastore via configuration."
             )
 
-        location, formatter = self._determine_put_formatter_location(ref)
+        location, formatter = self._determine_put_formatter_location(ref, provenance)
 
         # The external storage class can differ from the registry storage
         # class AND the given in-memory dataset might not match any of the
@@ -2313,7 +2323,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         )
 
     @transactional
-    def put(self, inMemoryDataset: Any, ref: DatasetRef) -> None:
+    def put(self, inMemoryDataset: Any, ref: DatasetRef, provenance: DatasetProvenance | None = None) -> None:
         """Write a InMemoryDataset with a given `DatasetRef` to the store.
 
         Parameters
@@ -2322,6 +2332,9 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             The dataset to store.
         ref : `DatasetRef`
             Reference to the associated Dataset.
+        provenance : `DatasetProvenance` or `None`, optional
+            Any provenance that should be attached to the serialized dataset.
+            Can be ignored by a formatter or delegate.
 
         Raises
         ------
@@ -2343,7 +2356,9 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         artifacts = []
         if doDisassembly:
-            inMemoryDataset = ref.datasetType.storageClass.delegate().add_provenance(inMemoryDataset, ref)
+            inMemoryDataset = ref.datasetType.storageClass.delegate().add_provenance(
+                inMemoryDataset, ref, provenance=provenance
+            )
             components = ref.datasetType.storageClass.delegate().disassemble(inMemoryDataset)
             if components is None:
                 raise RuntimeError(
@@ -2358,11 +2373,12 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                 # DatasetType does not refer to the types of components
                 # So we construct one ourselves.
                 compRef = ref.makeComponentRef(component)
+                # Provenance has already been attached above.
                 storedInfo = self._write_in_memory_to_artifact(componentInfo.component, compRef)
                 artifacts.append((compRef, storedInfo))
         else:
             # Write the entire thing out
-            storedInfo = self._write_in_memory_to_artifact(inMemoryDataset, ref)
+            storedInfo = self._write_in_memory_to_artifact(inMemoryDataset, ref, provenance=provenance)
             artifacts.append((ref, storedInfo))
 
         self._register_datasets(artifacts, insert_mode=DatabaseInsertMode.INSERT)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2343,6 +2343,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         artifacts = []
         if doDisassembly:
+            inMemoryDataset = ref.datasetType.storageClass.delegate().add_provenance(inMemoryDataset, ref)
             components = ref.datasetType.storageClass.delegate().disassemble(inMemoryDataset)
             if components is None:
                 raise RuntimeError(

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1312,7 +1312,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                 f"Dataset {ref} has been rejected by this datastore via configuration."
             )
 
-        location, formatter = self._determine_put_formatter_location(ref, provenance)
+        location, formatter = self._determine_put_formatter_location(ref)
 
         # The external storage class can differ from the registry storage
         # class AND the given in-memory dataset might not match any of the
@@ -1372,7 +1372,9 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         with time_this(log, msg="Writing dataset %s with formatter %s", args=(ref, formatter.name())):
             try:
-                formatter_compat.write(inMemoryDataset, cache_manager=self.cacheManager)
+                formatter_compat.write(
+                    inMemoryDataset, cache_manager=self.cacheManager, provenance=provenance
+                )
             except Exception as e:
                 raise RuntimeError(
                     f"Failed to serialize dataset {ref} of type {get_full_type_name(inMemoryDataset)} "

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1217,8 +1217,7 @@ class Database(ABC):
         )
         if table.key in self._temp_tables and table.key != name:
             raise ValueError(
-                f"A temporary table with name {name} (transformed to {table.key} by "
-                "Database) already exists."
+                f"A temporary table with name {name} (transformed to {table.key} by Database) already exists."
             )
         with self._transaction():
             table.create(connection)

--- a/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
+++ b/python/lsst/daf/butler/registry/queries/_sql_query_backend.py
@@ -34,6 +34,7 @@ from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, cast
 
 from lsst.daf.relation import ColumnError, ColumnExpression, ColumnTag, Join, Predicate, Relation
+from lsst.utils.introspection import find_outside_stacklevel
 
 from ..._collection_type import CollectionType
 from ..._column_categorization import ColumnCategorization
@@ -343,6 +344,7 @@ class SqlQueryBackend(QueryBackend[SqlQueryContext]):
                         "DataIdValueError will no longer be raised for invalid governor dimension values."
                         " Instead, an empty list will be returned.  Will be changed after v28.",
                         FutureWarning,
+                        stacklevel=find_outside_stacklevel("lsst.daf.butler"),
                     )
                     raise DataIdValueError(
                         f"Unknown values specified for governor dimension {dimension_name}: "

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -3350,7 +3350,7 @@ class RegistryTests(ABC):
 
         with self.assertRaisesRegex(
             (ValueError, InvalidQueryError),
-            "(Field 'name' does not exist in 'tract')" "|(Unrecognized field 'name' for tract.)",
+            "(Field 'name' does not exist in 'tract')|(Unrecognized field 'name' for tract.)",
         ):
             list(do_query("tract").order_by("tract.name"))
 

--- a/python/lsst/daf/butler/remote_butler/_query_driver.py
+++ b/python/lsst/daf/butler/remote_butler/_query_driver.py
@@ -271,7 +271,7 @@ def _convert_general_result(spec: GeneralResultSpec, model: GeneralResultModel) 
         # is True, but it will be None if remote server was not upgraded.
         if model.dimension_records is None:
             raise ValueError(
-                "Missing dimension records in general result -- " "it is likely that server needs an upgrade."
+                "Missing dimension records in general result -- it is likely that server needs an upgrade."
             )
 
     columns = spec.get_result_columns()

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -86,6 +86,7 @@ from .server_models import (
 )
 
 if TYPE_CHECKING:
+    from .._dataset_provenance import DatasetProvenance
     from .._file_dataset import FileDataset
     from .._limited_butler import LimitedButler
     from .._timespan import Timespan
@@ -238,6 +239,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         dataId: DataId | None = None,
         *,
         run: str | None = None,
+        provenance: DatasetProvenance | None = None,
         **kwargs: Any,
     ) -> DatasetRef:
         # Docstring inherited.

--- a/python/lsst/daf/butler/tests/_examplePythonTypes.py
+++ b/python/lsst/daf/butler/tests/_examplePythonTypes.py
@@ -46,10 +46,11 @@ __all__ = (
 import copy
 import dataclasses
 import types
+import uuid
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from lsst.daf.butler import StorageClass, StorageClassDelegate
+from lsst.daf.butler import DatasetProvenance, StorageClass, StorageClassDelegate
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
@@ -297,6 +298,8 @@ class MetricsExampleModel(BaseModel):
     summary: dict[str, Any] | None = None
     output: dict[str, Any] | None = None
     data: list[Any] | None = None
+    provenance: DatasetProvenance | None = None
+    dataset_id: uuid.UUID | None = None
 
     @classmethod
     def from_metrics(cls, metrics: MetricsExample) -> MetricsExampleModel:

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -37,6 +37,7 @@ from lsst.resources import ResourcePath, ResourcePathExpression
 from .._butler import Butler
 from .._butler_collections import ButlerCollections
 from .._dataset_existence import DatasetExistence
+from .._dataset_provenance import DatasetProvenance
 from .._dataset_ref import DatasetId, DatasetRef
 from .._dataset_type import DatasetType
 from .._deferredDatasetHandle import DeferredDatasetHandle
@@ -92,9 +93,12 @@ class HybridButler(Butler):
         dataId: DataId | None = None,
         *,
         run: str | None = None,
+        provenance: DatasetProvenance | None = None,
         **kwargs: Any,
     ) -> DatasetRef:
-        return self._direct_butler.put(obj, datasetRefOrType, dataId, run=run, **kwargs)
+        return self._direct_butler.put(
+            obj, datasetRefOrType, dataId, run=run, provenance=provenance, **kwargs
+        )
 
     def getDeferred(
         self,

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -44,6 +44,7 @@ import yaml
 from lsst.resources import ResourceHandleProtocol
 
 from .._formatter import Formatter, FormatterV2
+from ..formatters.json import JsonFormatter
 from ..formatters.yaml import YamlFormatter
 
 if TYPE_CHECKING:
@@ -271,3 +272,14 @@ class MetricsExampleDataFormatter(Formatter):
 
         with open(fileDescriptor.location.path, "w") as fd:
             yaml.dump(inMemoryDataset, fd)
+
+
+class MetricsExampleModelProvenanceFormatter(JsonFormatter):
+    """Specialist formatter to test provenance addition."""
+
+    def add_provenance(self, in_memory_dataset: Any) -> Any:
+        # Copy it to prove that works.
+        new = in_memory_dataset.model_copy()
+        new.provenance = self._provenance
+        new.dataset_id = self.dataset_ref.id
+        return new

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -48,6 +48,7 @@ from ..formatters.json import JsonFormatter
 from ..formatters.yaml import YamlFormatter
 
 if TYPE_CHECKING:
+    from .._dataset_provenance import DatasetProvenance
     from .._location import Location
 
 
@@ -277,9 +278,11 @@ class MetricsExampleDataFormatter(Formatter):
 class MetricsExampleModelProvenanceFormatter(JsonFormatter):
     """Specialist formatter to test provenance addition."""
 
-    def add_provenance(self, in_memory_dataset: Any) -> Any:
+    def add_provenance(
+        self, in_memory_dataset: Any, /, *, provenance: DatasetProvenance | None = None
+    ) -> Any:
         # Copy it to prove that works.
         new = in_memory_dataset.model_copy()
-        new.provenance = self._provenance
+        new.provenance = provenance
         new.dataset_id = self.dataset_ref.id
         return new

--- a/tests/config/basic/formatters.yaml
+++ b/tests/config/basic/formatters.yaml
@@ -47,3 +47,4 @@ MetricsExampleModelB: lsst.daf.butler.formatters.yaml.YamlFormatter
 TupleExampleA: lsst.daf.butler.formatters.json.JsonFormatter
 TupleExampleB: lsst.daf.butler.formatters.yaml.YamlFormatter
 MetricsConversion: lsst.daf.butler.formatters.json.JsonFormatter
+MetricsExampleModelProvenance: lsst.daf.butler.tests.testFormatters.MetricsExampleModelProvenanceFormatter

--- a/tests/config/basic/storageClasses.yaml
+++ b/tests/config/basic/storageClasses.yaml
@@ -145,3 +145,5 @@ storageClasses:
     pytype: tuple
   TupleExampleB:
     pytype: tuple
+  MetricsExampleModelProvenance:
+    pytype: lsst.daf.butler.tests.MetricsExampleModel


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
