### PR TITLE
DM-46178: Documentation fixes for new query system

### DIFF
--- a/python/lsst/daf/butler/_butler_config.py
+++ b/python/lsst/daf/butler/_butler_config.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Configuration classes specific to the Butler.
-"""
+"""Configuration classes specific to the Butler."""
 from __future__ import annotations
 
 __all__ = ("ButlerConfig",)

--- a/python/lsst/daf/butler/_dataset_association.py
+++ b/python/lsst/daf/butler/_dataset_association.py
@@ -72,10 +72,11 @@ class DatasetAssociation:
 
         Parameters
         ----------
-        result : `GeneralQueryResults`
-            General query result returned by `Query.general` method. The result
-            has to include "{dataset_type.name}.timespan" and
-            "{dataset_type.name}.collection" columns.
+        result : `~lsst.daf.butler.queries.GeneralQueryResults`
+            General query result returned by
+            `Query.general <lsst.daf.butler.queries.Query.general>` method. The
+            result has to include "dataset_id", "run", "collection", and
+            "timespan" dataset fields for ``dataset_type``.
         dataset_type : `DatasetType`
             Dataset type, query has to include this dataset type.
         """

--- a/python/lsst/daf/butler/_deferredDatasetHandle.py
+++ b/python/lsst/daf/butler/_deferredDatasetHandle.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Module containing classes used with deferring dataset loading.
-"""
+"""Module containing classes used with deferring dataset loading."""
 from __future__ import annotations
 
 __all__ = ("DeferredDatasetHandle",)

--- a/python/lsst/daf/butler/queries/_base.py
+++ b/python/lsst/daf/butler/queries/_base.py
@@ -138,10 +138,10 @@ class QueryBase(ABC):
 
         Notes
         -----
-        If an expression references a dimension or dimension element that is
-        not already present in the query, it will be joined in, but dataset
-        searches must already be joined into a query in order to reference
-        their fields in expressions.
+        Expressions referring to dimensions or dimension elements are resolved
+        automatically. References to dataset fields (see `expression_factory`
+        for the distinction) may or may not be resolvable, depending on the
+        implementation class.
 
         Data ID values are not checked for consistency; they are extracted from
         ``args`` and then ``kwargs`` and combined, with later values overriding

--- a/python/lsst/daf/butler/queries/_base.py
+++ b/python/lsst/daf/butler/queries/_base.py
@@ -41,16 +41,17 @@ from .tree import OrderExpression, Predicate, QueryTree
 
 
 class QueryBase(ABC):
-    """Common base class for `Query` and all `QueryResult` objects.
+    """Common base class for `~lsst.daf.butler.queries.Query` and all
+    ``QueryResult`` objects.
 
     This class should rarely be referenced directly; it is public only because
     it provides public methods to its subclasses.
 
     Parameters
     ----------
-    driver : `QueryDriver`
+    driver : `~lsst.daf.butler.queries.driver.QueryDriver`
         Implementation object that knows how to actually execute queries.
-    tree : `QueryTree`
+    tree : `~lsst.daf.butler.queries.tree.QueryTree`
         Description of the query as a tree of joins and column expressions.
     """
 
@@ -113,8 +114,11 @@ class QueryBase(ABC):
         ----------
         *args
             Constraints to apply, combined with logical AND.  Arguments may be
-            `str` expressions to parse, `Predicate` objects (these are
-            typically constructed via `expression_factory`) or data IDs.
+            `str` expressions to parse,
+            `~lsst.daf.butler.queries.tree.Predicate` objects (these are
+            typically constructed via
+            `Query.expression_factory <lsst.daf.butler.queries.Query.expression_factory>`)
+            or data IDs.
         bind : `~collections.abc.Mapping`
             Mapping from string identifier appearing in a string expression to
             a literal value that should be substituted for it.  This is
@@ -142,7 +146,7 @@ class QueryBase(ABC):
         Data ID values are not checked for consistency; they are extracted from
         ``args`` and then ``kwargs`` and combined, with later values overriding
         earlier ones.
-        """
+        """  # noqa: W505, long docstrings
         raise NotImplementedError()
 
 

--- a/python/lsst/daf/butler/queries/_general_query_results.py
+++ b/python/lsst/daf/butler/queries/_general_query_results.py
@@ -111,6 +111,9 @@ class GeneralQueryResults(QueryResultsBase):
         """Iterate over result rows and return data coordinate, and dataset
         refs constructed from each row, and an original row.
 
+        This object has to include "dataset_id" and "run" columns for each type
+        in ``dataset_types``.
+
         Parameters
         ----------
         *dataset_types : `DatasetType`

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -74,16 +74,17 @@ class Query(QueryBase):
 
     Parameters
     ----------
-    driver : `QueryDriver`
+    driver : `~lsst.daf.butler.queries.driver.QueryDriver`
         Implementation object that knows how to actually execute queries.
-    tree : `QueryTree`, optional
+    tree : `~lsst.daf.butler.queries.tree.QueryTree`, optional
         Description of the query as a tree of joins and column expressions.
-        Defaults to the result of a call to  `tree.make_identity_query_tree`.
+        Defaults to the result of a call to
+        `~lsst.daf.butler.queries.tree.make_identity_query_tree`.
 
     Notes
     -----
     `Query` objects should never be constructed directly by users; use
-    `Butler.query` instead.
+    `Butler.query <lsst.daf.butler.Butler.query>` instead.
 
     A `Query` object represents the first stage of query construction, in which
     constraints and joins are defined (roughly corresponding to the WHERE and
@@ -158,62 +159,77 @@ class Query(QueryBase):
                     x.any(x.band == 'u', x.band == 'y'),
                 )
 
-        As shown above, the returned object also has an `any` method to create
-        combine expressions with logical OR (as well as `not_` and `all`,
+        As shown above, the returned object also has an
+        `~lsst.daf.butler.queries.expression_factory.ExpressionFactory.any`
+        method to create combine expressions with logical OR (as well as
+        `~lsst.daf.butler.queries.expression_factory.ExpressionFactory.not_`
+        and
+        `~lsst.daf.butler.queries.expression_factory.ExpressionFactory.all`,
         though the latter is rarely necessary since `where` already combines
         its arguments with AND).
 
         Proxies for fields associated with dataset types (``dataset_id``,
         ``ingest_date``, ``run``, ``collection``, as well as ``timespan`` for
-        `~CollectionType.CALIBRATION` collection searches) can be obtained with
-        dict-like access instead::
+        `~lsst.daf.butler.CollectionType.CALIBRATION` collection searches) can
+        be obtained with dict-like access instead::
 
             with butler.query() as query:
                 query = query.order_by(x["raw"].ingest_date)
 
         Expression proxy objects that correspond to scalar columns overload the
         standard comparison operators (``==``, ``!=``, ``<``, ``>``, ``<=``,
-        ``>=``) and provide `~ScalarExpressionProxy.in_range`,
-        `~ScalarExpressionProxy.in_iterable`, and
-        `~ScalarExpressionProxy.in_query` methods for membership tests.  For
-        `order_by` contexts, they also have a `~ScalarExpressionProxy.desc`
+        ``>=``) and provide
+        `~lsst.daf.butler.queries.expression_factory.ScalarExpressionProxy.in_range`,
+        `~lsst.daf.butler.queries.expression_factory.ScalarExpressionProxy.in_iterable`, and
+        `~lsst.daf.butler.queries.expression_factory.ScalarExpressionProxy.in_query`
+        methods for membership tests.  For ``order_by`` contexts, they also have a
+        `~lsst.daf.butler.queries.expression_factory.ScalarExpressionProxy.desc`
         property to indicate that the sort order for that expression should be
         reversed.
 
-        Proxy objects for region and timespan fields have an `overlaps` method,
-        and timespans also have `~TimespanProxy.begin` and `~TimespanProxy.end`
+        Proxy objects for
+        `region <lsst.daf.butler.queries.expression_factory.RegionProxy>` and
+        `timespan <lsst.daf.butler.queries.expression_factory.TimespanProxy>`
+        fields have an ``overlaps`` method, and timespans also have
+        `~lsst.daf.butler.queries.expression_factory.TimespanProxy.begin` and
+        `~lsst.daf.butler.queries.expression_factory.TimespanProxy.end`
         properties to access scalar expression proxies for the bounds.
 
-        All proxy objects also have a `~ExpressionProxy.is_null` property.
+        All proxy objects also have an
+        `~lsst.daf.butler.queries.expression_factory.ExpressionProxy.is_null`
+        property.
 
-        Literal values can be created by calling `ExpressionFactory.literal`,
+        Literal values can be created by calling
+        `ExpressionFactory.literal <lsst.daf.butler.queries.expression_factory.ExpressionFactory.literal>`,
         but can almost always be created implicitly via overloaded operators
         instead.
-        """
+        """  # noqa: W505, long docstrings
         return ExpressionFactory(self._driver.universe)
 
     def data_ids(
         self, dimensions: DimensionGroup | Iterable[str] | str | None = None
     ) -> DataCoordinateQueryResults:
-        """Return a result object that is a `DataCoordinate` iterable.
+        """Return a result object that is a `~lsst.daf.butler.DataCoordinate`
+        iterable.
 
         Parameters
         ----------
-        dimensions : `DimensionGroup`, `str`, or \
+        dimensions : `~lsst.daf.butler.DimensionGroup`, `str`, or \
                 `~collections.abc.Iterable` [`str`], optional
-            The dimensions of the data IDs to yield, as either `DimensionGroup`
-            instances or `str` names.  Will be automatically expanded to a
-            complete `DimensionGroup`.  These dimensions do not need to match
-            the query's current `dimensions`.  Default is
+            The dimensions of the data IDs to yield, as either
+            `~lsst.daf.butler.DimensionGroup` instances or `str` names.  Will
+            be automatically expanded to a complete
+            `~lsst.daf.butler.DimensionGroup`.  These dimensions do not need to
+            match the query's current dimensions.  Default is
             `constraint_dimensions`.
 
         Returns
         -------
-        data_ids : `DataCoordinateQueryResults`
+        data_ids : `~lsst.daf.butler.queries.DataCoordinateQueryResults`
             Data IDs matching the given query parameters.  These are guaranteed
-            to identify all dimensions (`DataCoordinate.hasFull` returns
-            `True`), but will not contain `DimensionRecord` objects
-            (`DataCoordinate.hasRecords` returns `False`).  Call
+            to identify all dimensions (``DataCoordinate.hasFull`` returns
+            `True`), but will not contain `~lsst.daf.butler.DimensionRecord`
+            objects (``DataCoordinate.hasRecords`` returns `False`).  Call
             `~DataCoordinateQueryResults.with_dimension_records` on the
             returned object to include dimension records as well.
         """
@@ -238,11 +254,12 @@ class Query(QueryBase):
         *,
         find_first: bool = True,
     ) -> DatasetRefQueryResults:
-        """Return a result object that is a `DatasetRef` iterable.
+        """Return a result object that is a `~lsst.daf.butler.DatasetRef`
+        iterable.
 
         Parameters
         ----------
-        dataset_type : `str` or `DatasetType`
+        dataset_type : `str` or `~lsst.daf.butler.DatasetType`
             The dataset type to search for.
         collections : `str` or `~collections.abc.Iterable` [ `str` ], optional
             The collection or collections to search, in order.  If not provided
@@ -250,18 +267,19 @@ class Query(QueryBase):
             query, the default collection search path for this butler is used.
         find_first : `bool`, optional
             If `True` (default), for each result data ID, only yield one
-            `DatasetRef` of each `DatasetType`, from the first collection in
+            `~lsst.daf.butler.DatasetRef` of each
+            `~lsst.daf.butler.DatasetType`, from the first collection in
             which a dataset of that dataset type appears (according to the
             order of ``collections`` passed in).  If `True`, ``collections``
             must not be ``...``.
 
         Returns
         -------
-        refs : `.queries.DatasetRefQueryResults`
+        refs : `lsst.daf.butler.queries.DatasetRefQueryResults`
             Dataset references matching the given query criteria.  Nested data
             IDs are guaranteed to include values for all implied dimensions
-            (i.e. `DataCoordinate.hasFull` will return `True`), but will not
-            include dimension records (`DataCoordinate.hasRecords` will be
+            (i.e. ``DataCoordinate.hasFull`` will return `True`), but will not
+            include dimension records (``DataCoordinate.hasRecords`` will be
             `False`) unless
             `~.queries.DatasetRefQueryResults.with_dimension_records` is
             called on the result object (which returns a new one).
@@ -299,7 +317,8 @@ class Query(QueryBase):
         return DatasetRefQueryResults(self._driver, tree=query._tree, spec=spec)
 
     def dimension_records(self, element: str) -> DimensionRecordQueryResults:
-        """Return a result object that is a `DimensionRecord` iterable.
+        """Return a result object that is a `~lsst.daf.butler.DimensionRecord`
+        iterable.
 
         Parameters
         ----------
@@ -308,7 +327,7 @@ class Query(QueryBase):
 
         Returns
         -------
-        records : `.queries.DimensionRecordQueryResults`
+        records : `lsst.daf.butler.queries.DimensionRecordQueryResults`
             Data IDs matching the given query parameters.
         """
         if element not in self._driver.universe:
@@ -338,22 +357,23 @@ class Query(QueryBase):
 
         Parameters
         ----------
-        dimensions : `DimensionGroup` or `~collections.abc.Iterable` [ `str` ]
+        dimensions : `~lsst.daf.butler.DimensionGroup` or \
+                `~collections.abc.Iterable` [ `str` ]
             The dimensions that span all fields returned by this query.
         *names : `str`
             Names of dimensions fields (in  "dimension.field" format), dataset
             fields (in  "dataset_type.field" format) to include in this query.
         dimension_fields : `~collections.abc.Mapping` [`str`, \
-                `~collections.abc.Set`[`str` ]], optional
+                `~collections.abc.Set` [`str`]], optional
             Dimension record fields included in this query, keyed by dimension
             element name.
         dataset_fields : `~collections.abc.Mapping` [`str`, \
-            `~collections.abc.Set`[`DatasetFieldName`] | ``...`` ], optional
+                `~collections.abc.Set` | ``...`` ], optional
             Dataset fields included in this query, the key in the mapping is
             dataset type name. Ellipsis (``...``) can be used for value
-            to include all dataset fields needed to extract `DatasetRef`
-            instances later.
-        find_first : bool, optional
+            to include all dataset fields needed to extract
+            `~lsst.daf.butler.DatasetRef` instances later.
+        find_first : `bool`, optional
             Whether this query requires find-first resolution for a dataset.
             This is ignored and can be omitted if the query has no dataset
             fields.  It must be explicitly set to `False` if there are multiple
@@ -362,7 +382,7 @@ class Query(QueryBase):
 
         Returns
         -------
-        result : `GeneralQueryResults`
+        result : `~lsst.daf.butler.queries.GeneralQueryResults`
             Query result that can be iterated over.
 
         Notes
@@ -475,7 +495,7 @@ class Query(QueryBase):
         Parameters
         ----------
         dimensions : `~collections.abc.Iterable` [ `str` ] or \
-                `DimensionGroup`, optional
+                `~lsst.daf.butler.DimensionGroup`, optional
             Dimensions to include in the temporary results.  Default is to
             include all dimensions in the query.
         datasets : `~collections.abc.Iterable` [ `str` ], optional
@@ -536,7 +556,7 @@ class Query(QueryBase):
 
         Parameters
         ----------
-        dataset_type : `str` or `DatasetType`
+        dataset_type : `str` or `~lsst.daf.butler.DatasetType`
             Dataset type or name.  May not refer to a dataset component.
         collections : `~collections.abc.Iterable` [ `str` ], optional
             Iterable of collections to search.  Order is preserved, but will
@@ -576,9 +596,10 @@ class Query(QueryBase):
 
         Parameters
         ----------
-        iterable : `~collections.abc.Iterable` [ `DataCoordinate` ]
-            Iterable of `DataCoordinate`.  All items must have the same
-            dimensions.  Must have at least one item.
+        iterable : `~collections.abc.Iterable` \
+                [`~lsst.daf.butler.DataCoordinate`]
+            Iterable of `~lsst.daf.butler.DataCoordinate`.  All items must have
+            the same dimensions.  Must have at least one item.
 
         Returns
         -------
@@ -609,7 +630,8 @@ class Query(QueryBase):
 
         Parameters
         ----------
-        dimensions : `~collections.abc.Iterable` [ `str` ] or `DimensionGroup`
+        dimensions : `~collections.abc.Iterable` [ `str` ] or \
+                `~lsst.daf.butler.DimensionGroup`
             Names of dimensions to join in.
 
         Returns
@@ -637,7 +659,8 @@ class Query(QueryBase):
         ----------
         *args
             Constraints to apply, combined with logical AND.  Arguments may be
-            `str` expressions to parse, `Predicate` objects (these are
+            `str` expressions to parse,
+            `~lsst.daf.butler.queries.tree.Predicate` objects (these are
             typically constructed via `expression_factory`) or data IDs.
         bind : `~collections.abc.Mapping`
             Mapping from string identifier appearing in a string expression to

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -168,8 +168,9 @@ class Query(QueryBase):
         though the latter is rarely necessary since `where` already combines
         its arguments with AND).
 
-        Proxies for fields associated with dataset types (``dataset_id``,
-        ``ingest_date``, ``run``, ``collection``, as well as ``timespan`` for
+        Proxies for fields associated with individual datasets but not
+        dimension records (``dataset_id``, ``ingest_date``, ``run``,
+        ``collection``, as well as ``timespan`` for
         `~lsst.daf.butler.CollectionType.CALIBRATION` collection searches) can
         be obtained with dict-like access instead::
 
@@ -377,7 +378,7 @@ class Query(QueryBase):
             Whether this query requires find-first resolution for a dataset.
             This is ignored and can be omitted if the query has no dataset
             fields.  It must be explicitly set to `False` if there are multiple
-            dataset types with fields, or if any dataset type's ``collections``
+            dataset types with fields, or if any dataset's ``collections``
             or ``timespan`` fields are included in the results.
 
         Returns
@@ -574,7 +575,7 @@ class Query(QueryBase):
         Raises
         ------
         DatasetTypeError
-            Raised given dataset type is inconsistent with the registered
+            Raised if given dataset type is inconsistent with the registered
             dataset type.
         MissingDatasetTypeError
             Raised if the dataset type has not been registered and only a

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -675,15 +675,17 @@ class Query(QueryBase):
 
         Notes
         -----
-        If an expression references a dimension or dimension element that is
-        not already present in the query, it will be joined in, but dataset
-        searches must already be joined into a query in order to reference
-        their fields in expressions.
+        Expressions referring to dimensions or dimension elements are resolved
+        automatically. References to dataset fields (see `expression_factory`
+        for the distinction) cannot be resolved by default; they must either be
+        preceded by a call to `join_dataset_search` or must be passed to
+        `DatasetRefQueryResults.where <lsst.daf.butler.queries.DatasetRefQueryResults.where>`
+        instead.
 
         Data ID values are not checked for consistency; they are extracted from
         ``args`` and then ``kwargs`` and combined, with later values overriding
         earlier ones.
-        """
+        """  # noqa: W505, long docstrings
         return Query(
             tree=self._tree.where(
                 convert_where_args(

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -295,13 +295,6 @@ class Query(QueryBase):
         TypeError
             Raised when the arguments are incompatible, such as when a
             collection wildcard is passed when ``find_first`` is `True`
-
-        Notes
-        -----
-        When multiple dataset types are queried in a single call, the
-        results of this operation are equivalent to querying for each dataset
-        type separately in turn, and no information about the relationships
-        between datasets of different types is included.
         """
         dataset_type_name, storage_class_name, query = self._join_dataset_search_impl(
             dataset_type, collections

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Interfaces for classes that manage obscore table(s) in a `Registry`.
-"""
+"""Interfaces for classes that manage obscore table(s) in a `Registry`."""
 
 from __future__ import annotations
 

--- a/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
@@ -227,7 +227,9 @@ class PredicateConversionVisitor(TreeVisitor[VisitorResult]):
                     dtype=b.int | b.float | b.str | astropy.time.Time | datetime.datetime
                 ) as lhs,
                 ColumnExpression() as rhs,
-            ] if lhs.dtype is rhs.dtype:
+            ] if (
+                lhs.dtype is rhs.dtype
+            ):
                 return lhs.predicate_method(self.OPERATOR_MAP[operator], rhs)
             # Allow comparisons between datetime expressions and
             # astropy.time.Time literals/binds (only), by coercing the
@@ -321,7 +323,9 @@ class PredicateConversionVisitor(TreeVisitor[VisitorResult]):
                 "+" | "-" | "*",
                 ColumnExpression(dtype=b.int | b.float) as lhs,
                 ColumnExpression() as rhs,
-            ] if lhs.dtype is rhs.dtype:
+            ] if (
+                lhs.dtype is rhs.dtype
+            ):
                 return lhs.method(self.OPERATOR_MAP[operator], rhs, dtype=lhs.dtype)
             case ["/", ColumnExpression(dtype=b.float) as lhs, ColumnExpression(dtype=b.float) as rhs]:
                 return lhs.method("__truediv__", rhs, dtype=b.float)
@@ -411,9 +415,9 @@ class PredicateConversionVisitor(TreeVisitor[VisitorResult]):
         assert isinstance(lhs, ColumnExpression), "LHS of IN guaranteed to be scalar by parser."
         for rhs_item in values:
             match rhs_item:
-                case ColumnExpressionSequence(
-                    items=rhs_items, dtype=rhs_dtype
-                ) if rhs_dtype is None or rhs_dtype == lhs.dtype:
+                case ColumnExpressionSequence(items=rhs_items, dtype=rhs_dtype) if (
+                    rhs_dtype is None or rhs_dtype == lhs.dtype
+                ):
                     items.extend(rhs_items)
                 case ColumnContainer(dtype=lhs.dtype):
                     clauses.append(rhs_item.contains(lhs))

--- a/tests/test_astropyTableFormatter.py
+++ b/tests/test_astropyTableFormatter.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for AstropyTableFormatter.
-"""
+"""Tests for AstropyTableFormatter."""
 
 import os
 import unittest

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for Butler.
-"""
+"""Tests for Butler."""
 from __future__ import annotations
 
 import json

--- a/tests/test_cliCmdAssociate.py
+++ b/tests/test_cliCmdAssociate.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI prune-datasets subcommand.
-"""
+"""Unit tests for daf_butler CLI prune-datasets subcommand."""
 
 import unittest
 from unittest.mock import patch

--- a/tests/test_cliCmdConfigDump.py
+++ b/tests/test_cliCmdConfigDump.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI config-dump command.
-"""
+"""Unit tests for daf_butler CLI config-dump command."""
 
 import os
 import os.path

--- a/tests/test_cliCmdConfigValidate.py
+++ b/tests/test_cliCmdConfigValidate.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI config-validate command.
-"""
+"""Unit tests for daf_butler CLI config-validate command."""
 
 import unittest
 

--- a/tests/test_cliCmdImport.py
+++ b/tests/test_cliCmdImport.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI config-dump command.
-"""
+"""Unit tests for daf_butler CLI config-dump command."""
 
 import unittest
 import unittest.mock

--- a/tests/test_cliCmdIngestFiles.py
+++ b/tests/test_cliCmdIngestFiles.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI ingest-files command.
-"""
+"""Unit tests for daf_butler CLI ingest-files command."""
 
 import json
 import os

--- a/tests/test_cliCmdPruneDatasets.py
+++ b/tests/test_cliCmdPruneDatasets.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI prune-datasets subcommand.
-"""
+"""Unit tests for daf_butler CLI prune-datasets subcommand."""
 
 import unittest
 from itertools import chain

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI query-collections command.
-"""
+"""Unit tests for daf_butler CLI query-collections command."""
 
 import os
 import unittest

--- a/tests/test_cliCmdQueryDataIds.py
+++ b/tests/test_cliCmdQueryDataIds.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI query-collections command.
-"""
+"""Unit tests for daf_butler CLI query-collections command."""
 
 import os
 import unittest

--- a/tests/test_cliCmdQueryDatasetTypes.py
+++ b/tests/test_cliCmdQueryDatasetTypes.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI query-collections command.
-"""
+"""Unit tests for daf_butler CLI query-collections command."""
 
 import unittest
 

--- a/tests/test_cliCmdQueryDatasets.py
+++ b/tests/test_cliCmdQueryDatasets.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI query-datasets command.
-"""
+"""Unit tests for daf_butler CLI query-datasets command."""
 
 import os
 import unittest

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI query-collections command.
-"""
+"""Unit tests for daf_butler CLI query-collections command."""
 
 import os
 import unittest

--- a/tests/test_cliCmdRemoveCollections.py
+++ b/tests/test_cliCmdRemoveCollections.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI prune-collections subcommand.
-"""
+"""Unit tests for daf_butler CLI prune-collections subcommand."""
 
 import os
 import unittest

--- a/tests/test_cliCmdRemoveRuns.py
+++ b/tests/test_cliCmdRemoveRuns.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI remove-runs subcommand.
-"""
+"""Unit tests for daf_butler CLI remove-runs subcommand."""
 
 
 import os

--- a/tests/test_cliCmdRetrieveArtifacts.py
+++ b/tests/test_cliCmdRetrieveArtifacts.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI retrieve-artifacts command.
-"""
+"""Unit tests for daf_butler CLI retrieve-artifacts command."""
 
 import os
 import unittest

--- a/tests/test_cliLog.py
+++ b/tests/test_cliLog.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler dataset-type CLI option.
-"""
+"""Unit tests for the daf_butler dataset-type CLI option."""
 
 import logging
 import unittest

--- a/tests/test_cliPluginLoader.py
+++ b/tests/test_cliPluginLoader.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler CLI plugin loader.
-"""
+"""Unit tests for the daf_butler CLI plugin loader."""
 
 import os
 import unittest

--- a/tests/test_cliUtilSplitCommas.py
+++ b/tests/test_cliUtilSplitCommas.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler shared CLI options.
-"""
+"""Unit tests for the daf_butler shared CLI options."""
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/test_cliUtilSplitKv.py
+++ b/tests/test_cliUtilSplitKv.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler shared CLI options.
-"""
+"""Unit tests for the daf_butler shared CLI options."""
 
 import unittest
 from functools import partial

--- a/tests/test_cliUtilToUpper.py
+++ b/tests/test_cliUtilToUpper.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler shared CLI options.
-"""
+"""Unit tests for the daf_butler shared CLI options."""
 
 import unittest
 

--- a/tests/test_cliUtils.py
+++ b/tests/test_cliUtils.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler shared CLI options.
-"""
+"""Unit tests for the daf_butler shared CLI options."""
 
 import unittest
 from unittest.mock import MagicMock

--- a/tests/test_connectionString.py
+++ b/tests/test_connectionString.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for ConnectionStringBuilder.
-"""
+"""Tests for ConnectionStringBuilder."""
 
 import glob
 import os

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Unit tests for methods in butler.ddl module.
-"""
+"""Unit tests for methods in butler.ddl module."""
 
 import unittest
 

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple unit test for expr_parser/parserLex module.
-"""
+"""Simple unit test for expr_parser/parserLex module."""
 
 import re
 import unittest

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple unit test for exprParser subpackage module.
-"""
+"""Simple unit test for exprParser subpackage module."""
 
 import unittest
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests related to the formatter infrastructure.
-"""
+"""Tests related to the formatter infrastructure."""
 
 import inspect
 import os.path

--- a/tests/test_logFormatter.py
+++ b/tests/test_logFormatter.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for ButlerLogRecordsFormatter.
-"""
+"""Tests for ButlerLogRecordsFormatter."""
 
 import logging
 import os

--- a/tests/test_matplotlibFormatter.py
+++ b/tests/test_matplotlibFormatter.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for MatplotlibFormatter.
-"""
+"""Tests for MatplotlibFormatter."""
 
 import os
 import tempfile

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for PackagesFormatter.
-"""
+"""Tests for PackagesFormatter."""
 
 import os
 import unittest

--- a/tests/test_query_direct_postgresql.py
+++ b/tests/test_query_direct_postgresql.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for DirectButler._query with PostgreSQL.
-"""
+"""Tests for DirectButler._query with PostgreSQL."""
 
 from __future__ import annotations
 

--- a/tests/test_query_direct_sqlite.py
+++ b/tests/test_query_direct_sqlite.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for DirectButler._query with SQLite.
-"""
+"""Tests for DirectButler._query with SQLite."""
 
 from __future__ import annotations
 

--- a/tests/test_query_remote.py
+++ b/tests/test_query_remote.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Tests for DirectButler._query with SQLite.
-"""
+"""Tests for DirectButler._query with SQLite."""
 
 from __future__ import annotations
 

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Unit tests for methods in butler.time module.
-"""
+"""Unit tests for methods in butler.time module."""
 
 import unittest
 import warnings


### PR DESCRIPTION
This PR addresses various documentation issues that came up while working on lsst-dm/prompt_processing#249.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
