### PR TITLE
DM-48589: Fix timespans in DimensionRecordTable empty

### DIFF
--- a/python/lsst/daf/butler/arrow_utils.py
+++ b/python/lsst/daf/butler/arrow_utils.py
@@ -516,9 +516,7 @@ class TimespanArrowScalar(pa.ExtensionScalar):
     """
 
     def as_py(self) -> Timespan:
-        return Timespan(
-            None, None, _nsec=(self.value["begin_nsec"].as_py(), self.value["begin_nsec"].as_py())
-        )
+        return Timespan(None, None, _nsec=(self.value["begin_nsec"].as_py(), self.value["end_nsec"].as_py()))
 
 
 @final

--- a/tests/test_dimension_record_containers.py
+++ b/tests/test_dimension_record_containers.py
@@ -130,6 +130,8 @@ class DimensionRecordContainersTestCase(unittest.TestCase):
         self.assertEqual(table[0], self.records["visit"][0])
         self.assertEqual(table[1], self.records["visit"][1])
         self.assertEqual(list(table), list(self.records["visit"]))
+        self.assertListEqual([x.region for x in table], [x.region for x in self.records["visit"]])
+        self.assertListEqual([x.timespan for x in table], [x.timespan for x in self.records["visit"]])
         self.assertEqual(table.element, self.universe["visit"])
         self.assertEqual(table.column("instrument")[0].as_py(), "Cam1")
         self.assertEqual(table.column("instrument")[1].as_py(), "Cam1")
@@ -169,6 +171,7 @@ class DimensionRecordContainersTestCase(unittest.TestCase):
         and regions, and those are the tricky column types for interoperability
         with Arrow.
         """
+        original_records = list(self.records["visit"])
         table1 = DimensionRecordTable(self.universe["visit"], self.records["visit"])
         stream = pa.BufferOutputStream()
         pq.write_table(table1.to_arrow(), stream)
@@ -176,6 +179,11 @@ class DimensionRecordContainersTestCase(unittest.TestCase):
             universe=self.universe, table=pq.read_table(pa.BufferReader(stream.getvalue()))
         )
         self.assertEqual(list(table1), list(table2))
+        self.assertEqual(original_records, list(table2))
+        self.assertListEqual([x.region for x in table1], [x.region for x in table2])
+        self.assertListEqual([x.region for x in original_records], [x.region for x in table2])
+        self.assertListEqual([x.timespan for x in table1], [x.timespan for x in table2])
+        self.assertListEqual([x.timespan for x in original_records], [x.timespan for x in table2])
 
     def test_record_table_parquet_skymap(self):
         """Test round-tripping a dimension record table through Parquet.


### PR DESCRIPTION
Fix an issue where timespans in dimension records read out of DimensionRecordTable would always be empty, due to an error in the deserialization logic.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
