### PR TITLE
DM-47201: Fix duplicates in non-find-first dataset search

### DIFF
--- a/doc/changes/DM-47201.bugfix.md
+++ b/doc/changes/DM-47201.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue where `find_first=False` dataset queries would sometimes return duplicate results if more than one collection was being searched.

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -504,6 +504,11 @@ class SimpleButlerTests(TestCaseMixin):
         )
         self.assertEqual(bias3b_id, bias3b.id)
 
+        # Query for a calibration in a RUN and CALIBRATION collection to
+        # ensure we do not get duplicate results.
+        results = butler.query_datasets("bias", collections=["calibs", "imported_g"], find_first=False)
+        self.assertEqual(len(set(results)), len(results))
+
         # Extra but inconsistent record values are a problem.
         with self.assertRaises(ValueError):
             bias3b_id, _ = butler.get(


### PR DESCRIPTION
Fix an issue where duplicate results could appear in a non-find-first dataset search, if the same dataset appeared in multiple collections in a chain.

This was occurring because we were forcing the addition of the collection key field to make the rows distinct.  But on a non-find-first search, we don't have the window function to de-duplicate the rows by dataset ID.  So we need to:
1.  Keep the collection key out of the rows (because this is preventing rows from being de-duplicated) 
2. Treat dataset ID as a unique key instead (so that we don't drop rows with the same data ID but different dataset IDs).

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
