### PR TITLE
DM-48880: avoid too-coarse spatial joins in queries

### DIFF
--- a/doc/changes/DM-48880.bugfix.md
+++ b/doc/changes/DM-48880.bugfix.md
@@ -1,0 +1,5 @@
+Fix a query bug that could lead to unexpectedly coarse spatial joins.
+
+When dataset search or other join operand had some dimensions from either side of a potential spatial join (e.g. `{tract, visit}`), we had been blocking the addition of an automatic spatial join on the assumption that this would be embedded in that join operand.
+But this is only desirable when the spatial join that would have been added actually the same one implied by that join operand's dimensions; if it's something more fine grained (e.g. `{tract, patch, visit}`) we end up with result rows that relate dimensions (e.g. `patch` and `visit`) that do not actually overlap.
+Now automatic spatial joins are only blocked when the join operand includes all dimensions that would have participated in the automatic join.

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -1124,7 +1124,7 @@ class DirectQueryDriver(QueryDriver):
                                 select_builder.joins.fields[logical_table][field]
                             )
                 else:
-                    _LOG.warning(
+                    _LOG.debug(
                         "Adding %d fields to GROUP BY because this database backend does not support the "
                         "ANY_VALUE aggregate function (or equivalent).  This may result in a poor query "
                         "plan.  Materializing the query first sometimes avoids this problem.  This warning "

--- a/python/lsst/daf/butler/queries/overlaps.py
+++ b/python/lsst/daf/butler/queries/overlaps.py
@@ -278,7 +278,7 @@ class OverlapsVisitor(SimplePredicateVisitor):
         association between non-overlapping things that we'd want to respect by
         *not* adding a more restrictive automatic join.
         """
-        for a_family, b_family in itertools.pairwise(families):
+        for a_family, b_family in itertools.combinations(families, 2):
             a_element = a_family.choose(self.dimensions)
             b_element = b_family.choose(self.dimensions)
             if (

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -1370,12 +1370,7 @@ class ButlerQueryTests(ABC, TestCaseMixin):
             self.check_detector_records(
                 query.join_dimensions(["visit", "detector", "tract"])
                 .materialize()
-                # The patch constraint here should do nothing, because only the
-                # spatial join from the materialization should exist.  The
-                # behavior is surprising no matter what here, and the
-                # recommendation to users is to add an explicit overlap
-                # expression any time it's not obvious what the default is.
-                .where(skymap="SkyMap1", tract=0, instrument="Cam1", visit=2, patch=5)
+                .where(skymap="SkyMap1", tract=0, instrument="Cam1", visit=2)
                 .dimension_records("detector"),
                 [1, 2],
                 has_postprocessing=True,

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -1009,6 +1009,77 @@ class ButlerQueryTests(ABC, TestCaseMixin):
                     bind={"my_point": array_point},
                 )
 
+    def test_auto_spatial_joins(self) -> None:
+        """Test the addition of automatic spatial joins in the presence and
+        absence of datasets with dimensions that cross spatial families.
+        """
+        butler = self.make_butler("base.yaml", "spatial.yaml")
+        # Set default governor data ID values both to test that code path and
+        # to keep us from having to repeat them in every 'where' call below.
+        butler.registry.defaults = RegistryDefaults(instrument="Cam1", skymap="SkyMap1")
+        # Add some datasets with {tract, visit, detector} dimensions.
+        # These will cover all {visit, detector}s that overlap tract=0.
+        cat = DatasetType(
+            "cat",
+            dimensions=butler.dimensions.conform(["visit", "detector", "tract"]),
+            storageClass="ArrowTable",
+        )
+        butler.registry.registerDatasetType(cat)
+        butler.collections.register("run1")
+        butler.registry.insertDatasets(
+            cat,
+            [
+                {"instrument": "Cam1", "skymap": "SkyMap1", "visit": 1, "detector": 1, "tract": 0},
+                {"instrument": "Cam1", "skymap": "SkyMap1", "visit": 1, "detector": 2, "tract": 0},
+                {"instrument": "Cam1", "skymap": "SkyMap1", "visit": 1, "detector": 3, "tract": 0},
+                {"instrument": "Cam1", "skymap": "SkyMap1", "visit": 1, "detector": 4, "tract": 0},
+                {"instrument": "Cam1", "skymap": "SkyMap1", "visit": 2, "detector": 1, "tract": 0},
+                {"instrument": "Cam1", "skymap": "SkyMap1", "visit": 2, "detector": 2, "tract": 0},
+            ],
+            run="run1",
+        )
+        with butler.query() as query:
+            # When we query for just these dimensions with that dataset type
+            # included, we shouldn't need a spatial join, because we assume
+            # it's embedded in the rows of that dataset search.
+            q1 = query.join_dataset_search(cat, "run1").data_ids(["visit", "detector", "tract"])
+            # If there's no explicit spatial join, there's no postprocessing,
+            # and hence we can do an exact count with discard=False.
+            self.assertEqual(q1.count(exact=True, discard=False), 6)
+            self.assertCountEqual(
+                [(row["visit"], row["detector"], row["tract"]) for row in q1],
+                [
+                    (1, 1, 0),
+                    (1, 2, 0),
+                    (1, 3, 0),
+                    (1, 4, 0),
+                    (2, 1, 0),
+                    (2, 2, 0),
+                ],
+            )
+            # When we query for these dimensions and another one that wants
+            # a more precise spatial join, we should get that more precise
+            # spatial join.
+            q1 = query.join_dataset_search(cat, "run1").data_ids(["visit", "detector", "tract", "patch"])
+            self.assertCountEqual(
+                [(row["visit"], row["detector"], row["tract"], row["patch"]) for row in q1],
+                [
+                    (1, 1, 0, 0),
+                    (1, 1, 0, 2),
+                    (1, 2, 0, 0),
+                    (1, 2, 0, 1),
+                    (1, 2, 0, 2),
+                    (1, 2, 0, 3),
+                    (1, 3, 0, 2),
+                    (1, 3, 0, 4),
+                    (1, 4, 0, 2),
+                    (1, 4, 0, 3),
+                    (2, 1, 0, 4),
+                    (2, 2, 0, 4),
+                    (2, 2, 0, 5),
+                ],
+            )
+
     def test_common_skypix_overlaps(self) -> None:
         """Test spatial overlap queries that return htm7 records."""
         butler = self.make_butler("base.yaml", "spatial.yaml")

--- a/tests/test_query_utilities.py
+++ b/tests/test_query_utilities.py
@@ -387,7 +387,8 @@ class OverlapsVisitorTestCase(unittest.TestCase):
         self.assertEqual(visitor.spatial_joins, [("tract", "visit", PredicateVisitFlags(0))])
         self.assertFalse(visitor.spatial_constraints)
         self.assertFalse(visitor.temporal_dimension_joins)
-        # Add a "join operand" whose dimensions include both spatial families.
+        # Add a "join operand" whose dimensions include both spatial families
+        # with the most fine-grained dimensions in the query.
         # This blocks an automatic join from being created, because we assume
         # that join operand (e.g. a materialization or dataset search) already
         # encodes some spatial join.
@@ -395,7 +396,7 @@ class OverlapsVisitorTestCase(unittest.TestCase):
             ["visit", "detector", "patch"],
             qt.Predicate.from_bool(True),
             "True",
-            join_operands=[self.universe.conform(["tract", "visit_detector_region"])],
+            join_operands=[self.universe.conform(["patch", "visit_detector_region"])],
         )
         self.assertFalse(visitor.spatial_joins)
         self.assertFalse(visitor.spatial_constraints)
@@ -429,12 +430,13 @@ class OverlapsVisitorTestCase(unittest.TestCase):
         self.assertFalse(visitor.spatial_constraints)
         self.assertFalse(visitor.temporal_dimension_joins)
         # Add a "join operand" whose dimensions includes two spatial families,
-        # with a predicate that joins the third in.
+        # with the most fine-grained dimensions in the query, and a predicate
+        # that joins the third in.
         visitor = self.run_visitor(
             ["visit", "patch", "htm7"],
             x.tract.region.overlaps(x.htm7.region),
             "tract.region OVERLAPS htm7.region",
-            join_operands=[self.universe.conform(["visit", "tract"])],
+            join_operands=[self.universe.conform(["visit", "patch"])],
         )
         self.assertEqual(
             visitor.spatial_joins,


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
