### PR TITLE
DM-48869: Add method to return dataset provenance in a flat dict

### DIFF
--- a/doc/changes/DM-48869.feature.rst
+++ b/doc/changes/DM-48869.feature.rst
@@ -1,0 +1,2 @@
+* Added new methods to ``DatasetProvenance`` for serializing provenance to a flat dictionary and recovering provenance from that dictionary.
+* Modifed ``ParquetFormatter`` to write provenance metadata to Astropy tables.

--- a/python/lsst/daf/butler/_dataset_provenance.py
+++ b/python/lsst/daf/butler/_dataset_provenance.py
@@ -29,12 +29,15 @@ from __future__ import annotations
 
 __all__ = ("DatasetProvenance",)
 
-import typing
 import uuid
+from typing import TYPE_CHECKING, Any, Self
 
 import pydantic
 
 from ._dataset_ref import DatasetRef, SerializedDatasetRef
+
+if TYPE_CHECKING:
+    from .dimensions import DataIdValue
 
 
 class DatasetProvenance(pydantic.BaseModel):
@@ -44,12 +47,12 @@ class DatasetProvenance(pydantic.BaseModel):
     """The input datasets."""
     quantum_id: uuid.UUID | None = None
     """Identifier of the Quantum that was executed."""
-    extras: dict[uuid.UUID, dict[str, int | float | str | bool]] = pydantic.Field(default_factory=dict)
+    extras: dict[uuid.UUID, dict[str, Any]] = pydantic.Field(default_factory=dict)
     """Extra provenance information associated with a particular dataset."""
     _uuids: set[uuid.UUID] = pydantic.PrivateAttr(default_factory=set)
 
     @pydantic.model_validator(mode="after")
-    def populate_cache(self) -> typing.Self:
+    def populate_cache(self) -> Self:
         for ref in self.inputs:
             self._uuids.add(ref.id)
         return self
@@ -68,7 +71,7 @@ class DatasetProvenance(pydantic.BaseModel):
         self._uuids.add(ref.id)
         self.inputs.append(ref.to_simple())
 
-    def add_extra_provenance(self, dataset_id: uuid.UUID, extra: dict[str, int | float | str | bool]) -> None:
+    def add_extra_provenance(self, dataset_id: uuid.UUID, extra: dict[str, Any]) -> None:
         """Attach extra provenance to a specific dataset.
 
         Parameters
@@ -82,3 +85,94 @@ class DatasetProvenance(pydantic.BaseModel):
         if dataset_id not in self._uuids:
             raise ValueError(f"The given dataset ID {dataset_id} is not known to this provenance instance.")
         self.extras.setdefault(dataset_id, {}).update(extra)
+
+    def to_flat_dict(
+        self,
+        ref: DatasetRef | None,
+        /,
+        *,
+        prefix: str = "",
+        sep: str = ".",
+        simple_types: bool = False,
+    ) -> dict[str, int | str | bool | float | uuid.UUID | DataIdValue]:
+        """Return provenance as a flattened dictionary.
+
+        Parameters
+        ----------
+        ref : `DatasetRef` or `None`
+            If given, a dataset for which this provenance is relevant and
+            should be included.
+        prefix : `str`, optional
+            A prefix to use for each key in the provenance dictionary.
+        sep : `str`, optional
+            Separator to use to represent hierarchy.
+        simple_types : `bool`, optional
+            If `True` only simple Python types will be used in the returned
+            dictionary, specifically UUIDs will be returned as `str`. If
+            `False`, UUIDs will be returned as `uuid.UUID`. Complex types
+            found in `DatasetProvenance.extras` will be cast to a `str`
+            if `True`.
+
+        Returns
+        -------
+        prov : `dict`
+            Dictionary representing the provenance. The keys are defined
+            in the notes below.
+
+        Notes
+        -----
+        The provenance keys created by this method are defined below. The
+        case of the keys will match the case of the first character of the
+        prefix (defined by whether `str.isupper()` returns true, else they will
+        be lower case).
+
+        Keys from the given dataset (all optional if no dataset is given):
+
+        :id: UUID of the given dataset.
+        :run: Run of the given dataset.
+        :datasettype: Dataset type of the given dataset.
+        :dataid x: An entry for each required dimension in the data ID.
+
+        Each input dataset will have the ``id``, ``run``, and ``datasettype``
+        keys as defined above (but no ``dataid`` key) with an ``input N``
+        prefix where ``N`` starts counting at 0.
+
+        The quantum ID, if present, will use key ``quantum``.
+        """
+        use_upper = prefix[0].isupper() if prefix else False
+
+        def _make_key(*keys: str | int) -> str:
+            """Make the key in the correct form."""
+            start = prefix
+            if start:
+                start += sep
+            k = sep.join(str(kk) for kk in keys)
+            if use_upper:
+                k = k.upper()
+            return f"{start}{k}"
+
+        prov: dict[str, int | float | str | bool | uuid.UUID | DataIdValue] = {}
+        if ref is not None:
+            prov[_make_key("id")] = ref.id if not simple_types else str(ref.id)
+            prov[_make_key("run")] = ref.run
+            prov[_make_key("datasettype")] = ref.datasetType.name
+            for k, v in sorted(ref.dataId.required.items()):
+                prov[_make_key("dataid", k)] = v
+
+        if self.quantum_id is not None:
+            prov[_make_key("quantum")] = self.quantum_id if not simple_types else str(self.quantum_id)
+
+        for i, input in enumerate(self.inputs):
+            prov[_make_key("input", i, "id")] = input.id if not simple_types else str(input.id)
+            if input.run is not None:  # for mypy
+                prov[_make_key("input", i, "run")] = input.run
+            if input.datasetType is not None:  # for mypy
+                prov[_make_key("input", i, "datasettype")] = input.datasetType.name
+
+            if input.id in self.extras:
+                for xk, xv in self.extras[input.id].items():
+                    if simple_types and not isinstance(xv, str | float | int | bool):
+                        xv = str(xv)
+                    prov[_make_key("input", i, xk)] = xv
+
+        return prov

--- a/python/lsst/daf/butler/_dataset_provenance.py
+++ b/python/lsst/daf/butler/_dataset_provenance.py
@@ -136,13 +136,33 @@ class DatasetProvenance(pydantic.BaseModel):
         :id: UUID of the given dataset.
         :run: Run of the given dataset.
         :datasettype: Dataset type of the given dataset.
-        :dataid x: An entry for each required dimension in the data ID.
+        :dataid x: An entry for each required dimension, "x", in the data ID.
 
         Each input dataset will have the ``id``, ``run``, and ``datasettype``
         keys as defined above (but no ``dataid`` key) with an ``input N``
         prefix where ``N`` starts counting at 0.
 
         The quantum ID, if present, will use key ``quantum``.
+
+        Examples
+        --------
+        >>> provenance.to_flat_dict(
+        ...     ref, prefix="lsst.butler", sep=".", simple_types=True
+        ... )
+        {
+            "lsst.butler.id": "ae0fa83d-cc89-41dd-9680-f97ede49f01e",
+            "lsst.butler.run": "test_run",
+            "lsst.butler.datasettype": "data",
+            "lsst.butler.dataid.detector": 10,
+            "lsst.butler.dataid.instrument": "LSSTCam",
+            "lsst.butler.quantum": "d93a735b-08f0-477d-bc95-2cc32d6d898b",
+            "lsst.butler.input.0.id": "3dfd7ba5-5e35-4565-9d87-4b33880ed06c",
+            "lsst.butler.input.0.run": "other_run",
+            "lsst.butler.input.0.datasettype": "astropy_parquet",
+            "lsst.butler.input.1.id": "7a99f6e9-4035-3d68-842e-58ecce1dc935",
+            "lsst.butler.input.1.run": "other_run",
+            "lsst.butler.input.1.datasettype": "astropy_parquet",
+        }
 
         Raises
         ------

--- a/python/lsst/daf/butler/_dataset_provenance.py
+++ b/python/lsst/daf/butler/_dataset_provenance.py
@@ -85,9 +85,18 @@ class DatasetProvenance(pydantic.BaseModel):
         extra : `dict` [ `str`, `typing.Any` ]
             The extra provenance information as a dictionary. The values
             must be simple Python scalars.
+
+        Notes
+        -----
+        The keys in the extra provenance can not include provenance keys of
+        ``run``, ``id``, or ``datasettype`` (in upper or lower case).
         """
         if dataset_id not in self._uuids:
             raise ValueError(f"The given dataset ID {dataset_id} is not known to this provenance instance.")
+        extra_keys = {k.lower() for k in extra.keys()}
+        if overlap := (extra_keys & {"run", "id", "datasettype"}):
+            raise ValueError(f"Extra provenance includes a reserved provenance key: {overlap}")
+
         self.extras.setdefault(dataset_id, {}).update(extra)
 
     def to_flat_dict(

--- a/python/lsst/daf/butler/_dataset_provenance.py
+++ b/python/lsst/daf/butler/_dataset_provenance.py
@@ -246,7 +246,7 @@ class DatasetProvenance(pydantic.BaseModel):
         return f"{prefix}{k}"
 
     @staticmethod
-    def _find_prefix_and_sep(prov_dict: Mapping) -> tuple[str, str] | tuple[None, None]:
+    def _find_prefix_and_sep(prov_dict: Mapping[str, Any]) -> tuple[str, str] | tuple[None, None]:
         """Given a mapping try to determine the prefix and separator for
         provenance keys.
 
@@ -332,7 +332,7 @@ class DatasetProvenance(pydantic.BaseModel):
         return prefixes.pop(), separators.pop()
 
     @classmethod
-    def _find_provenance_keys_in_flat_dict(cls, prov_dict: Mapping) -> dict[str, str]:
+    def _find_provenance_keys_in_flat_dict(cls, prov_dict: Mapping[str, Any]) -> dict[str, str]:
         """Find the provenance keys in a dictionary.
 
         Parameters
@@ -385,7 +385,7 @@ class DatasetProvenance(pydantic.BaseModel):
         return prov_keys
 
     @classmethod
-    def strip_provenance_from_flat_dict(cls, prov_dict: MutableMapping) -> None:
+    def strip_provenance_from_flat_dict(cls, prov_dict: MutableMapping[str, Any]) -> None:
         """Remove provenance keys from a mapping that had been populated
         by `to_flat_dict`.
 
@@ -400,7 +400,7 @@ class DatasetProvenance(pydantic.BaseModel):
         return
 
     @classmethod
-    def from_flat_dict(cls, prov_dict: Mapping, butler: Butler) -> tuple[Self, DatasetRef | None]:
+    def from_flat_dict(cls, prov_dict: Mapping[str, Any], butler: Butler) -> tuple[Self, DatasetRef | None]:
         """Create a provenance object from a provenance dictionary.
 
         Parameters

--- a/python/lsst/daf/butler/delegates/arrowtable.py
+++ b/python/lsst/daf/butler/delegates/arrowtable.py
@@ -224,6 +224,10 @@ def _add_arrow_provenance(
     if type_string == "astropy":
         provenance = provenance if provenance is not None else DatasetProvenance()
         prov_dict = provenance.to_flat_dict(ref, prefix="lsst.butler", sep=".", simple_types=True)
+
+        # Strip any previous provenance.
+        DatasetProvenance.strip_provenance_from_flat_dict(in_memory_dataset.meta)
+
         in_memory_dataset.meta.update(prov_dict)
     return in_memory_dataset
 

--- a/python/lsst/daf/butler/delegates/arrowtable.py
+++ b/python/lsst/daf/butler/delegates/arrowtable.py
@@ -36,12 +36,14 @@ from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 
-from lsst.daf.butler import StorageClassDelegate
+from lsst.daf.butler import DatasetProvenance, StorageClassDelegate
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import ensure_iterable
 
 if TYPE_CHECKING:
     import pandas
+
+    from lsst.daf.butler import DatasetRef
 
 
 class ArrowTableDelegate(StorageClassDelegate):
@@ -205,6 +207,25 @@ class ArrowTableDelegate(StorageClassDelegate):
             allColumns.extend(dataset.index.names)
 
         return allColumns
+
+    def add_provenance(
+        self, in_memory_dataset: Any, ref: DatasetRef, provenance: DatasetProvenance | None = None
+    ) -> Any:
+        return _add_arrow_provenance(in_memory_dataset, ref, provenance)
+
+
+def _add_arrow_provenance(
+    in_memory_dataset: Any, ref: DatasetRef, provenance: DatasetProvenance | None = None
+) -> Any:
+    # Add provenance as a flat dict. For now only do this for Astropy
+    # tables which have an implemented mechanism for round tripping
+    # metadata.
+    type_string = _checkArrowCompatibleType(in_memory_dataset)
+    if type_string == "astropy":
+        provenance = provenance if provenance is not None else DatasetProvenance()
+        prov_dict = provenance.to_flat_dict(ref, prefix="lsst.butler", sep=".", simple_types=True)
+        in_memory_dataset.meta.update(prov_dict)
+    return in_memory_dataset
 
 
 def _checkArrowCompatibleType(dataset: Any) -> str | None:

--- a/python/lsst/daf/butler/delegates/arrowtable.py
+++ b/python/lsst/daf/butler/delegates/arrowtable.py
@@ -223,7 +223,7 @@ def _add_arrow_provenance(
     type_string = _checkArrowCompatibleType(in_memory_dataset)
     if type_string == "astropy":
         provenance = provenance if provenance is not None else DatasetProvenance()
-        prov_dict = provenance.to_flat_dict(ref, prefix="lsst.butler", sep=".", simple_types=True)
+        prov_dict = provenance.to_flat_dict(ref, prefix="LSST.BUTLER", sep=".", simple_types=True)
 
         # Strip any previous provenance.
         DatasetProvenance.strip_provenance_from_flat_dict(in_memory_dataset.meta)

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -59,8 +59,8 @@ from typing import TYPE_CHECKING, Any, cast
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from lsst.daf.butler import FormatterV2
-from lsst.daf.butler.delegates.arrowtable import _checkArrowCompatibleType
+from lsst.daf.butler import DatasetProvenance, FormatterV2
+from lsst.daf.butler.delegates.arrowtable import _add_arrow_provenance, _checkArrowCompatibleType
 from lsst.resources import ResourcePath
 from lsst.utils.introspection import get_full_type_name
 from lsst.utils.iteration import ensure_iterable
@@ -183,6 +183,9 @@ class ParquetFormatter(FormatterV2):
         )
 
         return arrow_table
+
+    def add_provenance(self, in_memory_dataset: Any, provenance: DatasetProvenance | None = None) -> Any:
+        return _add_arrow_provenance(in_memory_dataset, self.dataset_ref, provenance)
 
     def write_local_file(self, in_memory_dataset: Any, uri: ResourcePath) -> None:
         if isinstance(in_memory_dataset, pa.Schema):

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2151,9 +2151,30 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         # Put with provenance.
         prov = DatasetProvenance(quantum_id=uuid.uuid4())
         prov.add_input(metric_ref)
+        prov.add_extra_provenance(metric_ref.id, {"answer": 42})
         metric_ref2 = butler.put(metric, datasetType, visit=423, instrument="DummyCamComp", provenance=prov)
         metric_3 = butler.get(metric_ref2)
         self.assertEqual(metric_3.provenance, prov)
+
+        # Check that we can extract provenance from dict form.
+        prov_dict = prov.to_flat_dict(metric_ref2)
+        prov_from_prov, ref_from_prov = DatasetProvenance.from_flat_dict(prov_dict, butler)
+        self.assertEqual(ref_from_prov, metric_ref2)
+        # Direct __eq__ of the provenance does not work because one side
+        # includes dimension records.
+        self.assertEqual({ref.id for ref in prov_from_prov.inputs}, {ref.id for ref in prov.inputs})
+        self.assertEqual(prov_from_prov.quantum_id, prov.quantum_id)
+        self.assertEqual(prov_from_prov.extras, prov.extras)
+
+        # Check that simple types can be reconstructed with non-standard
+        # separators.
+        prov_dict = prov.to_flat_dict(metric_ref2, prefix="XYZ", sep="😎", simple_types=True)
+        prov_from_prov, ref_from_prov = DatasetProvenance.from_flat_dict(prov_dict, butler)
+        self.assertEqual(ref_from_prov, metric_ref2)
+        self.assertEqual({ref.id for ref in prov_from_prov.inputs}, {ref.id for ref in prov.inputs})
+
+        with self.assertRaises(ValueError):
+            DatasetProvenance.from_flat_dict({"unknown": 42}, butler)
 
 
 class PostgresPosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2166,6 +2166,15 @@ class PosixDatastoreButlerTestCase(FileDatastoreButlerTests, unittest.TestCase):
         self.assertEqual(prov_from_prov.quantum_id, prov.quantum_id)
         self.assertEqual(prov_from_prov.extras, prov.extras)
 
+        # Force a bad ID into the dict.
+        prov_dict["id"] = uuid.uuid4()
+        with self.assertRaises(ValueError):
+            DatasetProvenance.from_flat_dict(prov_dict, butler)
+        del prov_dict["id"]
+        prov_dict["input 0 id"] = uuid.uuid4()
+        with self.assertRaises(ValueError):
+            DatasetProvenance.from_flat_dict(prov_dict, butler)
+
         # Check that simple types can be reconstructed with non-standard
         # separators.
         prov_dict = prov.to_flat_dict(metric_ref2, prefix="XYZ", sep="😎", simple_types=True)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -782,6 +782,10 @@ class DatasetRefTestCase(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
+            prov.add_extra_provenance(ref2.id, {"extra_string": "value", "extra_number": 42, "id": extra_id})
+
+        with self.assertRaises(ValueError):
+            # Unknown dataset.
             prov.add_extra_provenance(ref1.id, {"extra": 42})
 
         expected = {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -843,6 +843,15 @@ class DatasetRefTestCase(unittest.TestCase):
         DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
         self.assertEqual(prov_dict, {})
 
+        # Prefix has no case but force upper.
+        prov_dict = prov.to_flat_dict(ref1, prefix="🔭 LSST BUTLER", sep="→", use_upper=True)
+        self.assertIn("🔭 LSST BUTLER→RUN", prov_dict)
+        self.assertIn("🔭 LSST BUTLER→INPUT→0→EXTRA_NUMBER", prov_dict)
+        self.assertEqual(prov_dict["🔭 LSST BUTLER→RUN"], "somerun")
+        self.assertEqual(prov_dict["🔭 LSST BUTLER→INPUT→0→EXTRA_NUMBER"], 42)
+        DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
+        self.assertEqual(prov_dict, {})
+
         prov_dict = prov.to_flat_dict(None, prefix="butler", sep=" ")
         self.assertNotIn("butler run", prov_dict)
         self.assertIn("butler quantum", prov_dict)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -884,6 +884,32 @@ class DatasetRefTestCase(unittest.TestCase):
         DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
         self.assertEqual(prov_dict, {})
 
+        with self.assertRaises(ValueError):
+            prov3.to_flat_dict(empty_ref, sep="abc")
+
+        # Dictionary with inconsistent prefixes and separators.
+        test_dicts = (
+            {
+                "xyz-dataid.instrument": "LATISS",
+            },
+            {
+                "xyz-dataid-detector": 10,
+                "abc-dataid-instrument": "LATISS",
+            },
+            {
+                "abc.input.0.id": "id",
+                "xyz.input.0.run": "run",
+                "abc.dataid.instrument": "latiss",
+            },
+            {
+                "abc.input.0.id": "id0",
+                "abc input 0 id": "id1",
+            },
+        )
+        for prov_dict in test_dicts:
+            with self.assertRaises(ValueError):
+                DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
+
 
 class ZipIndexTestCase(unittest.TestCase):
     """Test that a ZipIndex can be read."""

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -779,9 +779,9 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
 
         # Check that minimal provenance was written by default.
         expected = {
-            "lsst.butler.id": str(put_ref.id),
-            "lsst.butler.run": "test_run",
-            "lsst.butler.datasettype": "data",
+            "LSST.BUTLER.ID": str(put_ref.id),
+            "LSST.BUTLER.RUN": "test_run",
+            "LSST.BUTLER.DATASETTYPE": "data",
         }
 
         self.assertEqual(tab2.meta, expected)
@@ -810,13 +810,13 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
 
         expected = {
-            "lsst.butler.id": str(put_ref.id),
-            "lsst.butler.run": "test_run",
-            "lsst.butler.datasettype": "data",
-            "lsst.butler.quantum": str(quantum_id),
-            "lsst.butler.input.0.id": str(input_ref.id),
-            "lsst.butler.input.0.run": "other_run",
-            "lsst.butler.input.0.datasettype": "astropy_parquet",
+            "LSST.BUTLER.ID": str(put_ref.id),
+            "LSST.BUTLER.RUN": "test_run",
+            "LSST.BUTLER.DATASETTYPE": "data",
+            "LSST.BUTLER.QUANTUM": str(quantum_id),
+            "LSST.BUTLER.INPUT.0.ID": str(input_ref.id),
+            "LSST.BUTLER.INPUT.0.RUN": "other_run",
+            "LSST.BUTLER.INPUT.0.DATASETTYPE": "astropy_parquet",
         }
         self.assertEqual(tab2.meta, expected)
 
@@ -827,9 +827,9 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
 
         # tab2 will have been updated in place.
         expected = {
-            "lsst.butler.id": str(put_ref3.id),
-            "lsst.butler.run": "new_run",
-            "lsst.butler.datasettype": "data",
+            "LSST.BUTLER.ID": str(put_ref3.id),
+            "LSST.BUTLER.RUN": "new_run",
+            "LSST.BUTLER.DATASETTYPE": "data",
         }
         self.assertEqual(tab2.meta, expected)
         null_prov, prov_ref = DatasetProvenance.from_flat_dict(tab2.meta, self.butler)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -777,8 +777,6 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
 
         tab2 = self.butler.get(self.datasetType, dataId={}, storageClass="ArrowAstropy")
 
-        _checkAstropyTableEquality(tab1, tab2)
-
         # Check that minimal provenance was written by default.
         expected = {
             "lsst.butler.id": str(put_ref.id),
@@ -787,6 +785,8 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         }
 
         self.assertEqual(tab2.meta, expected)
+
+        _checkAstropyTableEquality(tab1, tab2)
 
     @unittest.skipUnless(atable is not None, "Cannot test reading as astropy without astropy.")
     def testWriteReadAstropyTableProvenance(self):
@@ -2434,6 +2434,9 @@ def _checkAstropyTableEquality(table1, table2, skip_units=False, has_bigendian=F
             # Only check type matches, force to little-endian.
             assert table1.dtype[name].newbyteorder(">") == table2.dtype[name].newbyteorder(">")
 
+    # Strip provenance before comparison.
+    DatasetProvenance.strip_provenance_from_flat_dict(table1.meta)
+    DatasetProvenance.strip_provenance_from_flat_dict(table2.meta)
     assert table1.meta == table2.meta
     if not skip_units:
         for name in table1.columns:

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -156,7 +156,7 @@ def _makeSimpleNumpyTable(include_multidim=False, include_bigendian=False):
         ("ddd", "f8"),
         ("f", "i8"),
         ("strcol", "U10"),
-        ("bytecol", "a10"),
+        ("bytecol", "S10"),
         ("dtn", "datetime64[ns]"),
         ("dtu", "datetime64[us]"),
     ]

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -819,7 +819,19 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
             "lsst.butler.input.0.datasettype": "astropy_parquet",
         }
         self.assertEqual(tab2.meta, expected)
-        _checkAstropyTableEquality(tab1, tab2)
+
+        # Put the dataset again, with different provenance and ensure
+        # that the previous provenance was stripped.
+        self.butler.collections.register("new_run")
+        put_ref3 = self.butler.put(tab2, self.datasetType, dataId={}, run="new_run")
+
+        # tab2 will have been updated in place.
+        expected = {
+            "lsst.butler.id": str(put_ref3.id),
+            "lsst.butler.run": "new_run",
+            "lsst.butler.datasettype": "data",
+        }
+        self.assertEqual(tab2.meta, expected)
 
     @unittest.skipUnless(np is not None, "Cannot test reading as numpy without numpy.")
     def testWriteReadNumpyTableLossless(self):

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -832,6 +832,9 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
             "lsst.butler.datasettype": "data",
         }
         self.assertEqual(tab2.meta, expected)
+        null_prov, prov_ref = DatasetProvenance.from_flat_dict(tab2.meta, self.butler)
+        self.assertEqual(prov_ref, put_ref3)
+        self.assertEqual(null_prov, DatasetProvenance())
 
     @unittest.skipUnless(np is not None, "Cannot test reading as numpy without numpy.")
     def testWriteReadNumpyTableLossless(self):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
