### PR TITLE
DM-48974: Fix overzealous dataset query short-circuiting

### DIFF
--- a/doc/changes/DM-48974.bugfix.md
+++ b/doc/changes/DM-48974.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that could result in incorrectly empty query results when a data ID constraint was inconsistent with some dataset types in a collection, but not the on actually being queried for.

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -469,7 +469,7 @@ class DirectQueryDriver(QueryDriver):
             Column expressions to sort by.
         find_first_dataset : `str`, ``ANY_DATASET``, or `None`, optional
             Name of a dataset type for which only one result row for each data
-            ID should be returned, with the colletions searched in order.
+            ID should be returned, with the collections searched in order.
             ``ANY_DATASET`` is used to represent the search for all dataset
             types with a particular set of dimensions in ``tree.any_dataset``.
         analyze_only : `bool`, optional
@@ -538,7 +538,7 @@ class DirectQueryDriver(QueryDriver):
           with the same dimensions as a UNION ALL combination of SELECTs, in
           which each component SELECT has the joins/projection/find-first
           structure.  This cannot be implemented as a sequence of
-          `SingleSelectQueryBuilder` objets, however, since the need for the
+          `SingleSelectQueryBuilder` objects, however, since the need for the
           terms to share a single `Postprocessing` object and column list means
           that they are not independent.
 
@@ -724,7 +724,7 @@ class DirectQueryDriver(QueryDriver):
         Parameters
         ----------
         dimensions : `DimensionGroup`
-            Dimnensions of the union dataset types in this query.
+            Dimensions of the union dataset types in this query.
         collection_analysis : `CollectionAnalysis`
             Information about the collections appearing in this collection.
 
@@ -964,7 +964,7 @@ class DirectQueryDriver(QueryDriver):
         needs_validity_match_count : `bool`
             Whether this query needs a COUNT column to track the number of
             datasets for each data ID and dataset type.  If this is `False` but
-            ``postprocessing.check_valdity_match_count`` is `True`, a dummy
+            ``postprocessing.check_validity_match_count`` is `True`, a dummy
             count column that is just "1" should be added, because the check
             is needed only for some other SELECT term in a UNION ALL.
         find_first_dataset : `str` or ``ANY_DATASET`` or `None`
@@ -994,7 +994,7 @@ class DirectQueryDriver(QueryDriver):
         ]
 
         # Many of our fields derive their uniqueness from the unique_key
-        # fields: if rows are uniqe over the 'unique_key' fields, then they're
+        # fields: if rows are unique over the 'unique_key' fields, then they're
         # automatically unique over these 'derived_fields'.  We just remember
         # these as pairs of (logical_table, field) for now.
         derived_fields: list[tuple[str | qt.AnyDatasetType, str]] = []

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -1358,7 +1358,11 @@ class DirectQueryDriver(QueryDriver):
                     f"No datasets of type {result.name!r} in collection {collection_record.name!r}."
                 )
                 rejected = True
-            for governor in constraint_data_id.keys() & collection_summary.governors.keys():
+            for governor in (
+                constraint_data_id.keys()
+                & collection_summary.governors.keys()
+                & dataset_search.dimensions.names
+            ):
                 if constraint_data_id[governor] not in collection_summary.governors[governor]:
                     result.messages.append(
                         f"No datasets with {governor}={constraint_data_id[governor]!r} "

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -2396,7 +2396,7 @@ class ButlerQueryTests(ABC, TestCaseMixin):
         self.assertEqual(butler.query_datasets("a", collections=collection, skymap="SkyMap1"), [ref_a])
         # In the second case there is a dataset of a different type that is
         # inconsistent with the constraint in the collection:
-        self.assertEqual(butler.query_datasets("b", collections=collection, skymap="Cam2"), [ref_b])
+        self.assertEqual(butler.query_datasets("b", collections=collection, instrument="Cam2"), [ref_b])
 
 
 def _get_exposure_ids_from_dimension_records(dimension_records: Iterable[DimensionRecord]) -> list[int]:

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -2373,6 +2373,31 @@ class ButlerQueryTests(ABC, TestCaseMixin):
             ["51352db4-a47a-447c-b12d-a50b206b17cd", "60c8a65c-7290-4c38-b1de-e3b1cdcf872d"],
         )
 
+    def test_irrelevant_governor_constraints(self) -> None:
+        """Test that constraining an irrelevant governor dimension doesn't
+        break dataset queries.
+        """
+        butler = self.make_butler("base.yaml", "spatial.yaml")
+        butler.registry.insertDimensionData("instrument", {"name": "Cam2"})
+        a = DatasetType("a", {"detector"}, "StructuredDataDict", universe=butler.dimensions)
+        b = DatasetType("b", {"tract"}, "StructuredDataDict", universe=butler.dimensions)
+        butler.registry.registerDatasetType(a)
+        butler.registry.registerDatasetType(b)
+        collection = "run1"
+        butler.collections.register(collection)
+        (ref_a,) = butler.registry.insertDatasets(a, [{"instrument": "Cam1", "detector": 2}], run=collection)
+        (ref_b,) = butler.registry.insertDatasets(b, [{"skymap": "SkyMap1", "tract": 1}], run=collection)
+        # First, some sanity-check query that's mostly to check the test setup.
+        self.assertEqual(butler.query_datasets("a", collections=collection), [ref_a])
+        self.assertEqual(butler.query_datasets("b", collections=collection), [ref_b])
+        # Now check that we can get both with an irrelevant constraint.
+        # In the first case, there is a dataset of a different type that is
+        # consistent with the constraint in the collection:
+        self.assertEqual(butler.query_datasets("a", collections=collection, skymap="SkyMap1"), [ref_a])
+        # In the second case there is a dataset of a different type that is
+        # inconsistent with the constraint in the collection:
+        self.assertEqual(butler.query_datasets("b", collections=collection, skymap="Cam2"), [ref_b])
+
 
 def _get_exposure_ids_from_dimension_records(dimension_records: Iterable[DimensionRecord]) -> list[int]:
     output = []


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
