### PR TITLE
DM-49197: Fix astropy pformat_all deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 keywords = ["lsst"]
 dependencies = [
-    "astropy >=4.0",
+    "astropy >=7.0",
     "pyyaml >=5.1",
     "sqlalchemy >=1.4",
     "click >= 7.0",

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -123,7 +123,7 @@ def astropyTablesToStr(tables: list[Table]) -> str:
     ret = ""
     for table in tables:
         ret += "\n"
-        table.pformat_all()
+        table.pformat()
     ret += "\n"
     return ret
 

--- a/python/lsst/daf/butler/tests/utils.py
+++ b/python/lsst/daf/butler/tests/utils.py
@@ -208,8 +208,8 @@ class ButlerTestHelper:
             # Assert that they match.
             # Recommendation from Astropy Slack is to format the table into
             # lines for comparison. We do not compare column data types.
-            table1 = table.pformat_all()
-            expected1 = expected.pformat_all()
+            table1 = table.pformat()
+            expected1 = expected.pformat()
             original_max = self.maxDiff
             self.maxDiff = None  # This is required to get the full diff.
             try:


### PR DESCRIPTION
Astropy's Table.pformat_all() is now deprecated -- Table.pformat() is an exact replacement as of Astropy v7.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
