### PR TITLE
DM-49180: Check universe version before registering dataset type

### DIFF
--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -317,6 +317,16 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
             raise ValueError(
                 f"Component dataset types can not be stored in registry. Rejecting {dataset_type.name}"
             )
+
+        # If database universe and dimension group universe are different it
+        # can cause unexpected effects.
+        if dataset_type.dimensions.universe is not self._dimensions.universe:
+            raise ValueError(
+                "Incompatible dimension universe versions - "
+                f"database universe: {self._dimensions.universe}, "
+                f"dataset type universe: {dataset_type.dimensions.universe}."
+            )
+
         record = self._fetch_dataset_type_record(dataset_type.name)
         if record is None:
             if (dynamic_tables := self._cache.get_by_dimensions(dataset_type.dimensions)) is None:

--- a/python/lsst/daf/butler/tests/hybrid_butler_registry.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_registry.py
@@ -144,6 +144,16 @@ class HybridButlerRegistry(Registry):
         return self._remote.getCollectionSummary(collection)
 
     def registerDatasetType(self, datasetType: DatasetType) -> bool:
+        # We need to make sure that dataset type universe is the same as
+        # direct registry universe.
+        if datasetType.dimensions.universe is self._remote.dimensions:
+            datasetType = DatasetType(
+                datasetType.name,
+                datasetType.dimensions.names,
+                datasetType.storageClass,
+                universe=self._direct.dimensions,
+                isCalibration=datasetType.isCalibration(),
+            )
         return self._direct.registerDatasetType(datasetType)
 
     def removeDatasetType(self, name: str | tuple[str, ...]) -> None:

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -847,6 +847,16 @@ class SimpleButlerTests(TestCaseMixin):
         self.assertEqual(butler1.get_dataset_type("b"), b)
         # Register them in the opposite order in a new repo.
         butler2 = self.makeButler(writeable=True)
+        # Dataset types have to use correct universe and with RemoteButler
+        # each butler instance has its own universe instance.
+        a = DatasetType("a", ["instrument"], universe=butler2.dimensions, storageClass="StructuredDataDict")
+        b = DatasetType(
+            "b",
+            ["instrument"],
+            universe=butler2.dimensions,
+            storageClass="StructuredDataDict",
+            isCalibration=True,
+        )
         butler2.registry.registerDatasetType(b)
         butler2.registry.registerDatasetType(a)
         self.assertEqual(butler2.get_dataset_type("a"), a)


### PR DESCRIPTION
A mismatch in the universe versions causes some unexpected issues, sometimes silently. A simple version check before new dataset type registration should solve some of the cases.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
