### PR TITLE
DM-49296-v29: backport constant_rows_max adjustments

### DIFF
--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -156,7 +156,7 @@ class DirectQueryDriver(QueryDriver):
         self._exit_stack: ExitStack | None = None
         self._raw_page_size = raw_page_size
         self._postprocessing_filter_factor = postprocessing_filter_factor
-        self._constant_rows_limit = constant_rows_limit
+        self._constant_rows_limit = min(constant_rows_limit, db.get_constant_rows_max())
         self._cursors: set[_Cursor] = set()
 
     def __enter__(self) -> None:

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -398,6 +398,12 @@ class SqliteDatabase(Database):
         ]
         return sqlalchemy.sql.union_all(*selects).alias(name)
 
+    def get_constant_rows_max(self) -> int:
+        # Docstring inherited.
+        # This is the default SQLITE_MAX_COMPOUND_SELECT (see
+        # https://www.sqlite.org/limits.html):
+        return 500
+
     @property
     def has_distinct_on(self) -> bool:
         # Docstring inherited.

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1918,7 +1918,7 @@ class Database(ABC):
         This should reflect typical performance profiles (or a guess at these),
         not just hard database engine limits.
         """
-        return 100
+        return 1000
 
     @property
     @abstractmethod


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
