### PR TITLE
DM-38497: Introduce special syntax for binds

### DIFF
--- a/doc/changes/DM-38497.feature.md
+++ b/doc/changes/DM-38497.feature.md
@@ -1,0 +1,2 @@
+User expressions add support for explicit specification of bind identifiers with a preceding colon symbol.
+Legacy format of bind identifiers without colon is still supported, but will be deprecated in the future.

--- a/doc/changes/DM-38497.feature.md
+++ b/doc/changes/DM-38497.feature.md
@@ -1,2 +1,2 @@
-User expressions add support for explicit specification of bind identifiers with a preceding colon symbol.
+Add support in user expressions for explicit specification of bind identifiers with a preceding colon symbol.
 Legacy format of bind identifiers without colon is still supported, but will be deprecated in the future.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -168,7 +168,7 @@ filter query results based on that property of datasets.
 Registry methods accepting user expressions also accept a ``bind`` parameter, which is a mapping from identifier name to its corresponding value.
 Identifiers appearing in user expressions will be replaced with the corresponding value from this mapping.
 Bind identifiers in expressions are specified with a preceding colon (e.g. ``:id``).
-Legacy format where bind identifiers can be specified without colon is still supported, but discouraged, and will be deprecated and removed in the future.
+The legacy format where bind identifiers can be specified without a colon is still supported, but discouraged, and will be deprecated and removed in the future.
 Using the ``bind`` parameter is encouraged when possible to simplify rendering of the query strings.
 A partial example of comparing two approaches, without and with ``bind``:
 

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -167,6 +167,8 @@ filter query results based on that property of datasets.
 
 Registry methods accepting user expressions also accept a ``bind`` parameter, which is a mapping from identifier name to its corresponding value.
 Identifiers appearing in user expressions will be replaced with the corresponding value from this mapping.
+Bind identifiers in expressions are specified with a preceding colon (e.g. ``:id``).
+Legacy format where bind identifiers can be specified without colon is still supported, but discouraged, and will be deprecated and removed in the future.
 Using the ``bind`` parameter is encouraged when possible to simplify rendering of the query strings.
 A partial example of comparing two approaches, without and with ``bind``:
 
@@ -186,7 +188,7 @@ A partial example of comparing two approaches, without and with ``bind``:
     # Same functionality using bind parameter
     result = butler.query_datasets(
         dataset_type,
-        where="instrument = instrument_name AND visit = visit_id",
+        where="instrument = :instrument_name AND visit = :visit_id",
         bind={"instrument_name": instrument_name, "visit_id": visit_id},
     )
 
@@ -201,7 +203,7 @@ An example of this feature:
     visit_ids = (12345, 12346, 12350)
     result = butler.query_datasets(
         dataset_type,
-        where="instrument = instrument_name AND visit IN (visit_ids)",
+        where="instrument = :instrument_name AND visit IN (:visit_ids)",
         bind={"instrument_name": instrument_name, "visit_ids": visit_ids},
     )
 

--- a/python/lsst/daf/butler/queries/_expression_strings.py
+++ b/python/lsst/daf/butler/queries/_expression_strings.py
@@ -230,6 +230,13 @@ class _ConversionVisitor(TreeVisitor[_VisitorResult]):
         else:
             return _ColExpr(column_expression)
 
+    def visitBind(self, name: str, node: Node) -> _VisitorResult:
+        name = name.lower()
+        if name not in self.context.bind:
+            raise InvalidQueryError("Name {name!r} is not in the bind map.")
+        # Logic in visitIdentifier handles binds.
+        return self.visitIdentifier(name, node)
+
     def visitNumericLiteral(self, value: str, node: Node) -> _VisitorResult:
         numeric: int | float
         try:

--- a/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
@@ -1040,6 +1040,10 @@ class TransformationVisitor(TreeVisitor[TransformationWrapper]):
         # Docstring inherited from TreeVisitor.visitIdentifier
         return Opaque(node, PrecedenceTier.TOKEN)
 
+    def visitBind(self, name: str, node: Node) -> TransformationWrapper:
+        # Docstring inherited from TreeVisitor.visitBind
+        return Opaque(node, PrecedenceTier.TOKEN)
+
     def visitUnaryOp(
         self,
         operator: str,

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
@@ -256,6 +256,29 @@ class Identifier(Node):
         return "{name}".format(**vars(self))
 
 
+class BindName(Node):
+    """Node representing a bind name.
+
+    Value of the bind is its name, which is a simple identifier.
+
+    Parameters
+    ----------
+    name : str
+        Bind name.
+    """
+
+    def __init__(self, name: str):
+        Node.__init__(self)
+        self.name = name
+
+    def visit(self, visitor: TreeVisitor) -> Any:
+        # Docstring inherited from Node.visit
+        return visitor.visitBind(self.name, self)
+
+    def __str__(self) -> str:
+        return "{name}".format(**vars(self))
+
+
 class RangeLiteral(Node):
     """Node representing range literal appearing in `IN` list.
 

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/parserLex.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/parserLex.py
@@ -128,6 +128,7 @@ class ParserLex:
         # 'DURATION_LITERAL',
         "QUALIFIED_IDENTIFIER",
         "SIMPLE_IDENTIFIER",
+        "BIND_NAME",
         "LPAREN",
         "RPAREN",
         "EQ",
@@ -219,6 +220,14 @@ class ParserLex:
             t.value = reserved
         else:
             t.type = "SIMPLE_IDENTIFIER"
+        return t
+
+    # we only support ASCII in identifier names
+    def t_BIND_NAME(self, t: LexToken) -> LexToken:
+        """[:][a-zA-Z_][a-zA-Z0-9_]*"""
+        # Drop colon to get the name.
+        t.value = t.value[1:]
+        t.type = "BIND_NAME"
         return t
 
     def t_error(self, t: LexToken) -> None:

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 __all__ = ["TreeVisitor"]
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class TreeVisitor(Generic[T]):
+class TreeVisitor(Generic[T], ABC):
     """Definition of interface for visitor classes.
 
     Visitors and tree node classes implement Visitor pattern for tree
@@ -117,6 +117,18 @@ class TreeVisitor(Generic[T]):
         ----------
         name : `str`
             Identifier name.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitBind(self, name: str, node: Node) -> T:
+        """Visit BindName node.
+
+        Parameters
+        ----------
+        name : `str`
+            Bind name.
         node : `Node`
             Corresponding tree node, mostly useful for diagnostics.
         """

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1422,7 +1422,7 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.queryDatasets(
                 datasetType,
                 collections=self.default_run,
-                where="day_obs = dayObs AND instrument = instr",
+                where="day_obs = :dayObs AND instrument = :instr",
                 bind={"dayObs": dayobs, "instr": "DummyCamComp"},
             )
         )
@@ -1430,7 +1430,7 @@ class ButlerTests(ButlerPutGetTests):
             butler.registry.queryDatasets(
                 datasetType,
                 collections=self.default_run,
-                where="exposure.day_obs = dayObs AND instrument = instr",
+                where="exposure.day_obs = :dayObs AND instrument = :instr",
                 bind={"dayObs": dayobs, "instr": "DummyCamComp"},
             )
         )

--- a/tests/test_exprParserLex.py
+++ b/tests/test_exprParserLex.py
@@ -200,6 +200,29 @@ class ParserLexTestCase(unittest.TestCase):
         with self.assertRaises(ParserLexError):
             lexer.token()
 
+    def testNinds(self):
+        """Test for bind names"""
+        lexer = ParserLex.make_lexer()
+
+        lexer.input(":name :visit :in :___")
+        self._assertToken(lexer.token(), "BIND_NAME", "name")
+        self._assertToken(lexer.token(), "BIND_NAME", "visit")
+        self._assertToken(lexer.token(), "BIND_NAME", "in")
+        self._assertToken(lexer.token(), "BIND_NAME", "___")
+
+        lexer.input(":1")
+        with self.assertRaises(ParserLexError):
+            lexer.token()
+
+        lexer.input(":.id")
+        with self.assertRaises(ParserLexError):
+            lexer.token()
+
+        lexer.input(":id.")
+        self._assertToken(lexer.token(), "BIND_NAME", "id")
+        with self.assertRaises(ParserLexError):
+            lexer.token()
+
     def testExpression(self):
         """Test for more or less complete expression"""
         lexer = ParserLex.make_lexer()

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -113,7 +113,7 @@ class ConvertExpressionToPredicateTestCase(unittest.TestCase):
         """Test with bind parameters"""
         self.assertEqual(
             make_string_expression_predicate(
-                "a > b OR t in (x, y, z)",
+                ":a > :b OR :t in (:x, :y, :z)",
                 self.column_types.universe.empty,
                 column_types=self.column_types,
                 bind={"a": 1, "b": 2, "t": 0, "x": 10, "y": 20, "z": 30},
@@ -136,7 +136,7 @@ class ConvertExpressionToPredicateTestCase(unittest.TestCase):
         """Test with bind parameter which is list/tuple/set inside IN rhs."""
         self.assertEqual(
             make_string_expression_predicate(
-                "a > b OR t in (x)",
+                ":a > :b OR :t in (:x)",
                 self.column_types.universe.empty,
                 column_types=self.column_types,
                 bind={"a": 1, "b": 2, "t": 0, "x": (10, 20, 30)},
@@ -160,7 +160,7 @@ class ConvertExpressionToPredicateTestCase(unittest.TestCase):
         # of scalars and list.
         self.assertEqual(
             make_string_expression_predicate(
-                "a > b OR t in (x, y)",
+                ":a > :b OR :t in (:x, :y)",
                 self.column_types.universe.empty,
                 column_types=self.column_types,
                 bind={"a": 1, "b": 2, "t": 0, "x": 10, "y": 20},
@@ -181,7 +181,7 @@ class ConvertExpressionToPredicateTestCase(unittest.TestCase):
         )
         self.assertEqual(
             make_string_expression_predicate(
-                "a > b OR t in (x, y)",
+                ":a > :b OR :t in (:x, :y)",
                 self.column_types.universe.empty,
                 column_types=self.column_types,
                 bind={"a": 1, "b": 2, "t": 0, "x": [10, 30], "y": 20},
@@ -203,7 +203,7 @@ class ConvertExpressionToPredicateTestCase(unittest.TestCase):
         )
         self.assertEqual(
             make_string_expression_predicate(
-                "a > b OR t in (x, y)",
+                ":a > :b OR :t in (:x, :y)",
                 self.column_types.universe.empty,
                 column_types=self.column_types,
                 bind={"a": 1, "b": 2, "t": 0, "x": (10, 30), "y": {20}},

--- a/tests/test_normalFormExpression.py
+++ b/tests/test_normalFormExpression.py
@@ -28,6 +28,7 @@
 
 import random
 import unittest
+from typing import Any
 
 import astropy.time
 
@@ -44,7 +45,8 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
     boolean values for identifiers.
     """
 
-    def __init__(self, **kwargs: bool):
+    def __init__(self, binds: dict[str, Any] = {}, **kwargs: bool):
+        self.binds = binds
         self.values = kwargs
 
     def init(self, form: NormalForm) -> None:
@@ -65,6 +67,10 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
     def visitIdentifier(self, name: str, node: Node) -> bool:
         # Docstring inherited from TreeVisitor.visitIdentifier
         return self.values[name]
+
+    def visitBind(self, name: str, node: Node) -> bool:
+        # Docstring inherited from TreeVisitor.visitIdentifier
+        return self.binds[name]
 
     def visitUnaryOp(
         self,
@@ -108,6 +114,12 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
     def visitRangeLiteral(self, start: int, stop: int, stride: int | None, node: Node) -> bool:
         # Docstring inherited from TreeVisitor.visitRangeLiteral
         raise NotImplementedError()
+
+    def visitPointNode(self, ra: float, dec: float, node: Node) -> bool:
+        raise NotImplementedError("Not implemented for bool operations")
+
+    def visitTupleNode(self, items: tuple, node: Node) -> bool:
+        raise NotImplementedError("Not implemented for bool operations")
 
 
 class NormalFormExpressionTestCase(unittest.TestCase):


### PR DESCRIPTION
Expression parser adds a new syntax which specifies bind identifiers.
Those identifiers are the names prefixed with colon, e.g. `:bind_name`.
The names are presumed to be bind names, as opposed to usual identifiers
that could be either bind names or any other sort of identifiers.

Eventually we want to deprecate simple identifier use for binds, for now
there are no deprecation warnings issued for old syntax.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
