### PR TITLE
Added string length keywords to pyarrow metadata for use with `astropy.Table.read`

### DIFF
--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1222,8 +1222,10 @@ def _append_numpy_string_metadata(metadata: dict[bytes, str], name: str, dtype: 
 
     if dtype.type is np.str_:
         metadata[f"lsst::arrow::len::{name}".encode()] = str(dtype.itemsize // 4)
+        metadata[f"table::len::{name}".encode()] = str(dtype.itemsize // 4)
     elif dtype.type is np.bytes_:
         metadata[f"lsst::arrow::len::{name}".encode()] = str(dtype.itemsize)
+        metadata[f"table::len::{name}".encode()] = str(dtype.itemsize)
 
 
 def _append_numpy_multidim_metadata(metadata: dict[bytes, str], name: str, dtype: np.dtype) -> None:


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`

**Background/Context**
Variations of the warning below kept popping up when trying to read astropy `Table` objects from parquet files written by [ParquetFormatter](https://github.com/lsst/daf_butler/blob/main/python/lsst/daf/butler/formatters/parquet.py#L86):
```
>>> import pyarrow as pa
>>> from astropy.table import Table, meta
>>> from lsst.resources import ResourcePath
>>> from pyarrow import parquet
>>> pipe_tab = Table.read("/stage/spherex-data-dev/gaby/SP-1375_str_col_fmt/original_parq_file/"
                          "phot_meas_2025W17_1A_0071_1D1_simu_27389_sst_sample_20250303_20250304T205444Z.parq")
WARNING: No table::len::external_source_id found in metadata. Using longest string (19 characters). [astropy.io.misc.parquet]
```

The [_append_numpy_string_metadata function](https://github.com/lsst/daf_butler/blob/main/python/lsst/daf/butler/formatters/parquet.py#L1205C1-L1226C77) already adds the string length keys for `lsst::arrow::len{name}` to the pyarrow metadata:
```
>>> pipe_schema = parquet.read_schema(
        "/stage/spherex-data-dev/gaby/SP-1375_str_col_fmt/original_parq_file/"
        "phot_meas_2025W17_1A_0071_1D1_simu_27389_sst_sample_20250303_20250304T205444Z.parq")
>>> pipe_pa_md = md = {k.decode("UTF-8"): v.decode("UTF-8") for k, v in pipe_schema.metadata.items()}
>>> pipe_pa_md
{'lsst::arrow::rowcount': '6127',
 'lsst::arrow::len::external_source_id': '21',
 'table_meta_yaml': REDACTED}
```
Since many users look at parquet files using `astropy.Table.read`, I modified the `_append_numpy_string_metadata` function to include compatible length keywords. For more info on the astropy warning, see [here](https://github.com/astropy/astropy/blob/main/astropy/io/misc/parquet.py#L222C1-L241C14).
