### PR TITLE
DM-49509: Fix warning when reading parquet files with astropy

### DIFF
--- a/doc/changes/DM-49509.bugfix.rst
+++ b/doc/changes/DM-49509.bugfix.rst
@@ -1,0 +1,1 @@
+Added pyarrow metadata keywords for astropy table to fix warnings on read.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -1222,8 +1222,10 @@ def _append_numpy_string_metadata(metadata: dict[bytes, str], name: str, dtype: 
 
     if dtype.type is np.str_:
         metadata[f"lsst::arrow::len::{name}".encode()] = str(dtype.itemsize // 4)
+        metadata[f"table::len::{name}".encode()] = str(dtype.itemsize // 4)
     elif dtype.type is np.bytes_:
         metadata[f"lsst::arrow::len::{name}".encode()] = str(dtype.itemsize)
+        metadata[f"table::len::{name}".encode()] = str(dtype.itemsize)
 
 
 def _append_numpy_multidim_metadata(metadata: dict[bytes, str], name: str, dtype: np.dtype) -> None:


### PR DESCRIPTION
Derived from #1167 

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
