### PR TITLE
DM-49670: Add pydantic model for FileDataset

### DIFF
--- a/doc/changes/DM-49670.bugfix.md
+++ b/doc/changes/DM-49670.bugfix.md
@@ -1,0 +1,1 @@
+`Butler.ingest()` will now register missing run collections instead of raising a `MissingCollectionError`.

--- a/doc/changes/DM-49670.feature.md
+++ b/doc/changes/DM-49670.feature.md
@@ -1,0 +1,1 @@
+Added `FileDataset.to_simple` and `FileDataset.from_simple` for serializing `FileDataset` instances.

--- a/python/lsst/daf/butler/_file_dataset.py
+++ b/python/lsst/daf/butler/_file_dataset.py
@@ -95,6 +95,14 @@ class FileDataset:
         return str(self.path) < str(other.path)
 
     def to_simple(self) -> SerializedFileDataset:
+        """
+        Convert this instance to a simplified, JSON-serializable object.
+
+        Returns
+        -------
+        serialized : `SerializedFileDataset`
+            Serializable representation of this `FileDataset` instance.
+        """
         if self.formatter is None:
             formatter = None
         elif isinstance(self.formatter, str):
@@ -114,6 +122,27 @@ class FileDataset:
     def from_simple(
         dataset: SerializedFileDataset, *, dataset_type_loader: DatasetTypeLoader, universe: DimensionUniverse
     ) -> FileDataset:
+        """
+        Deserialize a `SerializedFileDataset` into a `FileDataset`.
+
+        Parameters
+        ----------
+        dataset : `SerializedFileDataset`
+            Object to deserialize.
+        dataset_type_loader : `Callable` [[ `str` ], `DatasetType` ]
+            Function that takes a string dataset type name as its
+            only parameter, and returns an instance of `DatasetType`.
+            Used to deserialize the `DatasetRef` instances contained
+            in the serialized `FileDataset`.
+        universe : `DimensionUniverse`
+            Dimension universe associated with the `Butler` instance that
+            created the serialized `FileDataset` instance.
+
+        Returns
+        -------
+        file_dataset : `FileDataset`
+            Deserialized equivalent of the input dataset.
+        """
         refs = [
             ref.to_dataset_ref(id, universe=universe, dataset_type=dataset_type_loader(ref.dataset_type_name))
             for id, ref in dataset.refs.items()

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1631,7 +1631,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         self._import_dimension_records(import_info.dimension_records, dry_run=dry_run)
         imported_refs = self._import_grouped_refs(
-            import_info.grouped_refs, self, progress, dry_run=dry_run, expand_refs=True
+            import_info.grouped_refs, None, progress, dry_run=dry_run, expand_refs=True
         )
 
         # The expanded refs need to be attached back to the original
@@ -2066,7 +2066,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
     def _import_grouped_refs(
         self,
         grouped_refs: defaultdict[_RefGroup, list[DatasetRef]],
-        source_butler: LimitedButler,
+        source_butler: LimitedButler | None,
         progress: Progress,
         *,
         dry_run: bool = False,
@@ -2087,7 +2087,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
                 # May need to create output collection. If source butler
                 # has a registry, ask for documentation string.
                 run_doc = None
-                if registry := getattr(source_butler, "registry", None):
+                if source_butler is not None and (registry := getattr(source_butler, "registry", None)):
                     run_doc = registry.getCollectionDocumentation(run)
                 if not dry_run:
                     registered = self.collections.register(run, doc=run_doc)


### PR DESCRIPTION
Add a Pydantic model for serializing `FileDataset`.  This gives Prompt Processing a way to transfer `FileDataset` objects through Kafka in order to implement [DMTN-310](https://dmtn-310.lsst.io/).

Also fixed `Butler.ingest()` to register missing run collections, instead of raising a `MissingCollectionError`.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
