### PR TITLE
DM-49791: Fix pydantic initialization failure

### DIFF
--- a/python/lsst/daf/butler/queries/tree/__init__.py
+++ b/python/lsst/daf/butler/queries/tree/__init__.py
@@ -30,10 +30,12 @@ from ._column_expression import *
 from ._column_literal import *
 from ._column_reference import *
 from ._column_set import *
+from ._predicate import InQuery as _InQuery
 from ._predicate import LogicalNot as _LogicalNot
 from ._predicate import *
 from ._query_tree import *
 
+_InQuery.model_rebuild()
 _LogicalNot.model_rebuild()
 
 Predicate.model_rebuild()


### PR DESCRIPTION
Fix issue where a new version of pydantic is failing to load QueryTree-related classes with the error "pydantic.errors.PydanticUserError: `InQuery` is not fully defined; you should define `QueryTree`, then call `InQuery.model_rebuild()`."

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
