### PR TITLE
DM-49894: Add no-op Registry.caching_context for RemoteButler

### DIFF
--- a/python/lsst/daf/butler/remote_butler/_registry.py
+++ b/python/lsst/daf/butler/remote_butler/_registry.py
@@ -128,8 +128,9 @@ class RemoteButlerRegistry(Registry):
         # Docstring inherited from a base class.
         raise NotImplementedError()
 
-    def caching_context(self) -> contextlib.AbstractContextManager[None]:
-        raise NotImplementedError()
+    @contextlib.contextmanager
+    def caching_context(self) -> Iterator[None]:
+        yield
 
     @contextlib.contextmanager
     def transaction(self, *, savepoint: bool = False) -> Iterator[None]:

--- a/python/lsst/daf/butler/tests/hybrid_butler_registry.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler_registry.py
@@ -102,8 +102,11 @@ class HybridButlerRegistry(Registry):
     def refresh_collection_summaries(self) -> None:
         self._direct.refresh_collection_summaries()
 
-    def caching_context(self) -> contextlib.AbstractContextManager[None]:
-        return self._direct.caching_context()
+    @contextlib.contextmanager
+    def caching_context(self) -> Iterator[None]:
+        with self._direct.caching_context():
+            with self._remote.caching_context():
+                yield
 
     @contextlib.contextmanager
     def transaction(self, *, savepoint: bool = False) -> Iterator[None]:


### PR DESCRIPTION
Add a stub implementation of `Registry.caching_context` for RemoteButler so that it does not throw an exception if users call it.  This method is intended only to enable optimizations, not to change behavior, so it is OK for this to be a no-op.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
