### PR TITLE
Fix typos in docstrings mentioning DAF_BUTLER_CONFIG_PATHS

### DIFF
--- a/python/lsst/daf/butler/_config.py
+++ b/python/lsst/daf/butler/_config.py
@@ -1254,7 +1254,7 @@ class ConfigSubset(Config):
 
         Global defaults, at lowest priority, are found in the ``config``
         directory of the butler source tree. Additional defaults can be
-        defined using the environment variable ``$DAF_BUTLER_CONFIG_PATHS``
+        defined using the environment variable ``$DAF_BUTLER_CONFIG_PATH``
         which is a PATH-like variable where paths at the front of the list
         have priority over those later.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,11 +42,11 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 def modified_environment(**environ):
     """Temporarily set environment variables.
 
-    >>> with modified_environment(DAF_BUTLER_CONFIG_PATHS="/somewhere"):
-    ...     os.environ["DAF_BUTLER_CONFIG_PATHS"] == "/somewhere"
+    >>> with modified_environment(DAF_BUTLER_CONFIG_PATH="/somewhere"):
+    ...     os.environ["DAF_BUTLER_CONFIG_PATH"] == "/somewhere"
     True
 
-    >>> "DAF_BUTLER_CONFIG_PATHS" != "/somewhere"
+    >>> "DAF_BUTLER_CONFIG_PATH" != "/somewhere"
     True
 
     Parameters


### PR DESCRIPTION
The correct name is DAF_BUTLER_CONFIG_PATH.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`

Does this need a towncrier entry?