### PR TITLE
DM-50465: fix query identifier handling for unqualified dimension primary keys

### DIFF
--- a/doc/changes/DM-50465.bugfix.md
+++ b/doc/changes/DM-50465.bugfix.md
@@ -1,0 +1,1 @@
+Fix handling of expressions like "id=2" in contexts where "id" resolves unambigously to a dimension primary key column.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1741,8 +1741,8 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             warn_limit = True
         with self.query() as query:
             result = (
-                query.where(data_id, where, bind=bind, **kwargs)
-                .data_ids(dimensions)
+                query.data_ids(dimensions)
+                .where(data_id, where, bind=bind, **kwargs)
                 .order_by(*ensure_iterable(order_by))
                 .limit(query_limit)
             )
@@ -1979,8 +1979,8 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             warn_limit = True
         with self.query() as query:
             result = (
-                query.where(data_id, where, bind=bind, **kwargs)
-                .dimension_records(element)
+                query.dimension_records(element)
+                .where(data_id, where, bind=bind, **kwargs)
                 .order_by(*ensure_iterable(order_by))
                 .limit(query_limit)
             )

--- a/python/lsst/daf/butler/queries/_identifiers.py
+++ b/python/lsst/daf/butler/queries/_identifiers.py
@@ -128,7 +128,10 @@ def interpret_identifier(context: IdentifierContext, identifier: str) -> ColumnE
                 )
             elif element_matches:
                 element = dimensions.universe[element_matches.pop()]
-                return DimensionFieldReference.model_construct(element=element, field=identifier)
+                if isinstance(element, Dimension) and identifier == element.primary_key.name:
+                    return DimensionKeyReference(dimension=element)
+                else:
+                    return DimensionFieldReference.model_construct(element=element, field=identifier)
             elif dataset_matches:
                 return DatasetFieldReference.model_construct(
                     dataset_type=dataset_matches.pop(), field=cast(DatasetFieldName, identifier)

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -2398,6 +2398,16 @@ class ButlerQueryTests(ABC, TestCaseMixin):
         # inconsistent with the constraint in the collection:
         self.assertEqual(butler.query_datasets("b", collections=collection, instrument="Cam2"), [ref_b])
 
+    def test_inferred_primary_key(self) -> None:
+        """Test expressions that have an unqualified reference to a primary key
+        field whose dimension must be inferred from context.
+        """
+        butler = self.make_butler("base.yaml")
+        self.assertEqual(
+            butler.query_dimension_records("detector", instrument="Cam1", where="id=2"),
+            butler.query_dimension_records("detector", instrument="Cam1", detector=2),
+        )
+
 
 def _get_exposure_ids_from_dimension_records(dimension_records: Iterable[DimensionRecord]) -> list[int]:
     output = []


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
