### PR TITLE
DM-50191: Add GLOB() function to user expression language

### DIFF
--- a/doc/changes/DM-50191.feature.md
+++ b/doc/changes/DM-50191.feature.md
@@ -1,0 +1,3 @@
+User expression language adds support for `GLOB(expression, pattern)` function.
+The function performs case-sensitive match of the string expression against pattern.
+The pattern can include `*` and `?` meta-characters that match any number or a single character.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -229,7 +229,7 @@ Comparison operators
 
 Language supports set of regular comparison operators: ``=``, ``!=``, ``<``,
 ``<=``, ``>``, ``>=``. This can be used on operands that evaluate to a numeric
-values or timestamps.
+values, timestamps, or strings.
 
 .. note :: The equality comparison operator is a single ``=`` like in SQL, not
     double ``==`` like in Python or C++.
@@ -272,7 +272,7 @@ as are these:
 
 Another usage of ``IN`` operator is for checking whether a timestamp or a time
 range is contained wholly in other time range. Time range in this case can be
-specified as a tuple of two time literals or identifers each representing a
+specified as a tuple of two time literals or identifiers each representing a
 timestamp, or as a single identifier representing a time range. In case a
 single identifier appears on the right side of ``IN`` it has to be enclosed
 in parentheses.
@@ -352,11 +352,17 @@ Function call
 Function call syntax is similar to other languages, expression for call
 consists of an identifier followed by zero or more comma-separated arguments
 enclosed in parentheses (e.g. ``func(1, 2, 3)``). An argument to a function
-can be any expression.
+can be any expression. Names of the functions are not case-sensitive.
 
-Presently there only one construct that uses this syntax, ``POINT(ra, dec)``
-is function which declares (or returns) sky coordinates similarly to ADQL
-syntax. Name of the ``POINT`` function is not case-sensitive.
+Presently there only few functions implemented in query language:
+
+- ``POINT(ra, dec)`` - function which declares (or returns) sky coordinates
+  similarly to ADQL syntax.
+- ``GLOB(expression, pattern)`` - performs case-sensitive match of a string
+  ``expression`` against ``pattern``. Pattern can include ``*`` and ``?``
+  meta-characters, matching any number of characters or a single character
+  respectfully. All other characters in pattern are matched literally, and
+  whole expression string has to match for ``GLOB()`` to return ``True``.
 
 
 .. _time-literals-syntax:

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -354,7 +354,7 @@ consists of an identifier followed by zero or more comma-separated arguments
 enclosed in parentheses (e.g. ``func(1, 2, 3)``). An argument to a function
 can be any expression. Names of the functions are not case-sensitive.
 
-Presently there only few functions implemented in query language:
+Presently the following functions are implemented in the query language:
 
 - ``POINT(ra, dec)`` - function which declares (or returns) sky coordinates
   similarly to ADQL syntax.

--- a/python/lsst/daf/butler/direct_query_driver/_sql_column_visitor.py
+++ b/python/lsst/daf/butler/direct_query_driver/_sql_column_visitor.py
@@ -156,6 +156,15 @@ class SqlColumnVisitor(
                     f"Unexpected types {a.column_type},{b.column_type} in overlaps operator."
                 )
 
+        if operator == "glob":
+            # Second operand must be a string literal.
+            if isinstance(b, qt._column_literal.StringColumnLiteral):
+                pattern = b.value
+                expression = self.expect_scalar(a)
+                return self._driver.db.glob_expression(expression, pattern)
+            else:
+                raise AssertionError(f"Unexpected pattern type ({type(b)}) in glob operator.")
+
         lhs = self.expect_scalar(a)
         rhs = self.expect_scalar(b)
         # Special case to handle awkward situation where ingest_date is not

--- a/python/lsst/daf/butler/queries/expression_factory.py
+++ b/python/lsst/daf/butler/queries/expression_factory.py
@@ -237,6 +237,22 @@ class ScalarExpressionProxy(ExpressionProxy):
         """
         return tree.Predicate.in_query(self._expression, column._expression, query._tree)
 
+    def glob(self, pattern: str) -> tree.Predicate:
+        """Return a boolean expression that matches this expression against
+        pattern.
+
+        Parameters
+        ----------
+        pattern : `str`
+            Pattern to use for matching.
+
+        Returns
+        -------
+        predicate : `tree.Predicate`
+            Boolean expression object.
+        """
+        return self._make_comparison(pattern, "glob")
+
 
 class ResolvedScalarExpressionProxy(ScalarExpressionProxy):
     """A `ScalarExpressionProxy` backed by an actual expression.

--- a/python/lsst/daf/butler/queries/tree/_predicate.py
+++ b/python/lsst/daf/butler/queries/tree/_predicate.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
     from ._column_set import ColumnSet
     from ._query_tree import QueryTree
 
-ComparisonOperator: TypeAlias = Literal["==", "!=", "<", ">", ">=", "<=", "overlaps"]
+ComparisonOperator: TypeAlias = Literal["==", "!=", "<", ">", ">=", "<=", "overlaps", "glob"]
 
 
 _L = TypeVar("_L")
@@ -564,6 +564,8 @@ class Comparison(PredicateLeafBase):
                 case ("<" | ">" | ">=" | "<=", "int" | "string" | "float" | "datetime"):
                     pass
                 case ("overlaps", "region" | "timespan"):
+                    pass
+                case ("glob", "string"):
                     pass
                 case _:
                     raise InvalidQueryError(

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -1920,6 +1920,27 @@ class Database(ABC):
         """
         return 1000
 
+    @abstractmethod
+    def glob_expression(
+        self, expression: sqlalchemy.ColumnElement[Any], pattern: str
+    ) -> sqlalchemy.ColumnElement[bool]:
+        """Produce boolean expression for expression match against glob-like
+        pattern.
+
+        Parameters
+        ----------
+        expression : `sqlalchemy.ColumnElement`
+            Column expression that evaluates to string.
+        pattern : `str`
+            GLob pattern string.
+
+        Returns
+        -------
+        glob : `sqlalchemy.ColumnElement`
+            Boolean expression that matches ``expression`` against ``pattern``.
+        """
+        raise NotImplementedError()
+
     @property
     @abstractmethod
     def has_distinct_on(self) -> bool:

--- a/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
@@ -493,3 +493,7 @@ class PredicateConversionVisitor(TreeVisitor[VisitorResult]):
         raise ExpressionTypeError(
             f"Unary operator {operator!r} is not valid for operand of type {operand.dtype!s} in {node!s}."
         )
+
+    def visitGlobNode(self, expression: VisitorResult, pattern: VisitorResult, node: Node) -> VisitorResult:
+        # Docstring inherited.
+        raise NotImplementedError("GLOB() function is not supported yet")

--- a/python/lsst/daf/butler/registry/queries/expressions/check.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/check.py
@@ -280,6 +280,11 @@ class InspectionVisitor(TreeVisitor[TreeSummary]):
         # Docstring inherited from base class
         return TreeSummary()
 
+    def visitGlobNode(self, expression: TreeSummary, pattern: TreeSummary, node: Node) -> TreeSummary:
+        # Docstring inherited from base class
+        # pattern is a literal, but expression should refer to a dimension.
+        return expression
+
 
 @dataclasses.dataclass
 class InnerSummary(InspectionSummary):

--- a/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
@@ -1093,6 +1093,12 @@ class TransformationVisitor(TreeVisitor[TransformationWrapper]):
         # Docstring inherited from TreeVisitor.visitPointNode
         raise NotImplementedError("POINT() function is not supported yet")
 
+    def visitGlobNode(
+        self, expression: TransformationWrapper, pattern: TransformationWrapper, node: Node
+    ) -> TransformationWrapper:
+        # Docstring inherited from base class
+        return Opaque(node, PrecedenceTier.TOKEN)
+
 
 class TreeReconstructionVisitor(NormalFormVisitor[Node, Node, Node]):
     """A `NormalFormVisitor` that reconstructs complete expression tree.

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 if TYPE_CHECKING:
     import astropy.time
 
-    from .exprTree import Node, PointNode, RangeLiteral
+    from .exprTree import GlobNode, Node, PointNode, RangeLiteral
 
 
 T = TypeVar("T")
@@ -230,12 +230,12 @@ class TreeVisitor(Generic[T], ABC):
 
         Notes
         -----
-        For now we only have to support one specific function ``POINT()``
-        and for that function we define special node type `PointNode`.
-        `FunctionCall` node type represents a generic function and regular
-        visitors do not handle generic function. This non-abstract method
-        is a common implementation for those visitors which raises an
-        exception.
+        For now we only have to support a small set of functions, and for those
+        functions we define special node types (e.g. `PointNode`, `GlobNode`)
+        and special visit methods. `FunctionCall` node type represents a
+        generic function and regular visitors do not handle generic function.
+        This non-abstract method is a common implementation for those visitors
+        which raises an exception.
         """
         raise ValueError(f"Unknown function '{name}' in expression")
 
@@ -249,6 +249,20 @@ class TreeVisitor(Generic[T], ABC):
             Representation of 'ra' and 'dec' values, objects returned by
             methods of this class as a result of transformation of function
             arguments.
-        node : `Node`
+        node : `PointNode`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitGlobNode(self, expression: T, pattern: T, node: GlobNode) -> T:
+        """Visit GlobNode node.
+
+        Parameters
+        ----------
+        expression, pattern : `object`
+            Representation of 'pattern' and 'expression' values, objects
+            returned by methods of this class as a result of transformation of
+            function arguments.
+        node : `GlobNode`
             Corresponding tree node, mostly useful for diagnostics.
         """

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -223,6 +223,16 @@ class ButlerQueryTests(ABC, TestCaseMixin):
                 ),
                 ids=[3, 4],
             )
+            self.check_detector_records(
+                results.where(_x.detector.full_name.glob("B?"), instrument="Cam1"), [3, 4]
+            )
+            self.check_detector_records(
+                results.where(_x.detector.full_name.glob("*a"), instrument="Cam1"), [1, 3]
+            )
+
+            # Test incorrect type for glob() parameter.
+            with self.assertRaises(InvalidQueryError):
+                results.where(_x.detector.full_name.glob(1), instrument="Cam1")  # type: ignore[arg-type]
 
     def test_simple_data_coordinate_query(self) -> None:
         butler = self.make_butler("base.yaml")

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -81,8 +81,8 @@ class _Visitor(TreeVisitor):
     def visitParens(self, expression, node):
         return f"P({expression})"
 
-    def visitPointNode(self, expression, node):
-        return f"POINT({expression})"
+    def visitPointNode(self, ra, dec, node):
+        return f"POINT({ra}, {dec})"
 
     def visitTupleNode(self, expression, node):
         return f"TUPLE({expression})"
@@ -584,6 +584,10 @@ class ParserYaccTestCase(unittest.TestCase):
         tree = parser.parse("time > T'2020-03-30'")
         result = tree.visit(visitor)
         self.assertEqual(result, "B(ID(time) > T(2020-03-30 00:00:00.000))")
+
+        tree = parser.parse("point(ra, :dec)")
+        result = tree.visit(visitor)
+        self.assertEqual(result, "POINT(ID(ra), :(dec))")
 
     def testParseTimeStr(self):
         """Test for _parseTimeString method"""

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -273,6 +273,13 @@ class InspectionVisitorTestCase(unittest.TestCase):
         self.assertIsNone(summary.dataIdKey)
         self.assertIsNone(summary.dataIdValue)
 
+        tree = parser.parse("instrument = 'LSST' AND GLOB(group, 'prefix#*')")
+        summary = tree.visit(InspectionVisitor(universe, bind))
+        self.assertEqual(summary.dimensions, {"instrument", "group"})
+        self.assertFalse(summary.columns)
+        self.assertIsNone(summary.dataIdKey)
+        self.assertIsNone(summary.dataIdValue)
+
     def test_bind(self):
         """Test for simple expressions with binds."""
         universe = DimensionUniverse()

--- a/tests/test_normalFormExpression.py
+++ b/tests/test_normalFormExpression.py
@@ -121,6 +121,9 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
     def visitTupleNode(self, items: tuple, node: Node) -> bool:
         raise NotImplementedError("Not implemented for bool operations")
 
+    def visitGlobNode(self, expression: str, pattern: str, node: Node) -> bool:
+        raise NotImplementedError("Not implemented for bool operations")
+
 
 class NormalFormExpressionTestCase(unittest.TestCase):
     """Tests for `NormalFormExpression` and its helper classes."""


### PR DESCRIPTION
Only the new query system supports `GLOB()`, old query system will raise `NotImplementedError` for it.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
