### PR TITLE
DM-50451: Add support for UUID literals to user expressions

### DIFF
--- a/doc/changes/DM-50451.feature.md
+++ b/doc/changes/DM-50451.feature.md
@@ -1,0 +1,2 @@
+User expression language adds support for UUID literals that can be used to query dataset IDs.
+UUID literals are specified using function call syntax: `UUID('hex-string')`.

--- a/doc/lsst.daf.butler/queries.rst
+++ b/doc/lsst.daf.butler/queries.rst
@@ -136,6 +136,16 @@ Time literals
     time scale. For detailed description of supported time specification
     check section :ref:`time-literals-syntax`.
 
+UUID literals
+    UUID values are produced by ``UUID()`` function which accepts a string
+    representation of the UUID. The string can have any format acceptable
+    by Python ``uuid.UUID()`` method.
+
+    Examples:
+
+    - ``UUID('12345678-1234-5678-1234-567812345678')``
+    - ``UUID('12345678123456781234567812345678')``
+
 Range literals
     This sort of literal is allowed inside ``IN`` expressions only. It consists
     of two integer literals separated by double dots and optionally followed by
@@ -441,6 +451,8 @@ Few examples of valid expressions using some of the constructs:
     visit.timespan.end < T'mjd/58938.515/tai'
 
     ingest_date < T'2020-11-06 21:10:00'
+
+    flat.dataset_id = UUID('e15ab039-bc8b-4135-87c5-90902a7c0b22')
 
 
 .. _daf_butler_query_ordering:

--- a/python/lsst/daf/butler/queries/_expression_strings.py
+++ b/python/lsst/daf/butler/queries/_expression_strings.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from collections.abc import Set
 from typing import Literal, NamedTuple, TypeAlias
+from uuid import UUID
 
 import astropy.time
 
@@ -266,6 +267,9 @@ class _ConversionVisitor(TreeVisitor[_VisitorResult]):
         return _make_literal(value)
 
     def visitTimeLiteral(self, value: astropy.time.Time, node: Node) -> _VisitorResult:
+        return _make_literal(value)
+
+    def visitUuidLiteral(self, value: UUID, node: Node) -> _VisitorResult:
         return _make_literal(value)
 
     def visitTupleNode(self, items: tuple[_VisitorResult, ...], node: Node) -> _VisitorResult:

--- a/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/_predicate.py
@@ -34,6 +34,7 @@ import types
 import warnings
 from collections.abc import Mapping, Set
 from typing import Any, cast
+from uuid import UUID
 
 import astropy.time
 import astropy.utils.exceptions
@@ -467,6 +468,10 @@ class PredicateConversionVisitor(TreeVisitor[VisitorResult]):
     def visitTimeLiteral(self, value: astropy.time.Time, node: Node) -> VisitorResult:
         # Docstring inherited.
         return ColumnExpression.literal(value, dtype=astropy.time.Time)
+
+    def visitUuidLiteral(self, value: UUID, node: Node) -> VisitorResult:
+        # Docstring inherited.
+        return ColumnExpression.literal(value, dtype=UUID)
 
     def visitTupleNode(self, items: tuple[VisitorResult, ...], node: Node) -> VisitorResult:
         # Docstring inherited.

--- a/python/lsst/daf/butler/registry/queries/expressions/check.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/check.py
@@ -35,6 +35,7 @@ __all__ = (
 import dataclasses
 from collections.abc import Mapping, Sequence, Set
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from ...._column_tags import DatasetColumnTag, DimensionKeyColumnTag, DimensionRecordColumnTag
 from ....dimensions import DataCoordinate, DataIdValue, Dimension, DimensionGroup, DimensionUniverse
@@ -207,6 +208,10 @@ class InspectionVisitor(TreeVisitor[TreeSummary]):
 
     def visitTimeLiteral(self, value: astropy.time.Time, node: Node) -> TreeSummary:
         # Docstring inherited from TreeVisitor.visitTimeLiteral
+        return TreeSummary()
+
+    def visitUuidLiteral(self, value: UUID, node: Node) -> TreeSummary:
+        # Docstring inherited from TreeVisitor.visitUuidLiteral
         return TreeSummary()
 
     def visitIdentifier(self, name: str, node: Node) -> TreeSummary:

--- a/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/normalForm.py
@@ -37,6 +37,7 @@ import enum
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from typing import Generic, TypeVar
+from uuid import UUID
 
 import astropy.time
 
@@ -1028,6 +1029,10 @@ class TransformationVisitor(TreeVisitor[TransformationWrapper]):
 
     def visitTimeLiteral(self, value: astropy.time.Time, node: Node) -> TransformationWrapper:
         # Docstring inherited from TreeVisitor.visitTimeLiteral
+        return Opaque(node, PrecedenceTier.TOKEN)
+
+    def visitUuidLiteral(self, value: UUID, node: Node) -> TransformationWrapper:
+        # Docstring inherited from TreeVisitor.visitUuidLiteral
         return Opaque(node, PrecedenceTier.TOKEN)
 
     def visitRangeLiteral(

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
@@ -136,7 +136,7 @@ class BinaryOp(Node):
     """
 
     def __init__(self, lhs: Node, op: str, rhs: Node):
-        Node.__init__(self, (lhs, rhs))
+        super().__init__((lhs, rhs))
         self.lhs = lhs
         self.op = op
         self.rhs = rhs
@@ -166,7 +166,7 @@ class UnaryOp(Node):
     """
 
     def __init__(self, op: str, operand: Node):
-        Node.__init__(self, (operand,))
+        super().__init__((operand,))
         self.op = op
         self.operand = operand
 
@@ -189,7 +189,7 @@ class StringLiteral(LiteralNode):
     """
 
     def __init__(self, value: str):
-        Node.__init__(self)
+        super().__init__()
         self.value = value
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -210,7 +210,7 @@ class TimeLiteral(LiteralNode):
     """
 
     def __init__(self, value: astropy.time.Time):
-        Node.__init__(self)
+        super().__init__()
         self.value = value
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -234,7 +234,7 @@ class NumericLiteral(LiteralNode):
     """
 
     def __init__(self, value: str):
-        Node.__init__(self)
+        super().__init__()
         self.value = value
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -279,7 +279,7 @@ class Identifier(Node):
     """
 
     def __init__(self, name: str):
-        Node.__init__(self)
+        super().__init__()
         self.name = name
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -302,7 +302,7 @@ class BindName(Node):
     """
 
     def __init__(self, name: str):
-        Node.__init__(self)
+        super().__init__()
         self.name = name
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -334,6 +334,7 @@ class RangeLiteral(LiteralNode):
     """
 
     def __init__(self, start: int, stop: int, stride: int | None = None):
+        super().__init__()
         self.start = start
         self.stop = stop
         self.stride = stride
@@ -367,7 +368,7 @@ class IsIn(Node):
             node = _strip_parens(node)
             if not isinstance(node, LiteralNode | BindName | Identifier):
                 raise TypeError(f"Unsupported type of expression in IN operator: {node}")
-        Node.__init__(self, (lhs,) + tuple(values))
+        super().__init__((lhs,) + tuple(values))
         self.lhs = lhs
         self.values = values
         self.not_in = not_in
@@ -396,7 +397,7 @@ class Parens(Node):
     """
 
     def __init__(self, expr: Node):
-        Node.__init__(self, (expr,))
+        super().__init__((expr,))
         self.expr = expr
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -422,7 +423,7 @@ class TupleNode(Node):
     """
 
     def __init__(self, items: tuple[Node, ...]):
-        Node.__init__(self, items)
+        super().__init__(items)
         self.items = items
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -447,7 +448,7 @@ class FunctionCall(Node):
     """
 
     def __init__(self, function: str, args: list[Node]):
-        Node.__init__(self, tuple(args))
+        super().__init__(tuple(args))
         self.name = function
         self.args = args[:]
 
@@ -473,7 +474,7 @@ class PointNode(Node):
     """
 
     def __init__(self, ra: Node, dec: Node):
-        Node.__init__(self, (ra, dec))
+        super().__init__((ra, dec))
         self.ra = ra
         self.dec = dec
 
@@ -501,7 +502,7 @@ class GlobNode(Node):
     """
 
     def __init__(self, expression: Identifier, pattern: StringLiteral | BindName):
-        Node.__init__(self, (expression, pattern))
+        super().__init__((expression, pattern))
         self.expression = expression
         self.pattern = pattern
 

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/exprTree.py
@@ -255,7 +255,7 @@ class UuidLiteral(LiteralNode):
     """
 
     def __init__(self, value: UUID):
-        Node.__init__(self)
+        super().__init__()
         self.value = value
 
     def visit(self, visitor: TreeVisitor) -> Any:
@@ -263,7 +263,7 @@ class UuidLiteral(LiteralNode):
         return visitor.visitUuidLiteral(self.value, self)
 
     def __str__(self) -> str:
-        return "{value}".format(**vars(self))
+        return str(self.value)
 
 
 class Identifier(Node):

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/parserYacc.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/parserYacc.py
@@ -397,7 +397,7 @@ class ParserYacc:
         # include only literals and bind names (and identifiers as we still
         # allow simple identifiers as bind names). UUID literal is implemented
         # via UUID() function call, so we need to allow function calls here
-        # too. IsIn will check that all operands are literlas or binds.
+        # too. IsIn will check that all operands are literals or binds.
         if len(p) == 2:
             p[0] = [p[1]]
         else:

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/parserYacc.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/parserYacc.py
@@ -354,8 +354,8 @@ class ParserYacc:
 
     @classmethod
     def p_predicate(cls, p: YaccProduction) -> None:
-        """predicate : bit_expr IN LPAREN literal_or_id_list RPAREN
-        | bit_expr NOT IN LPAREN literal_or_id_list RPAREN
+        """predicate : bit_expr IN LPAREN literal_or_bind_list RPAREN
+        | bit_expr NOT IN LPAREN literal_or_bind_list RPAREN
         | bit_expr
         """
         if len(p) == 6:
@@ -366,21 +366,38 @@ class ParserYacc:
             p[0] = p[1]
 
     @classmethod
-    def p_identifier(cls, p: YaccProduction) -> None:
-        """identifier : SIMPLE_IDENTIFIER
-        | QUALIFIED_IDENTIFIER
-        """
+    def p_simple_id(cls, p: YaccProduction) -> None:
+        """simple_id : SIMPLE_IDENTIFIER"""
         p[0] = Identifier(p[1])
 
     @classmethod
-    def p_literal_or_id_list(cls, p: YaccProduction) -> None:
-        """literal_or_id_list : literal_or_id_list COMMA literal
-        | literal_or_id_list COMMA identifier
-        | literal_or_id_list COMMA bind_name
-        | literal
-        | identifier
-        | bind_name
+    def p_qualified_id(cls, p: YaccProduction) -> None:
+        """qualified_id : QUALIFIED_IDENTIFIER"""
+        p[0] = Identifier(p[1])
+
+    @classmethod
+    def p_identifier(cls, p: YaccProduction) -> None:
+        """identifier : simple_id
+        | qualified_id
         """
+        p[0] = p[1]
+
+    @classmethod
+    def p_literal_or_id_list(cls, p: YaccProduction) -> None:
+        """literal_or_bind_list : literal_or_bind_list COMMA literal
+        | literal_or_bind_list COMMA simple_id
+        | literal_or_bind_list COMMA bind_name
+        | literal_or_bind_list COMMA function_call
+        | literal
+        | simple_id
+        | bind_name
+        | function_call
+        """
+        # This expression is only used in IN() operator and it is supposed to
+        # include only literals and bind names (and identifiers as we still
+        # allow simple identifiers as bind names). UUID literal is implemented
+        # via UUID() function call, so we need to allow function calls here
+        # too. IsIn will check that all operands are literlas or binds.
         if len(p) == 2:
             p[0] = [p[1]]
         else:

--- a/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
+++ b/python/lsst/daf/butler/registry/queries/expressions/parser/treeVisitor.py
@@ -31,6 +31,7 @@ __all__ = ["TreeVisitor"]
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Generic, TypeVar
+from uuid import UUID
 
 if TYPE_CHECKING:
     import astropy.time
@@ -76,6 +77,18 @@ class TreeVisitor(Generic[T], ABC):
         ----------
         value : `str`
             The value associated with the visited node.
+        node : `Node`
+            Corresponding tree node, mostly useful for diagnostics.
+        """
+
+    @abstractmethod
+    def visitUuidLiteral(self, value: UUID, node: Node) -> T:
+        """Visit UuidLiteral node.
+
+        Parameters
+        ----------
+        value : `UUID`
+            The value associated with the visited node, the value is UUID.
         node : `Node`
             Corresponding tree node, mostly useful for diagnostics.
         """

--- a/tests/test_exprParserYacc.py
+++ b/tests/test_exprParserYacc.py
@@ -53,6 +53,9 @@ class _Visitor(TreeVisitor):
     def visitTimeLiteral(self, value, node):
         return f"T({value})"
 
+    def visitUuidLiteral(self, value, node):
+        return f"UUID({value})"
+
     def visitRangeLiteral(self, start, stop, stride, node):
         if stride is None:
             return f"R({start}..{stop})"
@@ -354,6 +357,21 @@ class ParserYaccTestCase(unittest.TestCase):
         self.assertIsInstance(tree.values[1], exprTree.BindName)
         self.assertIsInstance(tree.values[2], exprTree.Identifier)
         self.assertIsInstance(tree.values[3], exprTree.NumericLiteral)
+
+        expr = (
+            "id in ("
+            "UUID('38a42b54-0822-4dce-93b7-47e9b0d8ad66'), "
+            "UUID('782fb690-281a-4787-9b6e-f5324a9b6369'), "
+            ":uuid"
+            ")"
+        )
+        tree = parser.parse(expr)
+        self.assertIsInstance(tree, exprTree.IsIn)
+        self.assertIsInstance(tree.lhs, exprTree.Identifier)
+        self.assertEqual(len(tree.values), 3)
+        self.assertIsInstance(tree.values[0], exprTree.UuidLiteral)
+        self.assertIsInstance(tree.values[1], exprTree.UuidLiteral)
+        self.assertIsInstance(tree.values[2], exprTree.BindName)
 
         # parens on right hand side are required
         with self.assertRaises(ParseError):

--- a/tests/test_normalFormExpression.py
+++ b/tests/test_normalFormExpression.py
@@ -29,6 +29,7 @@
 import random
 import unittest
 from typing import Any
+from uuid import UUID
 
 import astropy.time
 
@@ -62,6 +63,10 @@ class BooleanEvaluationTreeVisitor(TreeVisitor[bool]):
 
     def visitTimeLiteral(self, value: astropy.time.Time, node: Node) -> bool:
         # Docstring inherited from TreeVisitor.visitTimeLiteral
+        raise NotImplementedError()
+
+    def visitUuidLiteral(self, value: UUID, node: Node) -> bool:
+        # Docstring inherited from TreeVisitor.visitUuidLiteral
         raise NotImplementedError()
 
     def visitIdentifier(self, name: str, node: Node) -> bool:


### PR DESCRIPTION
Queries on `dataset_id` were already working, but the only way to use
them was to provide UUID via bind parameters. This patch adds new
UUID literal type to parser which is specified in expression string
via function call `UUID('hex-string')`.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
