### PR TITLE
DM-50727: Change pruneDatasets to only prune the requested datasets

### DIFF
--- a/doc/changes/DM-50727.misc.rst
+++ b/doc/changes/DM-50727.misc.rst
@@ -1,0 +1,1 @@
+Modified trash emptying in datastore such that only the datasets to be removed as part of the original butler request are the ones that are trashed immediately.

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -516,8 +516,9 @@ class QuantumBackedButler(LimitedButler):
                 self._actual_output_refs.discard(ref)
 
         if unstore:
-            # Point of no return for removing artifacts
-            self._datastore.emptyTrash()
+            # Point of no return for removing artifacts. Only try to remove
+            # refs associated with this pruning.
+            self._datastore.emptyTrash(refs=refs)
 
     def retrieve_artifacts_zip(
         self,

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -1160,7 +1160,9 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def emptyTrash(self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None) -> None:
+    def emptyTrash(
+        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None
+    ) -> set[ResourcePath]:
         """Remove all datasets from the trash.
 
         Parameters
@@ -1172,6 +1174,12 @@ class Datastore(metaclass=ABCMeta):
             datasets are not already stored in the trash table they will be
             ignored. If `None` every entry in the trash table will be
             processed.
+
+        Returns
+        -------
+        removed : `set` [ `lsst.resources.ResourcePath` ]
+            List of artifacts that were removed. Can return nothing if
+            artifacts cannot be represented by URIs.
 
         Notes
         -----
@@ -1517,7 +1525,9 @@ class NullDatastore(Datastore):
     def trash(self, ref: DatasetRef | Iterable[DatasetRef], ignore_errors: bool = True) -> None:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
-    def emptyTrash(self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None) -> None:
+    def emptyTrash(
+        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None
+    ) -> set[ResourcePath]:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
     def transfer(self, inputDatastore: Datastore, datasetRef: DatasetRef) -> None:

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -1160,13 +1160,18 @@ class Datastore(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by subclass")
 
     @abstractmethod
-    def emptyTrash(self, ignore_errors: bool = True) -> None:
+    def emptyTrash(self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None) -> None:
         """Remove all datasets from the trash.
 
         Parameters
         ----------
         ignore_errors : `bool`, optional
             Determine whether errors should be ignored.
+        refs : `collections.abc.Collection` [ `DatasetRef` ] or `None`
+            Explicit list of datasets that can be removed from trash. If listed
+            datasets are not already stored in the trash table they will be
+            ignored. If `None` every entry in the trash table will be
+            processed.
 
         Notes
         -----
@@ -1512,7 +1517,7 @@ class NullDatastore(Datastore):
     def trash(self, ref: DatasetRef | Iterable[DatasetRef], ignore_errors: bool = True) -> None:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
-    def emptyTrash(self, ignore_errors: bool = True) -> None:
+    def emptyTrash(self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None) -> None:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
     def transfer(self, inputDatastore: Datastore, datasetRef: DatasetRef) -> None:

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -1161,7 +1161,7 @@ class Datastore(metaclass=ABCMeta):
 
     @abstractmethod
     def emptyTrash(
-        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None
+        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None, dry_run: bool = False
     ) -> set[ResourcePath]:
         """Remove all datasets from the trash.
 
@@ -1174,6 +1174,9 @@ class Datastore(metaclass=ABCMeta):
             datasets are not already stored in the trash table they will be
             ignored. If `None` every entry in the trash table will be
             processed.
+        dry_run : `bool`, optional
+            If `True`, the trash table will be queried and results reported
+            but no artifacts will be removed.
 
         Returns
         -------
@@ -1526,7 +1529,7 @@ class NullDatastore(Datastore):
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 
     def emptyTrash(
-        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None
+        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None, dry_run: bool = False
     ) -> set[ResourcePath]:
         raise NotImplementedError("This is a no-op datastore that can not access a real datastore")
 

--- a/python/lsst/daf/butler/datastore/generic_base.py
+++ b/python/lsst/daf/butler/datastore/generic_base.py
@@ -80,7 +80,7 @@ class GenericBaseDatastore(Datastore, Generic[_InfoType]):
         encountered during removal are not ignored.
         """
         self.trash(ref, ignore_errors=False)
-        self.emptyTrash(ignore_errors=False)
+        self.emptyTrash(ignore_errors=False, refs=[ref])
 
     def transfer(self, inputDatastore: Datastore, ref: DatasetRef) -> None:
         """Retrieve a dataset from an input `Datastore`,
@@ -89,7 +89,7 @@ class GenericBaseDatastore(Datastore, Generic[_InfoType]):
         Parameters
         ----------
         inputDatastore : `Datastore`
-            The external `Datastore` from which to retreive the Dataset.
+            The external `Datastore` from which to retrieve the Dataset.
         ref : `DatasetRef`
             Reference to the required dataset in the input data store.
         """

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -1028,9 +1028,13 @@ class ChainedDatastore(Datastore):
             else:
                 raise FileNotFoundError(err_msg)
 
-    def emptyTrash(self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None) -> None:
+    def emptyTrash(
+        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None
+    ) -> set[ResourcePath]:
+        removed = set()
         for datastore in self.datastores:
-            datastore.emptyTrash(ignore_errors=ignore_errors, refs=refs)
+            removed.update(datastore.emptyTrash(ignore_errors=ignore_errors, refs=refs))
+        return removed
 
     def transfer(self, inputDatastore: Datastore, ref: DatasetRef) -> None:
         """Retrieve a dataset from an input `Datastore`,

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -999,7 +999,7 @@ class ChainedDatastore(Datastore):
         """
         log.debug("Removing %s", ref)
         self.trash(ref, ignore_errors=False)
-        self.emptyTrash(ignore_errors=False)
+        self.emptyTrash(ignore_errors=False, refs=[ref])
 
     def forget(self, refs: Iterable[DatasetRef]) -> None:
         for datastore in tuple(self.datastores):
@@ -1028,9 +1028,9 @@ class ChainedDatastore(Datastore):
             else:
                 raise FileNotFoundError(err_msg)
 
-    def emptyTrash(self, ignore_errors: bool = True) -> None:
+    def emptyTrash(self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None) -> None:
         for datastore in self.datastores:
-            datastore.emptyTrash(ignore_errors=ignore_errors)
+            datastore.emptyTrash(ignore_errors=ignore_errors, refs=refs)
 
     def transfer(self, inputDatastore: Datastore, ref: DatasetRef) -> None:
         """Retrieve a dataset from an input `Datastore`,
@@ -1039,7 +1039,7 @@ class ChainedDatastore(Datastore):
         Parameters
         ----------
         inputDatastore : `Datastore`
-            The external `Datastore` from which to retreive the Dataset.
+            The external `Datastore` from which to retrieve the Dataset.
         ref : `DatasetRef`
             Reference to the required dataset in the input data store.
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -1029,11 +1029,11 @@ class ChainedDatastore(Datastore):
                 raise FileNotFoundError(err_msg)
 
     def emptyTrash(
-        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None
+        self, ignore_errors: bool = True, refs: Collection[DatasetRef] | None = None, dry_run: bool = False
     ) -> set[ResourcePath]:
         removed = set()
         for datastore in self.datastores:
-            removed.update(datastore.emptyTrash(ignore_errors=ignore_errors, refs=refs))
+            removed.update(datastore.emptyTrash(ignore_errors=ignore_errors, refs=refs, dry_run=dry_run))
         return removed
 
     def transfer(self, inputDatastore: Datastore, ref: DatasetRef) -> None:

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2684,15 +2684,22 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             if not artifacts_to_delete:
                 return set()
 
-            # Now do the deleting.
-            s_del = "s" if len(artifacts_to_delete) != 1 else ""
-            log.verbose(
-                "%s removing %d file artifact%s from datastore %s",
-                "Would be" if dry_run else "Now",
-                len(artifacts_to_delete),
-                s_del,
-                self.name,
-            )
+            # Now do the deleting. Special case the log message for a single
+            # artifact.
+            if len(artifacts_to_delete) == 1:
+                log.verbose(
+                    "%s removing file artifact %s from datastore %s",
+                    "Would be" if dry_run else "Now",
+                    list(artifacts_to_delete)[0],
+                    self.name,
+                )
+            else:
+                log.verbose(
+                    "%s removing %d file artifacts from datastore %s",
+                    "Would be" if dry_run else "Now",
+                    len(artifacts_to_delete),
+                    self.name,
+                )
 
             # For dry-run mode do not attempt to search the file store for
             # the artifacts to determine whether they exist or not. Simply
@@ -2732,7 +2739,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                         len(exceptions),
                         s_err,
                         len(artifacts_to_delete),
-                        s_del,
+                        "s" if len(artifacts_to_delete) != 1 else "",
                         self.name,
                         e,
                     )

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -628,7 +628,7 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
             self._trashedIds.update(ref.id for ref in ref_list)
 
     def emptyTrash(
-        self, ignore_errors: bool = False, refs: Collection[DatasetRef] | None = None
+        self, ignore_errors: bool = False, refs: Collection[DatasetRef] | None = None, dry_run: bool = False
     ) -> set[ResourcePath]:
         """Remove all datasets from the trash.
 
@@ -641,6 +641,9 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
             datasets are not already stored in the trash table they will be
             ignored. If `None` every entry in the trash table will be
             processed.
+        dry_run : `bool`, optional
+            If `True`, the trash table will be queried and results reported
+            but no artifacts will be removed.
 
         Returns
         -------
@@ -664,6 +667,12 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
             selected_ids = {ref.id for ref in refs}
             if selected_ids is not None:
                 trashed_ids = {tid for tid in trashed_ids if tid in selected_ids}
+
+        if dry_run:
+            log.info(
+                "Would attempt remove %s dataset%s.", len(trashed_ids), "s" if len(trashed_ids) != 1 else ""
+            )
+            return set()
 
         for dataset_id in trashed_ids:
             try:

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -627,7 +627,9 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
         with self._transaction.undoWith(f"Trash {len(ref_list)} datasets", _rollbackMoveToTrash, ref_list):
             self._trashedIds.update(ref.id for ref in ref_list)
 
-    def emptyTrash(self, ignore_errors: bool = False, refs: Collection[DatasetRef] | None = None) -> None:
+    def emptyTrash(
+        self, ignore_errors: bool = False, refs: Collection[DatasetRef] | None = None
+    ) -> set[ResourcePath]:
         """Remove all datasets from the trash.
 
         Parameters
@@ -639,6 +641,11 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
             datasets are not already stored in the trash table they will be
             ignored. If `None` every entry in the trash table will be
             processed.
+
+        Returns
+        -------
+        removed : `set` [ `lsst.resources.ResourcePath` ]
+            List of artifacts that were removed. Empty for this datastore.
 
         Notes
         -----
@@ -689,6 +696,7 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
 
         # Empty the trash table
         self._trashedIds = self._trashedIds - trashed_ids
+        return set()
 
     def validateConfiguration(
         self, entities: Iterable[DatasetRef | DatasetType | StorageClass], logFailures: bool = False

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -33,7 +33,7 @@ __all__ = ("InMemoryDatastore", "StoredMemoryItemInfo")
 
 import logging
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Collection, Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
@@ -627,13 +627,18 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
         with self._transaction.undoWith(f"Trash {len(ref_list)} datasets", _rollbackMoveToTrash, ref_list):
             self._trashedIds.update(ref.id for ref in ref_list)
 
-    def emptyTrash(self, ignore_errors: bool = False) -> None:
+    def emptyTrash(self, ignore_errors: bool = False, refs: Collection[DatasetRef] | None = None) -> None:
         """Remove all datasets from the trash.
 
         Parameters
         ----------
         ignore_errors : `bool`, optional
             Ignore errors.
+        refs : `collections.abc.Collection` [ `DatasetRef` ] or `None`
+            Explicit list of datasets that can be removed from trash. If listed
+            datasets are not already stored in the trash table they will be
+            ignored. If `None` every entry in the trash table will be
+            processed.
 
         Notes
         -----
@@ -647,7 +652,13 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
         """
         log.debug("Emptying trash in datastore %s", self.name)
 
-        for dataset_id in self._trashedIds:
+        trashed_ids = self._trashedIds
+        if refs:
+            selected_ids = {ref.id for ref in refs}
+            if selected_ids is not None:
+                trashed_ids = {tid for tid in trashed_ids if tid in selected_ids}
+
+        for dataset_id in trashed_ids:
             try:
                 realID, _ = self._get_dataset_info(dataset_id)
             except FileNotFoundError:
@@ -677,7 +688,7 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
             self._remove_stored_item_info(dataset_id)
 
         # Empty the trash table
-        self._trashedIds = set()
+        self._trashedIds = self._trashedIds - trashed_ids
 
     def validateConfiguration(
         self, entities: Iterable[DatasetRef | DatasetType | StorageClass], logFailures: bool = False

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1470,8 +1470,10 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             for name in names:
                 self._registry.removeCollection(name)
         if unstore:
-            # Point of no return for removing artifacts
-            self._datastore.emptyTrash()
+            # Point of no return for removing artifacts. Restrict the trash
+            # emptying to the datasets from this specific collection rather
+            # than everything in the trash.
+            self._datastore.emptyTrash(refs=refs)
 
     def pruneDatasets(
         self,
@@ -1535,8 +1537,9 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # deleting everything on disk and in private Datastore tables that is
         # in the dataset_location_trash table.
         if unstore:
-            # Point of no return for removing artifacts
-            self._datastore.emptyTrash()
+            # Point of no return for removing artifacts. Restrict the trash
+            # emptying to the refs that this call trashed.
+            self._datastore.emptyTrash(refs=refs)
 
     @transactional
     def ingest_zip(self, zip_file: ResourcePathExpression, transfer: str = "auto") -> None:

--- a/python/lsst/daf/butler/registry/bridge/ephemeral.py
+++ b/python/lsst/daf/butler/registry/bridge/ephemeral.py
@@ -101,6 +101,7 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         record_class: type[StoredDatastoreItemInfo] | None = None,
         record_column: str | None = None,
         selected_ids: Collection[DatasetId] | None = None,
+        dry_run: bool = False,
     ) -> Iterator[tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]]:
         # Docstring inherited from DatastoreRegistryBridge
         matches: Iterable[tuple[FakeDatasetRef, StoredDatastoreItemInfo | None]] = ()
@@ -123,6 +124,9 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         # Indicate to caller that we do not know about artifacts that
         # should be retained.
         yield ((matches, None))
+
+        if dry_run:
+            return
 
         if isinstance(records_table, OpaqueTableStorage):
             # Remove the records entries

--- a/python/lsst/daf/butler/registry/bridge/ephemeral.py
+++ b/python/lsst/daf/butler/registry/bridge/ephemeral.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 __all__ = ("EphemeralDatastoreRegistryBridge",)
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Collection, Iterable, Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -100,19 +100,25 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         records_table: OpaqueTableStorage | None = None,
         record_class: type[StoredDatastoreItemInfo] | None = None,
         record_column: str | None = None,
+        selected_ids: Collection[DatasetId] | None = None,
     ) -> Iterator[tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]]:
         # Docstring inherited from DatastoreRegistryBridge
         matches: Iterable[tuple[FakeDatasetRef, StoredDatastoreItemInfo | None]] = ()
+        trashed_ids = self._trashedIds
+
+        if selected_ids is not None:
+            trashed_ids = {tid for tid in trashed_ids if tid in selected_ids}
+
         if isinstance(records_table, OpaqueTableStorage):
             if record_class is None:
                 raise ValueError("Record class must be provided if records table is given.")
             matches = (
                 (FakeDatasetRef(id), record_class.from_record(record))
-                for id in self._trashedIds
+                for id in trashed_ids
                 for record in records_table.fetch(dataset_id=id)
             )
         else:
-            matches = ((FakeDatasetRef(id), None) for id in self._trashedIds)
+            matches = ((FakeDatasetRef(id), None) for id in trashed_ids)
 
         # Indicate to caller that we do not know about artifacts that
         # should be retained.
@@ -120,8 +126,8 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
 
         if isinstance(records_table, OpaqueTableStorage):
             # Remove the records entries
-            records_table.delete(["dataset_id"], *[{"dataset_id": id} for id in self._trashedIds])
+            records_table.delete(["dataset_id"], *[{"dataset_id": id} for id in trashed_ids])
 
         # Empty the trash table
-        self._datasetIds.difference_update(self._trashedIds)
-        self._trashedIds = set()
+        self._datasetIds.difference_update(trashed_ids)
+        self._trashedIds = self._trashedIds - trashed_ids

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -211,6 +211,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         record_class: type[StoredDatastoreItemInfo] | None = None,
         record_column: str | None = None,
         selected_ids: Collection[DatasetId] | None = None,
+        dry_run: bool = False,
     ) -> Iterator[tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]]:
         # Docstring inherited from DatastoreRegistryBridge
 
@@ -294,7 +295,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
         yield ((id_info, preserved))
 
         # No exception raised in context manager block.
-        if not rows:
+        if not rows or dry_run:
             return
 
         # Delete the rows from the records table

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -278,14 +278,16 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
                 items_in_trash = items_in_trash.where(
                     self._tables.dataset_location_trash.columns["dataset_id"].in_(selected_ids)
                 )
-            items_in_trash = items_in_trash.alias("items_in_trash")
+            items_in_trash_alias = items_in_trash.alias("items_in_trash")
 
             # A query for paths that are referenced by datasets in the trash
             # and datasets not in the trash.
-            items_to_preserve = sqlalchemy.sql.select(items_in_trash.columns[record_column]).select_from(
+            items_to_preserve = sqlalchemy.sql.select(
+                items_in_trash_alias.columns[record_column]
+            ).select_from(
                 items_not_in_trash.join(
-                    items_in_trash,
-                    onclause=items_in_trash.columns[record_column]
+                    items_in_trash_alias,
+                    onclause=items_in_trash_alias.columns[record_column]
                     == items_not_in_trash.columns[record_column],
                 )
             )

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 __all__ = ("DatasetIdRef", "DatastoreRegistryBridge", "DatastoreRegistryBridgeManager", "FakeDatasetRef")
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any
 
@@ -191,6 +191,7 @@ class DatastoreRegistryBridge(ABC):
         records_table: OpaqueTableStorage | None = None,
         record_class: type[StoredDatastoreItemInfo] | None = None,
         record_column: str | None = None,
+        selected_ids: Collection[DatasetId] | None = None,
     ) -> AbstractContextManager[
         tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]
     ]:
@@ -206,6 +207,13 @@ class DatastoreRegistryBridge(ABC):
             Class to use when reading records from ``records_table``.
         record_column : `str`, optional
             Name of the column in records_table that refers to the artifact.
+        selected_ids : `collections.abc.Collection` [ `DatasetId` ] \
+                or `None`, optional
+            If provided, collection of IDs that should be trashed. Only records
+            within this selection will be yielded and then removed. This
+            can be used to allow a subset of the trash table to be emptied.
+            If an empty set is given no artifacts will be trashed. If `None`
+            the full list from the trash table will be used.
 
         Yields
         ------

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -192,6 +192,7 @@ class DatastoreRegistryBridge(ABC):
         record_class: type[StoredDatastoreItemInfo] | None = None,
         record_column: str | None = None,
         selected_ids: Collection[DatasetId] | None = None,
+        dry_run: bool = False,
     ) -> AbstractContextManager[
         tuple[Iterable[tuple[DatasetIdRef, StoredDatastoreItemInfo | None]], set[str] | None]
     ]:
@@ -214,6 +215,9 @@ class DatastoreRegistryBridge(ABC):
             can be used to allow a subset of the trash table to be emptied.
             If an empty set is given no artifacts will be trashed. If `None`
             the full list from the trash table will be used.
+        dry_run : `bool`, optional
+            If `True`, the trash table will be queried and results reported
+            but no artifacts will be removed.
 
         Yields
         ------


### PR DESCRIPTION
Rather than emptyTrash always trying to clear the entire trash table, add the ability to constrain the removal by a specific set of refs (that generally are the refs that were just pruned). Also take the opportunity to chunk deletes into 50,000 files to reduce the size of transactions that could involve a million files.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
