### PR TITLE
DM-50823: Work with click 8.1 and 8.2

### DIFF
--- a/doc/changes/DM-50823.misc.rst
+++ b/doc/changes/DM-50823.misc.rst
@@ -1,0 +1,1 @@
+Modified CLI tooling to work with both click 8.1 and click 8.2.

--- a/python/lsst/daf/butler/cli/butler.py
+++ b/python/lsst/daf/butler/cli/butler.py
@@ -102,7 +102,7 @@ class PluginCommand:
     """Where the command came from (`str`)."""
 
 
-class LoaderCLI(click.MultiCommand, abc.ABC):
+class LoaderCLI(click.Group, abc.ABC):
     """Extends `click.MultiCommand`, which dispatches to subcommands, to load
     subcommands at runtime.
 

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -55,6 +55,7 @@ __all__ = (
 )
 
 
+import importlib.metadata
 import itertools
 import logging
 import os
@@ -76,6 +77,7 @@ import click
 import click.exceptions
 import click.testing
 import yaml
+from packaging.version import Version
 
 from lsst.utils.iteration import ensure_iterable
 
@@ -86,6 +88,12 @@ if TYPE_CHECKING:
     from astropy.table import Table
 
     from lsst.daf.butler import Dimension
+
+_click_version = Version(importlib.metadata.version("click"))
+if _click_version >= Version("8.2.0"):
+    _click_make_metavar_has_context = True
+else:
+    _click_make_metavar_has_context = False
 
 log = logging.getLogger(__name__)
 
@@ -765,7 +773,10 @@ class MWOption(click.Option):
         transformation that must apply to all types should be applied in
         get_help_record.
         """
-        metavar = super().make_metavar(ctx=ctx)  # type:ignore
+        if _click_make_metavar_has_context:
+            metavar = super().make_metavar(ctx=ctx)  # type: ignore
+        else:
+            metavar = super().make_metavar()  # type: ignore
         if self.multiple and self.nargs == 1:
             metavar += " ..."
         elif self.nargs != 1:
@@ -798,7 +809,10 @@ class MWArgument(click.Argument):
         metavar : `str`
             The metavar value.
         """
-        metavar = super().make_metavar(ctx=ctx)  # type: ignore
+        if _click_make_metavar_has_context:
+            metavar = super().make_metavar(ctx=ctx)  # type: ignore
+        else:
+            metavar = super().make_metavar()  # type: ignore
         if self.nargs != 1:
             metavar = f"{metavar[:-3]} ..."
         return metavar

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -741,9 +741,16 @@ class MWPath(click.Path):
 class MWOption(click.Option):
     """Overrides click.Option with desired behaviors."""
 
-    def make_metavar(self) -> str:
+    def make_metavar(self, ctx: click.Context | None = None) -> str:
         """Make the metavar for the help menu.
 
+        Parameters
+        ----------
+        ctx : `click.Context` or `None`
+            Context from the command.
+
+        Notes
+        -----
         Overrides `click.Option.make_metavar`.
         Adds a space and an ellipsis after the metavar name if
         the option accepts multiple inputs, otherwise defers to the base
@@ -758,7 +765,7 @@ class MWOption(click.Option):
         transformation that must apply to all types should be applied in
         get_help_record.
         """
-        metavar = super().make_metavar()
+        metavar = super().make_metavar(ctx=ctx)  # type:ignore
         if self.multiple and self.nargs == 1:
             metavar += " ..."
         elif self.nargs != 1:
@@ -769,9 +776,16 @@ class MWOption(click.Option):
 class MWArgument(click.Argument):
     """Overrides click.Argument with desired behaviors."""
 
-    def make_metavar(self) -> str:
+    def make_metavar(self, ctx: click.Context | None = None) -> str:
         """Make the metavar for the help menu.
 
+        Parameters
+        ----------
+        ctx : `click.Context` or `None`
+            Context from the command.
+
+        Notes
+        -----
         Overrides `click.Option.make_metavar`.
         Always adds a space and an ellipsis (' ...') after the
         metavar name if the option accepts multiple inputs.
@@ -784,7 +798,7 @@ class MWArgument(click.Argument):
         metavar : `str`
             The metavar value.
         """
-        metavar = super().make_metavar()
+        metavar = super().make_metavar(ctx=ctx)  # type: ignore
         if self.nargs != 1:
             metavar = f"{metavar[:-3]} ..."
         return metavar

--- a/python/lsst/daf/butler/tests/cliCmdTestBase.py
+++ b/python/lsst/daf/butler/tests/cliCmdTestBase.py
@@ -174,7 +174,7 @@ class CliCmdTestBase(abc.ABC):
         """
         result = self.run_command(inputs)
         self.assertNotEqual(result.exit_code, 0, clickResultMsg(result))
-        self.assertRegex(result.stdout, expectedMsg)
+        self.assertRegex(result.output, expectedMsg)
 
     def test_help(self) -> None:
         self.assertFalse(

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -411,9 +411,9 @@ lsst-daf-relation==28.2025.900 \
     --hash=sha256:77cdb15f6c72f37bedb576d419cc757b4e8e685caa283f830220a142b21da1ce \
     --hash=sha256:dae0433e9e009aa9814324392daa8860afc10ec77d8cad2b84f3ed0baad814d9
     # via -r ./docker.in
-lsst-resources==29.2025.1200 \
-    --hash=sha256:957cc5dafdf4752982d63fc74415a83d919a4027e51f604e800323e0418fefe7 \
-    --hash=sha256:a677b82f817d983905bcdf741f2daa37770beb477bbb327b7bc43c35ac8403eb
+lsst-resources==29.2025.1900 \
+    --hash=sha256:156078d48f963c647c4851f3af40d4f5754ea91f4c0c1cc472a9e066d56d0c74 \
+    --hash=sha256:86d520fd4b1c640abddedf66b3d94523520b7c71a335a5496d21b0acb759300e
     # via -r ./docker.in
 lsst-sphgeom==28.2025.800 \
     --hash=sha256:02cbe9ee936fd146a429d79611208a1349d3ef22412e8b415d54ad06101bb355 \

--- a/tests/test_cliPluginLoader.py
+++ b/tests/test_cliPluginLoader.py
@@ -96,7 +96,7 @@ class FailedLoadTest(unittest.TestCase):
             pass
 
         with self.assertLogs() as cm:
-            result = self.runner.invoke(cli)
+            result = self.runner.invoke(cli, "--help")
         self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
         expectedErrMsg = f"Could not import plugin from {FailCLI.localCmdPkg}, skipping."
         self.assertIn(expectedErrMsg, " ".join(cm.output))


### PR DESCRIPTION
Broken by pallets/click#2591, pallets/click#2796, pallets/click#2523 (and by a change to the exit status when a command is run without parameters).

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
