### PR TITLE
DM-50841: Butler server authorization using Gafaelfawr groups

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/_config.py
+++ b/python/lsst/daf/butler/remote_butler/server/_config.py
@@ -80,6 +80,19 @@ def load_config() -> ButlerServerConfig:
 
 @contextmanager
 def mock_config(temporary_config: ButlerServerConfig | None = None) -> Iterator[ButlerServerConfig]:
+    """Replace the global Butler server configuration with a temporary value.
+
+    Parameters
+    ----------
+    temporary_config : `ButlerServerConfig`, optional
+        Configuration to replace the global value with.  If not provided,
+        a default empty configuration will be used.
+
+    Returns
+    -------
+    config : `ButlerServerConfig`
+        The new configuration object.
+    """
     global _config
     orig = _config
     try:

--- a/python/lsst/daf/butler/remote_butler/server/_config.py
+++ b/python/lsst/daf/butler/remote_butler/server/_config.py
@@ -79,11 +79,18 @@ def load_config() -> ButlerServerConfig:
 
 
 @contextmanager
-def mock_config() -> Iterator[None]:
+def mock_config(temporary_config: ButlerServerConfig | None = None) -> Iterator[ButlerServerConfig]:
     global _config
     orig = _config
     try:
-        _config = ButlerServerConfig(repositories={}, gafaelfawr_url="http://gafaelfawr.example")
-        yield
+        if temporary_config is None:
+            temporary_config = ButlerServerConfig(
+                repositories={},
+                gafaelfawr_url="http://gafaelfawr.example",
+                static_files_path=None,
+            )
+        _config = temporary_config
+        load_config.cache_clear()
+        yield _config
     finally:
         _config = orig

--- a/python/lsst/daf/butler/remote_butler/server/_config.py
+++ b/python/lsst/daf/butler/remote_butler/server/_config.py
@@ -35,6 +35,18 @@ from pydantic import AnyHttpUrl, BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+class RepositoryConfig(BaseModel):
+    """Per-repository configuration for the Butler server."""
+
+    config_uri: str
+    """Path to DirectButler configuration YAML file for the repository."""
+    authorized_groups: list[str]
+    """List of Gafaelfawr groups that will be allowed to access this
+    repository.  If this list contains the special group `*`, all users will be
+    granted access.
+    """
+
+
 class ButlerServerConfig(BaseSettings):
     """Butler server configuration loaded from environment variables."""
 
@@ -51,18 +63,6 @@ class ButlerServerConfig(BaseSettings):
     static_files_path: str | None = None
     """Absolute path to a directory of files that will be served to end-users
     as static files from the `configs/` HTTP route.
-    """
-
-
-class RepositoryConfig(BaseModel):
-    """Per-repository configuration for the Butler server."""
-
-    config_uri: str
-    """Path to DirectButler configuration YAML file for the repository."""
-    authorized_groups: list[str]
-    """List of Gafaelfawr groups that will be allowed to access this
-    repository.  If this list contains the special group `*`, all users will be
-    granted access.
     """
 
 

--- a/python/lsst/daf/butler/remote_butler/server/_dependencies.py
+++ b/python/lsst/daf/butler/remote_butler/server/_dependencies.py
@@ -58,7 +58,7 @@ async def authorizer_dependency() -> GafaelfawrGroupAuthorizer:
     if _authorizer is None:
         config = load_config()
         authorized_groups = {k: v.authorized_groups for k, v in config.repositories.items()}
-        client = GafaelfawrClient(config.gafaelfawr_url)
+        client = GafaelfawrClient(str(config.gafaelfawr_url))
         _authorizer = GafaelfawrGroupAuthorizer(client, authorized_groups)
 
     return _authorizer

--- a/python/lsst/daf/butler/remote_butler/server/_dependencies.py
+++ b/python/lsst/daf/butler/remote_butler/server/_dependencies.py
@@ -31,9 +31,10 @@ from fastapi import Depends
 
 from lsst.daf.butler import LabeledButlerFactory
 
+from ._config import load_config
 from ._factory import Factory
 
-_butler_factory = LabeledButlerFactory()
+_butler_factory: LabeledButlerFactory | None = None
 
 
 async def butler_factory_dependency() -> LabeledButlerFactory:
@@ -41,6 +42,11 @@ async def butler_factory_dependency() -> LabeledButlerFactory:
     construct internal DirectButler instances for interacting with the Butler
     repositories we are serving.
     """
+    global _butler_factory
+    if _butler_factory is None:
+        config = load_config()
+        repositories = {k: v.config_uri for k, v in config.repositories.items()}
+        _butler_factory = LabeledButlerFactory(repositories)
     return _butler_factory
 
 

--- a/python/lsst/daf/butler/remote_butler/server/_dependencies.py
+++ b/python/lsst/daf/butler/remote_butler/server/_dependencies.py
@@ -54,6 +54,7 @@ async def butler_factory_dependency() -> LabeledButlerFactory:
 
 
 async def authorizer_dependency() -> GafaelfawrGroupAuthorizer:
+    """Instantiate a client for checking group membership via Gafaelfawr."""
     global _authorizer
     if _authorizer is None:
         config = load_config()

--- a/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
+++ b/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
@@ -44,10 +44,12 @@ class GafaelfawrClient:
     base_url : `str`
         The top-level HTTP path where Gafaelfawr can be found (e.g.
         ``"https://data-int.lsst.cloud"``).
+    transport : ``httpx.AsyncBaseTransport``, optional
+        Override the HTTP client's transport.  (For unit tests).
     """
 
-    def __init__(self, base_url: str) -> None:
-        self._client = httpx.AsyncClient(base_url=base_url)
+    def __init__(self, base_url: str, *, transport: httpx.AsyncBaseTransport | None = None) -> None:
+        self._client = httpx.AsyncClient(base_url=base_url, transport=transport)
 
     async def get_groups(self, user_token: str) -> list[str]:
         response = await self._client.get(

--- a/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
+++ b/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
@@ -94,3 +94,14 @@ class GafaelfawrGroupAuthorizer:
             return True
 
         return False
+
+
+class MockGafaelfawrGroupAuthorizer:
+    def __init__(self) -> None:
+        self._response = True
+
+    def set_response(self, value: bool) -> None:
+        self._response = value
+
+    async def is_user_authorized_for_repository(self, **kwargs: str) -> bool:
+        return self._response

--- a/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
+++ b/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
@@ -72,6 +72,20 @@ class _GafaelfawrGroup(pydantic.BaseModel):
 
 
 class GafaelfawrGroupAuthorizer:
+    """Authorizes access to Butler repositories on the basis of Gafaelfawr
+    groups.
+
+    Parameters
+    ----------
+    client : `GafaelfawrClient`
+        `GafaelfawrClient` instance that will be used to access group
+        information.
+    repository_groups : `dict` [ `str, `list` [ `str` ]]
+        Mapping from repository name to list of Gafaelfawr groups authorized to
+        access that repository.  If a user is a member of any one of the groups
+        in the list, access will be granted.
+    """
+
     def __init__(self, client: GafaelfawrClient, repository_groups: dict[str, list[str]]) -> None:
         self._client = client
         self._repository_groups = repository_groups
@@ -99,6 +113,8 @@ class GafaelfawrGroupAuthorizer:
 
 
 class MockGafaelfawrGroupAuthorizer:
+    """Mock implementation of ``GafaelfawrGroupAuthorizer`` for unit tests."""
+
     def __init__(self) -> None:
         self._response = True
 

--- a/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
+++ b/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
@@ -49,7 +49,9 @@ class GafaelfawrClient:
     """
 
     def __init__(self, base_url: str, *, transport: httpx.AsyncBaseTransport | None = None) -> None:
-        self._client = httpx.AsyncClient(base_url=base_url, transport=transport)
+        if transport is None:
+            transport = httpx.AsyncHTTPTransport(retries=3)
+        self._client = httpx.AsyncClient(base_url=base_url, transport=transport, timeout=20.0)
 
     async def get_groups(self, user_token: str) -> list[str]:
         response = await self._client.get(

--- a/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
+++ b/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
@@ -43,7 +43,7 @@ class GafaelfawrClient:
     ----------
     base_url : `str`
         The top-level HTTP path where Gafaelfawr can be found (e.g.
-        ``"https://data-int.lsst.cloud"``).
+        ``"https://data-int.lsst.cloud/auth"``).
     transport : ``httpx.AsyncBaseTransport``, optional
         Override the HTTP client's transport.  (For unit tests).
     """
@@ -54,9 +54,7 @@ class GafaelfawrClient:
         self._client = httpx.AsyncClient(base_url=base_url, transport=transport, timeout=20.0)
 
     async def get_groups(self, user_token: str) -> list[str]:
-        response = await self._client.get(
-            "/auth/api/v1/user-info", headers=get_authentication_headers(user_token)
-        )
+        response = await self._client.get("/api/v1/user-info", headers=get_authentication_headers(user_token))
         response.raise_for_status()
         info = _GafaelfawrUserInfo.model_validate_json(response.content)
         if info.groups is None:

--- a/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
+++ b/python/lsst/daf/butler/remote_butler/server/_gafaelfawr.py
@@ -1,0 +1,67 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import httpx
+import pydantic
+
+from .._authentication import get_authentication_headers
+
+
+class GafaelfawrClient:
+    """REST client for retrieving authentication information from
+    Gafaelfawr.
+
+    Parameters
+    ----------
+    base_url : `str`
+        The top-level HTTP path where Gafaelfawr can be found (e.g.
+        ``"https://data-int.lsst.cloud"``).
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self._client = httpx.AsyncClient(base_url=base_url)
+
+    async def get_groups(self, user_token: str) -> list[str]:
+        response = await self._client.get(
+            "/auth/api/v1/user-info", headers=get_authentication_headers(user_token)
+        )
+        response.raise_for_status()
+        info = _GafaelfawrUserInfo.model_validate_json(response.content)
+        if info.groups is None:
+            return []
+        return [group.name for group in info.groups]
+
+
+class _GafaelfawrUserInfo(pydantic.BaseModel):
+    username: str
+    groups: list[_GafaelfawrGroup] | None = None
+
+
+class _GafaelfawrGroup(pydantic.BaseModel):
+    name: str

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -62,9 +62,17 @@ from .._factory import Factory
 from ._utils import set_default_data_id
 
 external_router = APIRouter()
+"""Routes reachable by end users that apply authorization checks before
+granting access.
+"""
+
+unauthenticated_external_router = APIRouter()
+"""Publically accessible routes that do not require user authentication to
+access.
+"""
 
 
-@external_router.get(
+@unauthenticated_external_router.get(
     "/butler.yaml",
     description=(
         "Returns a Butler YAML configuration file that can be used to instantiate a Butler client"
@@ -73,7 +81,7 @@ external_router = APIRouter()
     summary="Client configuration file",
     response_model=dict[str, Any],
 )
-@external_router.get(
+@unauthenticated_external_router.get(
     "/butler.json",
     description=(
         "Returns a Butler JSON configuration file that can be used to instantiate a Butler client"

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from lsst.daf.butler import Butler, Config, LabeledButlerFactory
 from lsst.daf.butler.remote_butler import RemoteButler, RemoteButlerFactory
 from lsst.daf.butler.remote_butler.server import create_app
+from lsst.daf.butler.remote_butler.server._config import mock_config
 from lsst.daf.butler.remote_butler.server._dependencies import butler_factory_dependency
 from lsst.resources.s3utils import clean_test_environment_for_s3, getS3Client
 
@@ -97,7 +98,7 @@ def create_test_server(
             if postgres is not None:
                 postgres.patch_butler_config(config)
 
-            with TemporaryDirectory() as root:
+            with TemporaryDirectory() as root, mock_config():
                 Butler.makeRepo(root, config=config, forceConfigRoot=False)
                 config_file_path = os.path.join(root, "butler.yaml")
 

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -16,6 +16,7 @@ from lsst.daf.butler.remote_butler.server._dependencies import (
     auth_delegated_token_dependency,
     auth_dependency,
     butler_factory_dependency,
+    reset_dependency_caches,
 )
 from lsst.resources.s3utils import clean_test_environment_for_s3, getS3Client
 
@@ -117,6 +118,7 @@ def create_test_server(
                         config_uri=config_file_path, authorized_groups=["*"]
                     )
                 }
+                reset_dependency_caches()
 
                 app = create_app()
                 add_auth_header_check_middleware(app)

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -3,7 +3,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
-from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
@@ -201,8 +200,3 @@ def _add_root_exception_handler(app: FastAPI) -> None:
     @app.exception_handler(Exception)
     async def convert_exception_types(request: Request, exc: Exception) -> None:
         raise UnhandledServerError("Unhandled server exception") from exc
-
-
-class _MockGafaelfawrGroupAuthorizer:
-    async def is_user_authorized_for_repository(self, *args: Any, **kwargs: Any) -> bool:
-        return True

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from lsst.daf.butler import Butler, Config, LabeledButlerFactory
 from lsst.daf.butler.remote_butler import RemoteButler, RemoteButlerFactory
 from lsst.daf.butler.remote_butler.server import create_app
-from lsst.daf.butler.remote_butler.server._config import mock_config
+from lsst.daf.butler.remote_butler.server._config import ButlerServerConfig, mock_config
 from lsst.daf.butler.remote_butler.server._dependencies import (
     auth_delegated_token_dependency,
     auth_dependency,
@@ -69,7 +69,10 @@ class TestServerInstance:
 
 @contextmanager
 def create_test_server(
-    test_directory: str, *, postgres: TemporaryPostgresInstance | None = None
+    test_directory: str,
+    *,
+    postgres: TemporaryPostgresInstance | None = None,
+    server_config: ButlerServerConfig | None = None,
 ) -> Iterator[TestServerInstance]:
     """Create a temporary Butler server instance for testing.
 
@@ -82,6 +85,8 @@ def create_test_server(
         If provided, the Butler server will use this postgres database
         instance.  If no postgres instance is specified, the server will use a
         a SQLite database.
+    server_config : `ButlerServerConfig`, optional
+        Configuration to use for the Butler server.
 
     Returns
     -------
@@ -104,7 +109,7 @@ def create_test_server(
             if postgres is not None:
                 postgres.patch_butler_config(config)
 
-            with TemporaryDirectory() as root, mock_config():
+            with TemporaryDirectory() as root, mock_config(server_config):
                 Butler.makeRepo(root, config=config, forceConfigRoot=False)
                 config_file_path = os.path.join(root, "butler.yaml")
 

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -65,6 +65,8 @@ class TestServerInstance:
     """
     hybrid_butler: HybridButler
     """`HybridButler` instance connected to the temporary server."""
+    app: FastAPI
+    """Butler server FastAPI app."""
 
 
 @contextmanager
@@ -168,6 +170,7 @@ def create_test_server(
                         remote_butler=remote_butler,
                         remote_butler_without_error_propagation=remote_butler_without_error_propagation,
                         hybrid_butler=hybrid_butler,
+                        app=app,
                     )
 
 

--- a/tests/test_gafaelfawr.py
+++ b/tests/test_gafaelfawr.py
@@ -1,0 +1,104 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import fastapi
+    import httpx
+
+    from lsst.daf.butler.remote_butler.server._dependencies import repository_authorization_dependency
+    from lsst.daf.butler.remote_butler.server._gafaelfawr import GafaelfawrClient, GafaelfawrGroupAuthorizer
+
+    _IMPORT_FAILURE = None
+except ImportError as e:
+    _IMPORT_FAILURE = e
+
+
+# FastAPI is not installed during LSST Pipelines stack builds, so skip these
+# tests if it is not available.
+@unittest.skipIf(_IMPORT_FAILURE, str(_IMPORT_FAILURE))
+class GafaelfawrAuthorizationTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test authorization checks using Gafaelfawr group membership."""
+
+    async def test_gafaelfawr_group_auth(self) -> None:
+        response_code = 200
+        response_data = {"username": "some-user", "groups": [{"name": "some-group"}, {"name": "b"}]}
+        request_headers: httpx.Headers = httpx.Headers(None)
+        request_count = 0
+
+        def handler(request: httpx.Request):
+            nonlocal request_headers
+            request_headers = request.headers
+            nonlocal request_count
+            request_count += 1
+            return httpx.Response(response_code, json=response_data)
+
+        transport = httpx.MockTransport(handler)
+
+        client = GafaelfawrClient("http://gafaelfawr.example", transport=transport)
+        authorizer = GafaelfawrGroupAuthorizer(
+            client, {"any_group": ["*"], "group_a": ["a"], "group_b": ["c", "b"]}
+        )
+
+        with self.assertRaises(fastapi.HTTPException) as e:
+            await repository_authorization_dependency("group_a", "username", "mock-token", authorizer)
+        self.assertEqual(e.exception.status_code, 403)
+        self.assertEqual(request_headers.get("Authorization"), "Bearer mock-token")
+
+        # Should authorize the special '*' all users group without hitting
+        # Gafaelfawr service.
+        request_count = 0
+        await repository_authorization_dependency("any_group", "username", "mock-token", authorizer)
+        self.assertEqual(request_count, 0)
+
+        # Should hit the Gafaelfawr service to check that the user is in group
+        # "b".
+        request_count = 0
+        await repository_authorization_dependency("group_b", "username", "mock-token", authorizer)
+        self.assertEqual(request_count, 1)
+
+        # A second request with the same username should be cached...
+        request_count = 0
+        await repository_authorization_dependency("group_b", "username", "mock-token", authorizer)
+        self.assertEqual(request_count, 0)
+
+        # But it should go back to the server for a different user
+        request_count = 0
+        response_data = {"username": "other-username", "groups": [{"name": "incorrect-group"}]}
+        with self.assertRaises(fastapi.HTTPException) as e:
+            await repository_authorization_dependency("group_b", "other-username", "mock-token", authorizer)
+        self.assertEqual(e.exception.status_code, 403)
+        self.assertEqual(request_count, 1)
+
+        # Bad repository name
+        with self.assertRaises(ValueError):
+            await repository_authorization_dependency(
+                "unknown_repository", "username", "mock-token", authorizer
+            )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,11 +43,15 @@ try:
 
     import lsst.daf.butler.remote_butler._query_results
     import lsst.daf.butler.remote_butler.server.handlers._query_streaming
-    from lsst.daf.butler.remote_butler import RemoteButler
+    from lsst.daf.butler.remote_butler import ButlerServerError, RemoteButler
     from lsst.daf.butler.remote_butler._authentication import _EXPLICIT_BUTLER_ACCESS_TOKEN_ENVIRONMENT_KEY
     from lsst.daf.butler.remote_butler.server import create_app
     from lsst.daf.butler.remote_butler.server._config import mock_config
-    from lsst.daf.butler.remote_butler.server._dependencies import butler_factory_dependency
+    from lsst.daf.butler.remote_butler.server._dependencies import (
+        authorizer_dependency,
+        butler_factory_dependency,
+    )
+    from lsst.daf.butler.remote_butler.server._gafaelfawr import MockGafaelfawrGroupAuthorizer
     from lsst.daf.butler.remote_butler.server_models import QueryCollectionsRequestModel
     from lsst.daf.butler.tests.server import TEST_REPOSITORY_NAME, UnhandledServerError, create_test_server
 
@@ -62,6 +66,7 @@ from lsst.daf.butler import (
     DataCoordinate,
     DatasetNotFoundError,
     DatasetRef,
+    DatasetType,
     LabeledButlerFactory,
     MissingDatasetTypeError,
     NoDefaultCollectionError,
@@ -84,6 +89,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         server_instance = cls.enterClassContext(create_test_server(TESTDIR))
+        cls.server_instance = server_instance
         cls.client = server_instance.client
         cls.butler = server_instance.remote_butler
         cls.butler_without_error_propagation = server_instance.remote_butler_without_error_propagation
@@ -524,6 +530,33 @@ class ButlerClientServerTestCase(unittest.TestCase):
             ),
         ).json()
         self.assertCountEqual(json["collections"], ["imported_g", "imported_r"])
+
+
+class ButlerClientServerAuthorizationTestCase(unittest.TestCase):
+    """Test that group membership repository authorization is checked when
+    repository is accessed.
+    """
+
+    def test_group_authorization(self):
+        with create_test_server(TESTDIR) as server_instance:
+            mock = MockGafaelfawrGroupAuthorizer()
+            server_instance.app.dependency_overrides[authorizer_dependency] = lambda: mock
+            server_instance.direct_butler.registry.registerDatasetType(
+                DatasetType("bias", [], "int", universe=server_instance.direct_butler.dimensions)
+            )
+            server_instance.direct_butler.collections.register("collection")
+            butler = server_instance.remote_butler
+            mock.set_response(False)
+            with self.assertRaises(ButlerServerError) as e:
+                butler.get_dataset_type("bias")
+            self.assertEqual(e.exception.status_code, 403)
+            with self.assertRaises(ButlerServerError) as e:
+                butler.query_datasets("bias", collections="*", find_first=False)
+            self.assertEqual(e.exception.status_code, 403)
+
+            mock.set_response(True)
+            self.assertEqual(butler.get_dataset_type("bias").name, "bias")
+            self.assertEqual(butler.query_datasets("bias", collections="collection", explain=False), [])
 
 
 def _create_corrupted_dataset(repo: MetricTestRepo) -> DatasetRef:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -532,6 +532,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
         self.assertCountEqual(json["collections"], ["imported_g", "imported_r"])
 
 
+@unittest.skipIf(create_test_server is None, f"Server dependencies not installed: {reason_text}")
 class ButlerClientServerAuthorizationTestCase(unittest.TestCase):
     """Test that group membership repository authorization is checked when
     repository is accessed.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,6 +46,7 @@ try:
     from lsst.daf.butler.remote_butler import RemoteButler
     from lsst.daf.butler.remote_butler._authentication import _EXPLICIT_BUTLER_ACCESS_TOKEN_ENVIRONMENT_KEY
     from lsst.daf.butler.remote_butler.server import create_app
+    from lsst.daf.butler.remote_butler.server._config import mock_config
     from lsst.daf.butler.remote_butler.server._dependencies import butler_factory_dependency
     from lsst.daf.butler.remote_butler.server_models import QueryCollectionsRequestModel
     from lsst.daf.butler.tests.server import TEST_REPOSITORY_NAME, UnhandledServerError, create_test_server
@@ -122,8 +123,9 @@ class ButlerClientServerTestCase(unittest.TestCase):
             with open(os.path.join(tmpdir, "temp.txt"), "w") as fh:
                 fh.write("test data 123")
 
-            with mock_env({"DAF_BUTLER_SERVER_STATIC_FILES_PATH": tmpdir}):
-                with create_test_server(TESTDIR) as server:
+            with mock_config() as server_config:
+                server_config.static_files_path = tmpdir
+                with create_test_server(TESTDIR, server_config=server_config) as server:
                     response = server.client.get("/api/butler/configs/temp.txt")
                     self.assertEqual(response.status_code, 200)
                     self.assertEqual(response.text, "test data 123")


### PR DESCRIPTION
Butler server can now authorize access to specific repositories based on the user's Gafaelfawr group memberships.  This will be used to restrict access to Data Preview 1 ahead of its public release.

Prior to this PR, there was no concept of configuration specific to Butler server -- everything was shared with the `DirectButler` configuration.  `pydantic-settings` is now used to configure the server, adding configuration variables for group membership restrictions and the Gafaelfawr endpoint.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
