### PR TITLE
DM-50855: Reduce blocking in remove_from_chain

### DIFF
--- a/doc/changes/DM-50855.bugfix.md
+++ b/doc/changes/DM-50855.bugfix.md
@@ -1,0 +1,1 @@
+`butler remove-runs` will no longer block if a parallel process calls `butler remove-runs` on a run contained in the same collection chain.

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -205,6 +205,11 @@ class RemoteButlerRegistryTests(RegistryTests):
         # collection manager object.
         pass
 
+    def testCollectionChainRemoveConcurrency(self):
+        # This tests an implementation detail that requires access to the
+        # collection manager object.
+        pass
+
     def testAttributeManager(self):
         # Tests a non-public API that isn't relevant on the client side.
         pass


### PR DESCRIPTION
Allow multiple concurrent calls to `Butler.collections.remove_from_chain`, to fix an issue where `butler remove-runs` can block indefinitely while waiting for long-lived parallel transactions to complete.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
