### PR TITLE
DM-50935: Allow FileDatastore.transfer_from(ChainedDatastore)

### DIFF
--- a/doc/changes/DM-50935.misc.rst
+++ b/doc/changes/DM-50935.misc.rst
@@ -1,0 +1,1 @@
+Fixed handling of ``FileDatastore.transfer_from()`` such that it now works with chained datastores.

--- a/tests/config/basic/butler-inmemory-chain.yaml
+++ b/tests/config/basic/butler-inmemory-chain.yaml
@@ -1,0 +1,2 @@
+datastore: !include chainedDatastore2.yaml
+storageClasses: !include storageClasses.yaml

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2555,24 +2555,36 @@ class PosixDatastoreTransfers(unittest.TestCase):
     def tearDown(self) -> None:
         removeTestTempDir(self.root)
 
-    def create_butler(self, manager: str, label: str) -> Butler:
-        config = Config(self.configFile)
+    def create_butler(self, manager: str, label: str, config_file: str | None = None) -> Butler:
+        config = Config(config_file if config_file is not None else self.configFile)
         config["registry", "managers", "datasets"] = manager
         return Butler.from_config(
             Butler.makeRepo(f"{self.root}/butler{label}", config=config), writeable=True
         )
 
-    def create_butlers(self, manager1: str | None = None, manager2: str | None = None) -> None:
+    def create_butlers(
+        self, manager1: str | None = None, manager2: str | None = None, source_config: str | None = None
+    ) -> None:
         default = "lsst.daf.butler.registry.datasets.byDimensions.ByDimensionsDatasetRecordStorageManagerUUID"
         if manager1 is None:
             manager1 = default
         if manager2 is None:
             manager2 = default
-        self.source_butler = self.create_butler(manager1, "1")
+        self.source_butler = self.create_butler(manager1, "1", config_file=source_config)
         self.target_butler = self.create_butler(manager2, "2")
 
     def testTransferUuidToUuid(self) -> None:
         self.create_butlers()
+        self.assertButlerTransfers()
+
+    def testTransferFromChainedUuidToUuid(self) -> None:
+        """Force the source butler to be a ChainedDatastore."""
+        self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler-chained.yaml"))
+        self.assertButlerTransfers()
+
+    def testTransferFromFileUuidToUuid(self) -> None:
+        """Force the source butler to be a FileDatastore."""
+        self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler.yaml"))
         self.assertButlerTransfers()
 
     def testTransferMissing(self) -> None:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2582,6 +2582,18 @@ class PosixDatastoreTransfers(unittest.TestCase):
         self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler-chained.yaml"))
         self.assertButlerTransfers()
 
+    def testTransferFromIncompatibleUuidToUuid(self) -> None:
+        """Force the source butler to be a incompatible datastore."""
+        self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml"))
+        with self.assertRaises(TypeError):
+            self.assertButlerTransfers()
+
+    def testTransferFromIncompatibleChainUuidToUuid(self) -> None:
+        """Force the source butler to be a incompatible datastore."""
+        self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler-inmemory-chain.yaml"))
+        with self.assertRaises(TypeError):
+            self.assertButlerTransfers()
+
     def testTransferFromFileUuidToUuid(self) -> None:
         """Force the source butler to be a FileDatastore."""
         self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler.yaml"))


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
