### PR TITLE
DM-50996: Add unlink_from_chains parameter to removeRuns and reorganize transactions

### DIFF
--- a/doc/changes/DM-50996.api.rst
+++ b/doc/changes/DM-50996.api.rst
@@ -1,0 +1,3 @@
+* The ``unstore`` parameter for ``Butler.removeRuns()`` has been deprecated.
+  We now always remove the file artifacts when removing the collection.
+* Added a ``unlink_from_chains`` parameter to ``Butler.removeRuns()`` to allow the RUN collections to be unlinked from their parent chains automatically.

--- a/doc/changes/DM-50996.misc.rst
+++ b/doc/changes/DM-50996.misc.rst
@@ -1,0 +1,1 @@
+Reorganized ``Butler.removeRuns()`` to remove datasets in chunks to provide more feedback to the user and allow for restarting if the command fails for some reason.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1288,7 +1288,9 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         raise NotImplementedError()
 
     @abstractmethod
-    def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
+    def removeRuns(
+        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+    ) -> None:
         """Remove one or more `~CollectionType.RUN` collections and the
         datasets within them.
 
@@ -1302,6 +1304,10 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             datastore deletions fail (which may not always be possible).  If
             `False`, datastore records for these datasets are still removed,
             but any artifacts (e.g. files) will not be.
+        unlink_from_chains : `bool`, optional
+            If `True` remove the RUN collection from any chains prior to
+            removing the RUN. If `False` the removal will fail if any chains
+            still refer to the RUN.
 
         Raises
         ------

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -90,6 +90,10 @@ class SpecificButlerDataset:
     dataset: DatasetRef | None
 
 
+class _DeprecatedDefault:
+    """Default value for a deprecated parameter."""
+
+
 class Butler(LimitedButler):  # numpydoc ignore=PR02
     """Interface for data butler and factory for Butler instances.
 
@@ -1289,7 +1293,11 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
 
     @abstractmethod
     def removeRuns(
-        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+        self,
+        names: Iterable[str],
+        unstore: bool | type[_DeprecatedDefault] = _DeprecatedDefault,
+        *,
+        unlink_from_chains: bool = False,
     ) -> None:
         """Remove one or more `~CollectionType.RUN` collections and the
         datasets within them.
@@ -1303,7 +1311,9 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             they are present, and attempt to rollback the registry deletions if
             datastore deletions fail (which may not always be possible).  If
             `False`, datastore records for these datasets are still removed,
-            but any artifacts (e.g. files) will not be.
+            but any artifacts (e.g. files) will not be. This parameter is now
+            deprecated and no longer has any effect. Files are always deleted
+            from datastores unless they were ingested using full URIs.
         unlink_from_chains : `bool`, optional
             If `True` remove the RUN collection from any chains prior to
             removing the RUN. If `False` the removal will fail if any chains

--- a/python/lsst/daf/butler/_butler_collections.py
+++ b/python/lsst/daf/butler/_butler_collections.py
@@ -108,6 +108,10 @@ class ButlerCollections(ABC, Sequence):
         """Collection defaults associated with this butler."""
         raise NotImplementedError("Defaults must be implemented by a subclass")
 
+    def __str__(self) -> str:
+        """Return string representation."""
+        return f"{self.__class__.__name__}(defaults={self.defaults})"
+
     @abstractmethod
     def extend_chain(self, parent_collection_name: str, child_collection_names: str | Iterable[str]) -> None:
         """Add children to the end of a CHAINED collection.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2694,9 +2694,10 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
             if artifacts_to_keep:
                 log.verbose(
-                    "%d artifact%s were not deleted because they are associated with other datasets",
+                    "%d artifact%s %s not deleted because of association with other datasets",
                     len(artifacts_to_keep),
                     "s" if len(artifacts_to_keep) != 1 else "",
+                    "were" if len(artifacts_to_keep) != 1 else "was",
                 )
 
             if not artifacts_to_delete:

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -2339,6 +2339,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         # Find all the registered instruments (if "instrument" is in the
         # universe).
+        instruments: set[str] = set()
         if "instrument" in self.dimensions:
             instruments = {rec.name for rec in self.query_dimension_records("instrument", explain=False)}
 

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -2009,7 +2009,14 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             source_refs = list(source_refs)
 
         original_count = len(source_refs)
-        _LOG.info("Importing %d datasets into %s", original_count, str(self))
+        log_level = _LOG.INFO if original_count > 1 else _LOG.VERBOSE
+        _LOG.log(
+            log_level,
+            "Importing %d dataset%s into %s",
+            original_count,
+            "s" if original_count != 1 else "",
+            str(self),
+        )
 
         # In some situations the datastore artifact may be missing
         # and we do not want that registry entry to be imported.

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1442,27 +1442,47 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         return existence
 
-    def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
+    def removeRuns(
+        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+    ) -> None:
         # Docstring inherited.
         if not self.isWriteable():
             raise TypeError("Butler is read-only.")
         names = list(names)
         refs: list[DatasetRef] = []
         all_dataset_types = [dt.name for dt in self._registry.queryDatasetTypes(...)]
+        # Map of the chained collections to the RUN children.
+        parents_to_children: dict[str, set[str]] = defaultdict(set)
+
         with self._caching_context():
-            for name in names:
-                collectionType = self._registry.getCollectionType(name)
-                if collectionType is not CollectionType.RUN:
-                    raise TypeError(f"The collection type of '{name}' is {collectionType.name}, not RUN.")
-                with self.query() as query:
+            with self.query() as query:
+                # Get information about these RUNs.
+                collections_info = self.collections.query_info(
+                    names, include_summary=True, include_parents=unlink_from_chains
+                )
+                for info in collections_info:
+                    if info.type is not CollectionType.RUN:
+                        raise TypeError(f"The collection type of '{info.name}' is {info.type.name}, not RUN.")
+                    if unlink_from_chains:
+                        if info.parents is None:  # For mypy.
+                            raise AssertionError(
+                                "Internal error: Collection parents required but not received"
+                            )
+                        for parent in info.parents:
+                            parents_to_children[parent].add(info.name)
+
                     # Work out the dataset types that are relevant.
-                    collections_info = self.collections.query_info(name, include_summary=True)
                     filtered_dataset_types = self.collections._filter_dataset_types(
                         all_dataset_types, collections_info
                     )
                     for dt in filtered_dataset_types:
-                        refs.extend(query.datasets(dt, collections=name))
+                        refs.extend(query.datasets(dt, collections=info.name))
         with self._datastore.transaction(), self._registry.transaction():
+            if unlink_from_chains:
+                # Use deterministic order for deletions to attempt to minimize
+                # risk of deadlocks for parallel deletes.
+                for parent in sorted(parents_to_children):
+                    self.collections.remove_from_chain(parent, sorted(parents_to_children[parent]))
             if unstore:
                 with time_this(
                     _LOG, msg="Marking %d datasets for removal to clear RUN collections", args=(len(refs),)

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1497,10 +1497,13 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # incremental re-running of the command. The only issue will be if the
         # Ctrl-C comes during emptyTrash since an admin command would need to
         # run to finish the emptying of that chunk.
+        progress = Progress("lsst.daf.butler.Butler.ingest", level=_LOG.INFO)
         chunk_size = 50_000
         n_chunks = math.ceil(len(refs) / chunk_size)
         chunk_num = 0
-        for chunked_refs in chunk_iterable(refs, chunk_size=chunk_size):
+        for chunked_refs in progress.wrap(
+            chunk_iterable(refs, chunk_size=chunk_size), desc="Deleting datasets from RUNs", total=n_chunks
+        ):
             chunk_num += 1
             _LOG.verbose(
                 "Deleting %d dataset%s from requested RUN collections in chunk %d/%d",

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1541,18 +1541,23 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # but shouldn't change them), and hence all operations here are
         # Registry operations.
         with self._datastore.transaction(), self._registry.transaction():
+            plural = "s" if len(refs) != 1 else ""
             if unstore:
                 with time_this(
-                    _LOG, msg="Marking %d datasets for removal to during pruning", args=(len(refs),)
+                    _LOG,
+                    msg="Marking %d dataset%s for removal during pruneDatasets",
+                    args=(len(refs), plural),
                 ):
                     self._datastore.trash(refs)
             if purge:
-                with time_this(_LOG, msg="Removing %d pruned datasets from registry", args=(len(refs),)):
+                with time_this(
+                    _LOG, msg="Removing %d pruned dataset%s from registry", args=(len(refs), plural)
+                ):
                     self._registry.removeDatasets(refs)
             elif disassociate:
                 assert tags, "Guaranteed by earlier logic in this function."
                 with time_this(
-                    _LOG, msg="Disassociating %d datasets from tagged collections", args=(len(refs),)
+                    _LOG, msg="Disassociating %d dataset%ss from tagged collections", args=(len(refs), plural)
                 ):
                     for tag in tags:
                         self._registry.disassociate(tag, refs)
@@ -1570,8 +1575,8 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             # emptying to the refs that this call trashed.
             with time_this(
                 _LOG,
-                msg="Attempting to remove artifacts for %d datasets associated with pruning",
-                args=(len(refs),),
+                msg="Attempting to remove artifacts for %d dataset%s associated with pruning",
+                args=(len(refs), plural),
             ):
                 self._datastore.emptyTrash(refs=refs)
 

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1582,7 +1582,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # mutating the Registry (it can _look_ at Datastore-specific things,
         # but shouldn't change them), and hence all operations here are
         # Registry operations.
-        with self._datastore.transaction(), self._registry.transaction():
+        with self.transaction():
             plural = "s" if len(refs) != 1 else ""
             if unstore:
                 with time_this(

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -555,7 +555,9 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
     ) -> dict[DatasetRef, DatasetExistence]:
         return {ref: self.exists(ref, full_check=full_check) for ref in refs}
 
-    def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
+    def removeRuns(
+        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+    ) -> None:
         # Docstring inherited.
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -51,7 +51,7 @@ from lsst.daf.butler.datastores.fileDatastoreClient import (
 )
 from lsst.resources import ResourcePath, ResourcePathExpression
 
-from .._butler import Butler
+from .._butler import Butler, _DeprecatedDefault
 from .._butler_collections import ButlerCollections
 from .._butler_metrics import ButlerMetrics
 from .._dataset_existence import DatasetExistence
@@ -556,7 +556,11 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         return {ref: self.exists(ref, full_check=full_check) for ref in refs}
 
     def removeRuns(
-        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+        self,
+        names: Iterable[str],
+        unstore: bool | type[_DeprecatedDefault] = _DeprecatedDefault,
+        *,
+        unlink_from_chains: bool = False,
     ) -> None:
         # Docstring inherited.
         raise NotImplementedError()

--- a/python/lsst/daf/butler/script/removeRuns.py
+++ b/python/lsst/daf/butler/script/removeRuns.py
@@ -140,7 +140,7 @@ def removeRuns(
         """Perform the remove step."""
         butler = Butler.from_config(repo, writeable=True)
 
-        butler.removeRuns([r.name for r in runs], unstore=True, unlink_from_chains=True)
+        butler.removeRuns([r.name for r in runs], unlink_from_chains=True)
 
     result = RemoveRunsResult(
         onConfirmation=partial(_doRemove, runs),

--- a/python/lsst/daf/butler/script/removeRuns.py
+++ b/python/lsst/daf/butler/script/removeRuns.py
@@ -139,17 +139,8 @@ def removeRuns(
     def _doRemove(runs: Sequence[RemoveRun]) -> None:
         """Perform the remove step."""
         butler = Butler.from_config(repo, writeable=True)
-        # Collections must be removed from chains in a deterministic
-        # order to protect against parallelized purging on the same chain.
-        parents_to_children: dict[str, set[str]] = defaultdict(set)
-        for run in runs:
-            for parent in run.parents:
-                parents_to_children[parent].add(run.name)
 
-        with butler.transaction():
-            for parent in sorted(parents_to_children):
-                butler.collections.remove_from_chain(parent, sorted(parents_to_children[parent]))
-            butler.removeRuns([r.name for r in runs], unstore=True)
+        butler.removeRuns([r.name for r in runs], unstore=True, unlink_from_chains=True)
 
     result = RemoveRunsResult(
         onConfirmation=partial(_doRemove, runs),

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -34,7 +34,7 @@ from typing import Any, TextIO, cast
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 
-from .._butler import Butler
+from .._butler import Butler, _DeprecatedDefault
 from .._butler_collections import ButlerCollections
 from .._butler_metrics import ButlerMetrics
 from .._dataset_existence import DatasetExistence
@@ -266,7 +266,11 @@ class HybridButler(Butler):
         return self._remote_butler._exists_many(refs, full_check=full_check)
 
     def removeRuns(
-        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+        self,
+        names: Iterable[str],
+        unstore: bool | type[_DeprecatedDefault] = _DeprecatedDefault,
+        *,
+        unlink_from_chains: bool = False,
     ) -> None:
         return self._direct_butler.removeRuns(names, unstore, unlink_from_chains=unlink_from_chains)
 

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -265,8 +265,10 @@ class HybridButler(Butler):
     ) -> dict[DatasetRef, DatasetExistence]:
         return self._remote_butler._exists_many(refs, full_check=full_check)
 
-    def removeRuns(self, names: Iterable[str], unstore: bool = True) -> None:
-        return self._direct_butler.removeRuns(names, unstore)
+    def removeRuns(
+        self, names: Iterable[str], unstore: bool = True, *, unlink_from_chains: bool = False
+    ) -> None:
+        return self._direct_butler.removeRuns(names, unstore, unlink_from_chains=unlink_from_chains)
 
     def ingest_zip(
         self,

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1816,15 +1816,16 @@ class FileDatastoreButlerTests(ButlerTests):
 
         # Remove a non-run.
         with self.assertRaises(TypeError):
-            butler.removeRuns(["Chain"], unstore=True)
+            butler.removeRuns(["Chain"])
 
         # Remove without unlinking from chain should fail.
         with self.assertRaises(IntegrityError):
-            butler.removeRuns([run1], unstore=True)
+            butler.removeRuns([run1])
 
-        # Remove from both runs with different values for unstore.
-        butler.removeRuns([run1], unstore=True, unlink_from_chains=True)
-        butler.removeRuns([run2], unstore=False)
+        # Remove from both runs. No longer use unstore parameter since it
+        # always purges.
+        butler.removeRuns([run1, run2], unlink_from_chains=True)
+
         # Should be nothing in registry for either one, and datastore should
         # not think either exists.
         with self.assertRaises(MissingCollectionError):
@@ -1833,10 +1834,9 @@ class FileDatastoreButlerTests(ButlerTests):
             butler.collections.get_info(run1)
         self.assertFalse(butler.stored(ref1))
         self.assertFalse(butler.stored(ref2))
-        # The ref we unstored should be gone according to the URI, but the
-        # one we forgot should still be around.
+        # We always unstore so both URIs should be gone.
         self.assertFalse(uri1.exists())
-        self.assertTrue(uri2.exists())
+        self.assertFalse(uri2.exists())
 
         # Now that the collections have been pruned we can remove the
         # dataset type


### PR DESCRIPTION
Have separate transaction for the registry manipulation and the trash emptying. Previously the remove-runs CLI created its own transaction which included emptyTrash.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
