### PR TITLE
DM-47644: Loosen type restrictions in query expressions

### DIFF
--- a/doc/changes/DM-47644.bugfix.md
+++ b/doc/changes/DM-47644.bugfix.md
@@ -1,0 +1,2 @@
+Query expressions now allow float columns to be compared with int literals.
+Query expressions now allow OVERLAPS to be used to compare timespans with ingest_date.

--- a/python/lsst/daf/butler/queries/overlaps.py
+++ b/python/lsst/daf/butler/queries/overlaps.py
@@ -239,7 +239,7 @@ class OverlapsVisitor(SimplePredicateVisitor):
     ) -> tree.Predicate | None:
         # Docstring inherited.
         if operator == "overlaps":
-            if tree.is_one_timespan_and_one_datetime(a, b):
+            if tree.is_one_timespan_and_one_datetime(a, b) or tree.is_one_timespan_and_one_ingest_date(a, b):
                 # Can be transformed directly without special handling here.
                 return None
             elif a.column_type == "region":

--- a/python/lsst/daf/butler/queries/tree/_column_expression.py
+++ b/python/lsst/daf/butler/queries/tree/_column_expression.py
@@ -298,3 +298,14 @@ def is_one_datetime_and_one_ingest_date(
     return (a.column_type == "datetime" and b.column_type == "ingest_date") or (
         a.column_type == "ingest_date" and b.column_type == "datetime"
     )
+
+
+def is_numeric(expr: ColumnExpression) -> bool:
+    """Return `True` if the expression is a numeric type (float or int).
+
+    Parameters
+    ----------
+    expr : `ColumnExpression`
+        Column expression to test.
+    """
+    return expr.column_type == "float" or expr.column_type == "int"

--- a/python/lsst/daf/butler/queries/tree/_column_expression.py
+++ b/python/lsst/daf/butler/queries/tree/_column_expression.py
@@ -37,6 +37,7 @@ __all__ = (
     "UnaryOperator",
     "is_one_datetime_and_one_ingest_date",
     "is_one_timespan_and_one_datetime",
+    "is_one_timespan_and_one_ingest_date",
     "validate_order_expression",
 )
 
@@ -298,6 +299,33 @@ def is_one_datetime_and_one_ingest_date(
     return (a.column_type == "datetime" and b.column_type == "ingest_date") or (
         a.column_type == "ingest_date" and b.column_type == "datetime"
     )
+
+
+def is_one_timespan_and_one_ingest_date(
+    a: ColumnExpression, b: ColumnExpression
+) -> TimespanAndDatetime | None:
+    """Return `True` if the two columns ``a`` and `b`` include one timespan
+    column and one ingest_date column.
+
+    Parameters
+    ----------
+    a : `ColumnExpression`
+        First column expression.
+    b : `ColumnExpression`
+        Second column expression.
+
+    Returns
+    -------
+    which_is_which : `TimespanAndDatetime` | None
+        An object telling which column is the ingest_date and which is the
+        timespan, or `None` if the types were not as expected.
+    """
+    if a.column_type == "timespan" and b.column_type == "ingest_date":
+        return TimespanAndDatetime(a, b)
+    elif a.column_type == "ingest_date" and b.column_type == "timespan":
+        return TimespanAndDatetime(b, a)
+    else:
+        return None
 
 
 def is_numeric(expr: ColumnExpression) -> bool:

--- a/python/lsst/daf/butler/queries/tree/_predicate.py
+++ b/python/lsst/daf/butler/queries/tree/_predicate.py
@@ -50,6 +50,7 @@ from ._column_expression import (
     is_numeric,
     is_one_datetime_and_one_ingest_date,
     is_one_timespan_and_one_datetime,
+    is_one_timespan_and_one_ingest_date,
 )
 
 if TYPE_CHECKING:
@@ -549,8 +550,11 @@ class Comparison(PredicateLeafBase):
     @pydantic.model_validator(mode="after")
     def _validate_column_types(self) -> Comparison:
         comparison_operators = ("==", "!=", "<", ">", ">=", "<=")
-        if self.operator == "overlaps" and is_one_timespan_and_one_datetime(self.a, self.b):
-            # Allow mixed-type comparison of datetime overlaps timespan.
+        if self.operator == "overlaps" and (
+            is_one_timespan_and_one_datetime(self.a, self.b)
+            or is_one_timespan_and_one_ingest_date(self.a, self.b)
+        ):
+            # Allow timespan OVERLAPS datetime/ingest_date.
             pass
         elif is_one_datetime_and_one_ingest_date(self.a, self.b) and self.operator in comparison_operators:
             # ingest_date might be one of two different column types

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -1677,6 +1677,17 @@ class ButlerQueryTests(ABC, TestCaseMixin):
                 ],
                 [],
             )
+
+            # Allow comparison of float columns with int literals
+            self.assertCountEqual(
+                [record.id for record in query.where("visit.exposure_time > 50").dimension_records("visit")],
+                [1],
+            )
+            self.assertCountEqual(
+                [record.id for record in query.where(_x.visit.exposure_time > 50).dimension_records("visit")],
+                [1],
+            )
+
             self.check_detector_records(
                 query.where(_x.detector.in_iterable([1, 3, 4])).dimension_records("detector"),
                 [1, 3, 4],

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -2140,6 +2140,18 @@ class ButlerQueryTests(ABC, TestCaseMixin):
         self.assertEqual(len(result), 1)
         result = butler.query_datasets("dt", "run1", where="ingest_date < T'2000-01-01'", explain=False)
         self.assertEqual(len(result), 0)
+        result = butler.query_datasets(
+            "dt", "run1", where="ingest_date OVERLAPS (T'2000-01-01', T'2099-01-01')"
+        )
+        self.assertEqual(len(result), 1)
+        result = butler.query_datasets(
+            "dt", "run1", where="(T'2000-01-01', T'2099-01-01') OVERLAPS ingest_date"
+        )
+        self.assertEqual(len(result), 1)
+        result = butler.query_datasets(
+            "dt", "run1", where="(T'2000-01-01', T'2001-01-01') OVERLAPS ingest_date", explain=False
+        )
+        self.assertEqual(len(result), 0)
 
     def test_multiple_instrument_queries(self) -> None:
         """Test that multiple-instrument queries are not rejected as having

--- a/tests/test_query_interface.py
+++ b/tests/test_query_interface.py
@@ -852,8 +852,6 @@ class ColumnExpressionsTestCase(unittest.TestCase):
         # Mixed type comparisons.
         with self.assertRaises(InvalidQueryError):
             self.x.visit > "three"
-        with self.assertRaises(InvalidQueryError):
-            self.x.visit > 3.0
         # Invalid operator for type.
         with self.assertRaises(InvalidQueryError):
             self.x["raw"].dataset_id < uuid.uuid4()


### PR DESCRIPTION
Relax type restrictions in query expression language to allow expressions that users expected to work:
* Allow comparison operators between a mix of float and integer expressions (DM-47644)
* Allow OVERLAPS to be used to check if an `ingest_date`  is within a timespan (DM-50959)

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
