### PR TITLE
Fix sentry deprecation

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/_telemetry.py
+++ b/python/lsst/daf/butler/remote_butler/server/_telemetry.py
@@ -76,7 +76,7 @@ def enable_telemetry() -> None:
     # Configuration will be pulled from SENTRY_* environment variables
     # (see https://docs.sentry.io/platforms/python/configuration/options/).
     # If SENTRY_DSN is not present, telemetry is disabled.
-    sentry_sdk.init(enable_tracing=True, traces_sampler=_decide_whether_to_sample_trace)
+    sentry_sdk.init(traces_sampler=_decide_whether_to_sample_trace)
 
     global _telemetry_context
     _telemetry_context = SentryTelemetryContext()


### PR DESCRIPTION
Remove the use of the deprecated property `enable_tracing` from the call to `sentry_sdk.init()`.  The presence of `traces_sampler` now enables tracing automatically.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
