### PR TITLE
DM-51035: Sort the dataset types before inserting into summary table

### DIFF
--- a/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/summaries.py
@@ -279,14 +279,14 @@ class CollectionSummaryManager:
                     "dataset_type_id": dataset_type_id,
                     self._collectionKeyName: collection.key,
                 }
-                for dataset_type_id in dataset_type_ids
+                for dataset_type_id in sorted(dataset_type_ids)
             ],
         )
-        for dimension, values in summary.governors.items():
-            if values:
+        for dimension in sorted(summary.governors):
+            if values := summary.governors[dimension]:
                 self._db.ensure(
                     self._tables.dimensions[dimension],
-                    *[{self._collectionKeyName: collection.key, dimension: v} for v in values],
+                    *[{self._collectionKeyName: collection.key, dimension: v} for v in sorted(values)],
                 )
 
     def fetch_summaries(


### PR DESCRIPTION
This will help reduce deadlocks when inserts are happening in different orders in different processes.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
