### PR TITLE
DM-51125: Add registry configuration to disable temp tables

### DIFF
--- a/doc/changes/DM-51125.feature.md
+++ b/doc/changes/DM-51125.feature.md
@@ -1,0 +1,1 @@
+Added a new registry configuration option `temporary_tables: False` to disable the use of temporary tables by the database backend.

--- a/python/lsst/daf/butler/direct_query_driver/_driver.py
+++ b/python/lsst/daf/butler/direct_query_driver/_driver.py
@@ -353,7 +353,7 @@ class DirectQueryDriver(QueryDriver):
         else:
             dict_rows = [dict(zip(dimensions.required, values)) for values in rows]
         from_clause: sqlalchemy.FromClause
-        if len(dict_rows) > self._constant_rows_limit:
+        if self.db.supports_temporary_tables and len(dict_rows) > self._constant_rows_limit:
             from_clause = self._exit_stack.enter_context(self.db.temporary_table(table_spec))
             self.db.insert(from_clause, *dict_rows)
         else:

--- a/python/lsst/daf/butler/registry/_config.py
+++ b/python/lsst/daf/butler/registry/_config.py
@@ -119,3 +119,24 @@ class RegistryConfig(ConfigSubset):
         (`sqlalchemy.engine.url.URL`).
         """
         return ConnectionStringFactory.fromConfig(self)
+
+    @property
+    def areTemporaryTablesAllowed(self) -> bool:
+        """Return `True` if the database allows creating temporary tables for
+        read operations; `False` otherwise.
+
+        By default this is `True`, because there is a performance penalty
+        for some queries if temporary tables cannot be used.
+
+        This should be set to `False` when using a Postgres hot standby using
+        physical replication or an AlloyDB read pool, since these backends
+        do not support temporary tables.
+        """
+        key = "temporary_tables"
+        value = self.get(key)
+        if value is None:
+            return True
+        elif isinstance(value, bool):
+            return value
+
+        raise ValueError(f"Unexpected value '{value}' for '{key}' in registry configuration")

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -65,6 +65,10 @@ class PostgresqlDatabase(Database):
     writeable : `bool`, optional
         If `True`, allow write operations on the database, including
         ``CREATE TABLE``.
+    allow_temporary_tables : `bool`, optional
+        If `True`, database operations will be allowed to use temporary tables.
+        If `False`, other SQL constructs will be used instead of temporary
+        tables when possible.
 
     Notes
     -----
@@ -85,6 +89,7 @@ class PostgresqlDatabase(Database):
         origin: int,
         namespace: str | None = None,
         writeable: bool = True,
+        allow_temporary_tables: bool = True,
     ):
         with engine.connect() as connection:
             # `Any` to make mypy ignore the line below, can't use type: ignore
@@ -114,6 +119,7 @@ class PostgresqlDatabase(Database):
             dbname=dsn.get("dbname"),
             metadata=None,
             pg_version=pg_version,
+            allow_temporary_tables=allow_temporary_tables,
         )
 
     def _init(
@@ -126,9 +132,16 @@ class PostgresqlDatabase(Database):
         dbname: str,
         metadata: DatabaseMetadata | None,
         pg_version: tuple[int, int],
+        allow_temporary_tables: bool = True,
     ) -> None:
         # Initialization logic shared between ``__init__`` and ``clone``.
-        super().__init__(origin=origin, engine=engine, namespace=namespace, metadata=metadata)
+        super().__init__(
+            origin=origin,
+            engine=engine,
+            namespace=namespace,
+            metadata=metadata,
+            allow_temporary_tables=allow_temporary_tables,
+        )
         self._writeable = writeable
         self.dbname = dbname
         self._pg_version = pg_version
@@ -143,6 +156,7 @@ class PostgresqlDatabase(Database):
             dbname=self.dbname,
             metadata=self._metadata,
             pg_version=self._pg_version,
+            allow_temporary_tables=self._allow_temporary_tables,
         )
         return clone
 

--- a/python/lsst/daf/butler/registry/databases/sqlite.py
+++ b/python/lsst/daf/butler/registry/databases/sqlite.py
@@ -74,6 +74,11 @@ class SqliteDatabase(Database):
     writeable : `bool`, optional
         If `True`, allow write operations on the database, including
         ``CREATE TABLE``.
+    allow_temporary_tables : `bool`, optional
+        If `True`, database operations will be allowed to use temporary
+        tables.
+        If `False`, other SQL constructs will be used instead of temporary
+        tables when possible.
 
     Notes
     -----
@@ -90,6 +95,7 @@ class SqliteDatabase(Database):
         origin: int,
         namespace: str | None = None,
         writeable: bool = True,
+        allow_temporary_tables: bool = True,
     ):
         filename = _find_database_filename(engine, namespace)
         self._init(
@@ -99,6 +105,7 @@ class SqliteDatabase(Database):
             writeable=writeable,
             filename=filename,
             metadata=None,
+            allow_temporary_tables=allow_temporary_tables,
         )
 
     def _init(
@@ -110,9 +117,16 @@ class SqliteDatabase(Database):
         writeable: bool = True,
         filename: str | None,
         metadata: DatabaseMetadata | None,
+        allow_temporary_tables: bool,
     ) -> None:
         # Initialization logic shared between ``__init__`` and ``clone``.
-        super().__init__(origin=origin, engine=engine, namespace=namespace, metadata=metadata)
+        super().__init__(
+            origin=origin,
+            engine=engine,
+            namespace=namespace,
+            metadata=metadata,
+            allow_temporary_tables=allow_temporary_tables,
+        )
         self._writeable = writeable
         self.filename = filename
 
@@ -125,6 +139,7 @@ class SqliteDatabase(Database):
             writeable=self._writeable,
             filename=self.filename,
             metadata=self._metadata,
+            allow_temporary_tables=self._allow_temporary_tables,
         )
         return clone
 

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -324,6 +324,7 @@ class Database(ABC):
         origin: int,
         namespace: str | None = None,
         writeable: bool = True,
+        allow_temporary_tables: bool = True,
     ) -> Database:
         """Construct a database from a SQLAlchemy URI.
 
@@ -342,15 +343,22 @@ class Database(ABC):
         writeable : `bool`, optional
             If `True`, allow write operations on the database, including
             ``CREATE TABLE``.
+        allow_temporary_tables : `bool`, optional
+            If `True`, database operations will be allowed to use temporary
+            tables.
+            If `False`, other SQL constructs will be used instead of temporary
+            tables when possible.
 
         Returns
         -------
         db : `Database`
             A new `Database` instance.
         """
-        return cls.fromEngine(
+        db = cls.fromEngine(
             cls.makeEngine(uri, writeable=writeable), origin=origin, namespace=namespace, writeable=writeable
         )
+        db._allow_temporary_tables = allow_temporary_tables
+        return db
 
     @abstractmethod
     def clone(self) -> Database:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -187,7 +187,10 @@ class SqlRegistry:
 
         DatabaseClass = config.getDatabaseClass()
         database = DatabaseClass.fromUri(
-            config.connectionString, origin=config.get("origin", 0), namespace=config.get("namespace")
+            config.connectionString,
+            origin=config.get("origin", 0),
+            namespace=config.get("namespace"),
+            allow_temporary_tables=config.areTemporaryTablesAllowed,
         )
         managerTypes = RegistryManagerTypes.fromConfig(config)
         managers = managerTypes.makeRepo(database, dimensionConfig)
@@ -230,6 +233,7 @@ class SqlRegistry:
             origin=config.get("origin", 0),
             namespace=config.get("namespace"),
             writeable=writeable,
+            allow_temporary_tables=config.areTemporaryTablesAllowed,
         )
         managerTypes = RegistryManagerTypes.fromConfig(config)
         with database.session():

--- a/python/lsst/daf/butler/tests/utils.py
+++ b/python/lsst/daf/butler/tests/utils.py
@@ -47,7 +47,7 @@ from .. import Butler, ButlerConfig, Config, DatasetRef, StorageClassFactory, Ti
 from .._collection_type import CollectionType
 from ..datastore import NullDatastore
 from ..direct_butler import DirectButler
-from ..registry.sql_registry import SqlRegistry
+from ..registry.sql_registry import RegistryConfig, SqlRegistry
 from ..tests import MetricsExample, addDatasetType
 
 if TYPE_CHECKING:
@@ -129,13 +129,18 @@ def safeTestTempDir(default_base: str) -> Iterator[str]:
         removeTestTempDir(root)
 
 
-def create_populated_sqlite_registry(*args: ResourcePathExpression) -> Butler:
+def create_populated_sqlite_registry(
+    *args: ResourcePathExpression, registry_config: RegistryConfig | None = None
+) -> Butler:
     """Create an in-memory registry-only sqlite butler and populate it.
 
     Parameters
     ----------
     *args : convertible to `lsst.resources.ResourcePath`
         Paths to export YAML files that should be imported.
+    registry_config : ``RegistryConfig``, optional
+        Registry configuration to use as the basis for the Butler
+        configuration.
 
     Returns
     -------
@@ -143,6 +148,8 @@ def create_populated_sqlite_registry(*args: ResourcePathExpression) -> Butler:
         New butler populated with the specified import files.
     """
     config = ButlerConfig()
+    if registry_config is not None:
+        config["registry"] = registry_config
     config[".registry.db"] = "sqlite://"
     registry = SqlRegistry.createFromConfig(config["registry"])
     butler = DirectButler(

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -39,7 +39,7 @@ import sqlalchemy
 from lsst.daf.butler import Butler, ButlerConfig, StorageClassFactory, Timespan, ddl
 from lsst.daf.butler.datastore import NullDatastore
 from lsst.daf.butler.direct_butler import DirectButler
-from lsst.daf.butler.registry import _RegistryFactory
+from lsst.daf.butler.registry import RegistryConfig, _RegistryFactory
 from lsst.daf.butler.tests.postgresql import setup_postgres_test_db
 
 try:
@@ -215,8 +215,9 @@ class PostgresqlRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
-    def make_butler(self) -> Butler:
-        config = self.makeRegistryConfig()
+    def make_butler(self, config: RegistryConfig | None = None) -> Butler:
+        if config is None:
+            config = self.makeRegistryConfig()
         self.postgres.patch_registry_config(config)
         registry = _RegistryFactory(config).create_from_config()
 

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -36,6 +36,7 @@ from lsst.daf.butler._exceptions import UnknownButlerUserError
 from lsst.daf.butler.datastores.file_datastore.retrieve_artifacts import (
     determine_destination_for_retrieved_artifact,
 )
+from lsst.daf.butler.registry import RegistryConfig
 from lsst.daf.butler.registry.tests import RegistryTests
 from lsst.daf.butler.tests.postgresql import TemporaryPostgresInstance, setup_postgres_test_db
 from lsst.resources import ResourcePath
@@ -179,7 +180,7 @@ class RemoteButlerRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.join(TESTDIR, "data", "registry")
 
-    def make_butler(self) -> Butler:
+    def make_butler(self, registry_config: RegistryConfig | None = None) -> Butler:
         return self.server_instance.hybrid_butler
 
     def testBasicTransaction(self):

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -35,7 +35,7 @@ from contextlib import contextmanager
 import sqlalchemy
 
 from lsst.daf.butler import Butler, Config, ddl
-from lsst.daf.butler.registry import _RegistryFactory
+from lsst.daf.butler.registry import RegistryConfig, _RegistryFactory
 from lsst.daf.butler.registry.databases.sqlite import SqliteDatabase
 from lsst.daf.butler.registry.tests import DatabaseTests, RegistryTests
 from lsst.daf.butler.tests import makeTestRepo
@@ -207,9 +207,11 @@ class SqliteFileRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
-    def make_butler(self) -> Butler:
+    def make_butler(self, registry_config: RegistryConfig | None = None) -> Butler:
         config = Config()
-        config["registry"] = self.makeRegistryConfig()
+        if registry_config is None:
+            registry_config = self.makeRegistryConfig()
+        config["registry"] = registry_config
         return makeTestRepo(self.root, config=config)
 
 
@@ -231,8 +233,8 @@ class ClonedSqliteFileRegistryNameKeyCollMgrUUIDTestCase(
 ):
     """Test that NameKeyCollectionManager still works after cloning."""
 
-    def make_butler(self) -> Butler:
-        original = super().make_butler()
+    def make_butler(self, registry_config: RegistryConfig | None = None) -> Butler:
+        original = super().make_butler(registry_config)
         return original.clone()
 
 
@@ -259,10 +261,12 @@ class SqliteMemoryRegistryTests(RegistryTests):
     def getDataDir(cls) -> str:
         return os.path.normpath(os.path.join(os.path.dirname(__file__), "data", "registry"))
 
-    def make_butler(self) -> Butler:
+    def make_butler(self, registry_config: RegistryConfig | None = None) -> Butler:
         # This helper function always return in-memory registry
         # with default managers.
-        return create_populated_sqlite_registry()
+        if registry_config is None:
+            registry_config = self.makeRegistryConfig()
+        return create_populated_sqlite_registry(registry_config=registry_config)
 
     def testMissingAttributes(self):
         """Test for instantiating a registry against outdated schema which


### PR DESCRIPTION
Add a registry configuration option "temporary_tables" that lets you disable the usage of temporary tables in Butler queries.

This will allow Butler to be used on AlloyDB read pools and Postgres read replicas using physical replication, since neither of these backends support temp tables.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
