### PR TITLE
DM-49537 (v29.1): Revert scarlet model formatter configuration change

### DIFF
--- a/doc/changes/DM-49537.feature.md
+++ b/doc/changes/DM-49537.feature.md
@@ -1,1 +1,0 @@
-Store scarlet lite models as zip archives that can be accessed as single blends.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -86,7 +86,7 @@ TaskMetadata: lsst.daf.butler.formatters.json.JsonFormatter
 SpectractorSpectrum: lsst.atmospec.formatters.SpectractorSpectrumFormatter
 SpectractorImage: lsst.atmospec.formatters.SpectractorImageFormatter
 SpectractorFitParameters: lsst.atmospec.formatters.SpectractorFitParametersFormatter
-ScarletModelData: lsst.meas.extensions.scarlet.io.ScarletModelFormatter
+ScarletModelData: lsst.daf.butler.formatters.json.JsonFormatter
 MetricMeasurementBundle: lsst.daf.butler.formatters.json.JsonFormatter
 MultipleCellCoadd: lsst.cell_coadds.CellCoaddFitsFormatter
 NNModelPackagePayload: lsst.meas.transiNet.modelPackages.NNModelPackageFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -409,9 +409,6 @@ storageClasses:
     pytype: spectractor.fit.fitter.FitParameters
   ScarletModelData:
     pytype: lsst.scarlet.lite.io.ScarletModelData
-    parameters:
-      - blend_id
-    delegate: lsst.meas.extensions.scarlet.io.ScarletModelDelegate
   MetricMeasurementBundle:
     pytype: lsst.analysis.tools.interfaces.MetricMeasurementBundle
   MultipleCellCoadd:


### PR DESCRIPTION
v29.1 will not have the new scarlet formatter code in it.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
