### PR TITLE
DM-51075: Implement transfer_from RemoteButler

### DIFF
--- a/doc/changes/DM-51075.feature.md
+++ b/doc/changes/DM-51075.feature.md
@@ -1,0 +1,1 @@
+`RemoteButler` can now be used as a source Butler in `transfer_from`.

--- a/python/lsst/daf/butler/_limited_butler.py
+++ b/python/lsst/daf/butler/_limited_butler.py
@@ -42,7 +42,7 @@ from ._dataset_provenance import DatasetProvenance
 from ._dataset_ref import DatasetRef
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._storage_class import StorageClass, StorageClassFactory
-from .datastore import DatasetRefURIs, Datastore
+from .datastore import DatasetRefURIs, Datastore, FileTransferSource
 from .dimensions import DimensionUniverse
 
 log = logging.getLogger(__name__)
@@ -449,6 +449,13 @@ class LimitedButler(ABC):
         repository (`DimensionUniverse`).
         """
         raise NotImplementedError()
+
+    @property
+    def _file_transfer_source(self) -> FileTransferSource:
+        """Object that manages the transfer of files between Butler
+        repositories.
+        """
+        return self._datastore
 
     _datastore: Datastore
     """The object that manages actual dataset storage (`Datastore`)."""

--- a/python/lsst/daf/butler/datastore/__init__.py
+++ b/python/lsst/daf/butler/datastore/__init__.py
@@ -26,3 +26,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ._datastore import *
+from ._transfer import *

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -54,7 +54,7 @@ from .._config import Config, ConfigSubset
 from .._exceptions import DatasetTypeNotSupportedError, ValidationError
 from .._file_dataset import FileDataset
 from .._storage_class import StorageClassFactory
-from ._transfer import FileTransferInfo
+from ._transfer import FileTransferInfo, FileTransferSource
 from .constraints import Constraints
 
 if TYPE_CHECKING:
@@ -284,7 +284,7 @@ class DatasetRefURIs(abc.Sequence):
         return f"DatasetRefURIs({repr(self.primaryURI)}, {repr(self.componentURIs)})"
 
 
-class Datastore(metaclass=ABCMeta):
+class Datastore(FileTransferSource, metaclass=ABCMeta):
     """Datastore interface.
 
     Parameters
@@ -869,7 +869,7 @@ class Datastore(metaclass=ABCMeta):
 
     def transfer_from(
         self,
-        source_datastore: Datastore,
+        source_datastore: FileTransferSource,
         refs: Collection[DatasetRef],
         transfer: str = "auto",
         artifact_existence: dict[ResourcePath, bool] | None = None,
@@ -1421,7 +1421,7 @@ class Datastore(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def _get_file_info_for_transfer(
+    def get_file_info_for_transfer(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
     ) -> dict[DatasetId, list[FileTransferInfo]]:
         raise NotImplementedError(f"Transferring files is not supported by datastore {self}")
@@ -1500,7 +1500,7 @@ class NullDatastore(Datastore):
 
     def transfer_from(
         self,
-        source_datastore: Datastore,
+        source_datastore: FileTransferSource,
         refs: Iterable[DatasetRef],
         transfer: str = "auto",
         artifact_existence: dict[ResourcePath, bool] | None = None,

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -54,7 +54,7 @@ from .._config import Config, ConfigSubset
 from .._exceptions import DatasetTypeNotSupportedError, ValidationError
 from .._file_dataset import FileDataset
 from .._storage_class import StorageClassFactory
-from ._transfer import FileTransferInfo, FileTransferSource
+from ._transfer import FileTransferMap, FileTransferSource
 from .constraints import Constraints
 
 if TYPE_CHECKING:
@@ -1421,9 +1421,12 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def get_file_info_for_transfer(
+    def get_file_info_for_transfer(self, dataset_ids: Iterable[DatasetId]) -> FileTransferMap:
+        raise NotImplementedError(f"Transferring files is not supported by datastore {self}")
+
+    def locate_missing_files_for_transfer(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
-    ) -> dict[DatasetId, list[FileTransferInfo]]:
+    ) -> FileTransferMap:
         raise NotImplementedError(f"Transferring files is not supported by datastore {self}")
 
 

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -54,6 +54,7 @@ from .._config import Config, ConfigSubset
 from .._exceptions import DatasetTypeNotSupportedError, ValidationError
 from .._file_dataset import FileDataset
 from .._storage_class import StorageClassFactory
+from ._transfer import FileTransferInfo
 from .constraints import Constraints
 
 if TYPE_CHECKING:
@@ -62,7 +63,7 @@ if TYPE_CHECKING:
     from .. import ddl
     from .._config_support import LookupKey
     from .._dataset_provenance import DatasetProvenance
-    from .._dataset_ref import DatasetRef
+    from .._dataset_ref import DatasetId, DatasetRef
     from .._dataset_type import DatasetType
     from .._storage_class import StorageClass
     from ..datastores.file_datastore.retrieve_artifacts import ArtifactIndexInfo
@@ -1419,6 +1420,11 @@ class Datastore(metaclass=ABCMeta):
             datastore records.
         """
         raise NotImplementedError()
+
+    def _get_file_info_for_transfer(
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
+    ) -> dict[DatasetId, list[FileTransferInfo]]:
+        raise NotImplementedError(f"Transferring files is not supported by datastore {self}")
 
 
 class NullDatastore(Datastore):

--- a/python/lsst/daf/butler/datastore/_transfer.py
+++ b/python/lsst/daf/butler/datastore/_transfer.py
@@ -27,9 +27,27 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from collections.abc import Iterable
+from typing import NamedTuple, Protocol
 
+from lsst.resources import ResourcePath
+
+from .._dataset_ref import DatasetId, DatasetRef
 from .stored_file_info import Location, StoredFileInfo
+
+__all__ = ("FileTransferInfo", "FileTransferSource")
+
+
+class FileTransferSource(Protocol):
+    name: str
+
+    def get_file_info_for_transfer(
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
+    ) -> dict[DatasetId, list[FileTransferInfo]]: ...
+
+    def mexists(
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
+    ) -> dict[DatasetRef, bool]: ...
 
 
 class FileTransferInfo(NamedTuple):

--- a/python/lsst/daf/butler/datastore/_transfer.py
+++ b/python/lsst/daf/butler/datastore/_transfer.py
@@ -1,0 +1,37 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from .stored_file_info import Location, StoredFileInfo
+
+
+class FileTransferInfo(NamedTuple):
+    location: Location
+    file_info: StoredFileInfo

--- a/python/lsst/daf/butler/datastore/_transfer.py
+++ b/python/lsst/daf/butler/datastore/_transfer.py
@@ -28,28 +28,33 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import NamedTuple, Protocol
+from typing import NamedTuple, Protocol, TypeAlias
 
 from lsst.resources import ResourcePath
 
 from .._dataset_ref import DatasetId, DatasetRef
 from .stored_file_info import Location, StoredFileInfo
 
-__all__ = ("FileTransferInfo", "FileTransferSource")
+__all__ = ("FileTransferMap", "FileTransferRecord", "FileTransferSource")
 
 
 class FileTransferSource(Protocol):
     name: str
 
-    def get_file_info_for_transfer(
+    def get_file_info_for_transfer(self, dataset_ids: Iterable[DatasetId]) -> FileTransferMap: ...
+
+    def locate_missing_files_for_transfer(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
-    ) -> dict[DatasetId, list[FileTransferInfo]]: ...
+    ) -> FileTransferMap: ...
 
     def mexists(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
     ) -> dict[DatasetRef, bool]: ...
 
 
-class FileTransferInfo(NamedTuple):
+class FileTransferRecord(NamedTuple):
     location: Location
     file_info: StoredFileInfo
+
+
+FileTransferMap: TypeAlias = dict[DatasetId, list[FileTransferRecord]]

--- a/python/lsst/daf/butler/datastore/stored_file_info.py
+++ b/python/lsst/daf/butler/datastore/stored_file_info.py
@@ -410,7 +410,8 @@ def make_datastore_path_relative(path: str) -> str:
     ------
     normalized_path : `str`
         The original path, if it was relative. Otherwise, a version of it that
-        was converted to a relative path.
+        was converted to a relative path, stripping URI scheme and netloc from
+        it.
     """
     # Force the datastore file path sent to the client to be relative, since
     # absolute URLs in the server will generally not be reachable by the

--- a/python/lsst/daf/butler/datastore/stored_file_info.py
+++ b/python/lsst/daf/butler/datastore/stored_file_info.py
@@ -395,3 +395,36 @@ class SerializedStoredFileInfo(pydantic.BaseModel):
 
     file_size: int
     """Size of the serialized dataset in bytes."""
+
+
+def make_datastore_path_relative(path: str) -> str:
+    """Normalize a path from a `StoredFileInfo` object so
+    that it is always relative.
+
+    Parameters
+    ----------
+    path : `str`
+        The file path from a `StoredFileInfo`.
+
+    Return
+    ------
+    normalized_path : `str`
+        The original path, if it was relative. Otherwise, a version of it that
+        was converted to a relative path.
+    """
+    # Force the datastore file path sent to the client to be relative, since
+    # absolute URLs in the server will generally not be reachable by the
+    # client.  If an absolute URL is sent, it (or a portion of it) can end up
+    # baked into the FileDatastore that is the target of the transfer in some
+    # cases.
+    rpath = ResourcePath(path, forceAbsolute=False, forceDirectory=False)
+    if rpath.isabs():
+        relative = rpath.relativeToPathRoot
+        if rpath.fragment:
+            # Preserve the fragment, since this used to indicate special
+            # processing like zip extraction.
+            return f"{relative}#{rpath.fragment}"
+        else:
+            return relative
+    else:
+        return path

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -110,6 +110,7 @@ from lsst.utils.logging import VERBOSE, getLogger
 from lsst.utils.timer import time_this
 
 from ..datastore import FileTransferMap, FileTransferRecord, FileTransferSource
+from ..datastore.stored_file_info import make_datastore_path_relative
 
 if TYPE_CHECKING:
     from lsst.daf.butler import DatasetProvenance, LookupKey
@@ -3241,16 +3242,8 @@ def _to_file_info_payload(
 ) -> FileDatastoreGetPayloadFileInfo:
     location, file_info = info
 
-    # Make sure that we send only relative paths, to avoid leaking
-    # details of our configuration to the client.
-    path = location.pathInStore
-    if path.isabs():
-        relative_path = path.relativeToPathRoot
-    else:
-        relative_path = str(path)
-
     datastoreRecords = file_info.to_simple()
-    datastoreRecords.path = relative_path
+    datastoreRecords.path = make_datastore_path_relative(datastoreRecords.path)
 
     return FileDatastoreGetPayloadFileInfo(
         url=location.uri.generate_presigned_get_url(expiration_time_seconds=url_expiration_time_seconds),

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -2095,7 +2095,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # this with no datastore records.
         artifact_existence: dict[ResourcePath, bool] = {}
         if skip_missing:
-            dataset_existence = source_butler._datastore.mexists(
+            dataset_existence = source_butler._file_transfer_source.mexists(
                 source_refs, artifact_existence=artifact_existence
             )
             source_refs = [ref for ref, exists in dataset_existence.items() if exists]
@@ -2318,7 +2318,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             # Ask the datastore to transfer. The datastore has to check that
             # the source datastore is compatible with the target datastore.
             accepted, rejected = self._datastore.transfer_from(
-                source_butler._datastore,
+                source_butler._file_transfer_source,
                 imported_refs,
                 transfer=transfer,
                 artifact_existence=import_info.artifact_existence,

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -76,6 +76,7 @@ from ._query_results import convert_dataset_ref_results, read_query_results
 from ._ref_utils import apply_storage_class_override, normalize_dataset_type_name, simplify_dataId
 from ._registry import RemoteButlerRegistry
 from ._remote_butler_collections import RemoteButlerCollections
+from ._remote_file_transfer_source import RemoteFileTransferSource
 from .server_models import (
     CollectionList,
     FindDatasetRequestModel,
@@ -712,6 +713,10 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         return RemoteButler(
             connection=self._connection, cache=self._cache, defaults=defaults, metrics=metrics
         )
+
+    @property
+    def _file_transfer_source(self) -> RemoteFileTransferSource:
+        return RemoteFileTransferSource(self._connection)
 
     def __str__(self) -> str:
         return f"RemoteButler({self._connection.server_url})"

--- a/python/lsst/daf/butler/remote_butler/_remote_file_transfer_source.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_file_transfer_source.py
@@ -43,6 +43,15 @@ from .server_models import (
 
 
 class RemoteFileTransferSource(FileTransferSource):
+    """Implementation of `FileTransferSource` that retrieves information from
+    Butler server.
+
+    Parameters
+    ----------
+    connection : `RemoteButlerHttpConnection`
+        HTTP connection used to access the Butler server.
+    """
+
     def __init__(self, connection: RemoteButlerHttpConnection) -> None:
         self._connection = connection
         self.name = f"RemoteFileTransferSource{connection.server_url}"
@@ -67,9 +76,12 @@ class RemoteFileTransferSource(FileTransferSource):
     def mexists(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
     ) -> dict[DatasetRef, bool]:
-        # TODO: This is a stub.  It's not clear that this function makes much
+        # This is a stub.  It's not clear that this function makes much
         # sense in the context of Butler Server -- our data releases should
         # never include files that are accidentally missing.
+        # TODO DM-51302: Rework the transfer_from process so that we can use
+        # get_file_info_for_transfer() to implement
+        # transfer_from(skip_missing=True) instead of calling this function.
         return {ref: True for ref in refs}
 
 

--- a/python/lsst/daf/butler/remote_butler/_remote_file_transfer_source.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_file_transfer_source.py
@@ -1,0 +1,80 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Iterable
+
+from lsst.daf.butler._dataset_ref import DatasetId, DatasetRef
+from lsst.resources import ResourcePath
+from lsst.utils.iteration import chunk_iterable
+
+from .._location import Location
+from ..datastore import FileTransferMap, FileTransferRecord, FileTransferSource
+from ..datastore.stored_file_info import StoredFileInfo
+from ._http_connection import RemoteButlerHttpConnection, parse_model
+from .server_models import (
+    FileTransferRecordModel,
+    GetFileTransferInfoRequestModel,
+    GetFileTransferInfoResponseModel,
+)
+
+
+class RemoteFileTransferSource(FileTransferSource):
+    def __init__(self, connection: RemoteButlerHttpConnection) -> None:
+        self._connection = connection
+        self.name = f"RemoteFileTransferSource{connection.server_url}"
+
+    def get_file_info_for_transfer(self, dataset_ids: Iterable[DatasetId]) -> FileTransferMap:
+        output: FileTransferMap = {}
+        for chunk in chunk_iterable(dataset_ids, GetFileTransferInfoRequestModel.MAX_ITEMS_PER_REQUEST):
+            request = GetFileTransferInfoRequestModel(dataset_ids=chunk)
+            response = self._connection.post("file_transfer", request)
+            model = parse_model(response, GetFileTransferInfoResponseModel)
+            for id, records in model.files.items():
+                output[id] = [_deserialize_file_transfer_record(r) for r in records]
+
+        return output
+
+    def locate_missing_files_for_transfer(
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
+    ) -> FileTransferMap:
+        missing_ids = {ref.id for ref in refs}
+        raise ValueError(f"Some datasets could not be found in {self.name}: {missing_ids}")
+
+    def mexists(
+        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
+    ) -> dict[DatasetRef, bool]:
+        # TODO: This is a stub.  It's not clear that this function makes much
+        # sense in the context of Butler Server -- our data releases should
+        # never include files that are accidentally missing.
+        return {ref: True for ref in refs}
+
+
+def _deserialize_file_transfer_record(record: FileTransferRecordModel) -> FileTransferRecord:
+    return FileTransferRecord(
+        location=Location(None, ResourcePath(str(record.url))),
+        file_info=StoredFileInfo.from_simple(record.file_info),
+    )

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -231,7 +231,7 @@ def _serialize_file_transfer_record(record: FileTransferRecord) -> FileTransferR
     file_info.path = make_datastore_path_relative(file_info.path)
 
     return FileTransferRecordModel(
-        # TODO: return a permanent URL
+        # TODO DM-51301: return a permanent URL
         url=record.location.uri.generate_presigned_get_url(expiration_time_seconds=3600),
         file_info=file_info,
     )

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -38,10 +38,12 @@ from ...._butler import Butler
 from ...._collection_type import CollectionType
 from ...._dataset_ref import DatasetRef
 from ...._exceptions import DatasetNotFoundError
+from ....datastore import FileTransferRecord
 from ....registry.interfaces import ChainedCollectionRecord
 from ...server_models import (
     ExpandDataIdRequestModel,
     ExpandDataIdResponseModel,
+    FileTransferRecordModel,
     FindDatasetRequestModel,
     FindDatasetResponseModel,
     GetCollectionInfoResponseModel,
@@ -49,6 +51,8 @@ from ...server_models import (
     GetDatasetTypeResponseModel,
     GetFileByDataIdRequestModel,
     GetFileResponseModel,
+    GetFileTransferInfoRequestModel,
+    GetFileTransferInfoResponseModel,
     GetUniverseResponseModel,
     QueryCollectionInfoRequestModel,
     QueryCollectionInfoResponseModel,
@@ -206,6 +210,29 @@ def _get_file_by_ref(butler: Butler, ref: DatasetRef) -> GetFileResponseModel:
     """Return file information associated with ``ref``."""
     payload = butler._datastore.prepare_get_for_external_client(ref)
     return GetFileResponseModel(dataset_ref=ref.to_simple(), artifact=payload)
+
+
+@external_router.post(
+    "/v1/file_transfer",
+    summary="Retrieve information needed to transfer files to an external Butler repository",
+)
+def file_transfer(
+    request: GetFileTransferInfoRequestModel, factory: Factory = Depends(factory_dependency)
+) -> GetFileTransferInfoResponseModel:
+    butler = factory.create_butler()
+    files = butler._datastore.get_file_info_for_transfer(request.dataset_ids)
+    output = {id: [_serialize_file_transfer_record(r) for r in records] for id, records in files.items()}
+    return GetFileTransferInfoResponseModel(files=output)
+
+
+def _serialize_file_transfer_record(record: FileTransferRecord) -> FileTransferRecordModel:
+    return FileTransferRecordModel(
+        # TODO: return a permanent URL
+        url=record.location.uri.generate_presigned_get_url(expiration_time_seconds=3600),
+        # TODO: normalize path (like the get_file stuff does inside
+        # FileDatastore)
+        file_info=record.file_info.to_simple(),
+    )
 
 
 # TODO DM-46204: This can be removed once the RSP recommended image has been

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -39,6 +39,7 @@ from ...._collection_type import CollectionType
 from ...._dataset_ref import DatasetRef
 from ...._exceptions import DatasetNotFoundError
 from ....datastore import FileTransferRecord
+from ....datastore.stored_file_info import make_datastore_path_relative
 from ....registry.interfaces import ChainedCollectionRecord
 from ...server_models import (
     ExpandDataIdRequestModel,
@@ -226,12 +227,13 @@ def file_transfer(
 
 
 def _serialize_file_transfer_record(record: FileTransferRecord) -> FileTransferRecordModel:
+    file_info = record.file_info.to_simple()
+    file_info.path = make_datastore_path_relative(file_info.path)
+
     return FileTransferRecordModel(
         # TODO: return a permanent URL
         url=record.location.uri.generate_presigned_get_url(expiration_time_seconds=3600),
-        # TODO: normalize path (like the get_file stuff does inside
-        # FileDatastore)
-        file_info=record.file_info.to_simple(),
+        file_info=file_info,
     )
 
 

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -38,7 +38,7 @@ __all__ = [
 ]
 
 from collections.abc import Iterable
-from typing import Annotated, Any, Literal, NewType, Self, TypeAlias
+from typing import Annotated, Any, ClassVar, Literal, NewType, Self, TypeAlias
 from uuid import UUID
 
 import pydantic
@@ -58,6 +58,7 @@ from lsst.daf.butler import (
 from lsst.daf.butler.datastores.fileDatastoreClient import FileDatastoreGetPayload
 from lsst.daf.butler.registry import SerializedCollectionSummary
 
+from ..datastore.stored_file_info import SerializedStoredFileInfo
 from ..dimensions import SerializedDimensionConfig, SerializedDimensionRecord
 from ..queries.result_specs import SerializedResultSpec
 from ..queries.tree import ColumnLiteral, SerializedQueryTree
@@ -416,3 +417,17 @@ class QueryAllDatasetsRequestModel(pydantic.BaseModel):
     bind: dict[str, ColumnLiteral]
     limit: int | None
     with_dimension_records: bool
+
+
+class GetFileTransferInfoRequestModel(pydantic.BaseModel):
+    MAX_ITEMS_PER_REQUEST: ClassVar[int] = 10000
+    dataset_ids: Annotated[list[UUID], pydantic.Field(max_length=MAX_ITEMS_PER_REQUEST)]
+
+
+class FileTransferRecordModel(pydantic.BaseModel):
+    url: pydantic.AnyHttpUrl
+    file_info: SerializedStoredFileInfo
+
+
+class GetFileTransferInfoResponseModel(pydantic.BaseModel):
+    files: dict[UUID, list[FileTransferRecordModel]]

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -420,7 +420,7 @@ class QueryAllDatasetsRequestModel(pydantic.BaseModel):
 
 
 class GetFileTransferInfoRequestModel(pydantic.BaseModel):
-    MAX_ITEMS_PER_REQUEST: ClassVar[int] = 10000
+    MAX_ITEMS_PER_REQUEST: ClassVar[int] = 10_000
     dataset_ids: Annotated[list[UUID], pydantic.Field(max_length=MAX_ITEMS_PER_REQUEST)]
 
 

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -47,7 +47,7 @@ from .._limited_butler import LimitedButler
 from .._query_all_datasets import QueryAllDatasetsParameters
 from .._storage_class import StorageClass
 from .._timespan import Timespan
-from ..datastore import DatasetRefURIs
+from ..datastore import DatasetRefURIs, FileTransferSource
 from ..dimensions import DataCoordinate, DataId, DimensionElement, DimensionRecord, DimensionUniverse
 from ..direct_butler import DirectButler
 from ..queries import Query
@@ -430,3 +430,7 @@ class HybridButler(Butler):
         self, args: QueryAllDatasetsParameters
     ) -> AbstractContextManager[Iterator[list[DatasetRef]]]:
         return self._remote_butler._query_all_datasets_by_page(args)
+
+    @property
+    def _file_transfer_source(self) -> FileTransferSource:
+        return self._remote_butler._file_transfer_source

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -61,7 +61,7 @@ from lsst.daf.butler.datastore.cache_manager import (
     DatastoreCacheManagerConfig,
     DatastoreDisabledCacheManager,
 )
-from lsst.daf.butler.datastore.stored_file_info import StoredFileInfo
+from lsst.daf.butler.datastore.stored_file_info import StoredFileInfo, make_datastore_path_relative
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 from lsst.daf.butler.tests import (
     BadNoWriteFormatter,
@@ -2209,6 +2209,12 @@ class StoredFileInfoTestCase(DatasetTestHelper, unittest.TestCase):
         pickled_info = pickle.dumps(info)
         unpickled_info = pickle.loads(pickled_info)
         self.assertEqual(unpickled_info, info)
+
+    def test_make_datastore_path_relative(self):
+        self.assertEqual(make_datastore_path_relative("a/relative/path"), "a/relative/path")
+        self.assertEqual(make_datastore_path_relative("path/with#fragment"), "path/with#fragment")
+        self.assertEqual(make_datastore_path_relative("http://server.com/some/path"), "some/path")
+        self.assertEqual(make_datastore_path_relative("http://server.com/some/path#frag"), "some/path#frag")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
RemoteButler can now be used as the source Butler in `transfer_from()`.

This required re-factoring `FileDatastore.transfer_from()` to break it up into smaller pieces, so that execution could be divided between Butler server and the client side.  A `FileTransferSource` protocol was added to define the methods required for this.  This protocol is now implemented by `FileDatastore`, `ChainedDatastore`, and the new `RemoteFileTransferSource`.  Some `ChainedDatastore`-specific code was moved out of `FileDatastore` into `ChainedDatastore` itself as a result.

There are two known issues with this initial release, see [DM-51301](https://rubinobs.atlassian.net/browse/DM-51301) and [DM-51302](https://rubinobs.atlassian.net/browse/DM-51302).  Both will require additional re-organization of the existing code to resolve.

This PR will probably be easiest to review commit-by commit, since a lot of code was shuffled between files and functions.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`


[DM-51301]: https://rubinobs.atlassian.net/browse/DM-51301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DM-51302]: https://rubinobs.atlassian.net/browse/DM-51302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ