### PR TITLE
DM-51302: Handle missing transfer datastore records for Butler server

### DIFF
--- a/doc/changes/DM-51302.misc.md
+++ b/doc/changes/DM-51302.misc.md
@@ -1,0 +1,1 @@
+`Butler.transfer_from()` will now raise a `FileNotFoundError` while transferring files if a file listed in the database is not actually available on the filesystem.  Previously, it would silently skip the file.

--- a/doc/changes/DM-51302.perf.md
+++ b/doc/changes/DM-51302.perf.md
@@ -1,0 +1,1 @@
+`Butler.transfer_from` now uses fewer database queries.

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -1420,7 +1420,7 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
     def locate_missing_files_for_transfer(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
     ) -> FileTransferMap:
-        raise NotImplementedError(f"Transferring files is not supported by datastore {self}")
+        return {}
 
 
 class NullDatastore(Datastore):

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -869,7 +869,7 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
 
     def transfer_from(
         self,
-        source_datastore: FileTransferSource,
+        source_records: FileTransferMap,
         refs: Collection[DatasetRef],
         transfer: str = "auto",
         artifact_existence: dict[ResourcePath, bool] | None = None,
@@ -879,9 +879,8 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
 
         Parameters
         ----------
-        source_datastore : `Datastore`
-            The datastore from which to transfer artifacts. That datastore
-            must be compatible with this datastore receiving the artifacts.
+        source_records : `FileTransferMap`
+            The artifacts to be transferred into this datastore.
         refs : `~collections.abc.Collection` of `DatasetRef`
             The datasets to transfer from the source datastore.
         transfer : `str`, optional
@@ -916,13 +915,7 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
         TypeError
             Raised if the two datastores are not compatible.
         """
-        if type(self) is not type(source_datastore):
-            raise TypeError(
-                f"Datastore mismatch between this datastore ({type(self)}) and the "
-                f"source datastore ({type(source_datastore)})."
-            )
-
-        raise NotImplementedError(f"Datastore {type(self)} must implement a transfer_from method.")
+        raise NotImplementedError(f"Datastore {type(self)} does not implement a transfer_from method.")
 
     def getManyURIs(
         self,
@@ -1503,7 +1496,7 @@ class NullDatastore(Datastore):
 
     def transfer_from(
         self,
-        source_datastore: FileTransferSource,
+        source_records: FileTransferMap,
         refs: Iterable[DatasetRef],
         transfer: str = "auto",
         artifact_existence: dict[ResourcePath, bool] | None = None,

--- a/python/lsst/daf/butler/datastore/_transfer.py
+++ b/python/lsst/daf/butler/datastore/_transfer.py
@@ -78,38 +78,12 @@ class FileTransferSource(Protocol):
             Optional mapping of datastore artifact to existence. Updated by
             this method with details of all artifacts tested.
 
-        Raises
-        ------
-        ValueError
-            If this file transfer source cannot locate artifacts by searching
-            the filesystem.
-
         Return
         ------
         transfer_map : `FileTransferMap`
             Dictionary from `DatasetId` to a list of files found for that
             dataset.  If information about any  given dataset IDs could not
             be found, the missing IDs are omitted from the dictionary.
-        """
-
-    def mexists(
-        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
-    ) -> dict[DatasetRef, bool]:
-        """Scan the filesystem to determine whether the given datasets exist on
-        disk.
-
-        Parameters
-        ----------
-        refs : iterable of `DatasetRef`
-            The datasets to be checked.
-        artifact_existence : `dict` [`lsst.resources.ResourcePath`, `bool`]
-            Optional mapping of datastore artifact to existence. Updated by
-            this method with details of all artifacts tested.
-
-        Returns
-        -------
-        existence : `dict` of [`DatasetRef`, `bool`]
-            Mapping from dataset to boolean indicating existence.
         """
 
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -1253,7 +1253,10 @@ class ChainedDatastore(Datastore):
 
         if not found_acceptable_datastore:
             types = {get_full_type_name(d) for d in self.datastores}
-            raise TypeError(f"ChainedDatastore encountered that had no FileDatastores. Had {','.join(types)}")
+            raise TypeError(
+                "ChainedDatastore had no datastores able to provide file transfer information."
+                f" Had {','.join(types)}"
+            )
 
         return output
 

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -55,7 +55,6 @@ from lsst.utils.logging import getLogger
 
 from .._dataset_ref import DatasetId
 from ..datastore import FileTransferMap
-from .fileDatastore import FileDatastore
 
 if TYPE_CHECKING:
     from lsst.daf.butler import Config, DatasetProvenance, DatasetType, LookupKey, StorageClass
@@ -1239,59 +1238,41 @@ class ChainedDatastore(Datastore):
                 raise FileNotFoundError(f"Failed to export dataset {refs[i]}.")
             yield dataset
 
-    def _find_child_datastores_supporting_file_transfer(self) -> list[FileDatastore]:
-        datastores = self.datastores
-        incompatible: list[Datastore] = []
-        acceptable: list[FileDatastore] = []
-        for current_source in datastores:
-            if not isinstance(current_source, FileDatastore):
-                incompatible.append(current_source)
-            else:
-                acceptable.append(current_source)
-
-        if len(incompatible) == len(datastores):
-            if len(datastores) == 1:
-                raise TypeError(
-                    "Can only transfer to a FileDatastore from another FileDatastore, not"
-                    f" {get_full_type_name(datastores[0])}"
-                )
-            else:
-                types = [get_full_type_name(d) for d in datastores]
-                raise TypeError(
-                    f"ChainedDatastore encountered that had no FileDatastores. Had {','.join(types)}"
-                )
-
-        return acceptable
-
     def get_file_info_for_transfer(self, dataset_ids: Iterable[DatasetId]) -> FileTransferMap:
         unassigned_ids = set(dataset_ids)
         output: FileTransferMap = {}
-        datastores = self._find_child_datastores_supporting_file_transfer()
-        for datastore in datastores:
-            found = datastore.get_file_info_for_transfer(unassigned_ids)
-            output.update(found)
-            unassigned_ids -= found.keys()
+        found_acceptable_datastore = False
+        for datastore in self.datastores:
+            try:
+                found = datastore.get_file_info_for_transfer(unassigned_ids)
+                found_acceptable_datastore = True
+                output.update(found)
+                unassigned_ids -= found.keys()
+            except NotImplementedError:
+                pass
+
+        if not found_acceptable_datastore:
+            types = {get_full_type_name(d) for d in self.datastores}
+            raise TypeError(f"ChainedDatastore encountered that had no FileDatastores. Had {','.join(types)}")
+
         return output
 
     def locate_missing_files_for_transfer(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
     ) -> FileTransferMap:
-        datastores = self._find_child_datastores_supporting_file_transfer()
-
         missing_refs = {ref.id: ref for ref in refs}
         output: FileTransferMap = {}
-        for datastore in datastores:
-            if datastore.trustGetRequest:
-                # Have to check each datastore in turn. If we do not do
-                # this warnings will be issued further down for datasets
-                # that are in one and not the other. The existence cache
-                # will prevent repeat checks.
+        for datastore in self.datastores:
+            # Have to check each datastore in turn. If we do not do
+            # this warnings will be issued further down for datasets
+            # that are in one and not the other. The existence cache
+            # will prevent repeat checks.
 
-                found = datastore.locate_missing_files_for_transfer(missing_refs.values(), artifact_existence)
-                output.update(found)
-                for id in found.keys():
-                    missing_refs.pop(id)
-                log.debug("Adding %d missing refs to list for transfer from %s", len(found), datastore.name)
+            found = datastore.locate_missing_files_for_transfer(missing_refs.values(), artifact_existence)
+            output.update(found)
+            for id in found.keys():
+                missing_refs.pop(id)
+            log.debug("Adding %d missing refs to list for transfer from %s", len(found), datastore.name)
 
         return output
 

--- a/python/lsst/daf/butler/datastores/file_datastore/transfer.py
+++ b/python/lsst/daf/butler/datastores/file_datastore/transfer.py
@@ -71,10 +71,7 @@ def retrieve_file_transfer_records(
     """
     log.verbose("Looking up source datastore records in %s", source_datastore.name)
     refs_by_id = {ref.id: ref for ref in refs}
-    try:
-        source_records = source_datastore.get_file_info_for_transfer(refs_by_id.keys())
-    except NotImplementedError as e:
-        raise TypeError(f"Source datastore {source_datastore.name} does not support file transfer") from e
+    source_records = source_datastore.get_file_info_for_transfer(refs_by_id.keys())
 
     log.debug("Number of datastore records found in source: %d", len(source_records))
 

--- a/python/lsst/daf/butler/datastores/file_datastore/transfer.py
+++ b/python/lsst/daf/butler/datastores/file_datastore/transfer.py
@@ -43,7 +43,7 @@ def retrieve_file_transfer_records(
     refs: Iterable[DatasetRef],
     artifact_existence: dict[ResourcePath, bool],
 ) -> FileTransferMap:
-    """Look up the datastore records corresponding to the given `DatasetRef`s.
+    """Look up the datastore records corresponding to the given datasets.
 
     Parameters
     ----------

--- a/python/lsst/daf/butler/datastores/file_datastore/transfer.py
+++ b/python/lsst/daf/butler/datastores/file_datastore/transfer.py
@@ -1,0 +1,107 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from lsst.resources import ResourcePath
+from lsst.utils.logging import getLogger
+
+from ..._dataset_ref import DatasetRef
+from ...datastore import FileTransferMap, FileTransferSource
+
+log = getLogger(__name__)
+
+
+def retrieve_file_transfer_records(
+    source_datastore: FileTransferSource,
+    refs: Iterable[DatasetRef],
+    artifact_existence: dict[ResourcePath, bool],
+) -> FileTransferMap:
+    """Look up the datastore records corresponding to the given `DatasetRef`s.
+
+    Parameters
+    ----------
+    source_datastore : `FileTransferSource`
+        Object used to look up records.
+    refs : `~collections.abc.Iterable` [ `DatasetRef` ]
+        List of datasets to retrieve records for.
+    artifact_existence : `dict` [`lsst.resources.ResourcePath`, `bool`]
+        Cache mapping datastore artifact to existence. Updated by
+        this method with details of all artifacts tested.
+
+    Return
+    ------
+    files : `FileTransferMap`
+        A dictionary from `DatasetId` to a list of `FileTransferRecord`,
+        containing information about the files that were found for these
+        artifacts.  If files were not found for a given `DatasetRef`, there
+        will be no entry for it in this dictionary.
+
+    Notes
+    -----
+    This will first attempt to look up records using the database, and then
+    fall back to searching the filesystem if the transfer source is configured
+    to do so.
+    """
+    log.verbose("Looking up source datastore records in %s", source_datastore.name)
+    refs_by_id = {ref.id: ref for ref in refs}
+    try:
+        source_records = source_datastore.get_file_info_for_transfer(refs_by_id.keys())
+    except NotImplementedError as e:
+        raise TypeError(f"Source datastore {source_datastore.name} does not support file transfer") from e
+
+    log.debug("Number of datastore records found in source: %d", len(source_records))
+
+    # If we couldn't find all of the datasets in the database, continue
+    # searching.  Some datastores may have artifacts on disk that do not have
+    # corresponding records in the database.
+    missing_ids = refs_by_id.keys() - source_records.keys()
+    if missing_ids:
+        log.info(
+            "Number of expected datasets missing from source datastore records: %d out of %d",
+            len(missing_ids),
+            len(refs_by_id),
+        )
+        missing_refs = {refs_by_id[id] for id in missing_ids}
+        found_records = source_datastore.locate_missing_files_for_transfer(missing_refs, artifact_existence)
+        source_records |= found_records
+
+        still_missing = len(missing_refs) - len(found_records)
+        if still_missing:
+            for ref in missing_refs:
+                if ref.id not in found_records:
+                    log.warning("Asked to transfer dataset %s but no file artifacts exist for it.", ref)
+            log.warning(
+                "Encountered %d dataset%s where no file artifacts exist from the "
+                "source datastore and will be skipped.",
+                still_missing,
+                "s" if still_missing != 1 else "",
+            )
+
+    return source_records

--- a/python/lsst/daf/butler/remote_butler/_remote_file_transfer_source.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_file_transfer_source.py
@@ -70,19 +70,9 @@ class RemoteFileTransferSource(FileTransferSource):
     def locate_missing_files_for_transfer(
         self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
     ) -> FileTransferMap:
-        missing_ids = {ref.id for ref in refs}
-        raise ValueError(f"Some datasets could not be found in {self.name}: {missing_ids}")
-
-    def mexists(
-        self, refs: Iterable[DatasetRef], artifact_existence: dict[ResourcePath, bool]
-    ) -> dict[DatasetRef, bool]:
-        # This is a stub.  It's not clear that this function makes much
-        # sense in the context of Butler Server -- our data releases should
-        # never include files that are accidentally missing.
-        # TODO DM-51302: Rework the transfer_from process so that we can use
-        # get_file_info_for_transfer() to implement
-        # transfer_from(skip_missing=True) instead of calling this function.
-        return {ref: True for ref in refs}
+        # The server does not provide an alternate way to look up files that
+        # could not be found using the file transfer endpoint.
+        return {}
 
 
 def _deserialize_file_transfer_record(record: FileTransferRecordModel) -> FileTransferRecord:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2799,13 +2799,6 @@ class DatastoreTransfers(TestCaseMixin):
             transferred = self.target_butler.transfer_from(self.source_butler, source_refs)
             self.assertEqual(len(transferred), n_expected)
 
-            # Also do an explicit low-level transfer to trigger some
-            # edge cases.
-            with self.assertLogs(level=logging.DEBUG) as log_cm:
-                self.target_butler._datastore.transfer_from(self.source_butler._datastore, source_refs)
-            log_output = ";".join(log_cm.output)
-            self.assertIn("no file artifacts exist", log_output)
-
             with self.assertRaises((TypeError, AttributeError)):
                 self.target_butler._datastore.transfer_from(self.source_butler, source_refs)  # type: ignore
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -2876,7 +2876,7 @@ class PosixDatastoreTransfers(DatastoreTransfers, unittest.TestCase):
     def testTransferFromIncompatibleUuidToUuid(self) -> None:
         """Force the source butler to be a incompatible datastore."""
         self.create_butlers(source_config=os.path.join(TESTDIR, "config/basic/butler-inmemory.yaml"))
-        with self.assertRaises(TypeError):
+        with self.assertRaises(NotImplementedError):
             self.assertButlerTransfers()
 
     def testTransferFromIncompatibleChainUuidToUuid(self) -> None:


### PR DESCRIPTION
When using RemoteButler as the source for `transfer_from`, `skip_missing=True` will now skip importing refs that do not have datastore records available from the server.

There are two side-effects from this re-organization:
1. "Accidentally" missing files, for which the datastore has a database record but the file is gone, will now raise an error when they are transferred.
2. The number of database queries for the datastore is cut in half for transfer_from, since mexists is no longer called.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
