### PR TITLE
DM-51381: Defer looking up storage class definitions in StoredFileInfo.

### DIFF
--- a/doc/changes/DM-51381.bugfix.md
+++ b/doc/changes/DM-51381.bugfix.md
@@ -1,0 +1,3 @@
+Defer loading storage class definitions when deserializing datastore records.
+
+This prevents storage class lookup errors when loading quantum graphs, when the storage class definitions are defined somewhere other than the defaults in `daf_butler` (such as a repository root).


### PR DESCRIPTION
This allows a StoredFileInfo to be deserialized without assuming all relevant butler configuration has already been read and used to populate the StorageClassFactory singleton.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
