### PR TITLE
DM-51073 (v29.1): v29.1 release notes

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -47,7 +47,7 @@ jobs:
         run: sudo apt-get install graphviz
 
       - name: Install documenteer
-        run: uv pip install --system 'documenteer[pipelines]==0.8.2'
+        run: uv pip install --system 'documenteer[pipelines]==0.8.2' sphinx-automodapi==0.19
 
       - name: Build documentation
         working-directory: ./doc

--- a/doc/changes/DM-31824.misc.rst
+++ b/doc/changes/DM-31824.misc.rst
@@ -1,1 +1,0 @@
-``retrieveArtifacts`` and ``transfer_from`` now transfer their artifacts using multiple threads.

--- a/doc/changes/DM-38497.feature.md
+++ b/doc/changes/DM-38497.feature.md
@@ -1,2 +1,0 @@
-Add support in user expressions for explicit specification of bind identifiers with a preceding colon symbol.
-Legacy format of bind identifiers without colon is still supported, but will be deprecated in the future.

--- a/doc/changes/DM-47201.bugfix.md
+++ b/doc/changes/DM-47201.bugfix.md
@@ -1,1 +1,0 @@
-Fixed an issue where `find_first=False` dataset queries would sometimes return duplicate results if more than one collection was being searched.

--- a/doc/changes/DM-47644.bugfix.md
+++ b/doc/changes/DM-47644.bugfix.md
@@ -1,2 +1,0 @@
-Query expressions now allow float columns to be compared with int literals.
-Query expressions now allow OVERLAPS to be used to compare timespans with ingest_date.

--- a/doc/changes/DM-48975.feature.md
+++ b/doc/changes/DM-48975.feature.md
@@ -1,4 +1,0 @@
-Add a new `--show-dataset-types` argument (`-t`) to `butler query-collections`
-to list the dataset types in each collection.
-Also add a new `--exclude-dataset-types` which allows a comma-separated list
-of string globs to be passed in for exclusion when dataset types are shown.

--- a/doc/changes/DM-49513.perf.md
+++ b/doc/changes/DM-49513.perf.md
@@ -1,1 +1,0 @@
-`Butler.transfer_from()` now uses fewer database queries when inserting datasets of multiple dataset types, when some of the dataset types have the same dimensions.

--- a/doc/changes/DM-49622.feature.md
+++ b/doc/changes/DM-49622.feature.md
@@ -1,1 +1,0 @@
-Add Pydantic serialization for `DimensionRecordSet`.

--- a/doc/changes/DM-49670.bugfix.md
+++ b/doc/changes/DM-49670.bugfix.md
@@ -1,1 +1,0 @@
-`Butler.ingest()` will now register missing run collections instead of raising a `MissingCollectionError`.

--- a/doc/changes/DM-49670.feature.md
+++ b/doc/changes/DM-49670.feature.md
@@ -1,1 +1,0 @@
-Added `FileDataset.to_simple` and `FileDataset.from_simple` for serializing `FileDataset` instances.

--- a/doc/changes/DM-49949.feature.md
+++ b/doc/changes/DM-49949.feature.md
@@ -1,1 +1,0 @@
-The `Query` class now has a `join_data_coordinate_table` method for uploading data IDs from astropy tables.  This includes support for filling in required-dimension columns using constraints from a `where` string (e.g. so a table with just `visit` IDs along with `instrument='LSSTCam'` in the `where` string will work).

--- a/doc/changes/DM-50044.misc.rst
+++ b/doc/changes/DM-50044.misc.rst
@@ -1,3 +1,0 @@
-* Reorganized the code for ``Butler.ingest`` and ``Butler.ingest_zip`` to share the code from ``Butler.transfer_from`` in order to provide consistent error messages for incompatible dataset types and to allow a future possibility of registering dataset types and dimension records as part of ``ingest_zip``.
-* Removed the ``use_cache`` parameter from the ``DimensionUniverse`` constructor.
-  The universe is always cached and the remote butler now uses that cache and does not need to disable the cache.

--- a/doc/changes/DM-50191.feature.md
+++ b/doc/changes/DM-50191.feature.md
@@ -1,3 +1,0 @@
-User expression language adds support for `GLOB(expression, pattern)` function.
-The function performs case-sensitive match of the string expression against pattern.
-The pattern can include `*` and `?` meta-characters that match any number or a single character.

--- a/doc/changes/DM-50313.feature.rst
+++ b/doc/changes/DM-50313.feature.rst
@@ -1,3 +1,0 @@
-Added the ability for Zip ingest to register any missing dimension records.
-Note that if any datasets use ``visit`` that require registration then the records being registered will not fully define the visit and so can not be usable for graph building.
-It is recommended that visits be defined first before ingest at this time.

--- a/doc/changes/DM-50451.feature.md
+++ b/doc/changes/DM-50451.feature.md
@@ -1,2 +1,0 @@
-User expression language adds support for UUID literals that can be used to query dataset IDs.
-UUID literals are specified using function call syntax: `UUID('hex-string')`.

--- a/doc/changes/DM-50465.bugfix.md
+++ b/doc/changes/DM-50465.bugfix.md
@@ -1,1 +1,0 @@
-Fix handling of expressions like "id=2" in contexts where "id" resolves unambigously to a dimension primary key column.

--- a/doc/changes/DM-50491.feature.rst
+++ b/doc/changes/DM-50491.feature.rst
@@ -1,2 +1,0 @@
-Added ability for Butler to record timing metrics such as the amount of time spent in ``get()`` or ``put()`` and the number of times those are called.
-A metrics object can be given to the ``Butler`` constructor to record everything, or alternatively a new context manager ``Butler.record_metrics`` can be used to record metrics for a specific usage.

--- a/doc/changes/DM-50724.misc.rst
+++ b/doc/changes/DM-50724.misc.rst
@@ -1,1 +1,0 @@
-Significantly sped up ``Butler.pruneDatasets`` by using parallelized artifact deletions.

--- a/doc/changes/DM-50727.misc.rst
+++ b/doc/changes/DM-50727.misc.rst
@@ -1,1 +1,0 @@
-Modified trash emptying in datastore such that only the datasets to be removed as part of the original butler request are the ones that are trashed immediately.

--- a/doc/changes/DM-50823.misc.rst
+++ b/doc/changes/DM-50823.misc.rst
@@ -1,1 +1,0 @@
-Modified CLI tooling to work with both click 8.1 and click 8.2.

--- a/doc/changes/DM-50855.bugfix.md
+++ b/doc/changes/DM-50855.bugfix.md
@@ -1,1 +1,0 @@
-`butler remove-runs` will no longer block if a parallel process calls `butler remove-runs` on a run contained in the same collection chain.

--- a/doc/changes/DM-50935.misc.rst
+++ b/doc/changes/DM-50935.misc.rst
@@ -1,1 +1,0 @@
-Fixed handling of ``FileDatastore.transfer_from()`` such that it now works with chained datastores.

--- a/doc/changes/DM-50969.perf.md
+++ b/doc/changes/DM-50969.perf.md
@@ -1,1 +1,0 @@
-Improve the performance of certain queries by moving WHERE clause terms down into subqueries.

--- a/doc/changes/DM-50996.api.rst
+++ b/doc/changes/DM-50996.api.rst
@@ -1,3 +1,0 @@
-* The ``unstore`` parameter for ``Butler.removeRuns()`` has been deprecated.
-  We now always remove the file artifacts when removing the collection.
-* Added a ``unlink_from_chains`` parameter to ``Butler.removeRuns()`` to allow the RUN collections to be unlinked from their parent chains automatically.

--- a/doc/changes/DM-50996.misc.rst
+++ b/doc/changes/DM-50996.misc.rst
@@ -1,1 +1,0 @@
-Reorganized ``Butler.removeRuns()`` to remove datasets in chunks to provide more feedback to the user and allow for restarting if the command fails for some reason.

--- a/doc/changes/DM-51075.feature.md
+++ b/doc/changes/DM-51075.feature.md
@@ -1,1 +1,0 @@
-`RemoteButler` can now be used as a source Butler in `transfer_from`.

--- a/doc/changes/DM-51269.misc.rst
+++ b/doc/changes/DM-51269.misc.rst
@@ -1,2 +1,0 @@
-Added a ``fallback_instrument`` to ObsCore configurations.
-This instrument is used when an ObsCore record is constructed from a dataset type that has no instrument defined.

--- a/doc/changes/DM-51302.misc.md
+++ b/doc/changes/DM-51302.misc.md
@@ -1,1 +1,0 @@
-`Butler.transfer_from()` will now raise a `FileNotFoundError` while transferring files if a file listed in the database is not actually available on the filesystem.  Previously, it would silently skip the file.

--- a/doc/changes/DM-51302.perf.md
+++ b/doc/changes/DM-51302.perf.md
@@ -1,1 +1,0 @@
-`Butler.transfer_from` now uses fewer database queries.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -r requirements/main.in
 -r requirements/test.in
 
-lsst-sphgeom @ git+https://github.com/lsst/sphgeom@main
-lsst-utils @ git+https://github.com/lsst/utils@main
-lsst-resources[https,s3] @ git+https://github.com/lsst/resources@main
-lsst-daf-relation @ git+https://github.com/lsst/daf_relation@main
+lsst-sphgeom @ git+https://github.com/lsst/sphgeom@v29.1.x
+lsst-utils @ git+https://github.com/lsst/utils@v29.1.x
+lsst-resources[https,s3] @ git+https://github.com/lsst/resources@v29.1.x
+lsst-daf-relation @ git+https://github.com/lsst/daf_relation@v29.0.x


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
