### PR TITLE
DM-51401: Ensure subTest arguments are strings.

### DIFF
--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -1130,7 +1130,7 @@ class DatabaseTests(ABC):
         for rhsRow in aRows:
             if rhsRow[TimespanReprClass.NAME] is None:
                 continue
-            with self.subTest(rhsRow=rhsRow):
+            with self.subTest(rhsRow=repr(rhsRow)):
                 expected = {}
                 for lhsRow in aRows:
                     if lhsRow[TimespanReprClass.NAME] is None:
@@ -1191,7 +1191,7 @@ class DatabaseTests(ABC):
         # Test relationship expressions between in-database timespans and
         # Python-literal instantaneous times.
         for t in timestamps:
-            with self.subTest(t=t):
+            with self.subTest(t=repr(t)):
                 expected = {}
                 for lhsRow in aRows:
                     if lhsRow[TimespanReprClass.NAME] is None:

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -465,7 +465,7 @@ class RegistryTests(ABC):
         # Try a normal integer and something that looks like an int but
         # is not.
         for visit_id in (42, np.int64(42)):
-            with self.subTest(visit_id=visit_id, id_type=type(visit_id).__name__):
+            with self.subTest(visit_id=repr(visit_id), id_type=type(visit_id).__name__):
                 expanded = registry.expandDataId({"instrument": "DummyCam", "visit": visit_id})
                 self.assertEqual(expanded["visit"], int(visit_id))
                 self.assertIsInstance(expanded["visit"], int)
@@ -706,7 +706,7 @@ class RegistryTests(ABC):
 
         # Test for non-unique IDs, they can be re-imported multiple times.
         for run, idGenMode in ((2, DatasetIdGenEnum.DATAID_TYPE), (4, DatasetIdGenEnum.DATAID_TYPE_RUN)):
-            with self.subTest(idGenMode=idGenMode):
+            with self.subTest(idGenMode=repr(idGenMode)):
                 # Make dataset ref with reproducible dataset ID.
                 ref = DatasetRef(datasetTypeBias, dataIdBias1, run=f"run{run}", id_generation_mode=idGenMode)
                 (ref1,) = registry._importDatasets([ref])
@@ -3305,7 +3305,7 @@ class RegistryTests(ABC):
             )
 
         for test in test_data:
-            with self.subTest(test=test):
+            with self.subTest(test=repr(test)):
                 order_by = test.order_by.split(",")
                 keys = test.keys.split(",")
                 query = do_query(keys, test.datasets, test.collections).order_by(*order_by)

--- a/python/lsst/daf/butler/tests/butler_queries.py
+++ b/python/lsst/daf/butler/tests/butler_queries.py
@@ -1774,7 +1774,7 @@ class ButlerQueryTests(ABC, TestCaseMixin):
             ("new-query", _run_query),
             ("simple", _run_simple_query),
         ]:
-            with self.subTest(test):
+            with self.subTest(repr(test)):
                 # Boolean columns should be usable standalone as an expression.
                 self.assertCountEqual(query_func("exposure.can_see_sky"), [TRUE_ID])
 
@@ -2438,7 +2438,7 @@ class ButlerQueryTests(ABC, TestCaseMixin):
         # Limit of 3 lands at the boundary of a dataset type.
         # Limit of 4 is in the middle of a dataset type.
         for limit in [3, 4]:
-            with self.subTest(limit=limit):
+            with self.subTest(limit=repr(limit)):
                 results = butler._query_all_datasets("imported_g", limit=limit)
                 self.assertEqual(len(results), limit)
                 with self.assertLogs(level="WARNING") as log:

--- a/python/lsst/daf/butler/tests/cliLogTestBase.py
+++ b/python/lsst/daf/butler/tests/cliLogTestBase.py
@@ -293,7 +293,7 @@ class CliLogTestBase:
 
     def _test_levels(self, log_levels: tuple[tuple[str, str, int, int, int, Any, Any, int], ...]) -> None:
         for level1, level2, x_pyroot, x_pylsst, x_pybutler, x_lsstroot, x_lsstbutler, x_lsstx in log_levels:
-            with self.subTest("Test different log levels", level1=level1, level2=level2):
+            with self.subTest("Test different log levels", level1=repr(level1), level2=repr(level2)):
                 self.runTest(
                     partial(
                         self.runner.invoke,

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -318,7 +318,7 @@ class ButlerPutGetTests(TestCaseMixin):
             butler.collections.register(this_run)
             expected_collections.update({this_run})
 
-            with self.subTest(args=args):
+            with self.subTest(args=repr(args)):
                 kwargs: dict[str, Any] = {}
                 if not isinstance(args[0], DatasetRef):  # type: ignore
                     kwargs["run"] = this_run
@@ -1777,7 +1777,7 @@ class FileDatastoreButlerTests(ButlerTests):
                     )
                 importButler = Butler.from_config(importDir, run=self.default_run)
                 for ref in datasets:
-                    with self.subTest(ref=ref):
+                    with self.subTest(ref=repr(ref)):
                         # Test for existence by passing in the DatasetType and
                         # data ID separately, to avoid lookup by dataset_id.
                         self.assertTrue(importButler.exists(ref.datasetType, ref.dataId))

--- a/tests/test_cliCmdQueryDatasets.py
+++ b/tests/test_cliCmdQueryDatasets.py
@@ -275,7 +275,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
 
         for glob in (("*",), ("test_metric_comp",)):
-            with self.subTest(glob=glob):
+            with self.subTest(glob=repr(glob)):
                 tables = self._queryDatasets(
                     repo=testRepo.butler,
                     where="instrument='DummyCamComp' AND visit=423",

--- a/tests/test_connectionString.py
+++ b/tests/test_connectionString.py
@@ -60,7 +60,7 @@ class ConnectionStringBuilderTestCase(unittest.TestCase):
 
         for regConf, fileName in zip(regConfigs, self.configFiles, strict=True):
             conStr = ConnectionStringFactory.fromConfig(regConf, db_auth_path=self.db_auth_path)
-            with self.subTest(confFile=fileName):
+            with self.subTest(confFile=repr(fileName)):
                 self.assertEqual(
                     conStr.render_as_string(hide_password=False),
                     regConf["expected"],

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -115,11 +115,11 @@ class DatasetTypeTestCase(unittest.TestCase):
                 self.assertEqual(component.parentStorageClass.name, "test_StructuredData")
             for suffix in badNames:
                 full = DatasetType.nameWithComponent(name, suffix)
-                with self.subTest(full=full):
+                with self.subTest(full=repr(full)):
                     with self.assertRaises(ValueError):
                         DatasetType(full, dimensions, storageClass)
         for name in badNames:
-            with self.subTest(name=name):
+            with self.subTest(name=repr(name)):
                 with self.assertRaises(ValueError):
                     DatasetType(name, dimensions, storageClass)
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -755,7 +755,7 @@ class DatastoreTests(DatastoreTestsBase):
             if mode == "auto" and "auto" in self.ingestTransferModes and not self.canIngestNoTransferAuto:
                 continue
 
-            with self.subTest(mode=mode):
+            with self.subTest(mode=repr(mode)):
                 datastore = self.makeDatastore()
 
                 def succeed(
@@ -825,7 +825,7 @@ class DatastoreTests(DatastoreTestsBase):
     def testIngestTransfer(self) -> None:
         """Test ingesting existing files after transferring them."""
         for mode in ("copy", "move", "link", "hardlink", "symlink", "relsymlink", "auto"):
-            with self.subTest(mode=mode):
+            with self.subTest(mode=repr(mode)):
                 datastore = self.makeDatastore(mode)
 
                 def succeed(
@@ -1353,7 +1353,7 @@ class CleanupPosixDatastoreTestCase(DatastoreTestsBase, unittest.TestCase):
         # Try formatter that fails and formatter that fails and leaves
         # a file behind
         for formatter in (BadWriteFormatter, BadNoWriteFormatter):
-            with self.subTest(formatter=formatter):
+            with self.subTest(formatter=repr(formatter)):
                 # Monkey patch the formatter
                 datastore.formatterFactory.registerFormatter(ref.datasetType, formatter, overwrite=True)
 
@@ -1547,7 +1547,7 @@ class ChainedDatastorePerStoreConstraintsTests(DatastoreTestsBase, unittest.Test
             # Choose different temp file depending on StorageClass
             testfile = testfile_j if sc.name.endswith("Json") else testfile_y
 
-            with self.subTest(datasetTypeName=typeName, dataId=dataId, sc=sc.name):
+            with self.subTest(datasetTypeName=typeName, dataId=repr(dataId), sc=sc.name):
                 ref = self.makeDatasetRef(typeName, dimensions, sc, dataId)
                 if any(accept):
                     datastore.put(metrics, ref)

--- a/tests/test_dimension_record_containers.py
+++ b/tests/test_dimension_record_containers.py
@@ -395,7 +395,7 @@ class DimensionRecordContainersTestCase(unittest.TestCase):
         deserialize_value.
         """
         for element, records in self.records.items():
-            with self.subTest(element=element):
+            with self.subTest(element=repr(element)):
                 for record1 in records:
                     raw1 = record1.serialize_key_value()
                     self.assertIsInstance(raw1, list)
@@ -412,7 +412,7 @@ class DimensionRecordContainersTestCase(unittest.TestCase):
         """
         adapter = pydantic.TypeAdapter(list[SerializedKeyValueDimensionRecord])
         for element, records in self.records.items():
-            with self.subTest(element=element):
+            with self.subTest(element=repr(element)):
                 rs1 = DimensionRecordSet(element, records, universe=self.universe)
                 raw = adapter.validate_json(adapter.dump_json(rs1.serialize_records()))
                 rs2 = DimensionRecordSet(element, universe=self.universe)

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -158,7 +158,9 @@ class DimensionTestCase(unittest.TestCase):
         seen: set[str] = set()
         for element_name in group.lookup_order:
             element = self.universe[element_name]
-            with self.subTest(required=group.required, implied=group.implied, element=element):
+            with self.subTest(
+                required=repr(group.required), implied=repr(group.implied), element=repr(element)
+            ):
                 seen.add(element_name)
                 self.assertLessEqual(element.minimal_group.required, seen)
                 if element_name in group.implied:
@@ -622,7 +624,7 @@ class DataCoordinateTestCase(unittest.TestCase):
             dataIds = self.randomDataIds(n=1).subset(dimensions)
             split = self.splitByStateFlags(dataIds)
             for dataId in split.chain():
-                with self.subTest(dataId=dataId):
+                with self.subTest(dataId=repr(dataId)):
                     self.assertEqual(dataId.required.keys(), dataId.dimensions.required)
                     self.assertEqual(
                         list(dataId.required.values()), [dataId[d] for d in dataId.dimensions.required]
@@ -632,7 +634,7 @@ class DataCoordinateTestCase(unittest.TestCase):
                     )
                     self.assertEqual(dataId.required.keys(), dataId.dimensions.required)
             for dataId in itertools.chain(split.complete, split.expanded):
-                with self.subTest(dataId=dataId):
+                with self.subTest(dataId=repr(dataId)):
                     self.assertTrue(dataId.hasFull())
                     self.assertEqual(dataId.dimensions.names, dataId.mapping.keys())
                     self.assertEqual(
@@ -730,7 +732,7 @@ class DataCoordinateTestCase(unittest.TestCase):
                         DataCoordinate.standardize(dataId, dimensions=newDimensions, htm7=12),
                     ]
                     for newDataId in newDataIds:
-                        with self.subTest(newDataId=newDataId, type=type(dataId)):
+                        with self.subTest(newDataId=repr(newDataId), type=repr(type(dataId))):
                             commonKeys = dataId.dimensions.required & newDataId.dimensions.required
                             self.assertTrue(commonKeys)
                             self.assertEqual(
@@ -775,7 +777,9 @@ class DataCoordinateTestCase(unittest.TestCase):
                     ),
                 ]
                 for newDataId in newCompleteDataIds:
-                    with self.subTest(dataId=dataId, newDataId=newDataId, type=type(dataId)):
+                    with self.subTest(
+                        dataId=repr(dataId), newDataId=repr(newDataId), type=repr(type(dataId))
+                    ):
                         self.assertEqual(dataId, newDataId)
                         self.assertTrue(newDataId.hasFull())
 
@@ -796,7 +800,7 @@ class DataCoordinateTestCase(unittest.TestCase):
             (parentDataId,) = parentDataIds
             for lhs, rhs in itertools.product(split1.chain(), split2.chain()):
                 unioned = lhs.union(rhs)
-                with self.subTest(lhs=lhs, rhs=rhs, unioned=unioned):
+                with self.subTest(lhs=repr(lhs), rhs=repr(rhs), unioned=repr(unioned)):
                     self.assertEqual(unioned.dimensions, group1.union(group2))
                     self.assertEqual(unioned, parentDataId.subset(unioned.dimensions))
                     if unioned.hasFull():

--- a/tests/test_query_interface.py
+++ b/tests/test_query_interface.py
@@ -806,7 +806,7 @@ class ColumnExpressionsTestCase(unittest.TestCase):
                 (self.x.detector <= 5, "detector <= 5", detector <= 5),
                 (self.x.detector >= 5, "detector >= 5", detector >= 5),
             ]:
-                with self.subTest(string=string, detector=detector):
+                with self.subTest(string=string, detector=repr(detector)):
                     self.assertEqual(predicate.column_type, "bool")
                     self.assertEqual(str(predicate), string)
                     columns = qt.ColumnSet(self.universe.empty)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -227,7 +227,7 @@ class SchemaVersioningTestCase(unittest.TestCase):
         )
 
         for Manager, version, update, compatible in compat_matrix:
-            with self.subTest(test=(Manager, version, update, compatible)):
+            with self.subTest(test=repr((Manager, version, update, compatible))):
                 if compatible:
                     Manager.checkCompatibility(version, update)
                 else:


### PR DESCRIPTION
pytest-xdist chokes on the error messages otherwise, causing the test to fail.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
