### PR TITLE
DM-51373: Limit maximum concurrent queries per user

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_limits.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_limits.py
@@ -1,0 +1,82 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import HTTPException
+
+# Restrict the maximum number of streaming queries that can be running
+# simultaneously, to prevent the database connection pool and the thread pool
+# from being tied up indefinitely.  Beyond this number, the server will return
+# an HTTP 503 Service Unavailable with a Retry-After header.  We are currently
+# using the default FastAPI thread pool size of 40 (total) and have 40 maximum
+# database connections (per Butler repository.)
+_MAXIMUM_CONCURRENT_STREAMING_QUERIES = 25
+# How long we ask callers to wait before trying their query again.
+# The hope is that they will bounce to a less busy replica, so we don't want
+# them to wait too long.
+_QUERY_RETRY_SECONDS = 5
+
+
+class QueryLimits:
+    def __init__(self) -> None:
+        self._active_queries = 0
+
+    async def enforce_query_limits(self) -> None:
+        if self._active_queries >= _MAXIMUM_CONCURRENT_STREAMING_QUERIES:
+            await _block_retry_for_unit_test()
+            raise HTTPException(
+                status_code=503,  # service temporarily unavailable
+                detail="The Butler Server is currently overloaded with requests.",
+                headers={"retry-after": str(_QUERY_RETRY_SECONDS)},
+            )
+
+    @asynccontextmanager
+    async def track_query(self) -> AsyncIterator[None]:
+        try:
+            self._active_queries += 1
+            await _block_query_for_unit_test()
+            yield
+        finally:
+            self._active_queries -= 1
+
+
+async def _block_retry_for_unit_test() -> None:
+    """Will be overridden during unit tests to block the server,
+    in order to verify retry logic.
+    """
+    pass
+
+
+async def _block_query_for_unit_test() -> None:
+    """Will be overridden during unit tests to block the server,
+    in order to verify maximum concurrency logic.
+    """
+    pass

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,6 +43,7 @@ try:
     from fastapi.testclient import TestClient
 
     import lsst.daf.butler.remote_butler._query_results
+    import lsst.daf.butler.remote_butler.server.handlers._query_limits
     import lsst.daf.butler.remote_butler.server.handlers._query_streaming
     from lsst.daf.butler.remote_butler import ButlerServerError, RemoteButler
     from lsst.daf.butler.remote_butler._authentication import (
@@ -517,20 +518,20 @@ class ButlerClientServerTestCase(unittest.TestCase):
 
         with (
             patch.object(
-                lsst.daf.butler.remote_butler.server.handlers._query_streaming,
+                lsst.daf.butler.remote_butler.server.handlers._query_limits,
                 "_MAXIMUM_CONCURRENT_STREAMING_QUERIES",
                 new=1,
             ),
             patch.object(
-                lsst.daf.butler.remote_butler.server.handlers._query_streaming, "_QUERY_RETRY_SECONDS", new=1
+                lsst.daf.butler.remote_butler.server.handlers._query_limits, "_QUERY_RETRY_SECONDS", new=1
             ),
             patch.object(
-                lsst.daf.butler.remote_butler.server.handlers._query_streaming,
+                lsst.daf.butler.remote_butler.server.handlers._query_limits,
                 "_block_query_for_unit_test",
                 new=AsyncMock(wraps=block_first_request),
             ) as mock_first_client,
             patch.object(
-                lsst.daf.butler.remote_butler.server.handlers._query_streaming,
+                lsst.daf.butler.remote_butler.server.handlers._query_limits,
                 "_block_retry_for_unit_test",
                 new=AsyncMock(wraps=block_second_request),
             ) as mock_second_client,


### PR DESCRIPTION
Limit the maximum number of concurrent long-running queries to 2 per user per Butler server replica.  The fact that this limit is applied on a per-replica basis makes it somewhat nondeterministic, but for now it is hopefully sufficient to stop simple errors in end-user code from consuming all available database resources.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
