### PR TITLE
DM-51495: Place exposure in visit field for obs core records

### DIFF
--- a/doc/changes/DM-51495.misc.rst
+++ b/doc/changes/DM-51495.misc.rst
@@ -1,0 +1,3 @@
+* Modified ObsCore records to place "exposure" in any visit fields if there is an exposure but no visit defined.
+  This required the addition of a new method to the ``RecordFactory`` which can be subclassed by other plugins.
+* Added ability to hard code the ``s_xel1`` and ``s_xel2`` ObsCore fields per dataset type.

--- a/python/lsst/daf/butler/registry/obscore/_config.py
+++ b/python/lsst/daf/butler/registry/obscore/_config.py
@@ -101,6 +101,11 @@ class DatasetTypeConfig(pydantic.BaseModel):
     """Value for the ``obs_collection`` column, if specified it overrides
     global value in `ObsCoreConfig`."""
 
+    s_xel: tuple[int, int] | None = None
+    """The number of pixels in the first and second dimension of the dataset
+    type.
+    """
+
     extra_columns: (
         None | (dict[str, StrictFloat | StrictInt | StrictBool | StrictStr | ExtraColumnConfig])
     ) = None

--- a/python/lsst/daf/butler/registry/obscore/_records.py
+++ b/python/lsst/daf/butler/registry/obscore/_records.py
@@ -190,6 +190,11 @@ class RecordFactory:
         fmt_kws.update(run=ref.run)
         fmt_kws.update(dataset_type=dataset_type_name)
         fmt_kws.update(record)
+
+        # In some cases we would like some keys to be duplicated
+        # with different names. For example making an exposure be a visit.
+        self.finalize_format_keywords(fmt_kws)
+
         if dataset_config.obs_id_fmt:
             record["obs_id"] = dataset_config.obs_id_fmt.format(**fmt_kws)
             fmt_kws["obs_id"] = record["obs_id"]
@@ -330,6 +335,17 @@ class RecordFactory:
                 raise
         return record
 
+    def finalize_format_keywords(self, format_kws: dict[str, Any]) -> None:
+        """Modify the formatting dict as required after it has been populated
+        with generic content.
+
+        Parameters
+        ----------
+        format_kws : `dict`
+            Dictionary that might be modified in place.
+        """
+        pass
+
     @classmethod
     def get_record_type_from_universe(cls, universe: DimensionUniverse) -> type[RecordFactory]:
         namespace = universe.namespace
@@ -469,3 +485,9 @@ class DafButlerRecordFactory(RecordFactory):
             else:
                 return None, None
         return region_dim, "region"
+
+    def finalize_format_keywords(self, format_kws: dict[str, Any]) -> None:
+        # If we have an exposure but do not have a visit, copy the exposure
+        # into the visit field.
+        if "exposure" in format_kws and "visit" not in format_kws:
+            format_kws["visit"] = format_kws["exposure"]

--- a/python/lsst/daf/butler/registry/obscore/_records.py
+++ b/python/lsst/daf/butler/registry/obscore/_records.py
@@ -179,6 +179,10 @@ class RecordFactory:
             record["obs_collection"] = self.config.obs_collection
         record["access_format"] = dataset_config.access_format
 
+        if dataset_config.s_xel is not None:
+            record["s_xel1"] = dataset_config.s_xel[0]
+            record["s_xel2"] = dataset_config.s_xel[1]
+
         dataId = ref.dataId
         dataset_type_name = ref.datasetType.name
 


### PR DESCRIPTION
This allows the exposure ID to turn up in the lsst_visit record rather than being empty and saves us from needing and lsst_exposure column when in almost all cases the exposure ID is the same as the visit ID.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
