### PR TITLE
Temporarily disable per-user query limits

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_limits.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_limits.py
@@ -57,6 +57,7 @@ class QueryLimits:
         self._active_users: Counter[str] = Counter()
 
     async def enforce_query_limits(self, user: str) -> None:
+        return
         if self._active_queries >= _MAXIMUM_CONCURRENT_STREAMING_QUERIES:
             await _block_retry_for_unit_test()
             raise HTTPException(


### PR DESCRIPTION
Stelios is trying to test something that requires high concurrency with a single user

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
