### PR TITLE
DM-51593: Eliminate expandDataId loops

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -47,7 +47,7 @@ jobs:
         run: sudo apt-get install graphviz
 
       - name: Install documenteer
-        run: uv pip install --system 'documenteer[pipelines]==0.8.2' sphinx-automodapi==0.19
+        run: uv pip install --system 'documenteer[pipelines]==0.8.2' sphinx-automodapi==0.19 sphinx-prompt==1.6.0
 
       - name: Build documentation
         working-directory: ./doc

--- a/doc/changes/DM-51593.perf.md
+++ b/doc/changes/DM-51593.perf.md
@@ -1,0 +1,1 @@
+Fewer database queries are now used when inserting/exporting datasets, in cases where the datasets do not have "expanded data ID" values known in advance.

--- a/python/lsst/daf/butler/dimensions/_record_set.py
+++ b/python/lsst/daf/butler/dimensions/_record_set.py
@@ -822,12 +822,11 @@ class DimensionDataAttacher:
             Data IDs with dimension records attached, in the same order as the
             original iterable.
         """
-        incomplete: list[_InProgressRecordDicts] = []
         lookup_helpers = [
             _DimensionRecordLookupHelper.build(dimensions, element_name, self)
             for element_name in dimensions.lookup_order
         ]
-        records = [_InProgressRecordDicts(n, data_id) for n, data_id in enumerate(data_ids)]
+        records = [_InProgressRecordDicts(data_id) for data_id in data_ids]
         for lookup_helper in lookup_helpers:
             for r in records:
                 lookup_helper.lookup(r)
@@ -848,7 +847,6 @@ class DimensionDataAttacher:
 
 @dataclasses.dataclass
 class _InProgressRecordDicts:
-    index: int  # Index of the data ID these are for in the result list.
     data_id: DataCoordinate
     done: dict[str, DimensionRecord] = dataclasses.field(default_factory=dict)
 

--- a/python/lsst/daf/butler/dimensions/_record_set.py
+++ b/python/lsst/daf/butler/dimensions/_record_set.py
@@ -922,7 +922,7 @@ class _DimensionRecordLookupHelper:
     def _find_implied_value(self, implied_dimension: str, records: _InProgressRecordDicts) -> DataIdValue:
         for rec in records.done.values():
             if implied_dimension in rec.definition.implied:
-                return rec.toDict()[implied_dimension]
+                return rec.get(implied_dimension)
 
         raise LookupError(
             f"Implied value for dimension '{implied_dimension}' not found in records for"

--- a/python/lsst/daf/butler/dimensions/_records.py
+++ b/python/lsst/daf/butler/dimensions/_records.py
@@ -34,15 +34,7 @@ from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 import pydantic
-from pydantic import (
-    BaseModel,
-    Field,
-    StrictBool,
-    StrictFloat,
-    StrictInt,
-    StrictStr,
-    create_model,
-)
+from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr, create_model
 
 import lsst.sphgeom
 from lsst.utils.classes import immutable
@@ -532,6 +524,29 @@ class DimensionRecord:
                 results["datetime_begin"] = timespan.begin
                 results["datetime_end"] = timespan.end
         return results
+
+    def get(self, name: str) -> Any:
+        """Return a single metadata value associated with this record.
+
+        Parameters
+        ----------
+        name : `str`
+            Key of the metadata value to be retrieved.
+
+        Returns
+        -------
+        value
+            The metadata value.
+
+        Raises
+        ------
+        KeyError
+            If the given name is not a valid key in this dimension record.
+        """
+        if name not in self.__slots__:
+            raise KeyError(f"'{name}' is not a valid record key for dimension '{self.definition.name}'")
+
+        return getattr(self, name)
 
     def serialize_key_value(self) -> SerializedKeyValueDimensionRecord:
         """Serialize this record to a `list` that can be sliced into a key

--- a/python/lsst/daf/butler/transfers/_context.py
+++ b/python/lsst/daf/butler/transfers/_context.py
@@ -174,13 +174,9 @@ class RepoExportContext:
                     element = self._butler.dimensions[element]
                 if element.has_own_table:
                     standardized_elements.add(element)
-        for dataId in dataIds:
-            # This is potentially quite slow, because it's approximately
-            # len(dataId.graph.elements) queries per data ID.  But it's a no-op
-            # if the data ID is already expanded, and DM-26692 will add (or at
-            # least start to add / unblock) query functionality that should
-            # let us speed this up internally as well.
-            dataId = self._butler.registry.expandDataId(dataId)
+
+        expanded_data_ids = self._butler._registry.expand_data_ids(dataIds)
+        for dataId in expanded_data_ids:
             for element_name in dataId.dimensions.elements:
                 record = dataId.records[element_name]
                 if record is not None and record.definition in standardized_elements:

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1015,6 +1015,10 @@ class ButlerTests(ButlerPutGetTests):
             "physical_filter", {"instrument": "DummyCamComp", "name": "d-r", "band": "R"}
         )
         butler.registry.insertDimensionData("day_obs", {"instrument": "DummyCamComp", "id": 20250101})
+        for detector in (1, 2):
+            butler.registry.insertDimensionData(
+                "detector", {"instrument": "DummyCamComp", "id": detector, "full_name": f"detector{detector}"}
+            )
 
         butler.registry.insertDimensionData(
             "visit",
@@ -1033,16 +1037,6 @@ class ButlerTests(ButlerPutGetTests):
                 "day_obs": 20250101,
             },
         )
-
-        for detector in (1, 2):
-            butler.registry.insertDimensionData(
-                "detector", {"instrument": "DummyCamComp", "id": detector, "full_name": f"detector{detector}"}
-            )
-            for visit in (423, 424):
-                butler.registry.insertDimensionData(
-                    "visit_detector_region",
-                    {"instrument": "DummyCamComp", "visit": visit, "detector": detector},
-                )
 
         formatter = doImportType("lsst.daf.butler.formatters.yaml.YamlFormatter")
         dataRoot = os.path.join(TESTDIR, "data", "basic")

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1015,10 +1015,6 @@ class ButlerTests(ButlerPutGetTests):
             "physical_filter", {"instrument": "DummyCamComp", "name": "d-r", "band": "R"}
         )
         butler.registry.insertDimensionData("day_obs", {"instrument": "DummyCamComp", "id": 20250101})
-        for detector in (1, 2):
-            butler.registry.insertDimensionData(
-                "detector", {"instrument": "DummyCamComp", "id": detector, "full_name": f"detector{detector}"}
-            )
 
         butler.registry.insertDimensionData(
             "visit",
@@ -1037,6 +1033,16 @@ class ButlerTests(ButlerPutGetTests):
                 "day_obs": 20250101,
             },
         )
+
+        for detector in (1, 2):
+            butler.registry.insertDimensionData(
+                "detector", {"instrument": "DummyCamComp", "id": detector, "full_name": f"detector{detector}"}
+            )
+            for visit in (423, 424):
+                butler.registry.insertDimensionData(
+                    "visit_detector_region",
+                    {"instrument": "DummyCamComp", "visit": visit, "detector": detector},
+                )
 
         formatter = doImportType("lsst.daf.butler.formatters.yaml.YamlFormatter")
         dataRoot = os.path.join(TESTDIR, "data", "basic")


### PR DESCRIPTION
There were a number of places in the Butler internals that looped over `registry.expandDataId`, issuing a DB query per dataset per dimension (potentially millions).  These are now replaced by `DimensionDataAttacher`, which uses a query per dimension instead.

`DimensionDataAttacher` was also reworked so that it can operate on `DataCoordinate` values with `hasFull() = False`.  It now looks up the missing 'implied' data ID values from the dimension records it is attaching.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
