### PR TITLE
Fix handling of chained collections in resolve_wildcard (DM-51819)

### DIFF
--- a/doc/changes/DM-51819.bugfix.md
+++ b/doc/changes/DM-51819.bugfix.md
@@ -1,0 +1,3 @@
+Fix for a bug introduced in July 2024 in collection query methods that specify `flatten_chains=True` with name patterns.
+
+The bug resulted in not returning all children names for a chain collection that matches the pattern, only child names that also match the pattern were returned.


### PR DESCRIPTION
Children of chained collections whose name matches wildcard expression were not returned if they did not match. The fix is to add children names to explicit list of strings to query. Extended unit tests to cover this sort of failure.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
