### PR TITLE
DM-51824: Remove explicit DROP of temporary tables

### DIFF
--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -561,8 +561,6 @@ class Database(ABC):
             try:
                 yield table
             finally:
-                with self._transaction():
-                    table.drop(connection)
                 self._temp_tables.remove(table.key)
                 self._metadata.remove_table(table.name)
 


### PR DESCRIPTION
DROP causes problems when a transaction or server connection aborts inside context manager. Explicit drop is not needed for temp tables as their lifetime is managed by backend and they disappear either after the end of transaction (in Postgres) or when a session finishes.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
