### PR TITLE
DM-52013: Add an option for disabling Gafaelfawr group checks

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/_config.py
+++ b/python/lsst/daf/butler/remote_butler/server/_config.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import cache
+from typing import Literal
 
 from pydantic import AnyHttpUrl, BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -57,9 +58,12 @@ class ButlerServerConfig(BaseSettings):
     repositories: dict[str, RepositoryConfig]
     """Mapping from repository name to configuration for the repository."""
 
-    gafaelfawr_url: AnyHttpUrl
+    gafaelfawr_url: AnyHttpUrl | Literal["DISABLED"]
     """URL to the top-level HTTP path where Gafaelfawr can be found (e.g.
     "https://data-int.lsst.cloud").
+
+    This can instead be the special string "DISABLED" to turn off all features
+    requiring Gafaelfawr integration.
     """
 
     authentication: AuthenticationMode

--- a/python/lsst/daf/butler/remote_butler/server/_config.py
+++ b/python/lsst/daf/butler/remote_butler/server/_config.py
@@ -73,6 +73,10 @@ class ButlerServerConfig(BaseSettings):
     as static files from the `configs/` HTTP route.
     """
 
+    @property
+    def gafaelfawr_enabled(self) -> bool:
+        return self.gafaelfawr_url != "DISABLED"
+
 
 _config: ButlerServerConfig | None = None
 

--- a/python/lsst/daf/butler/remote_butler/server/_server.py
+++ b/python/lsst/daf/butler/remote_butler/server/_server.py
@@ -62,13 +62,16 @@ def create_app() -> FastAPI:
     # factory_dependency().
     default_api_path = "/api/butler"
     prefix = f"{default_api_path}/repo/{{repository}}"
+    auth_dependencies = [Depends(repository_authorization_dependency)]
+    if config.gafaelfawr_url == "DISABLED":
+        auth_dependencies = []
     for router in (external_router, query_router):
         app.include_router(
             router,
             prefix=prefix,
             # Verify that users have permission to access repository-specific
             # resources.
-            dependencies=[Depends(repository_authorization_dependency)],
+            dependencies=auth_dependencies,
             # document that 422 responses will include a JSON-formatted error
             # message, from `butler_exception_handler()` below.
             responses={422: {"model": ErrorResponseModel}},

--- a/python/lsst/daf/butler/remote_butler/server/_server.py
+++ b/python/lsst/daf/butler/remote_butler/server/_server.py
@@ -63,7 +63,7 @@ def create_app() -> FastAPI:
     default_api_path = "/api/butler"
     prefix = f"{default_api_path}/repo/{{repository}}"
     auth_dependencies = [Depends(repository_authorization_dependency)]
-    if config.gafaelfawr_url == "DISABLED":
+    if not config.gafaelfawr_enabled:
         auth_dependencies = []
     for router in (external_router, query_router):
         app.include_router(

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external_query.py
@@ -35,7 +35,6 @@ from typing import Annotated, NamedTuple
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
-from safir.dependencies.gafaelfawr import auth_dependency
 
 from lsst.daf.butler import Butler, DataCoordinate, DimensionGroup
 from lsst.daf.butler.remote_butler.server_models import (
@@ -56,7 +55,7 @@ from ...._exceptions import InvalidQueryError
 from ...._query_all_datasets import QueryAllDatasetsParameters, query_all_datasets
 from ....queries import Query
 from ....queries.driver import QueryDriver, QueryTree
-from .._dependencies import factory_dependency
+from .._dependencies import factory_dependency, user_name_dependency
 from .._factory import Factory
 from ._query_serialization import convert_query_page
 from ._query_streaming import StreamingQuery, execute_streaming_query
@@ -93,7 +92,7 @@ class _StreamQueryDriverExecute(StreamingQuery[_QueryContext]):
 async def query_execute(
     request: QueryExecuteRequestModel,
     factory: Annotated[Factory, Depends(factory_dependency)],
-    user_name: Annotated[str, Depends(auth_dependency)],
+    user_name: Annotated[str | None, Depends(user_name_dependency)],
 ) -> StreamingResponse:
     query = _StreamQueryDriverExecute(request, factory)
     return await execute_streaming_query(query, user_name)
@@ -140,7 +139,7 @@ class _StreamQueryAllDatasets(StreamingQuery[_QueryAllDatasetsContext]):
 async def query_all_datasets_execute(
     request: QueryAllDatasetsRequestModel,
     factory: Annotated[Factory, Depends(factory_dependency)],
-    user_name: Annotated[str, Depends(auth_dependency)],
+    user_name: Annotated[str | None, Depends(user_name_dependency)],
 ) -> StreamingResponse:
     query = _StreamQueryAllDatasets(request, factory)
     return await execute_streaming_query(query, user_name)

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
@@ -73,7 +73,7 @@ class StreamingQuery(Protocol[_TContext]):
         """
 
 
-async def execute_streaming_query(query: StreamingQuery, user: str) -> StreamingResponse:
+async def execute_streaming_query(query: StreamingQuery, user: str | None) -> StreamingResponse:
     """Run a query, streaming the response incrementally, one page at a time,
     as newline-separated chunks of JSON.
 
@@ -83,7 +83,7 @@ async def execute_streaming_query(query: StreamingQuery, user: str) -> Streaming
         Callers should define a class implementing the ``StreamingQuery``
         protocol to specify the inner logic that will be called during
         query execution.
-    user : `str`
+    user : `str`, optional
         Name of user running the query -- used to enforce usage limits.
 
     Returns
@@ -125,7 +125,7 @@ async def execute_streaming_query(query: StreamingQuery, user: str) -> Streaming
     )
 
 
-async def _stream_query_pages(query: StreamingQuery, user: str) -> AsyncIterator[str]:
+async def _stream_query_pages(query: StreamingQuery, user: str | None) -> AsyncIterator[str]:
     """Stream the query output with one page object per line, as
     newline-delimited JSON records in the "JSON Lines" format
     (https://jsonlines.org/).

--- a/python/lsst/daf/butler/tests/server.py
+++ b/python/lsst/daf/butler/tests/server.py
@@ -15,9 +15,9 @@ from lsst.daf.butler.remote_butler.server import create_app
 from lsst.daf.butler.remote_butler.server._config import ButlerServerConfig, RepositoryConfig, mock_config
 from lsst.daf.butler.remote_butler.server._dependencies import (
     auth_delegated_token_dependency,
-    auth_dependency,
     butler_factory_dependency,
     reset_dependency_caches,
+    user_name_dependency,
 )
 from lsst.resources import ResourcePath
 from lsst.resources.s3utils import clean_test_environment_for_s3, getS3Client
@@ -148,7 +148,7 @@ def create_test_server(
                 app.dependency_overrides[butler_factory_dependency] = lambda: server_butler_factory
                 # In an actual deployment, these headers would be provided by
                 # the Gafaelfawr ingress.
-                app.dependency_overrides[auth_dependency] = lambda: "mock-username"
+                app.dependency_overrides[user_name_dependency] = lambda: "mock-username"
                 app.dependency_overrides[auth_delegated_token_dependency] = lambda: "mock-delegated-token"
 
                 # Using TestClient in a context manager ensures that it uses

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -631,6 +631,7 @@ class ButlerClientServerAuthorizationTestCase(unittest.TestCase):
         """Test server running in CADC auth mode."""
         with mock_config() as config:
             config.authentication = "cadc"
+            config.gafaelfawr_url = "DISABLED"
             with create_test_server(TESTDIR, server_config=config) as instance:
                 self.assertIsInstance(instance.remote_butler._connection.auth, CadcAuthenticationProvider)
 


### PR DESCRIPTION
CADC won't initially be running the Gafaelfawr authentication service alongside their Butler server, so add an option to disable using it.  This means that group authorization will not be usable, and per-user query limits will not be enforced.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
