### PR TITLE
DM-42272: Preserve metadata when an exception escapes ButlerMDC context.

### DIFF
--- a/doc/changes/DM-42272.feature.md
+++ b/doc/changes/DM-42272.feature.md
@@ -1,0 +1,2 @@
+ButlerMDC now preserves metadata for exceptions that are raised in a context but handled outside it.
+This lets exceptions be logged by high-level handlers the same way they would have been if the problem were logged immediately.


### PR DESCRIPTION
This PR ports a feature from Prompt Processing's `RecordFactoryContextAdapter` that lets exceptions hang on to, and be logged with, metadata from the point where they were raised.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
