### PR TITLE
DM-51314: Ensure exceptions propagate from server to client

### DIFF
--- a/doc/changes/DM-51314.bugfix.md
+++ b/doc/changes/DM-51314.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a few server-side exceptions that should have been sent to RemoteButler clients as meaningful exceptions, but instead were triggering an HTTP 500 Internal Server Error.

--- a/python/lsst/daf/butler/_dataset_type.py
+++ b/python/lsst/daf/butler/_dataset_type.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from pydantic import BaseModel, StrictBool, StrictStr
 
 from ._config_support import LookupKey
+from ._exceptions import UnknownComponentError
 from ._storage_class import StorageClass, StorageClassFactory
 from .dimensions import DimensionGroup
 from .json import from_json_pydantic, to_json_pydantic
@@ -492,7 +493,9 @@ class DatasetType:
         """
         if component in self.storageClass.allComponents():
             return self.nameWithComponent(self.name, component)
-        raise KeyError(f"Requested component ({component}) not understood by this DatasetType ({self})")
+        raise UnknownComponentError(
+            f"Requested component ({component}) not understood by this DatasetType ({self})"
+        )
 
     def makeCompositeDatasetType(self) -> DatasetType:
         """Return a composite dataset type from the component.

--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -41,6 +41,7 @@ __all__ = (
     "InvalidQueryError",
     "MissingCollectionError",
     "MissingDatasetTypeError",
+    "UnknownComponentError",
     "ValidationError",
 )
 
@@ -170,6 +171,14 @@ class MissingDatasetTypeError(DatasetTypeError, KeyError, ButlerUserError):
     error_type = "missing_dataset_type"
 
 
+class UnknownComponentError(KeyError, ButlerUserError):
+    """Exception raised when the requested component of a DatasetType is not
+    known.
+    """
+
+    error_type = "unknown_component"
+
+
 class DatasetTypeNotSupportedError(RuntimeError):
     """A `DatasetType` is not handled by this routine.
 
@@ -227,6 +236,7 @@ _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     MissingDatasetTypeError,
     UnimplementedQueryError,
     UnknownButlerUserError,
+    UnknownComponentError,
 )
 _USER_ERROR_MAPPING = {e.error_type: e for e in _USER_ERROR_TYPES}
 assert len(_USER_ERROR_MAPPING) == len(_USER_ERROR_TYPES), (

--- a/python/lsst/daf/butler/dimensions/_coordinate.py
+++ b/python/lsst/daf/butler/dimensions/_coordinate.py
@@ -1005,10 +1005,12 @@ class _FullTupleDataCoordinate(_BasicTupleDataCoordinate):
         dimensions = self.universe.conform(dimensions)
         if self._dimensions == dimensions:
             return self
-        return DataCoordinate.from_full_values(
-            dimensions,
-            tuple(self[k] for k in dimensions.data_coordinate_keys),
-        )
+
+        try:
+            values = tuple(self[k] for k in dimensions.data_coordinate_keys)
+        except KeyError as e:
+            raise DimensionNameError(f"Data ID is missing value for dimension {str(e)}.")
+        return DataCoordinate.from_full_values(dimensions, values)
 
     def union(self, other: DataCoordinate) -> DataCoordinate:
         # Docstring inherited from DataCoordinate.

--- a/python/lsst/daf/butler/registry/dimensions/static.py
+++ b/python/lsst/daf/butler/registry/dimensions/static.py
@@ -468,7 +468,7 @@ class StaticDimensionRecordStorageManager(DimensionRecordStorageManager):
                 distinct=True,
             ).into_joins_builder(postprocessing=None)
         if not element.has_own_table:
-            raise NotImplementedError(f"Cannot join dimension element {element} with no table.")
+            raise UnimplementedQueryError(f"Cannot join dimension element {element} with no table.")
         table = self._tables[element.name]
         result = SqlJoinsBuilder(db=self._db, from_clause=table)
         for dimension_name, column_name in zip(element.required.names, element.schema.required.names):
@@ -1055,7 +1055,7 @@ class _CommonSkyPixMediatedOverlapsVisitor(OverlapsVisitor):
         # Reject spatial constraints that are nested inside OR or NOT, because
         # the postprocessing needed for those would be a lot harder.
         if flags & PredicateVisitFlags.INVERTED or flags & PredicateVisitFlags.HAS_OR_SIBLINGS:
-            raise NotImplementedError(
+            raise UnimplementedQueryError(
                 "Spatial overlap constraints nested inside OR or NOT are not supported."
             )
         # Delegate to super just because that's good practice with
@@ -1114,7 +1114,7 @@ class _CommonSkyPixMediatedOverlapsVisitor(OverlapsVisitor):
                 )
                 skypix = element
             case _:
-                raise NotImplementedError(
+                raise UnimplementedQueryError(
                     f"Spatial overlap constraint for dimension {element} not supported."
                 )
         # Convert the region-overlap constraint into a skypix

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -42,6 +42,7 @@ from lsst.daf.butler import (
     SerializedDatasetRefContainerV1,
     StorageClass,
     StorageClassFactory,
+    UnknownComponentError,
 )
 from lsst.daf.butler.datastore.stored_file_info import StoredFileInfo
 from lsst.daf.butler.datastores.file_datastore.retrieve_artifacts import ZipIndex
@@ -516,8 +517,11 @@ class DatasetTypeTestCase(unittest.TestCase):
         self.assertEqual(datasetTypeComponentB.parentStorageClass, storageClass)
         self.assertIsNone(datasetTypeComposite.parentStorageClass)
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(UnknownComponentError):
             datasetTypeComposite.makeComponentDatasetType("compF")
+
+        with self.assertRaises(UnknownComponentError):
+            datasetTypeComposite.componentTypeName("unknown")
 
 
 class DatasetRefTestCase(unittest.TestCase):

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -48,6 +48,7 @@ from lsst.daf.butler import (
     DimensionConfig,
     DimensionElement,
     DimensionGroup,
+    DimensionNameError,
     DimensionPacker,
     DimensionUniverse,
     NamedKeyDict,
@@ -796,6 +797,10 @@ class DataCoordinateTestCase(unittest.TestCase):
                     with self.subTest(dataId=dataId, newDataId=newDataId, type=type(dataId)):
                         self.assertEqual(dataId, newDataId)
                         self.assertTrue(newDataId.hasFull())
+
+        coord = DataCoordinate.standardize({"instrument": "HSC"}, universe=self.allDataIds.universe)
+        with self.assertRaises(DimensionNameError):
+            coord.subset(["detector"])
 
     def testUnion(self):
         """Test `DataCoordinate.union`."""


### PR DESCRIPTION
Fix a few server-side exceptions that should have been sent to RemoteButler clients as meaningful exceptions, but instead were triggering an HTTP 500 Internal Server Error.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
