### PR TITLE
DM-52180: Add "export-in-place" function for Prompt Processing

### DIFF
--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -321,7 +321,7 @@ class QuantumBackedButler(LimitedButler):
             Metrics object for gathering butler statistics.
         """
         butler_config = ButlerConfig(config, searchPaths=search_paths)
-        datastore = instantiate_standalone_datastore(
+        datastore, _ = instantiate_standalone_datastore(
             butler_config, dimensions, filename, OpaqueManagerClass, BridgeManagerClass
         )
 

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -27,8 +27,6 @@
 
 from __future__ import annotations
 
-from . import ddl
-
 __all__ = ("QuantumBackedButler", "QuantumProvenanceData")
 
 import itertools
@@ -51,54 +49,18 @@ from ._dataset_type import DatasetType
 from ._deferredDatasetHandle import DeferredDatasetHandle
 from ._limited_butler import LimitedButler
 from ._quantum import Quantum
+from ._standalone_datastore import instantiate_standalone_datastore
 from ._storage_class import StorageClass, StorageClassFactory
 from .datastore import Datastore
 from .datastore.record_data import DatastoreRecordData, SerializedDatastoreRecordData
 from .datastores.file_datastore.retrieve_artifacts import retrieve_and_zip
 from .dimensions import DimensionUniverse
-from .registry.bridge.monolithic import MonolithicDatastoreRegistryBridgeManager
-from .registry.databases.sqlite import SqliteDatabase
 from .registry.interfaces import DatastoreRegistryBridgeManager, OpaqueTableStorageManager
-from .registry.opaque import ByNameOpaqueTableStorageManager
 
 if TYPE_CHECKING:
     from ._butler import Butler
 
 _LOG = logging.getLogger(__name__)
-
-
-class _DatasetRecordStorageManagerDatastoreConstructionMimic:
-    """A partial implementation of `DatasetRecordStorageManager` that exists
-    only to allow a `DatastoreRegistryBridgeManager` (and hence a `Datastore`)
-    to be constructed without a full `Registry`.
-
-    Notes
-    -----
-    The interface implemented by this class should probably be its own ABC,
-    and that ABC should probably be used in the definition of
-    `DatastoreRegistryBridgeManager`, but while prototyping I'm trying to keep
-    changes minimal.
-    """
-
-    @classmethod
-    def getIdColumnType(cls) -> type:
-        # Docstring inherited.
-        return ddl.GUID
-
-    @classmethod
-    def addDatasetForeignKey(
-        cls,
-        tableSpec: ddl.TableSpec,
-        *,
-        name: str = "dataset",
-        constraint: bool = True,
-        onDelete: str | None = None,
-        **kwargs: Any,
-    ) -> ddl.FieldSpec:
-        # Docstring inherited.
-        idFieldSpec = ddl.FieldSpec(f"{name}_id", dtype=ddl.GUID, **kwargs)
-        tableSpec.fields.add(idFieldSpec)
-        return idFieldSpec
 
 
 class QuantumBackedButler(LimitedButler):
@@ -190,9 +152,9 @@ class QuantumBackedButler(LimitedButler):
         config: Config | ResourcePathExpression,
         quantum: Quantum,
         dimensions: DimensionUniverse,
-        filename: str = ":memory:",
-        OpaqueManagerClass: type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
-        BridgeManagerClass: type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
+        filename: str | None = None,
+        OpaqueManagerClass: type[OpaqueTableStorageManager] | None = None,
+        BridgeManagerClass: type[DatastoreRegistryBridgeManager] | None = None,
         search_paths: list[str] | None = None,
         dataset_types: Mapping[str, DatasetType] | None = None,
         metrics: ButlerMetrics | None = None,
@@ -253,9 +215,9 @@ class QuantumBackedButler(LimitedButler):
         predicted_outputs: Iterable[DatasetId],
         dimensions: DimensionUniverse,
         datastore_records: Mapping[str, DatastoreRecordData],
-        filename: str = ":memory:",
-        OpaqueManagerClass: type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
-        BridgeManagerClass: type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
+        filename: str | None = None,
+        OpaqueManagerClass: type[OpaqueTableStorageManager] | None = None,
+        BridgeManagerClass: type[DatastoreRegistryBridgeManager] | None = None,
         search_paths: list[str] | None = None,
         dataset_types: Mapping[str, DatasetType] | None = None,
         metrics: ButlerMetrics | None = None,
@@ -316,10 +278,10 @@ class QuantumBackedButler(LimitedButler):
         predicted_inputs: Iterable[DatasetId],
         predicted_outputs: Iterable[DatasetId],
         dimensions: DimensionUniverse,
-        filename: str = ":memory:",
+        filename: str | None = None,
         datastore_records: Mapping[str, DatastoreRecordData] | None = None,
-        OpaqueManagerClass: type[OpaqueTableStorageManager] = ByNameOpaqueTableStorageManager,
-        BridgeManagerClass: type[DatastoreRegistryBridgeManager] = MonolithicDatastoreRegistryBridgeManager,
+        OpaqueManagerClass: type[OpaqueTableStorageManager] | None = None,
+        BridgeManagerClass: type[DatastoreRegistryBridgeManager] | None = None,
         search_paths: list[str] | None = None,
         dataset_types: Mapping[str, DatasetType] | None = None,
         metrics: ButlerMetrics | None = None,
@@ -359,19 +321,9 @@ class QuantumBackedButler(LimitedButler):
             Metrics object for gathering butler statistics.
         """
         butler_config = ButlerConfig(config, searchPaths=search_paths)
-        butler_root = butler_config.get("root", butler_config.configDir)
-        db = SqliteDatabase.fromUri(f"sqlite:///{filename}", origin=0)
-        with db.declareStaticTables(create=True) as context:
-            opaque_manager = OpaqueManagerClass.initialize(db, context)
-            bridge_manager = BridgeManagerClass.initialize(
-                db,
-                context,
-                opaque=opaque_manager,
-                # MyPy can tell it's a fake, but we know it shouldn't care.
-                datasets=_DatasetRecordStorageManagerDatastoreConstructionMimic,  # type: ignore
-                universe=dimensions,
-            )
-        datastore = Datastore.fromConfig(butler_config, bridge_manager, butler_root)
+        datastore = instantiate_standalone_datastore(
+            butler_config, dimensions, filename, OpaqueManagerClass, BridgeManagerClass
+        )
 
         # TODO: We need to inform `Datastore` here that it needs to support
         # predictive reads; This only really works for file datastore but

--- a/python/lsst/daf/butler/_rubin/__init__.py
+++ b/python/lsst/daf/butler/_rubin/__init__.py
@@ -1,0 +1,31 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Modules in the ``_rubin`` package contain functions that are used internally
+by other LSST packages.  The interfaces and behavior of these functions are
+subject to change at any time.
+"""

--- a/python/lsst/daf/butler/_rubin/file_datasets.py
+++ b/python/lsst/daf/butler/_rubin/file_datasets.py
@@ -71,12 +71,18 @@ def transfer_datasets_to_datastore(
     # Refs must contain dimension records to allow for filename template
     # expansion in the datastore.
     refs = source_butler._registry.expand_refs(list(refs))
+    # Read out the absolute URLs of the datasets we are about to transfer.
     datasets = list(source_butler._datastore.export(refs, directory=None, transfer="direct"))
 
+    # Set up a temporary, initially empty, in-memory DB for the target
+    # Datastore.
     dimension_universe = datasets[0].refs[0].dimensions.universe
     datastore, db = instantiate_standalone_datastore(output_config, dimension_universe)
     try:
+        # Write the files to their destination in the target datastore.
         datastore.ingest(*datasets, transfer="copy", record_validation_info=False)
+        # Read out the relative URLs of the files, for their location
+        # in the target datastore.
         return list(datastore.export(refs, directory=None, transfer=None))
     finally:
         db.dispose()

--- a/python/lsst/daf/butler/_rubin/file_datasets.py
+++ b/python/lsst/daf/butler/_rubin/file_datasets.py
@@ -1,0 +1,80 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("transfer_datasets_to_datastore",)
+
+from collections.abc import Iterable
+
+from .._butler import Butler
+from .._butler_config import ButlerConfig
+from .._dataset_ref import DatasetRef
+from .._file_dataset import FileDataset
+from .._standalone_datastore import instantiate_standalone_datastore
+from ..direct_butler import DirectButler
+
+
+def transfer_datasets_to_datastore(
+    source_butler: Butler, output_config: ButlerConfig, refs: Iterable[DatasetRef]
+) -> list[FileDataset]:
+    """Copy datasets into a `Datastore` without writing entries into the
+    associated registry database.
+
+    Parameters
+    ----------
+    source_butler : `Butler`
+        Butler instance from which to copy datasets.
+    output_config : `ButlerConfig`
+        Butler configuration specifying the configuration for the target
+        datastore.
+    refs : `~collections.abc.Iterable` [ `DatasetRef` ]
+        List of datasets to copy into the target datastore.
+
+    Returns
+    -------
+    file_datasets : `list` [ `FileDataset` ]
+        `FileDataset` instances representing the artifacts copied to
+        the target datastore.
+    """
+    refs = list(refs)
+    if len(refs) == 0:
+        return []
+
+    if not isinstance(source_butler, DirectButler):
+        raise ValueError("Butler must be an instance of DirectButler")
+
+    # Refs must contain dimension records to allow for filename template
+    # expansion in the datastore.
+    refs = source_butler._registry.expand_refs(list(refs))
+    datasets = list(source_butler._datastore.export(refs, directory=None, transfer="direct"))
+
+    dimension_universe = datasets[0].refs[0].dimensions.universe
+    datastore = instantiate_standalone_datastore(output_config, dimension_universe)
+    datastore.ingest(*datasets, transfer="copy", record_validation_info=False)
+
+    return list(datastore.export(refs, directory=None, transfer=None))

--- a/python/lsst/daf/butler/_rubin/file_datasets.py
+++ b/python/lsst/daf/butler/_rubin/file_datasets.py
@@ -74,7 +74,9 @@ def transfer_datasets_to_datastore(
     datasets = list(source_butler._datastore.export(refs, directory=None, transfer="direct"))
 
     dimension_universe = datasets[0].refs[0].dimensions.universe
-    datastore = instantiate_standalone_datastore(output_config, dimension_universe)
-    datastore.ingest(*datasets, transfer="copy", record_validation_info=False)
-
-    return list(datastore.export(refs, directory=None, transfer=None))
+    datastore, db = instantiate_standalone_datastore(output_config, dimension_universe)
+    try:
+        datastore.ingest(*datasets, transfer="copy", record_validation_info=False)
+        return list(datastore.export(refs, directory=None, transfer=None))
+    finally:
+        db.dispose()

--- a/python/lsst/daf/butler/_standalone_datastore.py
+++ b/python/lsst/daf/butler/_standalone_datastore.py
@@ -37,7 +37,7 @@ from .datastore import Datastore
 from .dimensions import DimensionUniverse
 from .registry.bridge.monolithic import MonolithicDatastoreRegistryBridgeManager
 from .registry.databases.sqlite import SqliteDatabase
-from .registry.interfaces import DatastoreRegistryBridgeManager, OpaqueTableStorageManager
+from .registry.interfaces import Database, DatastoreRegistryBridgeManager, OpaqueTableStorageManager
 from .registry.opaque import ByNameOpaqueTableStorageManager
 
 
@@ -47,7 +47,7 @@ def instantiate_standalone_datastore(
     filename: str | None = None,
     OpaqueManagerClass: type[OpaqueTableStorageManager] | None = None,
     BridgeManagerClass: type[DatastoreRegistryBridgeManager] | None = None,
-) -> Datastore:
+) -> tuple[Datastore, Database]:
     """Initialize a `Datastore` instance without an associated `Registry`.
 
     Parameters
@@ -67,6 +67,11 @@ def instantiate_standalone_datastore(
     BridgeManagerClass : `type`, optional
         A subclass of `DatastoreRegistryBridgeManager` to use for datastore
         location records.  Default is a SQL-backed implementation.
+
+    Returns
+    -------
+    datastore_and_database : `tuple` [ `Datastore` , `Database` ]
+        The temporary datastore, and the database instance backing it.
 
     Notes
     -----
@@ -92,7 +97,9 @@ def instantiate_standalone_datastore(
             datasets=_DatasetRecordStorageManagerDatastoreConstructionMimic,  # type: ignore
             universe=dimensions,
         )
-    return Datastore.fromConfig(butler_config, bridge_manager, butler_root)
+
+    datastore = Datastore.fromConfig(butler_config, bridge_manager, butler_root)
+    return (datastore, db)
 
 
 class _DatasetRecordStorageManagerDatastoreConstructionMimic:

--- a/python/lsst/daf/butler/_standalone_datastore.py
+++ b/python/lsst/daf/butler/_standalone_datastore.py
@@ -1,0 +1,122 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("instantiate_standalone_datastore",)
+
+from typing import Any
+
+from . import ddl
+from ._butler_config import ButlerConfig
+from .datastore import Datastore
+from .dimensions import DimensionUniverse
+from .registry.bridge.monolithic import MonolithicDatastoreRegistryBridgeManager
+from .registry.databases.sqlite import SqliteDatabase
+from .registry.interfaces import DatastoreRegistryBridgeManager, OpaqueTableStorageManager
+from .registry.opaque import ByNameOpaqueTableStorageManager
+
+
+def instantiate_standalone_datastore(
+    butler_config: ButlerConfig,
+    dimensions: DimensionUniverse,
+    filename: str | None = None,
+    OpaqueManagerClass: type[OpaqueTableStorageManager] | None = None,
+    BridgeManagerClass: type[DatastoreRegistryBridgeManager] | None = None,
+) -> Datastore:
+    """Initialize a `Datastore` instance without an associated `Registry`.
+
+    Parameters
+    ----------
+    butler_config : `ButlerConfig`
+        Butler configuration that defines the configuration for the `Datastore`
+        to be initialized.
+    dimensions : `DimensionUniverse`
+        Dimension universe used by the Butler repository backing the
+        `Datastore`.
+    filename : `str`, optional
+        Name for the SQLite database that will back the `Datastore`; defaults
+        to an in-memory database.
+    OpaqueManagerClass : `type`, optional
+        A subclass of `OpaqueTableStorageManager` to use for datastore
+        opaque records.  Default is a SQL-backed implementation.
+    BridgeManagerClass : `type`, optional
+        A subclass of `DatastoreRegistryBridgeManager` to use for datastore
+        location records.  Default is a SQL-backed implementation.
+
+    Notes
+    -----
+    This allows files to be written and read without access to the Butler
+    database.  It is primarily used by `QuantumBackedButler`.
+    """
+    if filename is None:
+        filename = ":memory:"
+    if OpaqueManagerClass is None:
+        OpaqueManagerClass = ByNameOpaqueTableStorageManager
+    if BridgeManagerClass is None:
+        BridgeManagerClass = MonolithicDatastoreRegistryBridgeManager
+
+    butler_root = butler_config.get("root", butler_config.configDir)
+    db = SqliteDatabase.fromUri(f"sqlite:///{filename}", origin=0)
+    with db.declareStaticTables(create=True) as context:
+        opaque_manager = OpaqueManagerClass.initialize(db, context)
+        bridge_manager = BridgeManagerClass.initialize(
+            db,
+            context,
+            opaque=opaque_manager,
+            # MyPy can tell it's a fake, but we know it shouldn't care.
+            datasets=_DatasetRecordStorageManagerDatastoreConstructionMimic,  # type: ignore
+            universe=dimensions,
+        )
+    return Datastore.fromConfig(butler_config, bridge_manager, butler_root)
+
+
+class _DatasetRecordStorageManagerDatastoreConstructionMimic:
+    """A partial implementation of `DatasetRecordStorageManager` that exists
+    only to allow a `DatastoreRegistryBridgeManager` (and hence a `Datastore`)
+    to be constructed without a full `Registry`.
+    """
+
+    @classmethod
+    def getIdColumnType(cls) -> type:
+        # Docstring inherited.
+        return ddl.GUID
+
+    @classmethod
+    def addDatasetForeignKey(
+        cls,
+        tableSpec: ddl.TableSpec,
+        *,
+        name: str = "dataset",
+        constraint: bool = True,
+        onDelete: str | None = None,
+        **kwargs: Any,
+    ) -> ddl.FieldSpec:
+        # Docstring inherited.
+        idFieldSpec = ddl.FieldSpec(f"{name}_id", dtype=ddl.GUID, **kwargs)
+        tableSpec.fields.add(idFieldSpec)
+        return idFieldSpec

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -3050,17 +3050,11 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         if transfer == "auto" and directory is None:
             transfer = None
 
-        if transfer is not None and directory is None:
+        if transfer is not None and transfer != "direct" and directory is None:
             raise TypeError(f"Cannot export using transfer mode {transfer} with no export directory given")
 
         if transfer == "move":
             raise TypeError("Can not export by moving files out of datastore.")
-        elif transfer == "direct":
-            # For an export, treat this as equivalent to None. We do not
-            # want an import to risk using absolute URIs to datasets owned
-            # by another datastore.
-            log.info("Treating 'direct' transfer mode as in-place export.")
-            transfer = None
 
         # Force the directory to be a URI object
         directoryUri: ResourcePath | None = None

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -287,6 +287,12 @@ class Database(ABC):
         self._metadata = metadata
         self._allow_temporary_tables = allow_temporary_tables
 
+    def dispose(self) -> None:
+        """Close all open database connections held by this `Database`
+        instance.
+        """
+        self._engine.dispose()
+
     def __repr__(self) -> str:
         # Rather than try to reproduce all the parameters used to create
         # the object, instead report the more useful information of the

--- a/python/lsst/daf/butler/tests/utils.py
+++ b/python/lsst/daf/butler/tests/utils.py
@@ -381,8 +381,8 @@ class MetricTestRepo:
             ),
         )
 
-        self.addDataset({"instrument": "DummyCamComp", "visit": 423})
-        self.addDataset({"instrument": "DummyCamComp", "visit": 424})
+        self.ref1 = self.addDataset({"instrument": "DummyCamComp", "visit": 423})
+        self.ref2 = self.addDataset({"instrument": "DummyCamComp", "visit": 424})
 
     def addDataset(
         self, dataId: dict[str, Any], run: str | None = None, datasetType: DatasetType | None = None


### PR DESCRIPTION
Add functions that will be used by Prompt Processing to write outputs back to the central repository in their final destination, without immediately writing registry entries for the datasets.  This shares the code from `QuantumBackedButler` that is used to set up a `Datastore` instance detached from Butler/Registry.

This supports a tweak to the DMTN-310 butler writer service to avoid doubling the S3 I/O requirements for prompt processing writes.


## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
