### PR TITLE
DM-52179: Make Butler.ingest() retryable

### DIFF
--- a/doc/changes/DM-52179.bugfix.md
+++ b/doc/changes/DM-52179.bugfix.md
@@ -1,0 +1,1 @@
+`Butler.ingest()` now checks for conflicting datastore records before ingesting files, reducing the likelihood of an issue where existing files are overwritten/deleted by an ingest that fails due to conflicting datasets.

--- a/doc/changes/DM-52179.feature.md
+++ b/doc/changes/DM-52179.feature.md
@@ -1,0 +1,1 @@
+`Butler.ingest()` now has an optional `skip_existing` parameter that makes it ignore datasets that already exist in the repository instead of raising an error.  This makes it easier for applications to retry ingests.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1333,6 +1333,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         *datasets: FileDataset,
         transfer: str | None = "auto",
         record_validation_info: bool = True,
+        skip_existing: bool = False,
     ) -> None:
         """Store and register one or more datasets that already exist on disk.
 
@@ -1360,6 +1361,12 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             or file sizes. This can be useful if such information is tracked
             in an external system or if the file is to be compressed in place.
             It is up to the datastore whether this parameter is relevant.
+        skip_existing : `bool`, optional
+            If `True`, a dataset will not be ingested if a dataset with the
+            same dataset ID already exists in the datastore.
+            If `False` (the default), a `ConflictingDefinitionError` will be
+            raised if any datasets with the same dataset ID already exist
+            in the datastore.
 
         Raises
         ------
@@ -1375,6 +1382,9 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         FileExistsError
             Raised if transfer is not `None` but the (internal) location the
             file would be moved to is already occupied.
+        ConflictingDefinitionError
+            Raised if a dataset already exists in the repository and
+            ``skip_existing`` is `False`.
 
         Notes
         -----

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1385,6 +1385,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
     def knows_these(self, refs: Iterable[DatasetRef]) -> dict[DatasetRef, bool]:
         # Docstring inherited from the base class.
+        refs = list(refs)
 
         # The records themselves. Could be missing some entries.
         records = self._get_stored_records_associated_with_refs(refs, ignore_datastore_records=True)

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -576,6 +576,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         *datasets: FileDataset,
         transfer: str | None = "auto",
         record_validation_info: bool = True,
+        skip_existing: bool = False,
     ) -> None:
         # Docstring inherited.
         raise NotImplementedError()

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -292,9 +292,13 @@ class HybridButler(Butler):
         *datasets: FileDataset,
         transfer: str | None = "auto",
         record_validation_info: bool = True,
+        skip_existing: bool = False,
     ) -> None:
         return self._direct_butler.ingest(
-            *datasets, transfer=transfer, record_validation_info=record_validation_info
+            *datasets,
+            transfer=transfer,
+            record_validation_info=record_validation_info,
+            skip_existing=skip_existing,
         )
 
     def export(

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1077,6 +1077,13 @@ class ButlerTests(ButlerPutGetTests):
         uri2 = butler.getURI(datasetTypeName, dataId2, collections="a/new/run")
         self.assertFalse(self.are_uris_equivalent(uri1, uri2), f"Cf. {uri1} with {uri2}")
 
+        # Re-ingesting the same datasets raises an error with
+        # skip_existing=False.
+        with self.assertRaises(ConflictingDefinitionError):
+            butler.ingest(*datasets, transfer="copy")
+        # skip_existing=True makes it a no-op to re-ingest the same datasets.
+        butler.ingest(*datasets, transfer="copy", skip_existing=True)
+
         # Now do a multi-dataset but single file ingest
         metricFile = os.path.join(dataRoot, "detectors.yaml")
         refs = []


### PR DESCRIPTION
`Butler.ingest()` now has an optional `skip_existing` parameter that makes it ignore datasets that already exist in the repository instead of raising an error.  This makes it easier for applications to retry ingests.

As a side-effect, this moves the test for conflicting datastore records before file copying instead of after.  This will reduce the chances of a file getting incorrectly overwritten by a failed ingest. (But not totally prevent it, in the case of concurrent writes.)

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
