### PR TITLE
DM-52180b: Allow ChainedDatastore ingest with transfer=None

### DIFF
--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -562,9 +562,6 @@ class ChainedDatastore(Datastore):
 
     def _prepIngest(self, *datasets: FileDataset, transfer: str | None = None) -> _IngestPrepData:
         # Docstring inherited from Datastore._prepIngest.
-        if transfer is None:
-            raise NotImplementedError("ChainedDatastore does not support transfer=None.")
-
         def isDatasetAcceptable(dataset: FileDataset, *, name: str, constraints: Constraints) -> bool:
             acceptable = [ref for ref in dataset.refs if constraints.isAcceptable(ref)]
             if not acceptable:


### PR DESCRIPTION
Fix an issue encountered during integration testing of Prompt Processing with the Butler writer service.  Prompt Processing's target repository uses a ChainedDatastore, and the Butler code was explicitly disallowing ingests with transfer=None.

The exception was probably added to prevent confusion -- normally it would be difficult to split up the files correctly between the multiple roots in a ChainedDatastore.  However, PP's call to `transfer_datasets_to_datastore` writes the files into the correct place and the existing code works correctly if the files are where they need to be.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
