### PR TITLE
DM-52504: Handle use of exc_info=False in MDC logger

### DIFF
--- a/python/lsst/daf/butler/logging.py
+++ b/python/lsst/daf/butler/logging.py
@@ -36,7 +36,7 @@ from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
 from logging import Formatter, LogRecord, StreamHandler
 from types import TracebackType
-from typing import IO, Any, ClassVar, overload
+from typing import IO, Any, ClassVar, Literal, overload
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, RootModel
 
@@ -174,7 +174,7 @@ class ButlerMDC:
             lno: int,
             msg: str,
             args: tuple,
-            exc_info: tuple | None,
+            exc_info: tuple | None | Literal[False],
             func: str | None = None,
             sinfo: TracebackType | None = None,
             **kwargs: Any,
@@ -182,7 +182,7 @@ class ButlerMDC:
             record = old_factory(name, level, fn, lno, msg, args, exc_info, func, sinfo, **kwargs)
             # Make sure we send a copy of the global dict in the record.
             mdc = MDCDict(cls._MDC)
-            if exc_info is not None:
+            if exc_info is not None and exc_info is not False:
                 _, ex, _ = exc_info
                 # TODO: this doesn't handle chained exceptions, fix on DM-47546
                 if hasattr(ex, "mdc"):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -289,11 +289,14 @@ class LoggingTestCase(unittest.TestCase):
             self.log.exception("Exception raised:")
             self.log.warning("Implied exception", exc_info=True)
             self.log.critical("Explicit exception", exc_info=e)
+            self.log.error("Explicit exception info", exc_info=(Exception, e, e.__traceback__))
             # Is original context used *only* when logging the exception?
             self.log.error("Something went wrong")
-        for i in [-4, -3, -2]:
+            self.log.error("Boolean disabled exc info", exc_info=False)
+        for i in [-6, -5, -4, -3]:
             self.assertEqual(self.handler.records[i].MDC, {"foo": "fum", "answer": "42"})
-        self.assertEqual(self.handler.records[-1].MDC, {"foo": "bar"})
+        for i in [-2, -1]:
+            self.assertEqual(self.handler.records[i].MDC, {"foo": "bar"})
 
         self.log.setLevel(logging.INFO)
         self.log.info("Normal log")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -118,8 +118,13 @@ class LoggingTestCase(unittest.TestCase):
         self.log.warning("warning message")
         self.log.critical("critical message")
         self.log.verbose("verbose message")
+        self.log.error("error message")
+        try:
+            raise RuntimeError("An error has occurred")
+        except RuntimeError:
+            self.log.exception("exception message")
 
-        self.assertEqual(len(self.handler.records), 4)
+        self.assertEqual(len(self.handler.records), 6)
 
         format_default = str(self.handler.records)
 
@@ -128,7 +133,7 @@ class LoggingTestCase(unittest.TestCase):
         format_override = str(self.handler.records)
 
         self.assertNotEqual(format_default, format_override)
-        self.assertEqual(format_override, "DEBUG\nWARNING\nCRITICAL\nVERBOSE")
+        self.assertEqual(format_override, "DEBUG\nWARNING\nCRITICAL\nVERBOSE\nERROR\nERROR")
 
         # Reset the log format and it should match the original text.
         self.handler.records.set_log_format(None)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
