### PR TITLE
DM-52412: Set the ARROW_DEFAULT_MEMORY_POOL env var to jemalloc on eups set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Please cite [the SPIE paper](https://doi.org/10.1117/12.2629569) when using this
 
 This is a **Python 3 only** package (we assume Python 3.11 or higher).
 
-* SPIE Paper from 2022: [The Vera C. Rubin Observatory Data Butler and Pipeline Execution System](https://doi.org/10.1117/12.2629569) ([arXiv](https://arxiv.org/abs/2206.14941))
+* SPIE paper from 2024: [Converting Rubin Observatory's data butler to a client/server architecture](https://doi.org/10.1117/12.3019130) ([Tech note](https://dmtn-288.lsst.io))
+* SPIE Paper from 2022: [The Vera C. Rubin Observatory Data Butler and Pipeline Execution System](https://doi.org/10.1117/12.2629569) ([arXiv](https://arxiv.org/abs/2206.14941)) \[Primary reference]
 * ADASS paper from 2019: [Abstracting the Storage and Retrieval of Image Data at the LSST](https://ui.adsabs.harvard.edu/abs/2019ASPC..523..653J/abstract).
 * Early design note: [DMTN-056](https://dmtn-056.lsst.io)
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ PyPI: [lsst-daf-butler](https://pypi.org/project/lsst-daf-butler/)
 
 This software is dual licensed under the GNU General Public License (version 3 of the License, or (at your option) any later version, and also under a 3-clause BSD license).
 Recipients may choose which of these licenses to use; please see the files gpl-3.0.txt and/or bsd_license.txt, respectively.
+
+## Arrow Memory Leaks
+
+From version 18 of arrow we have seen significant memory leaks when accessing parquet files using the default memory allocator.
+If you see such leaks the workaround is to set the `ARROW_DEFAULT_MEMORY_POOL` environment variable to `jemalloc` following the advice from [apache/arrow#45882](https://github.com/apache/arrow/issues/45882).
+For EUPS users this variable is automatically set.

--- a/doc/changes/DM-52412.misc.rst
+++ b/doc/changes/DM-52412.misc.rst
@@ -1,0 +1,2 @@
+For EUPS users we now set the ``ARROW_DEFAULT_MEMORY_POOL`` environment variable to ``jemalloc``.
+This works around a memory leak reported in https://github.com/apache/arrow/issues/45882 for pyarrow v18 and newer.

--- a/ups/daf_butler.table
+++ b/ups/daf_butler.table
@@ -6,3 +6,7 @@ setupRequired(daf_relation)
 
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
+
+# Needed for https://github.com/apache/arrow/issues/45882
+# Memory leak in newer versions of pyarrow.
+envSet(ARROW_DEFAULT_MEMORY_POOL, jemalloc)


### PR DESCRIPTION
There is a memory leak in pyarrow 20 that occurs in butler usage in some scenarios. The current fix is to switch pyarrow to use the old memory allocator.

The pyarrow issue is at https://github.com/apache/arrow/issues/45882

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
