### PR TITLE
DM-52515: Add glob-style matching of column names in parquet parameters.

### DIFF
--- a/doc/changes/DM-52515.feature.md
+++ b/doc/changes/DM-52515.feature.md
@@ -1,0 +1,1 @@
+Add glob-style matching to column names in parquet tables, when specified via the `columns` parameter.

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -400,6 +400,10 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         self.assertTrue(df1.loc[:, ["ddd"]].equals(df6))
         df7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
         self.assertTrue(df1.loc[:, ["a"]].equals(df7))
+        df8 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d*"]})
+        self.assertTrue(df1.loc[:, ["ddd", "dtn", "dtu"]].equals(df8))
+        df9 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d*", "d*"]})
+        self.assertTrue(df1.loc[:, ["ddd", "dtn", "dtu"]].equals(df9))
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
@@ -989,6 +993,10 @@ class ParquetFormatterArrowAstropyTestCase(unittest.TestCase):
         _checkAstropyTableEquality(tab1[("ddd",)], tab6)
         tab7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
         _checkAstropyTableEquality(tab1[("a",)], tab7)
+        tab8 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d??"]})
+        _checkAstropyTableEquality(tab1[("ddd", "dtn", "dtu")], tab8)
+        tab9 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d??", "a*"]})
+        _checkAstropyTableEquality(tab1[("ddd", "dtn", "dtu", "a")], tab9)
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
@@ -1401,6 +1409,18 @@ class ParquetFormatterArrowNumpyTestCase(unittest.TestCase):
             ],
             tab7,
         )
+        tab8 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d??", "a*"]})
+        _checkNumpyTableEquality(
+            tab1[
+                [
+                    "ddd",
+                    "dtn",
+                    "dtu",
+                    "a",
+                ]
+            ],
+            tab8,
+        )
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
@@ -1673,6 +1693,8 @@ class ParquetFormatterArrowTableTestCase(unittest.TestCase):
         self.assertEqual(tab6, tab1.select(("ddd",)))
         tab7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
         self.assertEqual(tab7, tab1.select(("a",)))
+        tab8 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a*", "d??"]})
+        self.assertEqual(tab8, tab1.select(("a", "ddd", "dtn", "dtu")))
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
@@ -1984,6 +2006,9 @@ class ParquetFormatterArrowNumpyDictTestCase(unittest.TestCase):
         tab7 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["a", "a"]})
         subdict = {key: dict1[key] for key in ["a"]}
         _checkNumpyDictEquality(subdict, tab7)
+        tab8 = self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d??", "a*"]})
+        subdict = {key: dict1[key] for key in ["ddd", "dtn", "dtu", "a"]}
+        _checkNumpyDictEquality(subdict, tab8)
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
