### PR TITLE
DM-52635: Ignore extra properties when validating query models

### DIFF
--- a/python/lsst/daf/butler/queries/tree/_base.py
+++ b/python/lsst/daf/butler/queries/tree/_base.py
@@ -110,7 +110,7 @@ def is_dataset_field(s: str) -> TypeGuard[DatasetFieldName]:
 class QueryTreeBase(pydantic.BaseModel):
     """Base class for all non-primitive types in a query tree."""
 
-    model_config = pydantic.ConfigDict(frozen=True, extra="forbid", strict=True)
+    model_config = pydantic.ConfigDict(frozen=True, strict=True)
 
 
 class ColumnExpressionBase(QueryTreeBase, ABC):


### PR DESCRIPTION
Removed the `extra="forbid"` Pydantic option from QueryTree and its child models.   This will allow new properties to be added to these models without immediately breaking compatibility of a new client with an older Butler server.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
