### PR TITLE
DM-52653: Add QBB method for retrieving predicted datastore records

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-toml
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.6
+    rev: v0.13.0
     hooks:
       - id: ruff
         args: [--fix]

--- a/doc/changes/DM-52653.misc.md
+++ b/doc/changes/DM-52653.misc.md
@@ -1,0 +1,2 @@
+Added a new `Datastore` API for retrieving the datastore records for datasets that might not have been written yet.
+There is also a related API added to `QuantumBackedButler`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "setuptools.build_meta"
 name = "lsst-daf-butler"
 requires-python = ">=3.11.0"
 description = "An abstraction layer for reading and writing astronomical data to datastores."
-license = {text = "BSD 3-Clause License"}
+license = "BSD-3-Clause OR GPL-3.0-or-later"
+license-files = ["COPYRIGHT", "LICENSE", "bsd_license.txt", "gpl-v3.0.txt"]
 readme = "README.md"
 authors = [
     {name="Rubin Observatory Data Management", email="dm-admin@lists.lsst.org"},
 ]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -74,7 +74,6 @@ where = ["python"]
 
 [tool.setuptools]
 zip-safe = true
-license-files = ["COPYRIGHT", "LICENSE", "bsd_license.txt", "gpl-v3.0.txt"]
 
 [tool.setuptools.package-data]
 "lsst.daf.butler" = ["py.typed", "configs/*.yaml", "configs/*/*.yaml", "tests/registry_data/*.yaml"]

--- a/python/lsst/daf/butler/_quantum_backed.py
+++ b/python/lsst/daf/butler/_quantum_backed.py
@@ -614,6 +614,34 @@ class QuantumBackedButler(LimitedButler):
             datastore_records=provenance_records,
         )
 
+    def export_predicted_datastore_records(
+        self, refs: Iterable[DatasetRef]
+    ) -> dict[str, DatastoreRecordData]:
+        """Export datastore records for a set of predicted output dataset
+        references.
+
+        Parameters
+        ----------
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
+            Dataset references for which to export datastore records. These
+            refs must be known to this butler.
+
+        Returns
+        -------
+        records : `dict` [ `str`, `DatastoreRecordData` ]
+            Predicted datastore records indexed by datastore name. No attempt
+            is made to ensure that the associated datasets exist on disk.
+        """
+        unknowns = [
+            ref
+            for ref in refs
+            if (ref.id not in self._predicted_outputs and ref.id not in self._predicted_inputs)
+        ]
+        if unknowns:
+            raise ValueError(f"Cannot export datastore records for unknown outputs: {unknowns}")
+
+        return self._datastore.export_predicted_records(refs)
+
 
 class QuantumProvenanceData(pydantic.BaseModel):
     """A serializable struct for per-quantum provenance information and

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -1381,6 +1381,24 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
+    def export_predicted_records(self, refs: Iterable[DatasetRef]) -> dict[str, DatastoreRecordData]:
+        """Export predicted datastore records and locations to an in-memory
+        data structure.
+
+        Parameters
+        ----------
+        refs : `~collections.abc.Iterable` [ `DatasetRef` ]
+            Datastore records that would be used if the given refs were to
+            exist in this datastore.  No attempt is made to determine if these
+            datasets actually exist.
+
+        Returns
+        -------
+        data : `~collections.abc.Mapping` [ `str`, `DatastoreRecordData` ]
+            Exported datastore records indexed by datastore name.
+        """
+        raise NotImplementedError()
+
     def set_retrieve_dataset_type_method(self, method: Callable[[str], DatasetType | None] | None) -> None:
         """Specify a method that can be used by datastore to retrieve
         registry-defined dataset type.

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -1165,6 +1165,25 @@ class ChainedDatastore(Datastore):
 
         return all_records
 
+    def export_predicted_records(self, refs: Iterable[DatasetRef]) -> dict[str, DatastoreRecordData]:
+        # Docstring inherited from the base class.
+
+        all_records: dict[str, DatastoreRecordData] = {}
+
+        # Filter out datasets that this datastore is not allowed to contain.
+        refs = [ref for ref in refs if self.constraints.isAcceptable(ref)]
+
+        # Merge all sub-datastore records into one structure
+        for datastore in self.datastores:
+            sub_records = datastore.export_predicted_records(refs)
+            for name, record_data in sub_records.items():
+                # All datastore names must be unique in a chain.
+                if name in all_records:
+                    raise ValueError("Non-unique datastore name found in datastore {datastore}")
+                all_records[name] = record_data
+
+        return all_records
+
     def export(
         self,
         refs: Iterable[DatasetRef],

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -3188,6 +3188,24 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         record_data = DatastoreRecordData(records=records)
         return {self.name: record_data}
 
+    def export_predicted_records(self, refs: Iterable[DatasetRef]) -> dict[str, DatastoreRecordData]:
+        # Docstring inherited from the base class.
+        refs = [self._cast_storage_class(ref) for ref in refs]
+        records: dict[DatasetId, dict[str, list[StoredDatastoreItemInfo]]] = {}
+        for ref in refs:
+            if not self.constraints.isAcceptable(ref):
+                continue
+            fileLocations = self._get_expected_dataset_locations_info(ref)
+            if not fileLocations:
+                continue
+            dataset_records = records.setdefault(ref.id, {})
+            dataset_records.setdefault(self._table.name, [])
+            for _, storedFileInfo in fileLocations:
+                dataset_records[self._table.name].append(storedFileInfo)
+
+        record_data = DatastoreRecordData(records=records)
+        return {self.name: record_data}
+
     def set_retrieve_dataset_type_method(self, method: Callable[[str], DatasetType | None] | None) -> None:
         # Docstring inherited from the base class.
         self._retrieve_dataset_method = method

--- a/python/lsst/daf/butler/datastores/inMemoryDatastore.py
+++ b/python/lsst/daf/butler/datastores/inMemoryDatastore.py
@@ -763,6 +763,12 @@ class InMemoryDatastore(GenericBaseDatastore[StoredMemoryItemInfo]):
         # In-memory Datastore records cannot be exported or imported
         return {}
 
+    def export_predicted_records(self, refs: Iterable[DatasetIdRef]) -> dict[str, DatastoreRecordData]:
+        # Docstring inherited from the base class.
+
+        # In-memory Datastore records cannot be exported or imported
+        return {}
+
     def get_opaque_table_definitions(self) -> Mapping[str, DatastoreOpaqueTable]:
         # Docstring inherited from the base class.
         return {}

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -416,6 +416,19 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             for dataset_data in datastore_records.records[class_name].values():
                 self.assertEqual(set(dataset_data), {table_name})
 
+    def test_export_predicted_datastore_records(self) -> None:
+        """Test for export_predicted_datastore_records method"""
+        quantum = self.make_quantum()
+        qbb = QuantumBackedButler.initialize(
+            config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
+        )
+
+        records = qbb.export_predicted_datastore_records(self.output_refs)
+        self.assertEqual(len(records["FileDatastore@<butlerRoot>/datastore"].records), len(self.output_refs))
+
+        with self.assertRaises(ValueError):
+            qbb.export_predicted_datastore_records(self.missing_refs)
+
     def test_collect_and_transfer(self) -> None:
         """Test for collect_and_transfer method"""
         quantum1 = self.make_quantum(1)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
