### PR TITLE
DM-52398: Implement findDataset using the new query system 

### DIFF
--- a/doc/changes/DM-52398.bugfix.md
+++ b/doc/changes/DM-52398.bugfix.md
@@ -1,0 +1,1 @@
+Query generation will no longer throw `sqlalchemy.exc.ArgumentError` when attempting to use a dataset calibration timespan constraint for a dataset search without any calibration collections.

--- a/doc/changes/DM-52398.misc.md
+++ b/doc/changes/DM-52398.misc.md
@@ -1,0 +1,1 @@
+`Butler.find_dataset()`/`Butler.registry.findDataset()` have been re-implemented using the same query framework backing `Butler.query()`. These methods now always return `DatasetRef` instances with `dataId.hasFull() = True`.

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1302,7 +1302,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         data_id, kwargs = self._rewrite_data_id(data_id, parent_type, **kwargs)
 
-        ref = self._registry.findDataset(
+        ref = self.registry.findDataset(
             parent_type,
             data_id,
             collections=collections,

--- a/python/lsst/daf/butler/queries/_expression_strings.py
+++ b/python/lsst/daf/butler/queries/_expression_strings.py
@@ -241,7 +241,7 @@ class _ConversionVisitor(TreeVisitor[_VisitorResult]):
 
     def visitBind(self, name: str, node: Node) -> _VisitorResult:
         if name not in self.context.bind:
-            raise InvalidQueryError("Name {name!r} is not in the bind map.")
+            raise InvalidQueryError(f"Name {name!r} is not in the bind map.")
         # Logic in visitIdentifier handles binds.
         return self.visitIdentifier(name, node)
 

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -574,6 +574,18 @@ class RegistryTests(ABC):
             ),
         )
         self.assertEqual(
+            bias1,
+            registry.findDataset(
+                "bias",
+                instrument="Cam1",
+                detector=2,
+                # Calibration dataset type, with no calibration collection, but
+                # a timespan was provided.
+                collections=["imported_g"],
+                timespan=timespan,
+            ),
+        )
+        self.assertEqual(
             bias2,
             registry.findDataset(
                 "bias",

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -592,6 +592,43 @@ class RegistryTests(ABC):
                 "bias", instrument="Cam1", detector=2, collections=["empty", "Cam1/calib", "imported_g"]
             ),
         )
+        self.assertIsNone(
+            registry.findDataset("bias", instrument="Cam1", detector=2, collections=["Cam1/calib"])
+        )
+        # Test non-calibration dataset type.
+        registry.registerDatasetType(
+            DatasetType("noncalibration", ["instrument", "detector"], "int", universe=butler.dimensions)
+        )
+        (non_calibration_ref,) = registry.insertDatasets("noncalibration", dataIds=[dataId2], run=run)
+        self.assertIsNone(
+            registry.findDataset("noncalibration", instrument="Cam1", detector=2, collections=["imported_g"])
+        )
+        self.assertEqual(
+            non_calibration_ref,
+            registry.findDataset("noncalibration", instrument="Cam1", detector=2, collections=[run]),
+        )
+        # Timespan parameter is ignored for non-calibration dataset types.
+        self.assertIsNone(
+            registry.findDataset(
+                "noncalibration", instrument="Cam1", detector=2, collections=["imported_g"], timespan=timespan
+            )
+        )
+        self.assertEqual(
+            non_calibration_ref,
+            registry.findDataset(
+                "noncalibration", instrument="Cam1", detector=2, collections=[run], timespan=timespan
+            ),
+        )
+        self.assertEqual(
+            non_calibration_ref,
+            registry.findDataset(
+                "noncalibration",
+                instrument="Cam1",
+                detector=2,
+                collections=["Cam1/calib", run],
+                timespan=timespan,
+            ),
+        )
 
     def testRemoveDatasetTypeSuccess(self):
         """Test that SqlRegistry.removeDatasetType works when there are no

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -550,6 +550,11 @@ class RegistryTests(ABC):
                 "bias", instrument="Cam1", detector=2, collections=["empty", "imported_r", "imported_g"]
             ),
         )
+        # If the input data ID was an expanded DataCoordinate with records,
+        # then the output ref has records, too.
+        expanded_id = registry.expandDataId({"instrument": "Cam1", "detector": 2})
+        expanded_ref = registry.findDataset("bias", expanded_id, collections=["imported_r"])
+        self.assertTrue(expanded_ref.dataId.hasRecords())
         # Search more than one collection, with one of them a CALIBRATION
         # collection.
         registry.registerCollection("Cam1/calib", CollectionType.CALIBRATION)

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -661,7 +661,11 @@ class RegistryTests(ABC):
         )
         data_id = {"instrument": "Cam1", "physical_filter": "Cam1-G"}
         (implied_ref,) = registry.insertDatasets("dt_with_implied", dataIds=[data_id], run=run)
-        self.assertEqual(implied_ref, registry.findDataset("dt_with_implied", data_id, collections=[run]))
+        found_ref = registry.findDataset("dt_with_implied", data_id, collections=[run])
+        self.assertEqual(implied_ref, found_ref)
+        # The "full" data ID with implied values is looked up, even though we
+        # provided only the "required" values.
+        self.assertTrue(found_ref.dataId.hasFull())
         # The search ignores excess data ID values beyond the 'required' set.
         # This is not the correct band value for this physical_filter, but
         # the mismatch is ignored.

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -60,7 +60,7 @@ from .._storage_class import StorageClass, StorageClassFactory
 from .._utilities.locked_object import LockedObject
 from ..datastore import DatasetRefURIs, DatastoreConfig
 from ..datastore.cache_manager import AbstractDatastoreCacheManager, DatastoreCacheManager
-from ..dimensions import DataIdValue, DimensionConfig, DimensionUniverse, SerializedDataId
+from ..dimensions import DataCoordinate, DataIdValue, DimensionConfig, DimensionUniverse, SerializedDataId
 from ..queries import Query
 from ..queries.tree import make_column_literal
 from ..registry import CollectionArgType, NoDefaultCollectionError, Registry, RegistryDefaults
@@ -435,6 +435,8 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             return None
 
         ref = DatasetRef.from_simple(model.dataset_ref, universe=self.dimensions)
+        if isinstance(data_id, DataCoordinate) and data_id.hasRecords():
+            ref = ref.expanded(data_id)
         return apply_storage_class_override(ref, dataset_type, storage_class)
 
     def _retrieve_artifacts(

--- a/python/lsst/daf/butler/timespan_database_representation.py
+++ b/python/lsst/daf/butler/timespan_database_representation.py
@@ -615,6 +615,10 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         # Docstring inherited.
         if isinstance(other, sqlalchemy.sql.ColumnElement):
             return self.contains(other)
+
+        if self._is_null_literal() or other._is_null_literal():
+            return sqlalchemy.sql.null()
+
         return sqlalchemy.sql.and_(self._nsec[1] > other._nsec[0], other._nsec[1] > self._nsec[0])
 
     def contains(
@@ -652,6 +656,10 @@ class _CompoundTimespanDatabaseRepresentation(TimespanDatabaseRepresentation):
         return _CompoundTimespanDatabaseRepresentation(
             nsec=(func(self._nsec[0]), func(self._nsec[1])), name=self._name
         )
+
+    def _is_null_literal(self) -> bool:
+        null = sqlalchemy.sql.null()
+        return self._nsec[0] is null and self._nsec[1] is null
 
 
 TimespanDatabaseRepresentation.Compound = _CompoundTimespanDatabaseRepresentation


### PR DESCRIPTION
Replace the implementation of `Registry.findDataset()` with the new query system, to allow us to retire daf_relation.  This attempts to preserve the existing behavior, with one exception: returned DatasetRefs now have `dataId.hasFull() = True`, in line with the behavior of the new query system.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
