### PR TITLE
DM-52719: Use UUIDv7 for dataset IDs

### DIFF
--- a/doc/changes/DM-52719.perf.md
+++ b/doc/changes/DM-52719.perf.md
@@ -1,0 +1,1 @@
+New dataset UUIDs are now generated using UUIDv7 instead of UUIDv4, to improve Postgres insert performance.

--- a/python/lsst/daf/butler/_dataset_ref.py
+++ b/python/lsst/daf/butler/_dataset_ref.py
@@ -64,6 +64,7 @@ from lsst.utils.classes import immutable
 from ._config_support import LookupKey
 from ._dataset_type import DatasetType, SerializedDatasetType
 from ._named import NamedKeyDict
+from ._uuid import generate_uuidv7
 from .datastore.stored_file_info import StoredDatastoreItemInfo
 from .dimensions import (
     DataCoordinate,
@@ -182,7 +183,12 @@ class DatasetIdFactory:
             Dataset identifier.
         """
         if idGenerationMode is DatasetIdGenEnum.UNIQUE:
-            return uuid.uuid4()
+            # Earlier versions of this code used UUIDv4. However, totally
+            # random IDs create problems for Postgres insert performance,
+            # because it scatters index updates randomly around the disk.
+            # UUIDv7 has similar uniqueness properties to v4, but IDs generated
+            # at the same time are close together in the index.
+            return generate_uuidv7()
         else:
             # WARNING: If you modify this code make sure that the order of
             # items in the `items` list below never changes.

--- a/python/lsst/daf/butler/_rubin/__init__.py
+++ b/python/lsst/daf/butler/_rubin/__init__.py
@@ -29,3 +29,6 @@
 by other LSST packages.  The interfaces and behavior of these functions are
 subject to change at any time.
 """
+
+# UUIDv7 generation is used by pipe_base.
+from .._uuid import generate_uuidv7

--- a/python/lsst/daf/butler/_uuid.py
+++ b/python/lsst/daf/butler/_uuid.py
@@ -1,0 +1,79 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("generate_uuidv7",)
+
+import time
+from uuid import UUID, uuid4
+
+
+def generate_uuidv7() -> UUID:
+    """Generate a v7 UUID compliant with IETF RFC-9562.
+
+    Returns
+    -------
+    uuid : `uuid.UUID`
+        Version 7 UUID.
+    """
+    # Python 3.14 will include an implementation of UUIDv7 that can replace
+    # this, but at the time of writing 3.14 hasn't been released and we're
+    # still supporting 3.12. There are a few libraries on PyPI with an
+    # implementation of v7 UUIDs, but none of them look well-maintained.
+    #
+    # This is the format of a v7 UUID:
+    #  0                   1                   2                   3
+    #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |                           unix_ts_ms                          |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |          unix_ts_ms           |  ver  |       rand_a          |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |var|                        rand_b                             |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |                            rand_b                             |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    #
+    # It's basically identical to a UUID v4, but with the top 6 bytes
+    # replaced with a millisecond UNIX timestamp.
+
+    # Generate a UUIDv4 for the random portion of the data.
+    # A little wasteful, but means we inherit the best practices from
+    # the standard library for generating this random data.
+    byte_data = bytearray(uuid4().bytes)
+
+    # Replace high 6 bytes with millisecond UNIX timestamp.
+    timestamp = time.time_ns() // 1_000_000
+    timestamp_bytes = timestamp.to_bytes(length=6, byteorder="big")
+    byte_data[0:6] = timestamp_bytes
+
+    # Set 4-bit version field to 7.
+    byte_data[6] &= 0x0F
+    byte_data[6] |= 0x70
+
+    return UUID(bytes=bytes(byte_data))

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -3424,7 +3424,7 @@ class RegistryTests(ABC):
 
         datasetId = factory.makeDatasetId(run, dataset_type, data_id, DatasetIdGenEnum.UNIQUE)
         self.assertIsInstance(datasetId, uuid.UUID)
-        self.assertEqual(datasetId.version, 4)
+        self.assertEqual(datasetId.version, 7)
 
         datasetId = factory.makeDatasetId(run, dataset_type, data_id, DatasetIdGenEnum.DATAID_TYPE)
         self.assertIsInstance(datasetId, uuid.UUID)

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,0 +1,53 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import unittest.mock
+from uuid import RFC_4122
+
+from lsst.daf.butler._uuid import generate_uuidv7
+
+
+class UUIDv7TestCase(unittest.TestCase):
+    """Test generation of v7 UUIDs."""
+
+    def test_generate_uuidv7(self) -> None:
+        mock_timestamp_milliseconds = 1759355298139
+        mock_timestamp_nanoseconds = (mock_timestamp_milliseconds * 1_000_000) + 123456
+        with unittest.mock.patch("time.time_ns") as mock:
+            mock.return_value = mock_timestamp_nanoseconds
+            id = generate_uuidv7()
+            self.assertEqual(id.version, 7)
+            self.assertEqual(id.variant, RFC_4122)
+            self.assertEqual(int.from_bytes(id.bytes[0:6], byteorder="big"), mock_timestamp_milliseconds)
+            # The rest of the bytes in the ID are random, so just make sure
+            # that two consecutive IDs are generating different bytes.
+            second_id = generate_uuidv7()
+            self.assertNotEqual(second_id.bytes[6:], id.bytes[6:])
+            # But the top six bytes should be the same, because we mocked
+            # the same timestamp tick for both ID generations.
+            self.assertEqual(second_id.bytes[0:6], id.bytes[0:6])


### PR DESCRIPTION
Generate v7 UUIDs for dataset IDs instead of v4 UUIDs.  v4 UUIDs create problems for Postgres insert performance, because they  scatter index updates randomly around the disk.  v7 UUIDs have a timestamp in the most significant bits, so datasets generated at the same time will be close together in the index.  Initial testing shows up to 100x improvement in insert speed with v7 UUIDs.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
