### PR TITLE
Add CADC authorization token support for remote butler use.

### DIFF
--- a/python/lsst/daf/butler/remote_butler/_factory.py
+++ b/python/lsst/daf/butler/remote_butler/_factory.py
@@ -136,7 +136,7 @@ class RemoteButlerFactory:
         if self._config.authentication == "rubin_science_platform":
             auth = RubinAuthenticationProvider(access_token)
         elif self._config.authentication == "cadc":
-            auth = CadcAuthenticationProvider()
+            auth = CadcAuthenticationProvider(access_token)
         return self._create_butler(
             auth=auth, butler_options=butler_options, enable_datastore_cache=enable_datastore_cache
         )
@@ -151,7 +151,7 @@ class RemoteButlerFactory:
         if self._config.authentication == "rubin_science_platform":
             auth = RubinAuthenticationProvider.create_from_environment(self.server_url)
         elif self._config.authentication == "cadc":
-            auth = CadcAuthenticationProvider()
+            auth = CadcAuthenticationProvider.create_from_environment(self.server_url)
 
         return self._create_butler(
             auth=auth, butler_options=butler_options, enable_datastore_cache=enable_datastore_cache

--- a/python/lsst/daf/butler/remote_butler/authentication/cadc.py
+++ b/python/lsst/daf/butler/remote_butler/authentication/cadc.py
@@ -27,28 +27,80 @@
 
 from __future__ import annotations
 
+import os
+from fnmatch import fnmatchcase
+from urllib.parse import urlparse
+
 from .interface import RemoteButlerAuthenticationProvider
 
 
 class CadcAuthenticationProvider(RemoteButlerAuthenticationProvider):
-    """Provide HTTP headers required for authenticating the user at the
-    Canadian Astronomy Data Centre.
+    """
+    Represents an authentication provider for remote Butler services specific
+    to CADC connection requirements.
+
+    This class handles the creation and management of authentication headers
+    required for interaction with remote Butler services by handling bearer
+    tokens. It ensures that the object is pickleable as it may need to be
+    serialized and transferred between processes for file transfer operations.
+
+    Parameters
+    ----------
+    access_token : `str`
+        The bearer token used for authentication with CADC StorageInventory.
     """
 
     # NOTE -- This object needs to be pickleable. It will sometimes be
     # serialized and transferred to another process to execute file transfers.
 
-    def __init__(self) -> None:
-        # TODO: Load authentication information somehow
-        pass
+    def __init__(self, access_token: str):
+        # Access tokens are opaque bearer tokens. See https://sqr-069.lsst.io/
+        self._headers = {"Authorization": f"Bearer {access_token}"}
+
+    @staticmethod
+    def create_from_environment(server_url: str) -> CadcAuthenticationProvider:
+        access_token = _get_authentication_token_from_environment(server_url)
+        if access_token is None:
+            raise RuntimeError(
+                "Attempting to connect to Butler server,"
+                " but no access credentials were found in the environment."
+            )
+        return CadcAuthenticationProvider(access_token)
 
     def get_server_headers(self) -> dict[str, str]:
-        # TODO: I think you mentioned that you might not require
-        # authentication for the Butler server REST API initially --
-        # if so, you can leave this blank.
         return {}
 
     def get_datastore_headers(self) -> dict[str, str]:
-        # TODO: Supply the headers needed to access the Storage Inventory
-        # system.
-        return {"Authorization": "Bearer stub"}
+        return self._headers
+
+
+_SERVER_WHITELIST = ["*.canfar.net", "host.docker.internal"]
+_CADC_TOKEN_ENVIRONMENT_KEY = "CADC_TOKEN"
+
+
+def _get_authentication_token_from_environment(server_url: str) -> str | None:
+    """
+    Retrieve an authentication token from the environment.
+
+    This function checks if the provided server URL's hostname matches any
+    pattern in the server whitelist and if a valid token is available in
+    the environment variable. If both conditions are satisfied, the token is
+    returned; otherwise, None is returned.
+
+    Parameters
+    ----------
+        server_url (str): The URL of the server for which an authentication
+            token is being retrieved.
+
+    Returns
+    -------
+        str | None: The authentication token if available and hostname matches
+        the whitelist; otherwise, None.
+    """
+    hostname = urlparse(server_url.lower()).hostname
+    hostname_in_whitelist = any(hostname and fnmatchcase(hostname, pattern) for pattern in _SERVER_WHITELIST)
+    notebook_token = os.getenv(_CADC_TOKEN_ENVIRONMENT_KEY)
+    if hostname_in_whitelist and notebook_token:
+        return notebook_token
+
+    return None

--- a/python/lsst/daf/butler/remote_butler/authentication/cadc.py
+++ b/python/lsst/daf/butler/remote_butler/authentication/cadc.py
@@ -74,7 +74,7 @@ class CadcAuthenticationProvider(RemoteButlerAuthenticationProvider):
         return self._headers
 
 
-_SERVER_WHITELIST = ["*.canfar.net", "host.docker.internal"]
+_SERVER_WHITELIST = ["*.cadc-ccda.hia-hia.nrc-cnrc.gc.ca", "*.canfar.net", "host.docker.internal"]
 _CADC_TOKEN_ENVIRONMENT_KEY = "CADC_TOKEN"
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,11 +4,7 @@ from lsst.daf.butler.tests.utils import mock_env
 
 try:
     from lsst.daf.butler.remote_butler import RemoteButler
-    from lsst.daf.butler.remote_butler.authentication.cadc import (
-        _CADC_TOKEN_ENVIRONMENT_KEY,
-        CadcAuthenticationProvider,
-        _get_cadc_token_from_environment,
-    )
+    from lsst.daf.butler.remote_butler.authentication import cadc
     from lsst.daf.butler.remote_butler.authentication.rubin import (
         _EXPLICIT_BUTLER_ACCESS_TOKEN_ENVIRONMENT_KEY,
         _RSP_JUPYTER_ACCESS_TOKEN_ENVIRONMENT_KEY,
@@ -58,9 +54,9 @@ class TestButlerClientAuthentication(unittest.TestCase):
         self.assertEqual(auth.get_datastore_headers(), {})
 
     def test_cadc_auth(self):
-        auth = CadcAuthenticationProvider("tokendata")
+        auth = cadc.CadcAuthenticationProvider("tokendata")
         self.assertEqual(auth.get_server_headers(), {})
         self.assertEqual(auth.get_datastore_headers(), {"Authorization": "Bearer tokendata"})
-        with mock_env({_CADC_TOKEN_ENVIRONMENT_KEY: "tokendata"}):
-            token = _get_cadc_token_from_environment("https://www.canfar.net/butler")
+        with mock_env({cadc._CADC_TOKEN_ENVIRONMENT_KEY: "tokendata"}):
+            token = cadc._get_authentication_token_from_environment("https://www.canfar.net/butler")
             self.assertEqual(token, "tokendata")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,7 +4,11 @@ from lsst.daf.butler.tests.utils import mock_env
 
 try:
     from lsst.daf.butler.remote_butler import RemoteButler
-    from lsst.daf.butler.remote_butler.authentication.cadc import CadcAuthenticationProvider
+    from lsst.daf.butler.remote_butler.authentication.cadc import (
+        _CADC_TOKEN_ENVIRONMENT_KEY,
+        CadcAuthenticationProvider,
+        _get_cadc_token_from_environment,
+    )
     from lsst.daf.butler.remote_butler.authentication.rubin import (
         _EXPLICIT_BUTLER_ACCESS_TOKEN_ENVIRONMENT_KEY,
         _RSP_JUPYTER_ACCESS_TOKEN_ENVIRONMENT_KEY,
@@ -54,6 +58,9 @@ class TestButlerClientAuthentication(unittest.TestCase):
         self.assertEqual(auth.get_datastore_headers(), {})
 
     def test_cadc_auth(self):
-        auth = CadcAuthenticationProvider()
+        auth = CadcAuthenticationProvider("tokendata")
         self.assertEqual(auth.get_server_headers(), {})
-        self.assertEqual(auth.get_datastore_headers(), {"Authorization": "Bearer stub"})
+        self.assertEqual(auth.get_datastore_headers(), {"Authorization": "Bearer tokendata"})
+        with mock_env({_CADC_TOKEN_ENVIRONMENT_KEY: "tokendata"}):
+            token = _get_cadc_token_from_environment("https://www.canfar.net/butler")
+            self.assertEqual(token, "tokendata")


### PR DESCRIPTION
This implementation follows the Rubin authorization pattern.  User/platform is responsible for keeping the token fresh.  
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
