### PR TITLE
Make Butler server tests less fragile

### DIFF
--- a/python/lsst/daf/butler/tests/server_available.py
+++ b/python/lsst/daf/butler/tests/server_available.py
@@ -2,7 +2,7 @@
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project
-# (https://www.lsst.org).
+# (http://www.lsst.org).
 # See the COPYRIGHT file at the top-level directory of this distribution
 # for details of code ownership.
 #
@@ -23,40 +23,31 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-"""Tests for DirectButler._query with SQLite."""
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import annotations
 
-import os
-import unittest
+__all__ = (
+    "butler_server_import_error",
+    "butler_server_is_available",
+)
 
-from lsst.daf.butler import Butler
-from lsst.daf.butler.tests.butler_queries import ButlerQueryTests
-from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
+butler_server_is_available = True
+"""`True` if all dependencies required to use Butler server and RemoteButler
+are installed.
+"""
 
-if butler_server_is_available:
-    from lsst.daf.butler.tests.server import create_test_server
+butler_server_import_error = ""
+"""String containing a human-readable error message explaining why the server
+is not available, if ``butler_server_is_available`` is `False`.
+"""
 
-TESTDIR = os.path.abspath(os.path.dirname(__file__))
-
-
-@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
-class RemoteButlerQueryTests(ButlerQueryTests, unittest.TestCase):
-    """Test query system using client/server butler."""
-
-    data_dir = os.path.join(TESTDIR, "data/registry")
-
-    def make_butler(self, *args: str) -> Butler:
-        server_instance = self.enterContext(create_test_server(TESTDIR))
-        butler = server_instance.hybrid_butler
-
-        for arg in args:
-            self.load_data(butler, arg)
-
-        return butler
-
-
-if __name__ == "__main__":
-    unittest.main()
+try:
+    # Dependencies required by Butler server and RemoteButler, but not
+    # available in LSST Pipelines Stack.
+    import fastapi  # noqa: F401
+    import httpx  # noqa: F401
+    import safir  # noqa: F401
+except ImportError as e:
+    butler_server_is_available = False
+    butler_server_import_error = f"Server libraries could not be loaded: {str(e)}"

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,9 +1,9 @@
 import unittest
 
+from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
 from lsst.daf.butler.tests.utils import mock_env
 
-try:
-    from lsst.daf.butler.remote_butler import RemoteButler
+if butler_server_is_available:
     from lsst.daf.butler.remote_butler.authentication import cadc
     from lsst.daf.butler.remote_butler.authentication.rubin import (
         _EXPLICIT_BUTLER_ACCESS_TOKEN_ENVIRONMENT_KEY,
@@ -11,13 +11,9 @@ try:
         RubinAuthenticationProvider,
         _get_authentication_token_from_environment,
     )
-except ImportError:
-    RemoteButler = None
 
 
-@unittest.skipIf(
-    RemoteButler is None, "RemoteButler could not be imported, optional dependencies may not be installed"
-)
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class TestButlerClientAuthentication(unittest.TestCase):
     """Test access-token logic"""
 

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -64,11 +64,6 @@ except ImportError:
         return None
 
 
-try:
-    from lsst.daf.butler.tests.server import create_test_server
-except ImportError:
-    create_test_server = None
-
 import astropy.time
 from sqlalchemy.exc import IntegrityError
 
@@ -111,6 +106,7 @@ from lsst.daf.butler.registry.sql_registry import SqlRegistry
 from lsst.daf.butler.repo_relocation import BUTLER_ROOT_TAG
 from lsst.daf.butler.tests import MetricsExample, MetricsExampleModel, MultiDetectorFormatter
 from lsst.daf.butler.tests.postgresql import TemporaryPostgresInstance, setup_postgres_test_db
+from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
 from lsst.daf.butler.tests.utils import (
     MetricTestRepo,
     TestCaseMixin,
@@ -122,6 +118,10 @@ from lsst.resources import ResourcePath
 from lsst.resources.http import HttpResourcePath
 from lsst.utils import doImportType
 from lsst.utils.introspection import get_full_type_name
+
+if butler_server_is_available:
+    from lsst.daf.butler.tests.server import create_test_server
+
 
 if TYPE_CHECKING:
     import types
@@ -3144,7 +3144,7 @@ class ChainedDatastoreTransfers(PosixDatastoreTransfers):
     configFile = os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
 
 
-@unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class ButlerServerDatastoreTransfers(DatastoreTransfers, unittest.TestCase):
     """Test ``transfer_from`` involving Butler server."""
 
@@ -3227,7 +3227,7 @@ class NullDatastoreTestCase(unittest.TestCase):
             butler.getURI(ref)
 
 
-@unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class ButlerServerTests(FileDatastoreButlerTests):
     """Test RemoteButler and Butler server."""
 
@@ -3300,7 +3300,7 @@ class ButlerServerTests(FileDatastoreButlerTests):
         pass
 
 
-@unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class ButlerServerSqliteTests(ButlerServerTests, unittest.TestCase):
     """Tests for RemoteButler's registry shim, with a SQLite DB backing the
     server.
@@ -3309,7 +3309,7 @@ class ButlerServerSqliteTests(ButlerServerTests, unittest.TestCase):
     postgres = None
 
 
-@unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class ButlerServerPostgresTests(ButlerServerTests, unittest.TestCase):
     """Tests for RemoteButler's registry shim, with a Postgres DB backing the
     server.

--- a/tests/test_gafaelfawr.py
+++ b/tests/test_gafaelfawr.py
@@ -29,21 +29,19 @@ from __future__ import annotations
 
 import unittest
 
-try:
+from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
+
+if butler_server_is_available:
     import fastapi
     import httpx
 
     from lsst.daf.butler.remote_butler.server._dependencies import repository_authorization_dependency
     from lsst.daf.butler.remote_butler.server._gafaelfawr import GafaelfawrClient, GafaelfawrGroupAuthorizer
 
-    _IMPORT_FAILURE = None
-except ImportError as e:
-    _IMPORT_FAILURE = e
-
 
 # FastAPI is not installed during LSST Pipelines stack builds, so skip these
 # tests if it is not available.
-@unittest.skipIf(_IMPORT_FAILURE, str(_IMPORT_FAILURE))
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class GafaelfawrAuthorizationTestCase(unittest.IsolatedAsyncioTestCase):
     """Test authorization checks using Gafaelfawr group membership."""
 

--- a/tests/test_remote_butler.py
+++ b/tests/test_remote_butler.py
@@ -39,34 +39,19 @@ from lsst.daf.butler.datastores.file_datastore.retrieve_artifacts import (
 from lsst.daf.butler.registry import RegistryConfig
 from lsst.daf.butler.registry.tests import RegistryTests
 from lsst.daf.butler.tests.postgresql import TemporaryPostgresInstance, setup_postgres_test_db
+from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
 from lsst.resources import ResourcePath
 
-try:
+if butler_server_is_available:
     import httpx
 
-    from lsst.daf.butler.remote_butler import ButlerServerError, RemoteButler
-
-    remote_butler_import_fail_message = ""
-except ImportError as e:
-    # httpx is not available in rubin-env yet, so skip these tests if it's not
-    # available
-    RemoteButler = None
-    remote_butler_import_fail_message = str(e)
-
-try:
+    from lsst.daf.butler.remote_butler import ButlerServerError
     from lsst.daf.butler.tests.server import create_test_server
-
-    server_import_fail_message = ""
-except ImportError as e:
-    create_test_server = None
-    server_import_fail_message = str(e)
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
 
-@unittest.skipIf(
-    RemoteButler is None, f"Remote butler can not be imported: {remote_butler_import_fail_message}"
-)
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class RemoteButlerConfigTests(unittest.TestCase):
     """Test construction of RemoteButler via Butler()"""
 
@@ -75,9 +60,7 @@ class RemoteButlerConfigTests(unittest.TestCase):
             Butler({"cls": "lsst.daf.butler.remote_butler.RemoteButler", "remote_butler": {"url": "!"}})
 
 
-@unittest.skipIf(
-    create_test_server is None, f"Server dependencies not installed: {server_import_fail_message}"
-)
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class RemoteButlerErrorHandlingTests(unittest.TestCase):
     """Test RemoteButler error handling."""
 
@@ -201,9 +184,7 @@ class RemoteButlerRegistryTests(RegistryTests):
         pass
 
 
-@unittest.skipIf(
-    create_test_server is None, f"Server dependencies not installed: {server_import_fail_message}"
-)
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class RemoteButlerSqliteRegistryTests(RemoteButlerRegistryTests, unittest.TestCase):
     """Tests for RemoteButler's registry shim, with a SQLite DB backing the
     server.
@@ -212,9 +193,7 @@ class RemoteButlerSqliteRegistryTests(RemoteButlerRegistryTests, unittest.TestCa
     postgres = None
 
 
-@unittest.skipIf(
-    create_test_server is None, f"Server dependencies not installed: {server_import_fail_message}"
-)
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class RemoteButlerPostgresRegistryTests(RemoteButlerRegistryTests, unittest.TestCase):
     """Tests for RemoteButler's registry shim, with a Postgres DB backing the
     server.

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -57,12 +57,11 @@ from lsst.daf.butler import (
 from lsst.daf.butler.datastore.file_templates import FileTemplate
 from lsst.daf.butler.registry import RegistryConfig, RegistryDefaults, _RegistryFactory
 from lsst.daf.butler.tests import DatastoreMock
+from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
 from lsst.daf.butler.tests.utils import TestCaseMixin, makeTestTempDir, mock_env, removeTestTempDir
 
-try:
+if butler_server_is_available:
     from lsst.daf.butler.tests.server import create_test_server
-except ImportError:
-    create_test_server = None
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -982,7 +981,7 @@ class NameKeyCollectionManagerDirectSimpleButlerTestCase(DirectSimpleButlerTestC
     collectionsManager = "lsst.daf.butler.registry.collections.nameKey.NameKeyCollectionManager"
 
 
-@unittest.skipIf(create_test_server is None, "Server dependencies not installed.")
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
 class RemoteSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
     """Run tests against Butler client/server."""
 


### PR DESCRIPTION
Clean up the logic for deciding when to skip Butler server tests, so that real errors during import are less likely to result in silently skipping tests.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
