### PR TITLE
DM-52895: Use unbounded timespan for non-calibration collections.

### DIFF
--- a/doc/changes/DM-52895.bugfix.md
+++ b/doc/changes/DM-52895.bugfix.md
@@ -1,0 +1,5 @@
+Change the conceptual timespan associated with `RUN` and `TAGGED` collections from `None` / `NULL` to an unbounded timespan.
+
+This fixes the behavior of temporal joins in quantum graph builds, where prior to this change a `RUN` or `TAGGED` collection earlier in the search path would be silently ignored in favor of a later `CALIBRATION` collection.
+It also changes the value of timespan columns for these collection types via the `Query.general` interface.
+The behavior of `queryDatasetAssociations` has *not* been changed for backwards-compatibility; it continues to return `timespan=None` for non-`CALIBRATION` collections.

--- a/python/lsst/daf/butler/_registry_shim.py
+++ b/python/lsst/daf/butler/_registry_shim.py
@@ -234,10 +234,7 @@ class RegistryShim(RegistryBase):
                 and (timespan.begin is not None or timespan.end is not None)
             ):
                 timespan_column = query.expression_factory[dataset_type_name].timespan
-                # The 'logical_or(timespan.is_null)' allows non-calibration
-                # collections to participate in the search, with the assumption
-                # that they are valid for any time range.
-                result = result.where(timespan_column.overlaps(timespan).logical_or(timespan_column.is_null))
+                result = result.where(timespan_column.overlaps(timespan))
 
             datasets = list(result)
             if len(datasets) == 1:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -1425,7 +1425,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
             )
             if "timespan" in fields:
                 tags_builder.joins.timespans[fields_key] = self._db.getTimespanRepresentation().fromLiteral(
-                    None
+                    Timespan(None, None)
                 )
         calibs_builder: SqlSelectBuilder | None = None
         if CollectionType.CALIBRATION in collection_types:

--- a/python/lsst/daf/butler/transfers/_context.py
+++ b/python/lsst/daf/butler/transfers/_context.py
@@ -354,20 +354,9 @@ class RepoExportContext:
             collectionTypes = {CollectionType.TAGGED}
             if datasetType.isCalibration():
                 collectionTypes.add(CollectionType.CALIBRATION)
-            resolved_collections = self._butler.collections.query(
-                self._collections.keys(),
-                collection_types=collectionTypes,
-                flatten_chains=False,
-            )
-            with self._butler.query() as query:
-                query = query.join_dataset_search(datasetType, resolved_collections)
-                result = query.general(
-                    datasetType.dimensions,
-                    dataset_fields={datasetType.name: {"dataset_id", "run", "collection", "timespan"}},
-                    find_first=False,
-                )
-                for association in DatasetAssociation.from_query_result(result, datasetType):
-                    if association.ref.id in self._dataset_ids:
-                        results[association.collection].append(association)
-
+            for association in self._butler.registry.queryDatasetAssociations(
+                datasetType, self._collections.keys(), collectionTypes=collectionTypes, flattenChains=False
+            ):
+                if association.ref.id in self._dataset_ids:
+                    results[association.collection].append(association)
         return results


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
