### PR TITLE
DM-52952: Add missing ParentDatasetQueryResults.dataIds query shim

### DIFF
--- a/python/lsst/daf/butler/registry/queries/_query_common.py
+++ b/python/lsst/daf/butler/registry/queries/_query_common.py
@@ -58,6 +58,9 @@ class CommonQueryArguments:
     def replaceCollections(self, collections: list[str]) -> CommonQueryArguments:
         return dataclasses.replace(self, collections=collections)
 
+    def replaceDatasetTypes(self, dataset_types: list[str]) -> CommonQueryArguments:
+        return dataclasses.replace(self, dataset_types=dataset_types)
+
 
 _T = TypeVar("_T", bound=QueryResultsBase)
 _U = TypeVar("_U", bound=QueryResultsBase)

--- a/python/lsst/daf/butler/registry/queries/_query_datasets.py
+++ b/python/lsst/daf/butler/registry/queries/_query_datasets.py
@@ -119,7 +119,13 @@ class QueryDriverDatasetRefQueryResults(
 
     @property
     def dataIds(self) -> DataCoordinateQueryResults:
-        raise NotImplementedError()
+        from ._query_data_coordinates import QueryDriverDataCoordinateQueryResults
+
+        args = self._args.replaceDatasetTypes([self._dataset_type.name])
+
+        return QueryDriverDataCoordinateQueryResults(
+            self._butler, dimensions=self._dataset_type.dimensions, expanded=self._expanded, args=args
+        )
 
     def byParentDatasetType(self) -> Iterator[ParentDatasetQueryResults]:
         yield self


### PR DESCRIPTION
Added an implementation of ParentDatasetQueryResults.dataIds using the new query system.  This method did not previously have any test coverage, so I failed to notice that it did not have an implementation shim to the new query system in DM-52397.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
