### PR TITLE
DM-53019: make ButlerLogRecords extensible

### DIFF
--- a/doc/changes/DM-53019.feature.md
+++ b/doc/changes/DM-53019.feature.md
@@ -1,0 +1,9 @@
+Make `ButlerLogRecords` extensible.
+
+This changes the `ButlerLogRecords` file format (the old format can still be
+read) to allow arbitrary JSON data to be serialized with the log records.
+
+The `ButlerLogRecords` class has been modified to inherit from
+`collections.abc.MutableSequence` instead of `pydantic.RootModel`, which means
+Pydantic methods can no longer be called on it directly (in particular, use
+`to_json_data` to serialize instead of `model_dump_json`).

--- a/python/lsst/daf/butler/formatters/logs.py
+++ b/python/lsst/daf/butler/formatters/logs.py
@@ -66,5 +66,5 @@ class ButlerLogRecordsFormatter(FormatterV2):
         # over pre-downloading the whole file (which can be very large).
         return self._get_read_pytype().from_file(path)
 
-    def to_bytes(self, in_memory_dataset: Any) -> bytes:
-        return in_memory_dataset.model_dump_json(exclude_unset=True, exclude_defaults=True).encode()
+    def to_bytes(self, in_memory_dataset: ButlerLogRecords) -> bytes:
+        return in_memory_dataset.to_json_data().encode()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -80,9 +80,9 @@ class LoggingTestCase(unittest.TestCase):
             self.assertEqual(given[1], record.message)
 
         # Check that we can serialize the records
-        json = self.handler.records.model_dump_json()
+        json = self.handler.records.to_json_data()
 
-        records = ButlerLogRecords.model_validate_json(json)
+        records = ButlerLogRecords.from_raw(json)
         for original_record, new_record in zip(self.handler.records, records, strict=True):
             self.assertEqual(new_record, original_record)
         self.assertEqual(str(records), str(self.handler.records))
@@ -361,7 +361,7 @@ class TestJsonLogging(unittest.TestCase):
 
         # Serialize this model to stream.
         stream2 = io.StringIO()
-        print(records.model_dump_json(), file=stream2)
+        print(records.to_json_data(), file=stream2)
         stream2.seek(0)
         stream_records = ButlerLogRecords.from_stream(stream2)
         self.assertEqual(stream_records, records)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
