### PR TITLE
DM-52400: Remove daf_relation from obscore manager

### DIFF
--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -27,11 +27,12 @@
 
 from __future__ import annotations
 
-__all__ = ("Query",)
+__all__ = ("Query", "QueryFactoryFunction")
 
-from collections.abc import Iterable, Mapping, Set
+from collections.abc import Callable, Iterable, Mapping, Set
+from contextlib import AbstractContextManager
 from types import EllipsisType
-from typing import Any, final
+from typing import Any, TypeAlias, final
 
 import astropy.table
 
@@ -831,3 +832,10 @@ class Query(QueryBase):
             storage_class_name,
             Query(self._driver, self._tree.join_dataset(dataset_type_name, dataset_search)),
         )
+
+
+QueryFactoryFunction: TypeAlias = Callable[[], AbstractContextManager[Query]]
+"""
+Type signature for a function returning a context manager that sets up a
+`Query` object. (That is, a function equivalent to ``Butler.query()``).
+"""

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -5,8 +5,7 @@ __all__ = ("ByDimensionsDatasetRecordStorageManagerUUID",)
 import dataclasses
 import datetime
 import logging
-from collections.abc import Callable, Iterable, Mapping, Sequence, Set
-from contextlib import AbstractContextManager
+from collections.abc import Iterable, Mapping, Sequence, Set
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import astropy.time
@@ -21,7 +20,7 @@ from ...._exceptions_legacy import DatasetTypeError
 from ...._timespan import Timespan
 from ....dimensions import DataCoordinate, DimensionGroup, DimensionUniverse
 from ....direct_query_driver import SqlJoinsBuilder, SqlSelectBuilder  # new query system, server+direct only
-from ....queries import Query
+from ....queries import QueryFactoryFunction
 from ....queries import tree as qt  # new query system, both clients + server
 from ..._caching_context import CachingContext
 from ..._collection_summary import CollectionSummary
@@ -1012,7 +1011,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         collection: CollectionRecord,
         datasets: Iterable[DatasetRef],
         timespan: Timespan,
-        query_func: Callable[[], AbstractContextManager[Query]],
+        query_func: QueryFactoryFunction,
     ) -> None:
         # Docstring inherited from DatasetRecordStorageManager.
         if (storage := self._find_storage(dataset_type.name)) is None:
@@ -1100,7 +1099,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         timespan: Timespan,
         *,
         data_ids: Iterable[DataCoordinate] | None = None,
-        query_func: Callable[[], AbstractContextManager[Query]],
+        query_func: QueryFactoryFunction,
     ) -> None:
         # Docstring inherited from DatasetRecordStorageManager.
         if (storage := self._find_storage(dataset_type.name)) is None:

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -32,8 +32,7 @@ from ... import ddl
 __all__ = ("DatasetRecordStorageManager",)
 
 from abc import abstractmethod
-from collections.abc import Callable, Iterable, Mapping, Sequence, Set
-from contextlib import AbstractContextManager
+from collections.abc import Iterable, Mapping, Sequence, Set
 from typing import TYPE_CHECKING, Any
 
 from ..._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef
@@ -41,7 +40,7 @@ from ..._dataset_type import DatasetType
 from ..._exceptions import DatasetTypeError, DatasetTypeNotSupportedError
 from ..._timespan import Timespan
 from ...dimensions import DataCoordinate
-from ...queries import Query
+from ...queries import QueryFactoryFunction
 from ...queries.tree import AnyDatasetFieldName
 from ._versioning import VersionedExtension, VersionTuple
 
@@ -524,7 +523,7 @@ class DatasetRecordStorageManager(VersionedExtension):
         collection: CollectionRecord,
         datasets: Iterable[DatasetRef],
         timespan: Timespan,
-        query_func: Callable[[], AbstractContextManager[Query]],
+        query_func: QueryFactoryFunction,
     ) -> None:
         """Associate one or more datasets with a calibration collection and a
         validity range within it.
@@ -541,7 +540,7 @@ class DatasetRecordStorageManager(VersionedExtension):
             `DatasetType` as ``dataset_type``, but this is not checked.
         timespan : `Timespan`
             The validity range for these datasets within the collection.
-        query_func : `Callable` [[], `AbstractContextManager` [ `Query` ]],
+        query_func : `QueryFactoryFunction`
             Function returning a context manager that sets up a `Query` object
             for querying the registry. (That is, a function equivalent to
             ``Butler.query()``).
@@ -568,7 +567,7 @@ class DatasetRecordStorageManager(VersionedExtension):
         timespan: Timespan,
         *,
         data_ids: Iterable[DataCoordinate] | None = None,
-        query_func: Callable[[], AbstractContextManager[Query]],
+        query_func: QueryFactoryFunction,
     ) -> None:
         """Remove or adjust datasets to clear a validity range within a
         calibration collection.
@@ -589,7 +588,7 @@ class DatasetRecordStorageManager(VersionedExtension):
             Data IDs that should be decertified within the given validity range
             If `None`, all data IDs for ``dataset_type`` in ``collection`` will
             be decertified.
-        query_func : `Callable` [[], `AbstractContextManager` [ `Query` ]],
+        query_func : `QueryFactoryFunction`
             Function returning a context manager that sets up a `Query` object
             for querying the registry. (That is, a function equivalent to
             ``Butler.query()``).

--- a/python/lsst/daf/butler/registry/interfaces/_dimensions.py
+++ b/python/lsst/daf/butler/registry/interfaces/_dimensions.py
@@ -32,8 +32,6 @@ from abc import abstractmethod
 from collections.abc import Iterable, Mapping, Set
 from typing import TYPE_CHECKING, Any
 
-from lsst.daf.relation import Join, Relation
-
 from ...dimensions import (
     DataCoordinate,
     DataIdValue,
@@ -53,7 +51,6 @@ if TYPE_CHECKING:
         SqlSelectBuilder,
     )
     from ...queries.tree import AnyDatasetType, Predicate  # Future query system (direct,client,server).
-    from .. import queries  # Old Registry.query* system.
     from ._database import Database, StaticTablesContext
 
 
@@ -285,45 +282,6 @@ class DimensionRecordStorageManager(VersionedExtension):
         ------
         KeyError
             Raised if the given key cannot be found in the database.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def join(
-        self,
-        element_name: str,
-        target: Relation,
-        join: Join,
-        context: queries.SqlQueryContext,
-    ) -> Relation:
-        """Join this dimension element's records to a relation.
-
-        Parameters
-        ----------
-        element_name : `str`
-            Name of the dimension element whose relation should be joined in.
-        target : `~lsst.daf.relation.Relation`
-            Existing relation to join to.  Implementations may require that
-            this relation already include dimension key columns for this
-            dimension element and assume that dataset or spatial join relations
-            that might provide these will be included in the relation tree
-            first.
-        join : `~lsst.daf.relation.Join`
-            Join operation to use when the implementation is an actual join.
-            When a true join is being simulated by other relation operations,
-            this objects `~lsst.daf.relation.Join.min_columns` and
-            `~lsst.daf.relation.Join.max_columns` should still be respected.
-        context : `.queries.SqlQueryContext`
-            Object that manages relation engines and database-side state (e.g.
-            temporary tables) for the query.
-
-        Returns
-        -------
-        joined : `~lsst.daf.relation.Relation`
-            New relation that includes this relation's dimension key and record
-            columns, as well as all columns in ``target``,  with rows
-            constrained to those for which this element's dimension key values
-            exist in the registry and rows already exist in ``target``.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/interfaces/_obscore.py
+++ b/python/lsst/daf/butler/registry/interfaces/_obscore.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from ..._column_type_info import ColumnTypeInfo
     from ..._dataset_ref import DatasetRef
     from ...dimensions import DimensionUniverse
+    from ...queries import QueryFactoryFunction
     from ._collections import CollectionRecord
     from ._database import Database, StaticTablesContext
     from ._datasets import DatasetRecordStorageManager
@@ -134,6 +135,20 @@ class ObsCoreTableManager(VersionedExtension):
             An instance of a concrete `ObsCoreTableManager` subclass.
         """
         raise NotImplementedError()
+
+    @abstractmethod
+    def set_query_function(self, query_func: QueryFactoryFunction) -> None:
+        """Set up a function to be used for querying the database.  This must
+        be called before attempting to insert datasets.
+
+        Parameters
+        ----------
+        query_func : `QueryFactoryFunction`
+            Function returning a context manager that sets up a `Query` object
+            for querying the registry. (That is, a function equivalent to
+            ``Butler.query()``).
+        """
+        pass
 
     @abstractmethod
     def config_json(self) -> str:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -230,6 +230,7 @@ class SqlRegistry:
             managers = managerTypes.loadRepo(database)
         if defaults is None:
             defaults = RegistryDefaults()
+
         return cls(database, defaults, managers)
 
     def __init__(
@@ -240,6 +241,8 @@ class SqlRegistry:
     ):
         self._db = database
         self._managers = managers
+        if managers.obscore is not None:
+            managers.obscore.set_query_function(self._query)
         self.storageClasses = StorageClassFactory()
         # This is public to SqlRegistry's internal-to-daf_butler callers, but
         # it is intentionally not part of RegistryShim.


### PR DESCRIPTION
Re-implemented lookup of exposure regions in the Live ObsCore manager so that it uses the new query system instead of daf_relation.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
