### PR TITLE
DM-53176: Add get_many_datasets()

### DIFF
--- a/doc/changes/DM-53176.feature.md
+++ b/doc/changes/DM-53176.feature.md
@@ -1,0 +1,1 @@
+The `id` parameter to `Butler.get_dataset` now accepts hexadecimal strings, in addition to UUID instances.

--- a/doc/changes/DM-53176.feature.md
+++ b/doc/changes/DM-53176.feature.md
@@ -1,1 +1,2 @@
 The `id` parameter to `Butler.get_dataset` now accepts hexadecimal strings, in addition to UUID instances.
+A new method `Butler.get_many_datasets()` allows the efficient lookup of multiple `DatasetRef`s by dataset UUID.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1042,6 +1042,26 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         raise NotImplementedError()
 
     @abstractmethod
+    def get_many_datasets(self, ids: Iterable[DatasetId | str]) -> list[DatasetRef]:
+        """Retrieve a list of dataset entries.
+
+        Parameters
+        ----------
+        ids : `~collections.abc.Iterable` [ `DatasetId` or `str` ]
+            The unique identifiers for the datasets, as instances of
+            `uuid.UUID` or strings containing a hexadecimal number.
+
+        Returns
+        -------
+        refs : `list` [ `DatasetRef` ]
+            A list containing a `DatasetRef` for each of the given dataset IDs.
+            If a dataset was not found, no error is thrown -- it is just not
+            included in the list.  The returned datasets are in no particular
+            order.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def find_dataset(
         self,
         dataset_type: DatasetType | str,

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -1012,7 +1012,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
     @abstractmethod
     def get_dataset(
         self,
-        id: DatasetId,
+        id: DatasetId | str,
         *,
         storage_class: str | StorageClass | None = None,
         dimension_records: bool = False,
@@ -1023,7 +1023,8 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
         Parameters
         ----------
         id : `DatasetId`
-            The unique identifier for the dataset.
+            The unique identifier for the dataset, as an instance of
+            `uuid.UUID` or a string containing a hexadecimal number.
         storage_class : `str` or `StorageClass` or `None`
             A storage class to use when creating the returned entry. If given
             it must be compatible with the default storage class.

--- a/python/lsst/daf/butler/_dataset_provenance.py
+++ b/python/lsst/daf/butler/_dataset_provenance.py
@@ -445,7 +445,7 @@ class DatasetProvenance(pydantic.BaseModel):
 
         quantum_id = None
         ref_id = None
-        input_ids = {}
+        input_ids: dict[int, uuid.UUID] = {}
         extras: dict[int, dict[str, Any]] = {}
 
         for k, standard in prov_keys.items():
@@ -475,8 +475,9 @@ class DatasetProvenance(pydantic.BaseModel):
 
         provenance = cls(quantum_id=quantum_id)
 
+        input_refs = {ref.id: ref for ref in butler.get_many_datasets(input_ids.values())}
         for i in sorted(input_ids):
-            input_ref = butler.get_dataset(input_ids[i])
+            input_ref = input_refs.get(input_ids[i])
             if input_ref is None:
                 raise ValueError(f"Input dataset ({input_ids[i]}) is not known to this butler.")
             provenance.add_input(input_ref)

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1262,8 +1262,7 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         dimension_records: bool = False,
         datastore_records: bool = False,
     ) -> DatasetRef | None:
-        if not isinstance(id, uuid.UUID):
-            id = uuid.UUID(id)
+        id = _to_uuid(id)
         ref = self._registry.getDataset(id)
         if ref is not None:
             if dimension_records:
@@ -1275,6 +1274,10 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             if datastore_records:
                 ref = self._registry.get_datastore_records(ref)
         return ref
+
+    def get_many_datasets(self, ids: Iterable[DatasetId | str]) -> list[DatasetRef]:
+        uuids = [_to_uuid(id) for id in ids]
+        return self._registry._managers.datasets.get_dataset_refs(uuids)
 
     def find_dataset(
         self,
@@ -2612,3 +2615,10 @@ class _ImportDatasetsInfo(NamedTuple):
 
     grouped_refs: defaultdict[_RefGroup, list[DatasetRef]]
     dimension_records: dict[DimensionElement, dict[DataCoordinate, DimensionRecord]]
+
+
+def _to_uuid(id: DatasetId | str) -> uuid.UUID:
+    if isinstance(id, uuid.UUID):
+        return id
+    else:
+        return uuid.UUID(id)

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1256,12 +1256,14 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
     def get_dataset(
         self,
-        id: DatasetId,
+        id: DatasetId | str,
         *,
         storage_class: str | StorageClass | None = None,
         dimension_records: bool = False,
         datastore_records: bool = False,
     ) -> DatasetRef | None:
+        if not isinstance(id, uuid.UUID):
+            id = uuid.UUID(id)
         ref = self._registry.getDataset(id)
         if ref is not None:
             if dimension_records:

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1416,20 +1416,12 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
         # Docstring inherited.
         existence = {ref: DatasetExistence.UNRECOGNIZED for ref in refs}
 
-        # Registry does not have a bulk API to check for a ref.
-        for ref in refs:
-            registry_ref = self._registry.getDataset(ref.id)
-            if registry_ref is not None:
-                # It is possible, albeit unlikely, that the given ref does
-                # not match the one in registry even though the UUID matches.
-                # When checking a single ref we raise, but it's impolite to
-                # do that when potentially hundreds of refs are being checked.
-                # We could change the API to only accept UUIDs and that would
-                # remove the ability to even check and remove the worry
-                # about differing storage classes. Given the ongoing discussion
-                # on refs vs UUIDs and whether to raise or have a new
-                # private flag, treat this as a private API for now.
-                existence[ref] |= DatasetExistence.RECORDED
+        # Check which refs exist in the registry.
+        id_map = {ref.id: ref for ref in existence.keys()}
+        for registry_ref in self.get_many_datasets(id_map.keys()):
+            # Consistency between the given DatasetRef and the information
+            # recorded in the registry is not verified.
+            existence[id_map[registry_ref.id]] |= DatasetExistence.RECORDED
 
         # Ask datastore if it knows about these refs.
         knows = self._datastore.knows_these(refs)

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -38,7 +38,7 @@ from ... import ddl
 from ..._collection_type import CollectionType
 from ...column_spec import COLLECTION_NAME_MAX_LENGTH
 from ...timespan_database_representation import TimespanDatabaseRepresentation
-from ..interfaces import ChainedCollectionRecord, CollectionRecord, RunRecord, VersionTuple
+from ..interfaces import ChainedCollectionRecord, CollectionRecord, Joinable, RunRecord, VersionTuple
 from ._base import (
     CollectionTablesTuple,
     DefaultCollectionManager,
@@ -185,8 +185,8 @@ class NameKeyCollectionManager(DefaultCollectionManager[str]):
         return parent_names
 
     def lookup_name_sql(
-        self, sql_key: sqlalchemy.ColumnElement[str], sql_from_clause: sqlalchemy.FromClause
-    ) -> tuple[sqlalchemy.ColumnElement[str], sqlalchemy.FromClause]:
+        self, sql_key: sqlalchemy.ColumnElement[str], sql_from_clause: Joinable
+    ) -> tuple[sqlalchemy.ColumnElement[str], Joinable]:
         # Docstring inherited.
         return sql_key, sql_from_clause
 

--- a/python/lsst/daf/butler/registry/collections/nameKey.py
+++ b/python/lsst/daf/butler/registry/collections/nameKey.py
@@ -38,7 +38,14 @@ from ... import ddl
 from ..._collection_type import CollectionType
 from ...column_spec import COLLECTION_NAME_MAX_LENGTH
 from ...timespan_database_representation import TimespanDatabaseRepresentation
-from ..interfaces import ChainedCollectionRecord, CollectionRecord, Joinable, RunRecord, VersionTuple
+from ..interfaces import (
+    ChainedCollectionRecord,
+    CollectionRecord,
+    Joinable,
+    JoinedCollectionsTable,
+    RunRecord,
+    VersionTuple,
+)
 from ._base import (
     CollectionTablesTuple,
     DefaultCollectionManager,
@@ -189,6 +196,16 @@ class NameKeyCollectionManager(DefaultCollectionManager[str]):
     ) -> tuple[sqlalchemy.ColumnElement[str], Joinable]:
         # Docstring inherited.
         return sql_key, sql_from_clause
+
+    def join_collections_sql(
+        self, sql_key: sqlalchemy.ColumnElement[str], joinable: Joinable
+    ) -> JoinedCollectionsTable:
+        name_column = self._tables.collection.columns["name"]
+        return JoinedCollectionsTable(
+            joined_sql=joinable.join(self._tables.collection, onclause=name_column == sql_key),
+            name_column=sql_key,
+            type_column=self._tables.collection.columns["type"],
+        )
 
     def _fetch_by_name(self, names: Iterable[str], flatten_chains: bool) -> list[CollectionRecord[str]]:
         # Docstring inherited from base class.

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -39,7 +39,7 @@ import sqlalchemy
 from ..._collection_type import CollectionType
 from ...column_spec import COLLECTION_NAME_MAX_LENGTH
 from ...timespan_database_representation import TimespanDatabaseRepresentation
-from ..interfaces import ChainedCollectionRecord, CollectionRecord, RunRecord, VersionTuple
+from ..interfaces import ChainedCollectionRecord, CollectionRecord, Joinable, RunRecord, VersionTuple
 from ._base import (
     CollectionTablesTuple,
     DefaultCollectionManager,
@@ -186,8 +186,8 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager[int]):
         return parent_names
 
     def lookup_name_sql(
-        self, sql_key: sqlalchemy.ColumnElement[int], sql_from_clause: sqlalchemy.FromClause
-    ) -> tuple[sqlalchemy.ColumnElement[str], sqlalchemy.FromClause]:
+        self, sql_key: sqlalchemy.ColumnElement[int], sql_from_clause: Joinable
+    ) -> tuple[sqlalchemy.ColumnElement[str], Joinable]:
         # Docstring inherited.
         return (
             self._tables.collection.c.name,

--- a/python/lsst/daf/butler/registry/collections/synthIntKey.py
+++ b/python/lsst/daf/butler/registry/collections/synthIntKey.py
@@ -39,7 +39,14 @@ import sqlalchemy
 from ..._collection_type import CollectionType
 from ...column_spec import COLLECTION_NAME_MAX_LENGTH
 from ...timespan_database_representation import TimespanDatabaseRepresentation
-from ..interfaces import ChainedCollectionRecord, CollectionRecord, Joinable, RunRecord, VersionTuple
+from ..interfaces import (
+    ChainedCollectionRecord,
+    CollectionRecord,
+    Joinable,
+    JoinedCollectionsTable,
+    RunRecord,
+    VersionTuple,
+)
 from ._base import (
     CollectionTablesTuple,
     DefaultCollectionManager,
@@ -189,11 +196,18 @@ class SynthIntKeyCollectionManager(DefaultCollectionManager[int]):
         self, sql_key: sqlalchemy.ColumnElement[int], sql_from_clause: Joinable
     ) -> tuple[sqlalchemy.ColumnElement[str], Joinable]:
         # Docstring inherited.
-        return (
-            self._tables.collection.c.name,
-            sql_from_clause.join(
+        joined = self.join_collections_sql(sql_key, sql_from_clause)
+        return (joined.name_column, joined.joined_sql)
+
+    def join_collections_sql(
+        self, sql_key: sqlalchemy.ColumnElement[int], joinable: Joinable
+    ) -> JoinedCollectionsTable:
+        return JoinedCollectionsTable(
+            joined_sql=joinable.join(
                 self._tables.collection, onclause=self._tables.collection.c[_KEY_FIELD_SPEC.name] == sql_key
             ),
+            name_column=self._tables.collection.columns["name"],
+            type_column=self._tables.collection.columns["type"],
         )
 
     def _fetch_by_name(self, names: Iterable[str], flatten_chains: bool) -> list[CollectionRecord[int]]:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_dataset_type_cache.py
@@ -56,6 +56,7 @@ class DatasetTypeCache:
     def __init__(self) -> None:
         self.tables = TableCache()
         self._by_name_cache: dict[str, tuple[DatasetType, int]] = {}
+        self._by_id_cache: dict[int, DatasetType] = {}
         self._by_dimensions_cache: dict[DimensionGroup, DynamicTables] = {}
         self._full = False
         self._dimensions_full = False
@@ -112,6 +113,7 @@ class DatasetTypeCache:
             Additional opaque object stored with this dataset type.
         """
         self._by_name_cache[dataset_type.name] = (dataset_type, id)
+        self._by_id_cache[id] = dataset_type
 
     def set(
         self,
@@ -136,7 +138,7 @@ class DatasetTypeCache:
         """
         self.clear()
         for item in data:
-            self._by_name_cache[item[0].name] = item
+            self.add(item[0], item[1])
         self._full = full
         if dimensions_data is not None:
             self._by_dimensions_cache.update(dimensions_data)
@@ -146,6 +148,7 @@ class DatasetTypeCache:
         """Remove everything from the cache."""
         self._by_name_cache = {}
         self._by_dimensions_cache = {}
+        self._by_id_cache = {}
         self._full = False
         self._dimensions_full = False
 
@@ -157,7 +160,9 @@ class DatasetTypeCache:
         name : `str`
             Name of the dataset type to remove.
         """
-        self._by_name_cache.pop(name, None)
+        _, id = self._by_name_cache.pop(name, (None, None))
+        if id is not None:
+            self._by_id_cache.pop(id, None)
 
     def get(self, name: str) -> tuple[DatasetType | None, int | None]:
         """Return cached info given dataset type name.
@@ -180,6 +185,21 @@ class DatasetTypeCache:
         if item is None:
             return (None, None)
         return item
+
+    def get_by_id(self, id: int) -> DatasetType | None:
+        """Return cached dataset type given the dataset type ID.
+
+        Parameters
+        ----------
+        id : `int`
+            Dataset type ID (database key).
+
+        Returns
+        -------
+        dataset_type : `DatasetType`
+            The `DatasetType` information associated with the given ID.
+        """
+        return self._by_id_cache.get(id, None)
 
     def get_dataset_type(self, name: str) -> DatasetType | None:
         """Return dataset type given its name.

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -311,7 +311,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
     def register_dataset_type(self, dataset_type: DatasetType) -> bool:
         # Docstring inherited from DatasetRecordStorageManager.
         #
-        # This is one of three places where we populate the dataset type cache.
+        # This is one of the places where we populate the dataset type cache.
         # See the comment in _fetch_dataset_types for how these are related and
         # invariants they must maintain.
         #
@@ -424,37 +424,19 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
 
     def getDatasetRef(self, id: DatasetId) -> DatasetRef | None:
         # Docstring inherited from DatasetRecordStorageManager.
-        #
-        # This is one of three places where we populate the dataset type cache.
-        # See the comment in _fetch_dataset_types for how these are related and
-        # invariants they must maintain.
-        #
-        sql = (
-            sqlalchemy.sql.select(
-                self._static.dataset.columns.dataset_type_id,
-                self._static.dataset.columns[self._collections.getRunForeignKeyName()],
-                *self._static.dataset_type.columns,
-            )
-            .select_from(self._static.dataset)
-            .join(self._static.dataset_type)
-            .where(self._static.dataset.columns.id == id)
-        )
+        sql = sqlalchemy.sql.select(
+            self._static.dataset.columns.dataset_type_id,
+            self._static.dataset.columns[self._collections.getRunForeignKeyName()],
+        ).where(self._static.dataset.columns.id == id)
         with self._db.query(sql) as sql_result:
             row = sql_result.mappings().fetchone()
         if row is None:
             return None
         run = row[self._run_key_column]
-        record = self._record_from_row(row)
-        _, dataset_type_id = self._cache.get(record.dataset_type.name)
-        if dataset_type_id is None:
-            self._cache.add(record.dataset_type, record.dataset_type_id)
-        else:
-            assert record.dataset_type_id == dataset_type_id, "Two IDs for the same dataset type name!"
-        dynamic_tables = self._cache.get_by_dimensions(record.dataset_type.dimensions)
-        if dynamic_tables is None:
-            dynamic_tables = record.make_dynamic_tables()
-            self._cache.add_by_dimensions(record.dataset_type.dimensions, dynamic_tables)
-        if record.dataset_type.dimensions:
+        dataset_type_id = row["dataset_type_id"]
+        dataset_type = self._get_dataset_type_by_id(dataset_type_id)
+        dynamic_tables = self._get_dynamic_tables(dataset_type.dimensions)
+        if dataset_type.dimensions:
             # This query could return multiple rows (one for each tagged
             # collection the dataset is in, plus one for its run collection),
             # and we don't care which of those we get.
@@ -464,7 +446,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
                 .where(
                     sqlalchemy.sql.and_(
                         tags_table.columns.dataset_id == id,
-                        tags_table.columns.dataset_type_id == record.dataset_type_id,
+                        tags_table.columns.dataset_type_id == dataset_type_id,
                     )
                 )
                 .limit(1)
@@ -473,13 +455,13 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
                 data_id_row = sql_result.mappings().fetchone()
             assert data_id_row is not None, "Data ID should be present if dataset is."
             data_id = DataCoordinate.from_required_values(
-                record.dataset_type.dimensions,
-                tuple(data_id_row[dimension] for dimension in record.dataset_type.dimensions.required),
+                dataset_type.dimensions,
+                tuple(data_id_row[dimension] for dimension in dataset_type.dimensions.required),
             )
         else:
             data_id = DataCoordinate.make_empty(self._dimensions.universe)
         return DatasetRef(
-            record.dataset_type,
+            dataset_type,
             dataId=data_id,
             id=id,
             run=self._collections[run].name,
@@ -523,9 +505,9 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
     def preload_cache(self) -> None:
         self._fetch_dataset_types()
 
-    def _fetch_dataset_types(self) -> list[DatasetType]:
+    def _fetch_dataset_types(self, force_refresh: bool = False) -> list[DatasetType]:
         """Fetch list of all defined dataset types."""
-        # This is one of three places we populate the dataset type cache:
+        # This is one of two places we populate the dataset type cache:
         #
         # - This method handles almost all requests for dataset types that
         #   should already exist.  It always marks the cache as "full" in both
@@ -535,19 +517,11 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         #   not existing yet.  Since it can only add a single dataset type, it
         #   never changes whether the cache is full.
         #
-        # - getDatasetRef is a special case for a dataset type that should
-        #   already exist, but is looked up via a dataset ID rather than its
-        #   name.  It also never changes whether the cache is full, and it's
-        #   handles separately essentially as an optimization: we can fetch a
-        #   single dataset type definition record in a join when we query for
-        #   the dataset type based on the dataset ID, and this is better than
-        #   blindly fetching all dataset types in a separate query.
-        #
-        # In all three cases, we require that the per-dimensions data be cached
+        # In both cases, we require that the per-dimensions data be cached
         # whenever a dataset type is added to the cache by name, to reduce the
         # number of possible states the cache can be in and minimize the number
         # of queries.
-        if self._cache.full:
+        if self._cache.full and not force_refresh:
             return [dataset_type for dataset_type, _ in self._cache.items()]
         with self._db.query(self._static.dataset_type.select()) as sql_result:
             sql_rows = sql_result.mappings().fetchall()
@@ -567,16 +541,26 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         )
         return [record.dataset_type for record in records]
 
+    def _get_dataset_type_by_id(self, id: int) -> DatasetType:
+        dt = self._cache.get_by_id(id)
+        if dt is None:
+            # Since the ID is not a concept exposed to the public API, it
+            # had to have come from a dataset table, and our cache must be
+            # empty or out of date.
+            self._fetch_dataset_types(force_refresh=True)
+        dt = self._cache.get_by_id(id)
+        if dt is None:
+            raise RuntimeError(f"Failed to look up dataset type with ID {id}")
+        return dt
+
     def _find_storage(self, name: str) -> _DatasetRecordStorage:
         """Find a dataset type and the extra information needed to work with
         it, utilizing and populating the cache as needed.
         """
         dataset_type, dataset_type_id = self._cache.get(name)
         if dataset_type is not None:
-            tables = self._cache.get_by_dimensions(dataset_type.dimensions)
-            assert dataset_type_id is not None and tables is not None, (
-                "Dataset type cache population is incomplete."
-            )
+            tables = self._get_dynamic_tables(dataset_type.dimensions)
+            assert dataset_type_id is not None, "Dataset type cache population is incomplete."
             return _DatasetRecordStorage(
                 dataset_type=dataset_type, dataset_type_id=dataset_type_id, dynamic_tables=tables
             )
@@ -588,10 +572,8 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
                 # Try again
                 dataset_type, dataset_type_id = self._cache.get(name)
             if dataset_type is not None:
-                tables = self._cache.get_by_dimensions(dataset_type.dimensions)
-                assert dataset_type_id is not None and tables is not None, (
-                    "Dataset type cache population is incomplete."
-                )
+                tables = self._get_dynamic_tables(dataset_type.dimensions)
+                assert dataset_type_id is not None, "Dataset type cache population is incomplete."
                 return _DatasetRecordStorage(
                     dataset_type=dataset_type, dataset_type_id=dataset_type_id, dynamic_tables=tables
                 )
@@ -602,6 +584,13 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
             self._cache.add_by_dimensions(record.dataset_type.dimensions, tables)
             return _DatasetRecordStorage(record.dataset_type, record.dataset_type_id, tables)
         raise MissingDatasetTypeError(f"Dataset type {name!r} does not exist.")
+
+    def _get_dynamic_tables(self, dimensions: DimensionGroup) -> DynamicTables:
+        tables = self._cache.get_by_dimensions(dimensions)
+        assert tables is not None, (
+            "_fetch_dataset_types is supposed to guarantee that the tables cache is populated."
+        )
+        return tables
 
     def getCollectionSummary(self, collection: CollectionRecord) -> CollectionSummary:
         # Docstring inherited from DatasetRecordStorageManager.
@@ -726,10 +715,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
                 raise MissingDatasetTypeError(f"Dataset type {dt.name!r} has not been registered.")
             dataset_type_storage[dt.name] = storage
 
-        dynamic_tables = self._cache.get_by_dimensions(dimensions)
-        assert dynamic_tables is not None, (
-            "Table cache should have been populated when looking up dataset types"
-        )
+        dynamic_tables = self._get_dynamic_tables(dimensions)
         tags_table = self._get_tags_table(dynamic_tables)
         # Current timestamp, type depends on schema version.
         if self._use_astropy_ingest_date:

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -29,7 +29,14 @@ from ...interfaces import DatasetRecordStorageManager, RunRecord, VersionTuple
 from ...wildcards import DatasetTypeWildcard
 from ._dataset_type_cache import DatasetTypeCache
 from .summaries import CollectionSummaryManager
-from .tables import DynamicTables, addDatasetForeignKey, makeStaticTableSpecs, makeTagTableSpec
+from .tables import (
+    DynamicTables,
+    StaticDatasetTableSpecTuple,
+    StaticDatasetTablesTuple,
+    addDatasetForeignKey,
+    makeStaticTableSpecs,
+    makeTagTableSpec,
+)
 
 if TYPE_CHECKING:
     from ...interfaces import (
@@ -39,7 +46,6 @@ if TYPE_CHECKING:
         DimensionRecordStorageManager,
         StaticTablesContext,
     )
-    from .tables import StaticDatasetTablesTuple
 
 
 # This has to be updated on every schema change
@@ -208,7 +214,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         collections: type[CollectionManager],
         universe: DimensionUniverse,
         schema_version: VersionTuple | None,
-    ) -> StaticDatasetTablesTuple:
+    ) -> StaticDatasetTableSpecTuple:
         """Construct all static tables used by the classes in this package.
 
         Static tables are those that are present in all Registries and do not

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/tables.py
@@ -28,6 +28,7 @@
 from __future__ import annotations
 
 __all__ = (
+    "StaticDatasetTableSpecTuple",
     "StaticDatasetTablesTuple",
     "addDatasetForeignKey",
     "makeCalibTableName",
@@ -37,8 +38,7 @@ __all__ = (
     "makeTagTableSpec",
 )
 
-from collections import namedtuple
-from typing import Any, TypeAlias
+from typing import Any, NamedTuple, TypeAlias
 
 import sqlalchemy
 
@@ -57,13 +57,18 @@ class MissingDatabaseTableError(RuntimeError):
     """Exception raised when a table is not found in a database."""
 
 
-StaticDatasetTablesTuple = namedtuple(
-    "StaticDatasetTablesTuple",
-    [
-        "dataset_type",
-        "dataset",
-    ],
-)
+class StaticDatasetTableSpecTuple(NamedTuple):
+    """Table specifications for static dataset tables."""
+
+    dataset_type: ddl.TableSpec
+    dataset: ddl.TableSpec
+
+
+class StaticDatasetTablesTuple(NamedTuple):
+    """SQLAlchemy table objects for static dataset tables."""
+
+    dataset_type: sqlalchemy.Table
+    dataset: sqlalchemy.Table
 
 
 def addDatasetForeignKey(
@@ -118,7 +123,7 @@ def makeStaticTableSpecs(
     collections: type[CollectionManager],
     universe: DimensionUniverse,
     schema_version: VersionTuple,
-) -> StaticDatasetTablesTuple:
+) -> StaticDatasetTableSpecTuple:
     """Construct all static tables used by the classes in this package.
 
     Static tables are those that are present in all Registries and do not
@@ -135,7 +140,7 @@ def makeStaticTableSpecs(
 
     Returns
     -------
-    specs : `StaticDatasetTablesTuple`
+    specs : `StaticDatasetTableSpecTuple`
         A named tuple containing `ddl.TableSpec` instances.
     """
     ingest_date_type: type
@@ -148,7 +153,7 @@ def makeStaticTableSpecs(
         # default just to be consistent with the existing schema.
         ingest_date_default = sqlalchemy.sql.func.now()
 
-    specs = StaticDatasetTablesTuple(
+    specs = StaticDatasetTableSpecTuple(
         dataset_type=ddl.TableSpec(
             fields=[
                 ddl.FieldSpec(

--- a/python/lsst/daf/butler/registry/interfaces/_collections.py
+++ b/python/lsst/daf/butler/registry/interfaces/_collections.py
@@ -32,6 +32,7 @@ __all__ = [
     "ChainedCollectionRecord",
     "CollectionManager",
     "CollectionRecord",
+    "Joinable",
     "RunRecord",
 ]
 
@@ -52,6 +53,8 @@ if TYPE_CHECKING:
 
 
 _Key = TypeVar("_Key")
+
+Joinable = TypeVar("Joinable", sqlalchemy.Select, sqlalchemy.FromClause)
 
 
 class CollectionRecord(Generic[_Key]):
@@ -756,8 +759,8 @@ class CollectionManager(Generic[_Key], VersionedExtension):
         raise NotImplementedError()
 
     def lookup_name_sql(
-        self, sql_key: sqlalchemy.ColumnElement[_Key], sql_from_clause: sqlalchemy.FromClause
-    ) -> tuple[sqlalchemy.ColumnElement[str], sqlalchemy.FromClause]:
+        self, sql_key: sqlalchemy.ColumnElement[_Key], sql_from_clause: Joinable
+    ) -> tuple[sqlalchemy.ColumnElement[str], Joinable]:
         """Return a SQLAlchemy column and FROM clause that enable a query
         to look up a collection name from the key.
 

--- a/python/lsst/daf/butler/registry/interfaces/_datasets.py
+++ b/python/lsst/daf/butler/registry/interfaces/_datasets.py
@@ -323,20 +323,22 @@ class DatasetRecordStorageManager(VersionedExtension):
         raise NotImplementedError()
 
     @abstractmethod
-    def getDatasetRef(self, id: DatasetId) -> DatasetRef | None:
-        """Return a `DatasetRef` for the given dataset primary key
-        value.
+    def get_dataset_refs(self, ids: list[DatasetId]) -> list[DatasetRef]:
+        """
+        Return a `DatasetRef` for each of the given dataset UUID values.
 
         Parameters
         ----------
-        id : `DatasetId`
-            Primary key value for the dataset.
+        ids : `list` [ `DatasetId` ]
+            List of UUID instances to look up.
 
         Returns
         -------
-        ref : `DatasetRef` or `None`
-            Object representing the dataset, or `None` if no dataset with the
-            given primary key values exists in this layer.
+        refs : `list` [ `DatasetRef` ]
+            A list containing a `DatasetRef` for each of the given UUIDs that
+            was found in the database.  If a dataset was not found, no error is
+            thrown -- it is just not included in the list.  The returned
+            datasets are in no particular order.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -1024,7 +1024,11 @@ class SqlRegistry:
             A ref to the Dataset, or `None` if no matching Dataset
             was found.
         """
-        return self._managers.datasets.getDatasetRef(id)
+        refs = self._managers.datasets.get_dataset_refs([id])
+        if len(refs) == 0:
+            return None
+        else:
+            return refs[0]
 
     def _fetch_run_dataset_ids(self, run: str) -> list[DatasetId]:
         """Return the IDs of all datasets in the given ``RUN``

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -46,6 +46,7 @@ from lsst.daf.butler.datastores.file_datastore.retrieve_artifacts import (
     unpack_zips,
 )
 from lsst.resources import ResourcePath, ResourcePathExpression
+from lsst.utils.iteration import chunk_iterable
 
 from .._butler import Butler, _DeprecatedDefault
 from .._butler_collections import ButlerCollections
@@ -82,6 +83,8 @@ from .server_models import (
     GetDatasetTypeResponseModel,
     GetFileByDataIdRequestModel,
     GetFileResponseModel,
+    GetManyDatasetsRequestModel,
+    GetManyDatasetsResponseModel,
     GetUniverseResponseModel,
     QueryAllDatasetsRequestModel,
 )
@@ -403,6 +406,16 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         if storage_class is not None:
             ref = ref.overrideStorageClass(storage_class)
         return ref
+
+    def get_many_datasets(self, ids: Iterable[DatasetId | str]) -> list[DatasetRef]:
+        result = []
+        for batch in chunk_iterable(ids, GetManyDatasetsRequestModel.MAX_ITEMS_PER_REQUEST):
+            request = GetManyDatasetsRequestModel(dataset_ids=batch)
+            response = self._connection.post("datasets", request)
+            model = parse_model(response, GetManyDatasetsResponseModel)
+            refs = convert_dataset_ref_results(model, self.dimensions)
+            result.extend(refs)
+        return result
 
     def find_dataset(
         self,

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -386,7 +386,7 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
 
     def get_dataset(
         self,
-        id: DatasetId,
+        id: DatasetId | str,
         *,
         storage_class: str | StorageClass | None = None,
         dimension_records: bool = False,

--- a/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_external.py
@@ -56,6 +56,8 @@ from ...server_models import (
     GetFileResponseModel,
     GetFileTransferInfoRequestModel,
     GetFileTransferInfoResponseModel,
+    GetManyDatasetsRequestModel,
+    GetManyDatasetsResponseModel,
     GetUniverseResponseModel,
     QueryCollectionInfoRequestModel,
     QueryCollectionInfoResponseModel,
@@ -145,6 +147,15 @@ def get_dataset(
     ref = butler.get_dataset(id, dimension_records=dimension_records)
     serialized_ref = ref.to_simple() if ref else None
     return FindDatasetResponseModel(dataset_ref=serialized_ref)
+
+
+@external_router.post("/v1/datasets")
+def get_many_datasets(
+    input: GetManyDatasetsRequestModel, factory: Factory = Depends(factory_dependency)
+) -> GetManyDatasetsResponseModel:
+    butler = factory.create_butler()
+    refs = butler.get_many_datasets(input.dataset_ids)
+    return GetManyDatasetsResponseModel.from_refs(refs)
 
 
 @external_router.post(

--- a/python/lsst/daf/butler/remote_butler/server_models.py
+++ b/python/lsst/daf/butler/remote_butler/server_models.py
@@ -467,3 +467,11 @@ class FileInfoPayload(pydantic.BaseModel):
     """List of retrieval information for each file associated with this
     artifact.
     """
+
+
+class GetManyDatasetsRequestModel(pydantic.BaseModel):
+    MAX_ITEMS_PER_REQUEST: ClassVar[int] = 10_000
+    dataset_ids: Annotated[list[UUID], pydantic.Field(max_length=MAX_ITEMS_PER_REQUEST)]
+
+
+GetManyDatasetsResponseModel: TypeAlias = DatasetRefResultModel

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -201,6 +201,9 @@ class HybridButler(Butler):
             datastore_records=datastore_records,
         )
 
+    def get_many_datasets(self, ids: Iterable[DatasetId | str]) -> list[DatasetRef]:
+        return self._remote_butler.get_many_datasets(ids)
+
     def find_dataset(
         self,
         dataset_type: DatasetType | str,

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -188,7 +188,7 @@ class HybridButler(Butler):
 
     def get_dataset(
         self,
-        id: DatasetId,
+        id: DatasetId | str,
         *,
         storage_class: str | StorageClass | None = None,
         dimension_records: bool = False,

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1488,6 +1488,10 @@ class ButlerTests(ButlerPutGetTests):
         put_ref = writer_butler.put(123, datasetType, dataId)
         get_ref = reader_butler.get_dataset(put_ref.id)
         self.assertEqual(get_ref.id, put_ref.id)
+        # Also works when looking up via a hexadecimal string instead of a UUID
+        # instance.
+        hex_ref = reader_butler.get_dataset(put_ref.id.hex)
+        self.assertEqual(hex_ref.id, put_ref.id)
 
     def testCollectionChainRedefine(self):
         butler = self._setup_to_test_collection_chain()


### PR DESCRIPTION
Added a method `Butler.get_many_datasets()` to look up multiple `DatasetRef` instances from their UUIDs.  This will be used by the [DMTN-330](https://dmtn-330.lsst.io/) Prompt Publication Service when transferring groups of datasets between repositories.  

Also added support for passing dataset UUIDs as strings into the existing `get_dataset()` method, instead of requiring them to be manually converted to UUID objects.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
