### PR TITLE
DM-53179: Fix collection name KeyError in queryDatasetAssociations

### DIFF
--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -1438,8 +1438,7 @@ class Registry(ABC):
             If provided, only yield associations from collections of these
             types.
         flattenChains : `bool`, optional
-            If `True`, search in the children of `~CollectionType.CHAINED`
-            collections.  If `False`, ``CHAINED`` collections are ignored.
+            This parameter has no effect and is ignored.
 
         Yields
         ------

--- a/python/lsst/daf/butler/registry/_registry_base.py
+++ b/python/lsst/daf/butler/registry/_registry_base.py
@@ -238,7 +238,7 @@ class RegistryBase(Registry):
                 collections,
                 datasetType=datasetType,
                 collectionTypes=collectionTypes,
-                flattenChains=flattenChains,
+                flattenChains=True,
             )
             # It's annoyingly difficult to just do the collection query once,
             # since query_info doesn't accept all the expression types that

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -2540,6 +2540,26 @@ class RegistryTests(ABC):
             ],
         )
 
+        # Test dataset association query against a chained collection.
+        # This is a regression test for DM-53179, as well as verification
+        # that the flattenChains parameter has never had any effect.
+        butler.collections.register("chain", CollectionType.CHAINED)
+        butler.collections.redefine_chain("chain", [collection])
+        expected_datasets = (
+            DatasetAssociation(ref=bias2a, collection=collection, timespan=Timespan(begin=t2, end=t4)),
+            DatasetAssociation(ref=bias3a, collection=collection, timespan=Timespan(begin=t1, end=t3)),
+            DatasetAssociation(ref=bias2b, collection=collection, timespan=Timespan(begin=t4, end=None)),
+            DatasetAssociation(ref=bias3b, collection=collection, timespan=Timespan(begin=t4, end=None)),
+        )
+        self.assertCountEqual(
+            list(registry.queryDatasetAssociations("bias", collections=["chain"], flattenChains=False)),
+            expected_datasets,
+        )
+        self.assertCountEqual(
+            list(registry.queryDatasetAssociations("bias", collections=["chain"], flattenChains=True)),
+            expected_datasets,
+        )
+
         class Ambiguous:
             """Tag class to denote lookups that should be ambiguous."""
 


### PR DESCRIPTION
Fix a bug where queryDatasetAssociations against a chained collection would fail with `KeyError` when trying to look up the collection name from the `collection_info` dictionary.  This was happening because the associated collections are looked up by the calibration collection name, but we only had an entry in the dictionary for the parent chain when `flattenChains=False` (the default).

It also became clear that the `flattenChains` parameter to `queryDatasetAssociation` has no effect, at least since DM-45429 last year, and the documentation was updated to reflect this.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
