### PR TITLE
DM-53266: Fix tests for pytest 9

### DIFF
--- a/doc/changes/DM-53266.bugfix.md
+++ b/doc/changes/DM-53266.bugfix.md
@@ -1,0 +1,1 @@
+Fixed compatibility of the unit test suite with pytest 9.

--- a/python/lsst/daf/butler/registry/tests/_database.py
+++ b/python/lsst/daf/butler/registry/tests/_database.py
@@ -1130,7 +1130,7 @@ class DatabaseTests(ABC):
         for rhsRow in aRows:
             if rhsRow[TimespanReprClass.NAME] is None:
                 continue
-            with self.subTest(rhsRow=rhsRow):
+            with self.subTest(rhsRow=repr(rhsRow)):
                 expected = {}
                 for lhsRow in aRows:
                     if lhsRow[TimespanReprClass.NAME] is None:
@@ -1191,7 +1191,7 @@ class DatabaseTests(ABC):
         # Test relationship expressions between in-database timespans and
         # Python-literal instantaneous times.
         for t in timestamps:
-            with self.subTest(t=t):
+            with self.subTest(t=repr(t)):
                 expected = {}
                 for lhsRow in aRows:
                     if lhsRow[TimespanReprClass.NAME] is None:

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -419,7 +419,7 @@ class RegistryTests(ABC):
         # Try a normal integer and something that looks like an int but
         # is not.
         for visit_id in (42, np.int64(42)):
-            with self.subTest(visit_id=visit_id, id_type=type(visit_id).__name__):
+            with self.subTest(visit_id=repr(visit_id), id_type=type(visit_id).__name__):
                 expanded = registry.expandDataId({"instrument": "DummyCam", "visit": visit_id})
                 self.assertEqual(expanded["visit"], int(visit_id))
                 self.assertIsInstance(expanded["visit"], int)
@@ -767,7 +767,7 @@ class RegistryTests(ABC):
 
         # Test for non-unique IDs, they can be re-imported multiple times.
         for run, idGenMode in ((2, DatasetIdGenEnum.DATAID_TYPE), (4, DatasetIdGenEnum.DATAID_TYPE_RUN)):
-            with self.subTest(idGenMode=idGenMode):
+            with self.subTest(idGenMode=repr(idGenMode)):
                 # Make dataset ref with reproducible dataset ID.
                 ref = DatasetRef(datasetTypeBias, dataIdBias1, run=f"run{run}", id_generation_mode=idGenMode)
                 (ref1,) = registry._importDatasets([ref])
@@ -3273,7 +3273,7 @@ class RegistryTests(ABC):
         ]
 
         for test in test_data:
-            with self.subTest(test=test):
+            with self.subTest(test=repr(test)):
                 order_by = test.order_by.split(",")
                 keys = test.keys.split(",")
                 query = do_query(keys, test.datasets, test.collections).order_by(*order_by)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -325,7 +325,7 @@ class ButlerPutGetTests(TestCaseMixin):
             butler.collections.register(this_run)
             expected_collections.update({this_run})
 
-            with self.subTest(args=args):
+            with self.subTest(args=repr(args)):
                 kwargs: dict[str, Any] = {}
                 if not isinstance(args[0], DatasetRef):  # type: ignore
                     kwargs["run"] = this_run
@@ -1791,7 +1791,7 @@ class FileDatastoreButlerTests(ButlerTests):
                     )
                 importButler = Butler.from_config(importDir, run=self.default_run)
                 for ref in datasets:
-                    with self.subTest(ref=ref):
+                    with self.subTest(ref=repr(ref)):
                         # Test for existence by passing in the DatasetType and
                         # data ID separately, to avoid lookup by dataset_id.
                         self.assertTrue(importButler.exists(ref.datasetType, ref.dataId))

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -1386,7 +1386,7 @@ class CleanupPosixDatastoreTestCase(DatastoreTestsBase, unittest.TestCase):
         # Try formatter that fails and formatter that fails and leaves
         # a file behind
         for formatter in (BadWriteFormatter, BadNoWriteFormatter):
-            with self.subTest(formatter=formatter):
+            with self.subTest(formatter=str(formatter)):
                 # Monkey patch the formatter
                 datastore.formatterFactory.registerFormatter(ref.datasetType, formatter, overwrite=True)
 

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -159,7 +159,9 @@ class DimensionTestCase(unittest.TestCase):
         seen: set[str] = set()
         for element_name in group.lookup_order:
             element = self.universe[element_name]
-            with self.subTest(required=group.required, implied=group.implied, element=element):
+            with self.subTest(
+                required=repr(group.required), implied=repr(group.implied), element=repr(element)
+            ):
                 seen.add(element_name)
                 self.assertLessEqual(element.minimal_group.required, seen)
                 if element_name in group.implied:
@@ -641,7 +643,7 @@ class DataCoordinateTestCase(unittest.TestCase):
             dataIds = self.randomDataIds(n=1).subset(dimensions)
             split = self.splitByStateFlags(dataIds)
             for dataId in split.chain():
-                with self.subTest(dataId=dataId):
+                with self.subTest(dataId=repr(dataId)):
                     self.assertEqual(dataId.required.keys(), dataId.dimensions.required)
                     self.assertEqual(
                         list(dataId.required.values()), [dataId[d] for d in dataId.dimensions.required]
@@ -651,7 +653,7 @@ class DataCoordinateTestCase(unittest.TestCase):
                     )
                     self.assertEqual(dataId.required.keys(), dataId.dimensions.required)
             for dataId in itertools.chain(split.complete, split.expanded):
-                with self.subTest(dataId=dataId):
+                with self.subTest(dataId=repr(dataId)):
                     self.assertTrue(dataId.hasFull())
                     self.assertEqual(dataId.dimensions.names, dataId.mapping.keys())
                     self.assertEqual(
@@ -749,7 +751,7 @@ class DataCoordinateTestCase(unittest.TestCase):
                         DataCoordinate.standardize(dataId, dimensions=newDimensions, htm7=12),
                     ]
                     for newDataId in newDataIds:
-                        with self.subTest(newDataId=newDataId, type=type(dataId)):
+                        with self.subTest(newDataId=repr(newDataId), type=str(type(dataId))):
                             commonKeys = dataId.dimensions.required & newDataId.dimensions.required
                             self.assertTrue(commonKeys)
                             self.assertEqual(
@@ -794,7 +796,7 @@ class DataCoordinateTestCase(unittest.TestCase):
                     ),
                 ]
                 for newDataId in newCompleteDataIds:
-                    with self.subTest(dataId=dataId, newDataId=newDataId, type=type(dataId)):
+                    with self.subTest(dataId=repr(dataId), newDataId=repr(newDataId), type=str(type(dataId))):
                         self.assertEqual(dataId, newDataId)
                         self.assertTrue(newDataId.hasFull())
 
@@ -819,7 +821,7 @@ class DataCoordinateTestCase(unittest.TestCase):
             (parentDataId,) = parentDataIds
             for lhs, rhs in itertools.product(split1.chain(), split2.chain()):
                 unioned = lhs.union(rhs)
-                with self.subTest(lhs=lhs, rhs=rhs, unioned=unioned):
+                with self.subTest(lhs=repr(lhs), rhs=repr(rhs), unioned=repr(unioned)):
                     self.assertEqual(unioned.dimensions, group1.union(group2))
                     self.assertEqual(unioned, parentDataId.subset(unioned.dimensions))
                     if unioned.hasFull():

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -227,7 +227,7 @@ class SchemaVersioningTestCase(unittest.TestCase):
         )
 
         for Manager, version, update, compatible in compat_matrix:
-            with self.subTest(test=(Manager, version, update, compatible)):
+            with self.subTest(test=repr((Manager, version, update, compatible))):
                 if compatible:
                     Manager.checkCompatibility(version, update)
                 else:


### PR DESCRIPTION
Pytest 9 has a new implementation of `subTest` which requires all of the labels to be plain python types instead of complex objects.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
