### PR TITLE
DM-53233: Add resource cleanup interface to Butler

### DIFF
--- a/doc/changes/DM-53233.bugfix.md
+++ b/doc/changes/DM-53233.bugfix.md
@@ -1,0 +1,3 @@
+The unit tests will no longer fail due to file descriptor exhaustion.
+All `ResourceWarning` messages in the unit test suite have been fixed.
+Butler instances are now garbage-collected immediately when they are not longer referenced, although their database connections still might not be released until mark-and-sweep garbage collection runs.

--- a/doc/changes/DM-53233.feature.md
+++ b/doc/changes/DM-53233.feature.md
@@ -1,0 +1,1 @@
+Added `Butler.close()`, a context manager implementation for `Butler`, and `QuantumBackedButler.close()`.  These can be used to ensure that database connections are closed deterministically, rather than waiting for mark-and-sweep garbage collection.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -516,9 +516,10 @@ class Butler(LimitedButler, AbstractContextManager):  # numpydoc ignore=PR02
         # Create Registry and populate tables
         registryConfig = RegistryConfig(config.get("registry"))
         dimensionConfig = DimensionConfig(dimensionConfig)
-        _RegistryFactory(registryConfig).create_from_config(
+        registry = _RegistryFactory(registryConfig).create_from_config(
             dimensionConfig=dimensionConfig, butlerRoot=root_uri
         )
+        registry.close()
 
         _LOG.verbose("Wrote new Butler configuration file to %s", configURI)
 

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -36,7 +36,7 @@ from abc import abstractmethod
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from contextlib import AbstractContextManager
 from types import EllipsisType
-from typing import TYPE_CHECKING, Any, TextIO
+from typing import TYPE_CHECKING, Any, Literal, Self, TextIO
 
 from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.utils import doImportType
@@ -94,7 +94,7 @@ class _DeprecatedDefault:
     """Default value for a deprecated parameter."""
 
 
-class Butler(LimitedButler):  # numpydoc ignore=PR02
+class Butler(LimitedButler, AbstractContextManager):  # numpydoc ignore=PR02
     """Interface for data butler and factory for Butler instances.
 
     Parameters
@@ -357,6 +357,16 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
                 )
             case _:
                 raise TypeError(f"Unknown Butler type '{butler_type}'")
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Literal[False]:
+        try:
+            self.close()
+        except Exception:
+            _LOG.exception("An exception occured during Butler.close()")
+        return False
 
     @staticmethod
     def makeRepo(
@@ -2220,5 +2230,20 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
             values from original object.
         metrics : `ButlerMetrics` or `None`, optional
             Metrics object to record butler statistics.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release all resources associated with this Butler instance.  The
+        instance may no longer be used after this is called.
+
+        Notes
+        -----
+        Instead of calling ``close()``directly, you can use the Butler object
+        as a context manager.  For example::
+          with Butler(...) as butler:
+              butler.get(...)
+          # butler is closed after exiting the block.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/_utilities/thread_safe_cache.py
+++ b/python/lsst/daf/butler/_utilities/thread_safe_cache.py
@@ -76,3 +76,16 @@ class ThreadSafeCache(Generic[TKey, TValue]):
         """
         with self._mutex:
             return self._cache.setdefault(key, value)
+
+    def clear(self) -> dict[TKey, TValue]:
+        """Clear the cache.
+
+        Returns
+        -------
+        old_cache : `dict`
+            The values that were contained in the cache prior to clearing it.
+        """
+        with self._mutex:
+            old = self._cache
+            self._cache = {}
+            return old

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -2574,14 +2574,6 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
     accessible only via `SqlRegistry` methods.
     """
 
-    datastore: Datastore
-    """The object that manages actual dataset storage (`Datastore`).
-
-    Direct user access to the datastore should rarely be necessary; the primary
-    exception is the case where a `Datastore` implementation provides extra
-    functionality beyond what the base class defines.
-    """
-
     storageClasses: StorageClassFactory
     """An object that maps known storage class names to objects that fully
     describe them (`StorageClassFactory`).

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -258,6 +258,17 @@ class SqlRegistry:
         # eventually we'll need to do it during construction.
         # The mapping is indexed by the opaque table name.
         self._datastore_record_classes: Mapping[str, type[StoredDatastoreItemInfo]] = {}
+        self._is_clone = False
+
+    def close(self) -> None:
+        # Connection pool is shared between cloned instances, so only the root
+        # instance should close it.
+        # Note: The underlying SQLAlchemy call will create a fresh connection
+        # pool, so nothing breaks if the root instance is accidentally closed
+        # before the clones are finished -- we just have a small performance
+        # hit from re-creating the connections.
+        if not self._is_clone:
+            self._db.dispose()
 
     def __str__(self) -> str:
         return str(self._db)
@@ -296,6 +307,7 @@ class SqlRegistry:
         result = SqlRegistry(db, defaults, self._managers.clone(db))
         result._datastore_record_classes = dict(self._datastore_record_classes)
         result.dimension_record_cache.load_from(self.dimension_record_cache)
+        result._is_clone = True
         return result
 
     @property

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -735,6 +735,9 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             connection=self._connection, cache=self._cache, defaults=defaults, metrics=metrics
         )
 
+    def close(self) -> None:
+        pass
+
     @property
     def _file_transfer_source(self) -> RemoteFileTransferSource:
         return RemoteFileTransferSource(self._connection)

--- a/python/lsst/daf/butler/script/_associate.py
+++ b/python/lsst/daf/butler/script/_associate.py
@@ -64,20 +64,18 @@ def associate(
         unlimited. A negative value is used to specify a cap where a warning
         is issued if that cap is hit.
     """
-    butler = Butler.from_config(repo, writeable=True, without_datastore=True)
+    with Butler.from_config(repo, writeable=True, without_datastore=True) as butler:
+        butler.collections.register(collection, CollectionType.TAGGED)
 
-    butler.collections.register(collection, CollectionType.TAGGED)
+        results = QueryDatasets(
+            butler=butler,
+            glob=dataset_type,
+            collections=collections,
+            where=where,
+            find_first=find_first,
+            limit=limit,
+            order_by=(),
+            show_uri=False,
+        )
 
-    results = QueryDatasets(
-        butler=butler,
-        glob=dataset_type,
-        collections=collections,
-        where=where,
-        find_first=find_first,
-        limit=limit,
-        order_by=(),
-        show_uri=False,
-        repo=None,
-    )
-
-    butler.registry.associate(collection, itertools.chain(*results.getDatasets()))
+        butler.registry.associate(collection, itertools.chain(*results.getDatasets()))

--- a/python/lsst/daf/butler/script/butlerImport.py
+++ b/python/lsst/daf/butler/script/butlerImport.py
@@ -64,16 +64,15 @@ def butlerImport(
         be tracked by the datastore. Whether this parameter is honored
         depends on the specific datastore implementation.
     """
-    butler = Butler.from_config(repo, writeable=True)
+    with Butler.from_config(repo, writeable=True) as butler:
+        if skip_dimensions is not None:
+            skip_dimensions = set(skip_dimensions)
 
-    if skip_dimensions is not None:
-        skip_dimensions = set(skip_dimensions)
-
-    butler.import_(
-        directory=directory,
-        filename=export_file,
-        transfer=transfer,
-        format="yaml",
-        skip_dimensions=skip_dimensions,
-        record_validation_info=track_file_attrs,
-    )
+        butler.import_(
+            directory=directory,
+            filename=export_file,
+            transfer=transfer,
+            format="yaml",
+            skip_dimensions=skip_dimensions,
+            record_validation_info=track_file_attrs,
+        )

--- a/python/lsst/daf/butler/script/certifyCalibrations.py
+++ b/python/lsst/daf/butler/script/certifyCalibrations.py
@@ -69,23 +69,23 @@ def certifyCalibrations(
         Search all children of the inputCollection if it is a CHAINED
         collection, instead of just the most recent one.
     """
-    butler = Butler.from_config(repo, writeable=True, without_datastore=True)
-    timespan = Timespan(
-        begin=astropy.time.Time(begin_date, scale="tai") if begin_date is not None else None,
-        end=astropy.time.Time(end_date, scale="tai") if end_date is not None else None,
-    )
-    if not search_all_inputs:
-        collection_info = butler.collections.get_info(input_collection)
-        if collection_info.type is CollectionType.CHAINED:
-            input_collection = collection_info.children[0]
+    with Butler.from_config(repo, writeable=True, without_datastore=True) as butler:
+        timespan = Timespan(
+            begin=astropy.time.Time(begin_date, scale="tai") if begin_date is not None else None,
+            end=astropy.time.Time(end_date, scale="tai") if end_date is not None else None,
+        )
+        if not search_all_inputs:
+            collection_info = butler.collections.get_info(input_collection)
+            if collection_info.type is CollectionType.CHAINED:
+                input_collection = collection_info.children[0]
 
-    with butler.query() as query:
-        results = query.datasets(dataset_type_name, collections=input_collection)
-        refs = set(results)
-        if not refs:
-            explanation = "\n".join(results.explain_no_results())
-            raise RuntimeError(
-                f"No inputs found for dataset {dataset_type_name} in {input_collection}. {explanation}"
-            )
-    butler.collections.register(output_collection, type=CollectionType.CALIBRATION)
-    butler.registry.certify(output_collection, refs, timespan)
+        with butler.query() as query:
+            results = query.datasets(dataset_type_name, collections=input_collection)
+            refs = set(results)
+            if not refs:
+                explanation = "\n".join(results.explain_no_results())
+                raise RuntimeError(
+                    f"No inputs found for dataset {dataset_type_name} in {input_collection}. {explanation}"
+                )
+        butler.collections.register(output_collection, type=CollectionType.CALIBRATION)
+        butler.registry.certify(output_collection, refs, timespan)

--- a/python/lsst/daf/butler/script/configValidate.py
+++ b/python/lsst/daf/butler/script/configValidate.py
@@ -52,12 +52,14 @@ def configValidate(repo: str, quiet: bool, dataset_type: list[str], ignore: list
         error.
     """
     logFailures = not quiet
-    butler = Butler.from_config(config=repo)
-    is_good = True
-    try:
-        butler.validateConfiguration(logFailures=logFailures, datasetTypeNames=dataset_type, ignore=ignore)
-    except ValidationError:
-        is_good = False
-    else:
-        print("No problems encountered with configuration.")
-    return is_good
+    with Butler.from_config(config=repo) as butler:
+        is_good = True
+        try:
+            butler.validateConfiguration(
+                logFailures=logFailures, datasetTypeNames=dataset_type, ignore=ignore
+            )
+        except ValidationError:
+            is_good = False
+        else:
+            print("No problems encountered with configuration.")
+        return is_good

--- a/python/lsst/daf/butler/script/ingest_zip.py
+++ b/python/lsst/daf/butler/script/ingest_zip.py
@@ -59,6 +59,5 @@ def ingest_zip(
         If `True` no transfers are done but the number of transfers that
         would be done is reported.
     """
-    butler = Butler.from_config(repo, writeable=True)
-
-    butler.ingest_zip(zip, transfer=transfer, transfer_dimensions=transfer_dimensions, dry_run=dry_run)
+    with Butler.from_config(repo, writeable=True) as butler:
+        butler.ingest_zip(zip, transfer=transfer, transfer_dimensions=transfer_dimensions, dry_run=dry_run)

--- a/python/lsst/daf/butler/script/queryDatasetTypes.py
+++ b/python/lsst/daf/butler/script/queryDatasetTypes.py
@@ -60,26 +60,29 @@ def queryDatasetTypes(
         A dict whose key is "datasetTypes" and whose value is a list of
         collection names.
     """
-    butler = Butler.from_config(repo, without_datastore=True)
-    expression = glob or ...
-    datasetTypes = butler.registry.queryDatasetTypes(expression=expression)
+    with Butler.from_config(repo, without_datastore=True) as butler:
+        expression = glob or ...
+        datasetTypes = butler.registry.queryDatasetTypes(expression=expression)
 
-    if collections:
-        collections_info = butler.collections.query_info(collections, include_summary=True)
-        filtered_dataset_types = set(
-            butler.collections._filter_dataset_types([d.name for d in datasetTypes], collections_info)
-        )
-        datasetTypes = [d for d in datasetTypes if d.name in filtered_dataset_types]
+        if collections:
+            collections_info = butler.collections.query_info(collections, include_summary=True)
+            filtered_dataset_types = set(
+                butler.collections._filter_dataset_types([d.name for d in datasetTypes], collections_info)
+            )
+            datasetTypes = [d for d in datasetTypes if d.name in filtered_dataset_types]
 
-    if verbose:
-        table = Table(
-            array(
-                [(d.name, str(list(d.dimensions.names)) or "None", d.storageClass_name) for d in datasetTypes]
-            ),
-            names=("name", "dimensions", "storage class"),
-        )
-    else:
-        rows = ([d.name for d in datasetTypes],)
-        table = Table(rows, names=("name",))
-    table.sort("name")
-    return table
+        if verbose:
+            table = Table(
+                array(
+                    [
+                        (d.name, str(list(d.dimensions.names)) or "None", d.storageClass_name)
+                        for d in datasetTypes
+                    ]
+                ),
+                names=("name", "dimensions", "storage class"),
+            )
+        else:
+            rows = ([d.name for d in datasetTypes],)
+            table = Table(rows, names=("name",))
+        table.sort("name")
+        return table

--- a/python/lsst/daf/butler/script/queryDatasets.py
+++ b/python/lsst/daf/butler/script/queryDatasets.py
@@ -158,6 +158,8 @@ class QueryDatasets:
         wildcards.
     show_uri : `bool`
         If True, include the dataset URI in the output.
+    butler : `lsst.daf.butler.Butler`
+        The butler to use to query.
     limit : `int`, optional
         Limit the number of results to be returned. A value of 0 means
         unlimited. A negative value is used to specify a cap where a warning
@@ -167,13 +169,6 @@ class QueryDatasets:
         results of ``limit`` are undefined and default sorting of the resulting
         datasets will be applied. It is an error if the requested ordering
         is inconsistent with the dimensions of the dataset type being queried.
-    repo : `str` or `None`
-        URI to the location of the repo or URI to a config file describing the
-        repo and its location. One of `repo` and `butler` must be `None` and
-        the other must not be `None`.
-    butler : `lsst.daf.butler.Butler` or `None`
-        The butler to use to query. One of `repo` and `butler` must be `None`
-        and the other must not be `None`.
     with_dimension_records : `bool`, optional
         If `True` (default is `False`) then returned data IDs will have
         dimension records.
@@ -186,14 +181,11 @@ class QueryDatasets:
         where: str,
         find_first: bool,
         show_uri: bool,
+        butler: Butler,
         limit: int = 0,
         order_by: tuple[str, ...] = (),
-        repo: str | None = None,
-        butler: Butler | None = None,
         with_dimension_records: bool = False,
     ):
-        if (repo and butler) or (not repo and not butler):
-            raise RuntimeError("One of repo and butler must be provided and the other must be None.")
         collections = list(collections)
         if not collections:
             warnings.warn(
@@ -215,9 +207,7 @@ class QueryDatasets:
         if order_by and searches_multiple_dataset_types:
             raise NotImplementedError("--order-by is only supported for queries with a single dataset type.")
 
-        # show_uri requires a datastore.
-        without_datastore = not show_uri
-        self.butler = butler or Butler.from_config(repo, without_datastore=without_datastore)
+        self.butler = butler
         self.showUri = show_uri
         self._dataset_type_glob = glob
         self._collections_wildcard = collections

--- a/python/lsst/daf/butler/script/register_dataset_type.py
+++ b/python/lsst/daf/butler/script/register_dataset_type.py
@@ -69,19 +69,20 @@ def register_dataset_type(
         be created by this command. They are always derived from the composite
         dataset type.
     """
-    butler = Butler.from_config(repo, writeable=True, without_datastore=True)
+    with Butler.from_config(repo, writeable=True, without_datastore=True) as butler:
+        _, component = DatasetType.splitDatasetTypeName(dataset_type)
+        if component:
+            raise ValueError(
+                "Component dataset types are created automatically when the composite is created."
+            )
 
-    _, component = DatasetType.splitDatasetTypeName(dataset_type)
-    if component:
-        raise ValueError("Component dataset types are created automatically when the composite is created.")
+        datasetType = DatasetType(
+            dataset_type,
+            butler.dimensions.conform(dimensions),
+            storage_class,
+            parentStorageClass=None,
+            isCalibration=is_calibration,
+            universe=butler.dimensions,
+        )
 
-    datasetType = DatasetType(
-        dataset_type,
-        butler.dimensions.conform(dimensions),
-        storage_class,
-        parentStorageClass=None,
-        isCalibration=is_calibration,
-        universe=butler.dimensions,
-    )
-
-    return butler.registry.registerDatasetType(datasetType)
+        return butler.registry.registerDatasetType(datasetType)

--- a/python/lsst/daf/butler/script/removeDatasetType.py
+++ b/python/lsst/daf/butler/script/removeDatasetType.py
@@ -43,5 +43,5 @@ def removeDatasetType(repo: str, dataset_type_name: tuple[str, ...]) -> None:
     dataset_type_name : `str`
         The name of the dataset type to be removed.
     """
-    butler = Butler.from_config(repo, writeable=True, without_datastore=True)
-    butler.registry.removeDatasetType(dataset_type_name)
+    with Butler.from_config(repo, writeable=True, without_datastore=True) as butler:
+        butler.registry.removeDatasetType(dataset_type_name)

--- a/python/lsst/daf/butler/script/removeRuns.py
+++ b/python/lsst/daf/butler/script/removeRuns.py
@@ -85,8 +85,7 @@ def _getCollectionInfo(
     datasets : `dict` [`str`, `int`]
         The dataset types and and how many will be removed.
     """
-    butler = Butler.from_config(repo)
-    with butler.registry.caching_context():
+    with Butler.from_config(repo) as butler, butler.registry.caching_context():
         try:
             collections = butler.collections.query_info(
                 collection,
@@ -138,9 +137,8 @@ def removeRuns(
 
     def _doRemove(runs: Sequence[RemoveRun]) -> None:
         """Perform the remove step."""
-        butler = Butler.from_config(repo, writeable=True)
-
-        butler.removeRuns([r.name for r in runs], unlink_from_chains=True)
+        with Butler.from_config(repo, writeable=True) as butler:
+            butler.removeRuns([r.name for r in runs], unlink_from_chains=True)
 
     result = RemoveRunsResult(
         onConfirmation=partial(_doRemove, runs),

--- a/python/lsst/daf/butler/script/retrieveArtifacts.py
+++ b/python/lsst/daf/butler/script/retrieveArtifacts.py
@@ -102,32 +102,35 @@ def retrieveArtifacts(
     query_types = dataset_type or "*"
     query_collections: tuple[str, ...] = collections or ("*",)
 
-    butler = Butler.from_config(repo, writeable=False)
-
-    # Need to store in set so we can count the number to give some feedback
-    # to caller.
-    query = QueryDatasets(
-        butler=butler,
-        glob=query_types,
-        collections=query_collections,
-        where=where,
-        find_first=find_first,
-        limit=limit,
-        order_by=order_by,
-        show_uri=False,
-        with_dimension_records=True,
-    )
-    refs = set(itertools.chain(*query.getDatasets()))
-    log.info("Number of datasets matching query: %d", len(refs))
-    if not refs:
-        return []
-
-    if not zip:
-        transferred = butler.retrieveArtifacts(
-            refs, destination=destination, transfer=transfer, preserve_path=preserve_path, overwrite=clobber
+    with Butler.from_config(repo, writeable=False) as butler:
+        # Need to store in set so we can count the number to give some feedback
+        # to caller.
+        query = QueryDatasets(
+            butler=butler,
+            glob=query_types,
+            collections=query_collections,
+            where=where,
+            find_first=find_first,
+            limit=limit,
+            order_by=order_by,
+            show_uri=False,
+            with_dimension_records=True,
         )
-    else:
-        zip_file = butler.retrieve_artifacts_zip(refs, destination=destination, overwrite=clobber)
-        transferred = [zip_file]
+        refs = set(itertools.chain(*query.getDatasets()))
+        log.info("Number of datasets matching query: %d", len(refs))
+        if not refs:
+            return []
 
-    return transferred
+        if not zip:
+            transferred = butler.retrieveArtifacts(
+                refs,
+                destination=destination,
+                transfer=transfer,
+                preserve_path=preserve_path,
+                overwrite=clobber,
+            )
+        else:
+            zip_file = butler.retrieve_artifacts_zip(refs, destination=destination, overwrite=clobber)
+            transferred = [zip_file]
+
+        return transferred

--- a/python/lsst/daf/butler/tests/hybrid_butler.py
+++ b/python/lsst/daf/butler/tests/hybrid_butler.py
@@ -441,3 +441,7 @@ class HybridButler(Butler):
     @property
     def _file_transfer_source(self) -> FileTransferSource:
         return self._remote_butler._file_transfer_source
+
+    def close(self) -> None:
+        self._direct_butler.close()
+        self._remote_butler.close()

--- a/tests/test_astropyTableFormatter.py
+++ b/tests/test_astropyTableFormatter.py
@@ -56,6 +56,7 @@ class AstropyTableFormatterTestCase(unittest.TestCase):
 
     def testAstropyTableFormatter(self):
         butler = Butler(self.root, run="testrun")
+        self.enterContext(butler)
         datasetType = DatasetType("table", [], "AstropyTable", universe=butler.dimensions)
         butler.registry.registerDatasetType(datasetType)
         ref = butler.put(self.table, datasetType)

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -711,8 +711,10 @@ class ButlerTests(ButlerPutGetTests):
                     uri = Butler.get_repo_uri("label")
                     butler = Butler.from_config(uri, writeable=False)
                     self.assertIsInstance(butler, Butler)
+                    butler.close()
                     butler = Butler.from_config("label", writeable=False)
                     self.assertIsInstance(butler, Butler)
+                    butler.close()
                     with self.assertRaisesRegex(FileNotFoundError, "aliases:.*bad_label"):
                         Butler.from_config("not_there", writeable=False)
                     with self.assertRaisesRegex(FileNotFoundError, "resolved from alias 'bad_label'"):
@@ -1250,6 +1252,7 @@ class ButlerTests(ButlerPutGetTests):
         butler = self.create_empty_butler(run=self.default_run)
         assert isinstance(butler, DirectButler), "Expect DirectButler in configuration"
         butlerOut = pickle.loads(pickle.dumps(butler))
+        self.enterContext(butlerOut)
         self.assertIsInstance(butlerOut, Butler)
         self.assertEqual(butlerOut._config, butler._config)
         self.assertEqual(list(butlerOut.collections.defaults), list(butler.collections.defaults))

--- a/tests/test_butler_factory.py
+++ b/tests/test_butler_factory.py
@@ -44,7 +44,8 @@ class ButlerFactoryTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         repo_dir = cls.enterClassContext(tempfile.TemporaryDirectory())
-        makeTestRepo(repo_dir)
+        butler = makeTestRepo(repo_dir)
+        butler.close()
         cls.config_file_uri = f"file://{repo_dir}"
 
     def test_factory_via_global_repository_index(self):
@@ -53,10 +54,12 @@ class ButlerFactoryTestCase(unittest.TestCase):
             index_file.flush()
             with mock_env({"DAF_BUTLER_REPOSITORY_INDEX": index_file.name}):
                 factory = LabeledButlerFactory()
+                self.addCleanup(factory.close)
                 self._test_factory(factory)
 
     def test_factory_via_custom_index(self):
         factory = LabeledButlerFactory({"test_repo": self.config_file_uri})
+        self.addCleanup(factory.close)
         self._test_factory(factory)
 
     def _test_factory(self, factory: LabeledButlerFactory) -> None:

--- a/tests/test_cliCmdIngestFiles.py
+++ b/tests/test_cliCmdIngestFiles.py
@@ -105,6 +105,7 @@ class CliIngestFilesTest(unittest.TestCase, ButlerTestHelper):
             self.assertEqual(result.exit_code, 0, clickResultMsg(result))
 
             butler = Butler.from_config(self.root)
+            self.enterContext(butler)
             refs = list(butler.registry.queryDatasets("test_metric_comp", collections=run))
             self.assertEqual(len(refs), 2)
 

--- a/tests/test_cliCmdIngestFiles.py
+++ b/tests/test_cliCmdIngestFiles.py
@@ -52,6 +52,7 @@ class CliIngestFilesTest(unittest.TestCase, ButlerTestHelper):
         self.addCleanup(removeTestTempDir, self.root)
 
         self.testRepo = MetricTestRepo(self.root, configFile=self.configFile)
+        self.enterContext(self.testRepo.butler)
 
         self.root2 = makeTestTempDir(TESTDIR)
         self.addCleanup(removeTestTempDir, self.root2)

--- a/tests/test_cliCmdPruneDatasets.py
+++ b/tests/test_cliCmdPruneDatasets.py
@@ -29,7 +29,7 @@
 
 import unittest
 from itertools import chain
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from astropy.table import Table
 
@@ -99,9 +99,9 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.repo = "here"
 
     @staticmethod
-    def makeQueryDatasetsArgs(*, repo, **kwargs):
+    def makeQueryDatasetsArgs(**kwargs):
         expectedArgs = dict(
-            repo=repo, collections=("*",), where="", find_first=True, show_uri=False, glob=tuple()
+            butler=ANY, collections=("*",), where="", find_first=True, show_uri=False, glob=tuple()
         )
         expectedArgs.update(kwargs)
         return expectedArgs
@@ -233,7 +233,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=["myCollection", "--unstore"],
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(refs=getRefs(), unstore=True),
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=("myCollection",)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("myCollection",)),
             exGetTablesCalled=True,
             exMsgs=(
                 pruneDatasets_willRemoveMsg,
@@ -253,7 +253,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=["myCollection", "--unstore"],
             exPruneDatasetsCallArgs=None,
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=("myCollection",)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("myCollection",)),
             exGetTablesCalled=True,
             exMsgs=(
                 pruneDatasets_willRemoveMsg,
@@ -272,7 +272,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=["myCollection", "--dry-run", "--unstore"],
             exPruneDatasetsCallArgs=None,
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=("myCollection",)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("myCollection",)),
             exGetTablesCalled=True,
             exMsgs=(pruneDatasets_wouldRemoveMsg, astropyTablesToStr(getTables())),
         )
@@ -287,7 +287,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=[collection, "--dry-run", "--disassociate", "tag1"],
             exPruneDatasetsCallArgs=None,
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=(collection,)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=(collection,)),
             exGetTablesCalled=True,
             exMsgs=(
                 pruneDatasets_wouldDisassociateMsg.format(collections=(collection,)),
@@ -305,7 +305,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=[collection, "--dry-run", "--unstore", "--disassociate", "tag1"],
             exPruneDatasetsCallArgs=None,
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=(collection,)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=(collection,)),
             exGetTablesCalled=True,
             exMsgs=(
                 pruneDatasets_wouldDisassociateAndRemoveMsg.format(collections=(collection,)),
@@ -323,7 +323,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=["myCollection", "--no-confirm", "--unstore"],
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(refs=getRefs(), unstore=True),
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=("myCollection",)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("myCollection",)),
             exGetTablesCalled=True,
             exMsgs=(pruneDatasets_didRemoveMsg, astropyTablesToStr(getTables())),
         )
@@ -337,7 +337,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
         self.run_test(
             cliArgs=["myCollection", "--quiet", "--unstore"],
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(refs=getRefs(), unstore=True),
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(repo=self.repo, collections=("myCollection",)),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("myCollection",)),
             exGetTablesCalled=True,
             exMsgs=None,
         )
@@ -373,9 +373,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
             self.run_test(
                 cliArgs=["myCollection", "--unstore"],
                 exPruneDatasetsCallArgs=None,
-                exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
-                    repo=self.repo, collections=("myCollection",)
-                ),
+                exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("myCollection",)),
                 exGetTablesCalled=True,
                 exMsgs=(pruneDatasets_noDatasetsFound,),
             )
@@ -428,9 +426,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(
                 purge=True, refs=getRefs(), disassociate=True, unstore=True
             ),
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
-                repo=self.repo, collections=("run",), find_first=True
-            ),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("run",), find_first=True),
             exGetTablesCalled=True,
             exMsgs=(
                 pruneDatasets_willRemoveMsg,
@@ -454,7 +450,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
                 purge=True, disassociate=True, unstore=True, refs=getRefs()
             ),
             exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
-                repo=self.repo, collections=("myCollection",), find_first=True
+                collections=("myCollection",), find_first=True
             ),
             exGetTablesCalled=True,
             exMsgs=(
@@ -502,9 +498,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
             exPruneDatasetsCallArgs=self.makePruneDatasetsArgs(
                 tags=("tag1", "tag2"), disassociate=True, refs=getRefs()
             ),
-            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
-                repo=self.repo, collections=("tag1", "tag2"), find_first=True
-            ),
+            exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(collections=("tag1", "tag2"), find_first=True),
             exGetTablesCalled=True,
             exMsgs=(pruneDatasets_didRemoveMsg, astropyTablesToStr(getTables())),
         )
@@ -519,7 +513,7 @@ class PruneDatasetsTestCase(unittest.TestCase):
                 tags=("tag1", "tag2"), disassociate=True, refs=getRefs()
             ),
             exQueryDatasetsCallArgs=self.makeQueryDatasetsArgs(
-                repo=self.repo, collections=("myCollection",), find_first=True
+                collections=("myCollection",), find_first=True
             ),
             exGetTablesCalled=True,
             exMsgs=(pruneDatasets_didRemoveMsg, astropyTablesToStr(getTables())),

--- a/tests/test_cliCmdQueryCollections.py
+++ b/tests/test_cliCmdQueryCollections.py
@@ -154,6 +154,7 @@ class QueryCollectionsScriptTest(ButlerTestHelper, unittest.TestCase):
             butlerCfg = Butler.makeRepo("here")
             # the purpose of this call is to create some collections
             butler = Butler.from_config(butlerCfg, run=run, collections=[tag], writeable=True)
+            self.enterContext(butler)
             butler.registry.registerCollection(tag, CollectionType.TAGGED)
 
             # Verify collections that were created are found by
@@ -196,6 +197,7 @@ class ChainedCollectionsTest(ButlerTestHelper, unittest.TestCase):
             butlerCfg = Butler.makeRepo("here")
 
             butler1 = Butler.from_config(butlerCfg, writeable=True)
+            self.enterContext(butler1)
 
             # Replace datastore functions with mocks:
             DatastoreMock.apply(butler1)

--- a/tests/test_cliCmdQueryDataIds.py
+++ b/tests/test_cliCmdQueryDataIds.py
@@ -71,6 +71,7 @@ class QueryDataIdsTest(unittest.TestCase, ButlerTestHelper):
         which should be a YAML import/export file.
         """
         butler = Butler.from_config(self.repo, writeable=True)
+        self.enterContext(butler)
         assert isinstance(butler, DirectButler), "Test expects DirectButler"
         for filename in filenames:
             butler.import_(

--- a/tests/test_cliCmdQueryDatasets.py
+++ b/tests/test_cliCmdQueryDatasets.py
@@ -173,6 +173,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         testRepo = MetricTestRepo(
             self.repoDir, configFile=os.path.join(TESTDIR, "config/basic/butler-chained.yaml")
         )
+        self.enterContext(testRepo.butler)
 
         tables = self._queryDatasets(repo=testRepo.butler, show_uri=True, collections="*", glob="*")
 
@@ -191,6 +192,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
     def testShowURI(self):
         """Test for expected output with show_uri=True."""
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
+        self.enterContext(testRepo.butler)
 
         tables = self._queryDatasets(repo=testRepo.butler, show_uri=True, collections="*", glob="*")
 
@@ -208,6 +210,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
             configFile=self.configFile,
             storageClassName="StructuredCompositeReadCompNoDisassembly",
         )
+        self.enterContext(testRepo.butler)
 
         tables = self._queryDatasets(repo=testRepo.butler, show_uri=True, collections="*", glob="*")
 
@@ -251,6 +254,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
     def testNoShowURI(self):
         """Test for expected output without show_uri (default is False)."""
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
+        self.enterContext(testRepo.butler)
 
         tables = self._queryDatasets(repo=testRepo.butler, collections="*", glob="*")
 
@@ -273,6 +277,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         queryDatasets.
         """
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
+        self.enterContext(testRepo.butler)
 
         for glob in (("*",), ("test_metric_comp",)):
             with self.subTest(glob=glob):
@@ -299,6 +304,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         """Test specifying dataset type."""
         # Create and register an additional DatasetType
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
+        self.enterContext(testRepo.butler)
 
         testRepo.butler.registry.insertDimensionData(
             "visit",
@@ -346,6 +352,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         """Test limit and ordering."""
         # Create and register an additional DatasetType
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
+        self.enterContext(testRepo.butler)
 
         with self.assertLogs("lsst.daf.butler.script.queryDatasets", level="WARNING") as cm:
             tables = self._queryDatasets(
@@ -417,6 +424,7 @@ class QueryDatasetsTest(unittest.TestCase, ButlerTestHelper):
         is required for find-first.
         """
         testRepo = MetricTestRepo(self.repoDir, configFile=self.configFile)
+        self.enterContext(testRepo.butler)
 
         # Add a new run, and add a dataset to shadow an existing dataset.
         testRepo.addDataset(run="foo", dataId={"instrument": "DummyCamComp", "visit": 424})

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -77,6 +77,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
         self.testRepo = MetricTestRepo(
             self.root, configFile=os.path.join(TESTDIR, "config/basic/butler.yaml")
         )
+        self.enterContext(self.testRepo.butler)
         self.runner = LogCliRunner()
 
     def tearDown(self):

--- a/tests/test_cliCmdQueryDimensionRecords.py
+++ b/tests/test_cliCmdQueryDimensionRecords.py
@@ -162,6 +162,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
 
     def testCollection(self):
         butler = Butler.from_config(self.root, run="foo")
+        self.enterContext(butler)
 
         # try replacing the testRepo's butler with the one with the "foo" run.
         self.testRepo.butler = butler
@@ -270,6 +271,7 @@ class QueryDimensionRecordsTest(unittest.TestCase, ButlerTestHelper):
 
     def testSkymap(self):
         butler = Butler.from_config(self.root, run="foo")
+        self.enterContext(butler)
         # try replacing the testRepo's butler with the one with the "foo" run.
         self.testRepo.butler = butler
 

--- a/tests/test_cliCmdRemoveCollections.py
+++ b/tests/test_cliCmdRemoveCollections.py
@@ -71,6 +71,7 @@ class RemoveCollectionTest(unittest.TestCase, ButlerTestHelper):
         self.testRepo = MetricTestRepo(
             self.root, configFile=os.path.join(TESTDIR, "config/basic/butler.yaml")
         )
+        self.enterContext(self.testRepo.butler)
 
     def tearDown(self):
         removeTestTempDir(self.root)

--- a/tests/test_cliCmdRemoveCollections.py
+++ b/tests/test_cliCmdRemoveCollections.py
@@ -219,6 +219,7 @@ class RemoveCollectionTest(unittest.TestCase, ButlerTestHelper):
         # verify chained-run-1 was removed:
 
         butler = Butler.from_config(self.root)
+        self.enterContext(butler)
         collections = butler.registry.queryCollections(
             collectionTypes=frozenset(
                 (
@@ -275,6 +276,7 @@ class RemoveCollectionTest(unittest.TestCase, ButlerTestHelper):
 
     def testRemoveFromParents(self) -> None:
         butler = Butler(self.root, writeable=True)
+        self.enterContext(butler)
         butler.collections.register("tag1", CollectionType.TAGGED)
         butler.collections.register("tag2", CollectionType.TAGGED)
         butler.collections.register("chain1", CollectionType.CHAINED)

--- a/tests/test_cliCmdRemoveRuns.py
+++ b/tests/test_cliCmdRemoveRuns.py
@@ -59,6 +59,7 @@ class RemoveCollectionTest(unittest.TestCase):
         with self.runner.isolated_filesystem():
             root = "repo"
             repo = MetricTestRepo(root, configFile=os.path.join(TESTDIR, "config/basic/butler.yaml"))
+            self.enterContext(repo.butler)
             # Add a dataset type that will have no datasets to make sure it
             # isn't printed.
             repo.butler.registry.registerDatasetType(
@@ -120,7 +121,8 @@ class RemoveCollectionTest(unittest.TestCase):
 
             # Remake the repo and check --no-confirm option.
             root = "repo1"
-            MetricTestRepo(root, configFile=os.path.join(TESTDIR, "config/basic/butler.yaml"))
+            repo1 = MetricTestRepo(root, configFile=os.path.join(TESTDIR, "config/basic/butler.yaml"))
+            repo1.butler.close()
 
             # Add the run to a CHAINED collection.
             parentCollection = "parent"

--- a/tests/test_cliCmdRetrieveArtifacts.py
+++ b/tests/test_cliCmdRetrieveArtifacts.py
@@ -48,6 +48,7 @@ class CliRetrieveArtifactsTest(unittest.TestCase, ButlerTestHelper):
     def setUp(self):
         self.root = makeTestTempDir(TESTDIR)
         self.testRepo = MetricTestRepo(self.root, configFile=self.configFile)
+        self.enterContext(self.testRepo.butler)
 
     def tearDown(self):
         removeTestTempDir(self.root)

--- a/tests/test_dimension_record_containers.py
+++ b/tests/test_dimension_record_containers.py
@@ -60,6 +60,7 @@ class DimensionRecordContainersTestCase(unittest.TestCase):
         # Create an in-memory SQLite database and Registry just to import the
         # YAML data.
         cls.butler = create_populated_sqlite_registry(*DIMENSION_DATA_FILES)
+        cls.enterClassContext(cls.butler)
         cls.records = {
             element: tuple(list(cls.butler.registry.queryDimensionRecords(element)))
             for element in ("visit", "skymap", "patch")

--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -73,9 +73,9 @@ def loadDimensionData() -> DataCoordinateSequence:
     """
     # Create an in-memory SQLite database and Registry just to import the YAML
     # data and retrieve it as a set of DataCoordinate objects.
-    butler = create_populated_sqlite_registry(DIMENSION_DATA_FILE)
-    dimensions = butler.registry.dimensions.conform(["visit", "detector", "tract", "patch"])
-    return butler.registry.queryDataIds(dimensions).expanded().toSequence()
+    with create_populated_sqlite_registry(DIMENSION_DATA_FILE) as butler:
+        dimensions = butler.registry.dimensions.conform(["visit", "detector", "tract", "patch"])
+        return butler.registry.queryDataIds(dimensions).expanded().toSequence()
 
 
 class ConcreteTestDimensionPacker(DimensionPacker):

--- a/tests/test_logFormatter.py
+++ b/tests/test_logFormatter.py
@@ -56,6 +56,7 @@ class ButlerLogRecordsFormatterTestCase(unittest.TestCase):
 
         self.run = "testrun"
         self.butler = Butler.from_config(self.root, run=self.run)
+        self.enterContext(self.butler)
         self.datasetType = DatasetType("test_logs", [], "ButlerLogRecords", universe=self.butler.dimensions)
 
         self.butler.registry.registerDatasetType(self.datasetType)

--- a/tests/test_matplotlibFormatter.py
+++ b/tests/test_matplotlibFormatter.py
@@ -65,6 +65,7 @@ class MatplotlibFormatterTestCase(unittest.TestCase):
 
     def testMatplotlibFormatter(self):
         butler = Butler.from_config(self.root, run="testrun")
+        self.enterContext(butler)
         datasetType = DatasetType("test_plot", [], "Plot", universe=butler.dimensions)
         butler.registry.registerDatasetType(datasetType)
         # Does not have to be a random image

--- a/tests/test_obscore.py
+++ b/tests/test_obscore.py
@@ -25,7 +25,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import contextlib
 import os
 import tempfile
 import unittest
@@ -71,7 +70,7 @@ class ObsCoreTests(TestCaseMixin):
         """Create new empty Registry."""
         config = self.make_registry_config(collections, collection_type)
         registry = _RegistryFactory(config).create_from_config(butlerRoot=self.root)
-        self.enterContext(contextlib.closing(registry))
+        self.addCleanup(registry.close)
         self.initialize_registry(registry)
         return registry
 
@@ -528,7 +527,9 @@ class ClonedSqliteObscoreTest(SQLiteObsCoreTest, unittest.TestCase):
     ) -> SqlRegistry:
         """Create new empty Registry."""
         original = super().make_registry(collections, collection_type)
-        return original.copy()
+        copy = original.copy()
+        self.addCleanup(copy.close)
+        return copy
 
 
 class PostgresObsCoreTest(ObsCoreTests, unittest.TestCase):

--- a/tests/test_obscore.py
+++ b/tests/test_obscore.py
@@ -25,6 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import contextlib
 import os
 import tempfile
 import unittest
@@ -70,6 +71,7 @@ class ObsCoreTests(TestCaseMixin):
         """Create new empty Registry."""
         config = self.make_registry_config(collections, collection_type)
         registry = _RegistryFactory(config).create_from_config(butlerRoot=self.root)
+        self.enterContext(contextlib.closing(registry))
         self.initialize_registry(registry)
         return registry
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -45,6 +45,7 @@ class PackagesFormatterTestCase(unittest.TestCase):
         self.root = makeTestTempDir(TESTDIR)
         Butler.makeRepo(self.root)
         self.butler = Butler.from_config(self.root, run="test_run")
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -363,6 +363,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         self.butler = Butler.from_config(
             Butler.makeRepo(self.root, config=config), writeable=True, run=self.run
         )
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
@@ -957,6 +958,7 @@ class ParquetFormatterArrowAstropyTestCase(unittest.TestCase):
         self.butler = Butler.from_config(
             Butler.makeRepo(self.root, config=config), writeable=True, run=self.run
         )
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
@@ -1352,6 +1354,7 @@ class ParquetFormatterArrowNumpyTestCase(unittest.TestCase):
         self.butler = Butler.from_config(
             Butler.makeRepo(self.root, config=config), writeable=True, run="test_run"
         )
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
@@ -1651,6 +1654,7 @@ class ParquetFormatterArrowTableTestCase(unittest.TestCase):
         self.butler = Butler.from_config(
             Butler.makeRepo(self.root, config=config), writeable=True, run="test_run"
         )
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
@@ -1964,6 +1968,7 @@ class ParquetFormatterArrowNumpyDictTestCase(unittest.TestCase):
         self.butler = Butler.from_config(
             Butler.makeRepo(self.root, config=config), writeable=True, run="test_run"
         )
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
@@ -2125,6 +2130,7 @@ class ParquetFormatterArrowSchemaTestCase(unittest.TestCase):
         self.butler = Butler.from_config(
             Butler.makeRepo(self.root, config=config), writeable=True, run="test_run"
         )
+        self.enterContext(self.butler)
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.
         self.datasetType = DatasetType(
@@ -2334,6 +2340,7 @@ class ParquetFormatterArrowTableS3TestCase(unittest.TestCase):
         self.tmpConfigFile = posixpath.join(rooturi, "butler.yaml")
 
         self.butler = Butler(self.tmpConfigFile, writeable=True, run="test_run")
+        self.enterContext(self.butler)
 
         # No dimensions in dataset type so we don't have to worry about
         # inserting dimension data or defining data IDs.

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -32,6 +32,7 @@ import os
 import unittest
 import warnings
 from contextlib import contextmanager
+from typing import cast
 
 import astropy.time
 import sqlalchemy
@@ -218,12 +219,15 @@ class PostgresqlRegistryTests(RegistryTests):
         self.postgres.patch_registry_config(config)
         registry = _RegistryFactory(config).create_from_config()
 
-        return DirectButler(
+        butler = DirectButler(
             config=ButlerConfig(),
             registry=registry,
             datastore=NullDatastore(None, None),
             storageClasses=StorageClassFactory(),
         )
+        cast(unittest.TestCase, self).enterContext(butler)
+
+        return butler
 
     def testSkipCalibs(self):
         if self.postgres.server_major_version() < 16:

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -151,6 +151,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             dataset_types=self.dataset_types,
             metrics=self.metrics,
         )
+        self.addCleanup(qbb.close)
         self._test_factory(qbb)
 
     def test_initialize_repo_index(self) -> None:
@@ -172,6 +173,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
                     dataset_types=self.dataset_types,
                     metrics=self.metrics,
                 )
+                self.addCleanup(qbb.close)
                 self._test_factory(qbb)
 
     def test_from_predicted(self) -> None:
@@ -185,6 +187,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             datastore_records=datastore_records,
             dataset_types=self.dataset_types,
         )
+        self.addCleanup(qbb.close)
         self._test_factory(qbb)
 
     def _test_factory(self, qbb: QuantumBackedButler) -> None:
@@ -207,6 +210,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
             dataset_types=self.dataset_types,
             metrics=self.metrics,
         )
+        self.addCleanup(qbb.close)
 
         # Verify all input data are readable.
         for ref in self.input_refs:
@@ -263,6 +267,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb.close)
 
         # get some input data
         input_refs = self.input_refs[:2]
@@ -288,6 +293,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb.close)
 
         # get some input data
         input_refs = self.input_refs[:2]
@@ -322,6 +328,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb.close)
 
         # get some input data
         for ref in self.input_refs:
@@ -343,6 +350,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb.close)
 
         # Write all expected outputs.
         for ref in self.output_refs:
@@ -387,6 +395,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb.close)
 
         # read/store everything
         for ref in self.input_refs:
@@ -424,6 +433,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb.close)
 
         records = qbb.export_predicted_datastore_records(self.output_refs)
         self.assertEqual(len(records["FileDatastore@<butlerRoot>/datastore"].records), len(self.output_refs))
@@ -437,11 +447,13 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         qbb1 = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum1, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb1.close)
 
         quantum2 = self.make_quantum(2)
         qbb2 = QuantumBackedButler.initialize(
             config=self.config, quantum=quantum2, dimensions=self.universe, dataset_types=self.dataset_types
         )
+        self.addCleanup(qbb2.close)
 
         # read/store everything
         for ref in self.input_refs:

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -69,6 +69,7 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
         registryConfig = RegistryConfig(self.config.get("registry"))
         _RegistryFactory(registryConfig).create_from_config(butlerRoot=self.root)
         butler = Butler.from_config(self.config, writeable=True, run="RUN", metrics=self.metrics)
+        self.enterContext(butler)
         assert isinstance(butler, DirectButler)
         self.butler = butler
         self.butler.import_(filename="resource://lsst.daf.butler/tests/registry_data/base.yaml")

--- a/tests/test_quantumBackedButler.py
+++ b/tests/test_quantumBackedButler.py
@@ -67,7 +67,8 @@ class QuantumBackedButlerTestCase(unittest.TestCase):
 
         # Make a butler and import dimension definitions.
         registryConfig = RegistryConfig(self.config.get("registry"))
-        _RegistryFactory(registryConfig).create_from_config(butlerRoot=self.root)
+        registry = _RegistryFactory(registryConfig).create_from_config(butlerRoot=self.root)
+        registry.close()
         butler = Butler.from_config(self.config, writeable=True, run="RUN", metrics=self.metrics)
         self.enterContext(butler)
         assert isinstance(butler, DirectButler)

--- a/tests/test_query_direct_postgresql.py
+++ b/tests/test_query_direct_postgresql.py
@@ -61,6 +61,7 @@ class DirectButlerPostgreSQLTests(ButlerQueryTests, unittest.TestCase):
             datastore=NullDatastore(None, None),
             storageClasses=StorageClassFactory(),
         )
+        self.enterContext(butler)
         for arg in args:
             self.load_data(butler, arg)
         return butler

--- a/tests/test_query_direct_sqlite.py
+++ b/tests/test_query_direct_sqlite.py
@@ -49,6 +49,7 @@ class DirectButlerSQLiteTests(ButlerQueryTests, unittest.TestCase):
         # dir but create_populated_sqlite_registry does not and for consistency
         # call load_data to match the other usages.
         butler = create_populated_sqlite_registry()
+        self.enterContext(butler)
         for arg in args:
             self.load_data(butler, arg)
         return butler

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -247,6 +247,7 @@ class ButlerClientServerTestCase(unittest.TestCase):
                         collections=["collection1", "collection2"],
                         run="collection2",
                     )
+                    self.enterContext(butler)
                     self.assertIsInstance(butler, RemoteButler)
                     self.assertEqual(butler._connection.server_url, server_url)
                     self.assertEqual(butler.collections.defaults, ("collection1", "collection2"))

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -599,12 +599,14 @@ class SimpleButlerTests(TestCaseMixin):
         # This should not have a default instrument, because there are two.
         # Pass run instead of collections; this should set both.
         butler2 = Butler.from_config(butler=butler, run="imported_g")
+        self.enterContext(butler2)
         self.assertEqual(list(butler2.registry.defaults.collections), ["imported_g"])
         self.assertEqual(butler2.registry.defaults.run, "imported_g")
         self.assertFalse(butler2.registry.defaults.dataId)
         # Initialize a new butler with an instrument default explicitly given.
         # Set collections instead of run, which should then be None.
         butler3 = Butler.from_config(butler=butler, collections=["imported_g"], instrument="Cam2")
+        self.enterContext(butler3)
         self.assertEqual(list(butler3.registry.defaults.collections), ["imported_g"])
         self.assertIsNone(butler3.registry.defaults.run, None)
         self.assertEqual(butler3.registry.defaults.dataId.required, {"instrument": "Cam2"})
@@ -905,6 +907,7 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
         # Write the YAML file so that some tests can recreate butler from it.
         config.dumpToUri(os.path.join(self.root, "butler.yaml"))
         butler = Butler.from_config(config, writeable=writeable)
+        self.enterContext(butler)
         DatastoreMock.apply(butler)
         return butler
 

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -933,6 +933,7 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
             index_file.flush()
             with mock_env({"DAF_BUTLER_REPOSITORY_INDEX": index_file.name}):
                 butler_factory = LabeledButlerFactory()
+                self.addCleanup(butler_factory.close)
                 factory = butler_factory.bind(access_token=None)
 
                 for dataset_uri in (
@@ -942,6 +943,7 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
                     f"ivo://org.rubinobs/usdac/lsst-dp1?repo={label}&id={ref.id}",
                 ):
                     result = Butler.get_dataset_from_uri(dataset_uri)
+                    self.enterContext(result.butler)
                     self.assertEqual(result.dataset, ref)
                     # The returned butler needs to have the datastore mocked.
                     DatastoreMock.apply(result.butler)
@@ -949,6 +951,7 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
                     self.assertEqual(dataset_id, ref.id)
 
                     factory_result = Butler.get_dataset_from_uri(dataset_uri, factory=factory)
+                    self.enterContext(factory_result.butler)
                     self.assertEqual(factory_result.dataset, ref)
                     # The returned butler needs to have the datastore mocked.
                     DatastoreMock.apply(factory_result.butler)
@@ -958,6 +961,7 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
                 # Non existent dataset.
                 missing_id = str(ref.id).replace("2", "3")
                 result = Butler.get_dataset_from_uri(f"butler://{label}/{missing_id}")
+                self.enterContext(result.butler)
                 self.assertIsNone(result.dataset)
 
         # Test some failure modes.

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -902,7 +902,8 @@ class DirectSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
 
         # have to make a registry first
         registryConfig = RegistryConfig(config.get("registry"))
-        _RegistryFactory(registryConfig).create_from_config()
+        registry = _RegistryFactory(registryConfig).create_from_config()
+        registry.close()
 
         # Write the YAML file so that some tests can recreate butler from it.
         config.dumpToUri(os.path.join(self.root, "butler.yaml"))

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -31,6 +31,7 @@ import stat
 import tempfile
 import unittest
 from contextlib import contextmanager
+from typing import cast
 
 import sqlalchemy
 
@@ -209,7 +210,9 @@ class SqliteFileRegistryTests(RegistryTests):
         if registry_config is None:
             registry_config = self.makeRegistryConfig()
         config["registry"] = registry_config
-        return makeTestRepo(self.root, config=config)
+        butler = makeTestRepo(self.root, config=config)
+        cast(unittest.TestCase, self).enterContext(butler)
+        return butler
 
 
 class SqliteFileRegistryNameKeyCollMgrUUIDTestCase(SqliteFileRegistryTests, unittest.TestCase):
@@ -260,7 +263,9 @@ class SqliteMemoryRegistryTests(RegistryTests):
         # with default managers.
         if registry_config is None:
             registry_config = self.makeRegistryConfig()
-        return create_populated_sqlite_registry(registry_config=registry_config)
+        butler = create_populated_sqlite_registry(registry_config=registry_config)
+        cast(unittest.TestCase, self).enterContext(butler)
+        return butler
 
     def testMissingAttributes(self):
         """Test for instantiating a registry against outdated schema which

--- a/tests/test_testRepo.py
+++ b/tests/test_testRepo.py
@@ -66,6 +66,7 @@ class ButlerTestRepoTestCase(unittest.TestCase):
         }
 
         butler = makeTestRepo(self.root, dataIds)
+        self.enterContext(butler)
 
         records = list(butler.registry.queryDimensionRecords("visit"))
         self.assertEqual(len(records), 3)
@@ -81,6 +82,7 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         cls.root = makeTestTempDir(TESTDIR)
 
         cls.creatorButler = makeTestRepo(cls.root)
+        cls.enterClassContext(cls.creatorButler)
         addDataIdValue(cls.creatorButler, "instrument", "notACam")
         addDataIdValue(cls.creatorButler, "instrument", "dummyCam")
         addDataIdValue(cls.creatorButler, "physical_filter", "k2020", band="k", instrument="notACam")
@@ -112,7 +114,8 @@ class ButlerUtilsTestSuite(unittest.TestCase):
         # outfile has the most obvious effects of any Butler.makeRepo keyword
         with safeTestTempDir(TESTDIR) as temp:
             path = os.path.join(temp, "oddConfig.json")
-            makeTestRepo(temp, {}, outfile=path)
+            butler = makeTestRepo(temp, {}, outfile=path)
+            self.enterContext(butler)
             self.assertTrue(os.path.isfile(path))
 
     def _checkButlerDimension(self, dimensions, query, expected):
@@ -212,6 +215,7 @@ class ButlerUtilsTestSuite(unittest.TestCase):
 
             repo = lsst.daf.butler.Butler.makeRepo(temp, config=config)
             butler = lsst.daf.butler.Butler.from_config(repo, run="chainedExample")
+            self.enterContext(butler)
             registerMetricsExample(butler)
             addDatasetType(butler, "DummyType", {}, "StructuredDataNoComponents")
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -102,7 +102,9 @@ class SchemaVersioningTestCase(unittest.TestCase):
     def makeEmptyDatabase(self, origin: int = 0) -> Database:
         _, filename = tempfile.mkstemp(dir=self.root, suffix=".sqlite3")
         engine = SqliteDatabase.makeEngine(filename=filename)
-        return SqliteDatabase.fromEngine(engine=engine, origin=origin)
+        db = SqliteDatabase.fromEngine(engine=engine, origin=origin)
+        self.addCleanup(db.dispose)
+        return db
 
     def test_new_schema(self) -> None:
         """Test for creating new database schema."""


### PR DESCRIPTION
Added `Butler.close()`, a context manager implementation for `Butler`, and `QuantumBackedButler.close()`.  These can be used to ensure that database connections are closed deterministically, rather than waiting for mark-and-sweep garbage collection.

The Butler unit tests and CLI scripts were updated to use these, ensuring all file handles are closed promptly.  This fixes an issue where the unit tests could fail due to file descriptor exhaustion.

Also removed circular references from `DirectButler`, allowing it to be garbage collected immediately when it goes out of scope.  However, the underlying `SqlAlchemy.Engine` has internal circular references, so this does not release the database connections until mark-and-sweep garbage collection is run or `Butler.close()` is called.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
