### PR TITLE
DM-53326: Add provenance cap for inputs

### DIFF
--- a/doc/changes/DM-53326.misc.rst
+++ b/doc/changes/DM-53326.misc.rst
@@ -1,0 +1,2 @@
+Added new options to ``DatasetProvenance`` to prevent excessive numbers of input datasets being recorded in file metadata.
+The limit for parquet datasets was set to 2,000 inputs.

--- a/python/lsst/daf/butler/delegates/arrowtable.py
+++ b/python/lsst/daf/butler/delegates/arrowtable.py
@@ -229,7 +229,9 @@ def _add_arrow_provenance(
     type_string = _checkArrowCompatibleType(in_memory_dataset)
     if type_string == "astropy":
         provenance = provenance if provenance is not None else DatasetProvenance()
-        prov_dict = provenance.to_flat_dict(ref, prefix="LSST.BUTLER", sep=".", simple_types=True)
+        prov_dict = provenance.to_flat_dict(
+            ref, prefix="LSST.BUTLER", sep=".", simple_types=True, max_inputs=2000
+        )
 
         # Strip any previous provenance.
         DatasetProvenance.strip_provenance_from_flat_dict(in_memory_dataset.meta)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -822,6 +822,7 @@ class DatasetRefTestCase(unittest.TestCase):
             "dataid.visit": 42,
             "run": "somerun",
             "quantum": quantum_id,
+            "n_inputs": 2,
             "input.0.datasettype": "test",
             "input.0.run": "run",
             "input.0.id": ref2.id,
@@ -834,6 +835,41 @@ class DatasetRefTestCase(unittest.TestCase):
         }
 
         prov_dict = prov.to_flat_dict(ref1, sep=".")
+        self.assertEqual(prov_dict, expected)
+        DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
+        self.assertEqual(prov_dict, {})
+
+        expected = {
+            "id": ref1.id,
+            "datasettype": "test",
+            "dataid.instrument": "DummyCam",
+            "dataid.visit": 42,
+            "run": "somerun",
+            "quantum": quantum_id,
+            "n_inputs": 2,
+        }
+
+        prov_dict = prov.to_flat_dict(ref1, sep=".", max_inputs=1)
+        self.assertEqual(prov_dict, expected)
+        DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
+        self.assertEqual(prov_dict, {})
+
+        expected = {
+            "id": ref1.id,
+            "datasettype": "test",
+            "dataid.instrument": "DummyCam",
+            "dataid.visit": 42,
+            "run": "somerun",
+            "quantum": quantum_id,
+            "n_inputs": 2,
+            "input.0.id": ref2.id,
+            "input.0.extra_number": 42,
+            "input.0.extra_string": "value",
+            "input.0.extra_id": extra_id,
+            "input.1.id": ref3.id,
+        }
+
+        prov_dict = prov.to_flat_dict(ref1, sep=".", store_minimalist_inputs=True)
         self.assertEqual(prov_dict, expected)
         DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
         self.assertEqual(prov_dict, {})
@@ -901,6 +937,7 @@ class DatasetRefTestCase(unittest.TestCase):
             "dataid*instrument": "DummyCam",
             "dataid*visit": 42,
             "run": "somerun",
+            "n_inputs": 0,
         }
         self.assertEqual(prov_dict, expected)
         DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
@@ -915,6 +952,7 @@ class DatasetRefTestCase(unittest.TestCase):
             "id": empty_ref.id,
             "datasettype": "empty",
             "run": "empty_run",
+            "n_inputs": 0,
         }
         self.assertEqual(prov_dict, expected)
         DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)
@@ -925,6 +963,7 @@ class DatasetRefTestCase(unittest.TestCase):
             "x-yz-id": empty_ref.id,
             "x-yz-datasettype": "empty",
             "x-yz-run": "empty_run",
+            "x-yz-n_inputs": 0,
         }
         self.assertEqual(prov_dict, expected)
         DatasetProvenance.strip_provenance_from_flat_dict(prov_dict)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -786,6 +786,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
             "LSST.BUTLER.ID": str(put_ref.id),
             "LSST.BUTLER.RUN": "test_run",
             "LSST.BUTLER.DATASETTYPE": "data",
+            "LSST.BUTLER.N_INPUTS": 0,
         }
 
         self.assertEqual(tab2.meta, expected)
@@ -818,6 +819,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
             "LSST.BUTLER.RUN": "test_run",
             "LSST.BUTLER.DATASETTYPE": "data",
             "LSST.BUTLER.QUANTUM": str(quantum_id),
+            "LSST.BUTLER.N_INPUTS": 1,
             "LSST.BUTLER.INPUT.0.ID": str(input_ref.id),
             "LSST.BUTLER.INPUT.0.RUN": "other_run",
             "LSST.BUTLER.INPUT.0.DATASETTYPE": "astropy_parquet",
@@ -834,6 +836,7 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
             "LSST.BUTLER.ID": str(put_ref3.id),
             "LSST.BUTLER.RUN": "new_run",
             "LSST.BUTLER.DATASETTYPE": "data",
+            "LSST.BUTLER.N_INPUTS": 0,
         }
         self.assertEqual(tab2.meta, expected)
         null_prov, prov_ref = DatasetProvenance.from_flat_dict(tab2.meta, self.butler)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
