### PR TITLE
DM-53342: Fix minor bugs in registry queries

### DIFF
--- a/doc/changes/DM-53342.bugfix.md
+++ b/doc/changes/DM-53342.bugfix.md
@@ -1,0 +1,1 @@
+Storage classes are no longer loaded implicitly when using `Butler.registry.queryDatasets()`.

--- a/doc/changes/DM-53342.bugfix.md
+++ b/doc/changes/DM-53342.bugfix.md
@@ -1,1 +1,2 @@
 Storage classes are no longer loaded implicitly when using `Butler.registry.queryDatasets()`.
+A warning about the `datasetType` parameter being deprecated is no longer issued when calling `Butler.registry.queryDatasetAssociations`.

--- a/python/lsst/daf/butler/registry/_registry_base.py
+++ b/python/lsst/daf/butler/registry/_registry_base.py
@@ -236,7 +236,6 @@ class RegistryBase(Registry):
         with self._butler.query() as query:
             resolved_collections = self.queryCollections(
                 collections,
-                datasetType=datasetType,
                 collectionTypes=collectionTypes,
                 flattenChains=True,
             )

--- a/python/lsst/daf/butler/registry/queries/_query_datasets.py
+++ b/python/lsst/daf/butler/registry/queries/_query_datasets.py
@@ -106,9 +106,9 @@ class QueryDriverDatasetRefQueryResults(
 
     def _iterate_rows(self) -> Iterator[DatasetRef]:
         with self._build_query() as result:
-            target_storage_class = self._dataset_type.storageClass
+            target_storage_class = self._dataset_type.storageClass_name
             for ref in result:
-                if ref.datasetType.storageClass != target_storage_class:
+                if ref.datasetType.storageClass_name != target_storage_class:
                     yield ref.overrideStorageClass(target_storage_class)
                 else:
                     yield ref


### PR DESCRIPTION
* Fix an issue where StorageClass instances were being loaded unnecessarily when querying datasets via the legacy `Butler.registry.queryDatasets`
* Fix an issue where all calls to `Butler.registry.queryDatasetAssociations` were issuing a spurious warning about the datasetType parameter being deprecated.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
