### PR TITLE
bugfix: check if pq metadata exists before trying to read

### DIFF
--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -148,7 +148,7 @@ class ParquetFormatter(FormatterV2):
             par_columns = self.file_descriptor.parameters.pop("columns", None)
             if par_columns:
                 has_pandas_multi_index = False
-                if b"pandas" in schema.metadata:
+                if schema.metadata and b"pandas" in schema.metadata:
                     md = json.loads(schema.metadata[b"pandas"])
                     if len(md["column_indexes"]) > 1:
                         has_pandas_multi_index = True


### PR DESCRIPTION
Solves a crash with columns parameter when the ingested parquet file was created w/o a metadata attribute.

## Checklist

- [ ] ran Jenkins
- [-] added a release note for user-visible changes to `doc/changes`
- [-] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
