### PR TITLE
DM-51297: Add storage class and formatters for VisitGeometry.

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -99,3 +99,4 @@ PhotozModel: lsst.meas.photoz.base.model_formatter.ModelFormatter
 VisitBackgroundModel: lsst.daf.butler.formatters.json.JsonFormatter
 VignettingCorrection: lsst.ts.observatory.control.utils.extras.vignetting_storage.VignettingCorrectionFormatter
 SSPAuxiliaryFile: lsst.pipe.tasks.sspAuxiliaryFile.SSPAuxiliaryFileFormatter
+VisitGeometry: lsst.daf.butler.formatters.json.JsonFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -441,3 +441,6 @@ storageClasses:
     pytype: lsst.ts.observatory.control.utils.extras.vignetting_correction.VignettingCorrection
   SSPAuxiliaryFile:
     pytype: lsst.pipe.tasks.sspAuxiliaryFile.SSPAuxiliaryFile
+  VisitGeometry:
+    pytype: lsst.obs.base.visit_geometry.VisitGeometry
+


### PR DESCRIPTION
These are a PipelineTask output that will be used as the inputs to a script that updates the regions in the dimension records.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
