### PR TITLE
DM-53472: Fix closed Butler in prune-datasets CLI

### DIFF
--- a/python/lsst/daf/butler/script/_pruneDatasets.py
+++ b/python/lsst/daf/butler/script/_pruneDatasets.py
@@ -243,6 +243,7 @@ def pruneDatasets(
             find_first=not find_all,
             show_uri=False,
         )
+        dataset_refs = list(itertools.chain.from_iterable(datasets_found.getDatasets()))
 
         result = PruneDatasetsResult(list(datasets_found.getTables()))
 
@@ -258,7 +259,7 @@ def pruneDatasets(
     def doPruneDatasets() -> PruneDatasetsResult:
         with Butler.from_config(repo, writeable=True) as butler:
             butler.pruneDatasets(
-                refs=list(itertools.chain(*datasets_found.getDatasets())),
+                refs=dataset_refs,
                 disassociate=disassociate,
                 tags=disassociate_tags or (),
                 purge=purge,


### PR DESCRIPTION
Fix a bug introduced in DM-53233 where prune-datasets would attempt to use a Butler object after it had been closed.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
