### PR TITLE
DM-53580: Remove unnecessary calls to mkdir() and exists()

### DIFF
--- a/doc/changes/DM-53580.perf.md
+++ b/doc/changes/DM-53580.perf.md
@@ -1,0 +1,2 @@
+Removed unnecessary directory existence checks when writing files to the datastore.
+We no longer create zero-byte files to represent "directories" when writing files to an S3 datastore.

--- a/python/lsst/daf/butler/_formatter.py
+++ b/python/lsst/daf/butler/_formatter.py
@@ -1037,6 +1037,8 @@ class FormatterV2:
         # want it to remain in the correct place but in corrupt state.
         # For local files write to the output directory not temporary dir.
         prefix = uri.dirname() if uri.isLocal else None
+        if prefix is not None:
+            prefix.mkdir()
         with ResourcePath.temporary_uri(suffix=uri.getExtension(), prefix=prefix) as temporary_uri:
             # Need to configure the formatter to write to a different
             # location and that needs us to overwrite internals

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -1068,9 +1068,6 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             # Work out the name we want this ingested file to have
             # inside the datastore
             tgtLocation = self._calculate_ingested_datastore_name(srcUri, ref, formatter)
-            if not tgtLocation.uri.dirname().exists():
-                log.debug("Folder %s does not exist yet.", tgtLocation.uri.dirname())
-                tgtLocation.uri.dirname().mkdir()
 
             # if we are transferring from a local file to a remote location
             # it may be more efficient to get the size and checksum of the
@@ -1311,12 +1308,6 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                     f"and storage class type ({required_pytype})"
                 )
 
-        uri = location.uri
-
-        if not uri.dirname().exists():
-            log.debug("Folder %s does not exist yet so creating it.", uri.dirname())
-            uri.dirname().mkdir()
-
         if self._transaction is None:
             raise RuntimeError("Attempting to write artifact without transaction enabled")
 
@@ -1332,6 +1323,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         # Register a callback to try to delete the uploaded data if
         # something fails below
+        uri = location.uri
         self._transaction.registerUndo("artifactWrite", _removeFileExists, uri)
 
         # Need to record the specified formatter but if this is a V1 formatter
@@ -2220,9 +2212,6 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         else:
             # Name the zip file based on index contents.
             tgtLocation = self.locationFactory.fromPath(index.calculate_zip_file_path_in_store())
-            if not tgtLocation.uri.dirname().exists():
-                log.debug("Folder %s does not exist yet.", tgtLocation.uri.dirname())
-                tgtLocation.uri.dirname().mkdir()
 
             # Transfer the Zip file into the datastore.
             if not dry_run:

--- a/python/lsst/daf/butler/tests/testFormatters.py
+++ b/python/lsst/daf/butler/tests/testFormatters.py
@@ -272,8 +272,8 @@ class MetricsExampleDataFormatter(Formatter):
         # Update the location with the formatter-preferred file extension
         fileDescriptor.location.updateExtension(self.extension)
 
-        with open(fileDescriptor.location.path, "w") as fd:
-            yaml.dump(inMemoryDataset, fd)
+        data = yaml.dump(inMemoryDataset)
+        fileDescriptor.location.uri.write(data.encode("utf-8"))
 
 
 class MetricsExampleModelProvenanceFormatter(JsonFormatter):


### PR DESCRIPTION
We no longer explicitly call exists() and mkdir() to create the parent directories before calling transfer_from to write files into the datastore.  This saves round-trips when using network storage systems, and the underlying `ResourcePath` methods already take care of directory creation when it is needed.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
