### PR TITLE
Added parquet support for filters parameter

### DIFF
--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -408,6 +408,12 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["e"]})
+        # Filter predicates with unrecognized column should be a ValueError.
+        # FIXME: ValueErrorWeirdness1. This raises an AssertionError,
+        #        but Ctrl+f "ValueErrorWeirdness2" below.
+        # with self.assertRaises(ValueError):
+        #     self.butler.get(self.datasetType, dataId={},
+        #                     parameters={"filters": [("e", ">", 1)]})
 
     def testSingleIndexDataFrameWithLists(self):
         df1, allColumns = _makeSingleIndexDataFrame(include_lists=True)
@@ -455,6 +461,11 @@ class ParquetFormatterDataFrameTestCase(unittest.TestCase):
         # Passing an unrecognized column should be a ValueError.
         with self.assertRaises(ValueError):
             self.butler.get(self.datasetType, dataId={}, parameters={"columns": ["d"]})
+        # Filter predicates with unrecognized column should be a ValueError.
+        # FIXME: ValueErrorWeirdness2. This raises a ValueError, but Ctrl+f
+        #        "ValueErrorWeirdness1" above.
+        # df7 = self.butler.get(self.datasetType, dataId={},
+        #                       parameters={"filters": [("d", ">", 1)]})
 
     def testSingleIndexDataFrameEmptyString(self):
         """Test persisting a single index dataframe with empty strings."""


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`

## Notes
- Missing release note (no ticket associated yet).
- I didn't do any semantic validation on the filters, as this is performed by [filters_to_expression](https://github.com/apache/arrow/blob/main/python/pyarrow/parquet/core.py#L134C1-L196C53) early on in [ParquetDataset initialization](https://github.com/apache/arrow/blob/main/python/pyarrow/parquet/core.py#L1383C1-L1384C69). 
- I tried to get started on some basic unit test checks, but it seems there's a wrapper/`except` block preventing the `ValueError` for invalid columns in the filter predicates from being interpreted directly. See the #FIXME comments in `test_parquet.py`. The `get` call outside the `assertRaises` context manager DOES raise a `ValueError`, but the `get` call inside the `assertRaises` context manager raises an `AssertionError` for not raising a value error.
```
====================================== short test summary info =======================================
FAILED test_parquet.py::ParquetFormatterDataFrameTestCase::testMultiIndexDataFrame - ValueError: Failure from formatter 'lsst.daf.butler.formatters.parquet.ParquetFormatter' for data...
FAILED test_parquet.py::InMemoryDataFrameDelegateTestCase::testSingleIndexDataFrame - AssertionError: ValueError not raised
```