### PR TITLE
DM-53631: Fix bug that round-tripped checksums to UUIDs.

### DIFF
--- a/doc/changes/DM-53631.bufix.md
+++ b/doc/changes/DM-53631.bufix.md
@@ -1,0 +1,1 @@
+Fixed a bug that caused datastore checksums to be read back in as UUIDs, which would then break task execution with the `QuantumBackedButler`.

--- a/python/lsst/daf/butler/datastore/record_data.py
+++ b/python/lsst/daf/butler/datastore/record_data.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 # Pydantic requires the possible value types to be explicitly enumerated in
 # order for `uuid.UUID` in particular to work.  `typing.Any` does not work
 # here.
-_Record: TypeAlias = dict[str, int | str | uuid.UUID | None]
+_Record: TypeAlias = dict[str, int | str | None]
 
 
 class SerializedDatastoreRecordData(pydantic.BaseModel):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
