### PR TITLE
DM-53723: Avoid unnecessary data copy when reading parquet into astropy table.

### DIFF
--- a/doc/changes/DM-53723.perf.md
+++ b/doc/changes/DM-53723.perf.md
@@ -1,0 +1,1 @@
+Avoid unnecessary table copy when reading a parquet file into an astropy table.

--- a/python/lsst/daf/butler/formatters/parquet.py
+++ b/python/lsst/daf/butler/formatters/parquet.py
@@ -286,7 +286,7 @@ def arrow_to_astropy(arrow_table: pa.Table) -> atable.Table:
     """
     from astropy.table import Table
 
-    astropy_table = Table(arrow_to_numpy_dict(arrow_table))
+    astropy_table = Table(arrow_to_numpy_dict(arrow_table), copy=False)
 
     _apply_astropy_metadata(astropy_table, arrow_table.schema)
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
