### PR TITLE
DM-53739: Fix LabeledButlerFactory usability papercuts

### DIFF
--- a/doc/changes/DM-53739.feature.md
+++ b/doc/changes/DM-53739.feature.md
@@ -1,0 +1,1 @@
+LabeledButlerFactory now has a `writeable` constructor option to allow writeable Butlers to be instantiated.

--- a/doc/changes/DM-53739.feature.md
+++ b/doc/changes/DM-53739.feature.md
@@ -1,1 +1,2 @@
 LabeledButlerFactory now has a `writeable` constructor option to allow writeable Butlers to be instantiated.
+LabeledButlerFactory can now be used as a context manager to control the lifetime of its database connections.

--- a/python/lsst/daf/butler/_labeled_butler_factory.py
+++ b/python/lsst/daf/butler/_labeled_butler_factory.py
@@ -127,7 +127,7 @@ class LabeledButlerFactory(AbstractContextManager):
 
         return create
 
-    def create_butler(self, *, label: str, access_token: str | None) -> Butler:
+    def create_butler(self, label: str, *, access_token: str | None = None) -> Butler:
         """Create a Butler instance.
 
         Parameters
@@ -136,7 +136,7 @@ class LabeledButlerFactory(AbstractContextManager):
             Label of the repository to instantiate, from the ``repositories``
             parameter to the `LabeledButlerFactory` constructor or the global
             repository index file.
-        access_token : `str` | `None`
+        access_token : `str` | `None`, optional
             Gafaelfawr access token used to authenticate to a Butler server.
             This is required for any repositories configured to use
             `RemoteButler`.  If you only use `DirectButler`, this may be

--- a/tests/test_butler_factory.py
+++ b/tests/test_butler_factory.py
@@ -62,6 +62,13 @@ class ButlerFactoryTestCase(unittest.TestCase):
         self.addCleanup(factory.close)
         self._test_factory(factory)
 
+        writeable_factory = LabeledButlerFactory({"test_repo": self.config_file_uri}, writeable=True)
+        self.addCleanup(writeable_factory.close)
+        self._test_factory(factory)
+        with writeable_factory.create_butler(label="test_repo", access_token=None) as butler:
+            butler.collections.register("new_run")
+            self.assertIsNotNone(butler.collections.get_info("new_run"))
+
     def _test_factory(self, factory: LabeledButlerFactory) -> None:
         butler = factory.create_butler(label="test_repo", access_token=None)
         self.assertIsInstance(butler, DirectButler)

--- a/tests/test_butler_factory.py
+++ b/tests/test_butler_factory.py
@@ -53,21 +53,18 @@ class ButlerFactoryTestCase(unittest.TestCase):
             index_file.write(f"test_repo: {self.config_file_uri}\n".encode())
             index_file.flush()
             with mock_env({"DAF_BUTLER_REPOSITORY_INDEX": index_file.name}):
-                factory = LabeledButlerFactory()
-                self.addCleanup(factory.close)
-                self._test_factory(factory)
+                with LabeledButlerFactory() as factory:
+                    self._test_factory(factory)
 
     def test_factory_via_custom_index(self):
-        factory = LabeledButlerFactory({"test_repo": self.config_file_uri})
-        self.addCleanup(factory.close)
-        self._test_factory(factory)
+        with LabeledButlerFactory({"test_repo": self.config_file_uri}) as factory:
+            self._test_factory(factory)
 
-        writeable_factory = LabeledButlerFactory({"test_repo": self.config_file_uri}, writeable=True)
-        self.addCleanup(writeable_factory.close)
-        self._test_factory(factory)
-        with writeable_factory.create_butler(label="test_repo", access_token=None) as butler:
-            butler.collections.register("new_run")
-            self.assertIsNotNone(butler.collections.get_info("new_run"))
+        with LabeledButlerFactory({"test_repo": self.config_file_uri}, writeable=True) as writeable_factory:
+            self._test_factory(writeable_factory)
+            with writeable_factory.create_butler(label="test_repo", access_token=None) as butler:
+                butler.collections.register("new_run")
+                self.assertIsNotNone(butler.collections.get_info("new_run"))
 
     def _test_factory(self, factory: LabeledButlerFactory) -> None:
         butler = factory.create_butler(label="test_repo", access_token=None)

--- a/tests/test_butler_factory.py
+++ b/tests/test_butler_factory.py
@@ -67,7 +67,7 @@ class ButlerFactoryTestCase(unittest.TestCase):
                 self.assertIsNotNone(butler.collections.get_info("new_run"))
 
     def _test_factory(self, factory: LabeledButlerFactory) -> None:
-        butler = factory.create_butler(label="test_repo", access_token=None)
+        butler = factory.create_butler("test_repo")
         self.assertIsInstance(butler, DirectButler)
         # This identical second call covers a read from the cache.
         butler2 = factory.create_butler(label="test_repo", access_token=None)


### PR DESCRIPTION
Tweaked `LabeledButlerFactory` to allow it to be used more easily in use cases where it is backed by `DirectButler` instances:

* Added a `writeable` parameter to allow writeable instances to be created
* Added a context manager interface to augment the existing close() method
* In `create_butler`, made the access token optional and allow the repository label to be passed as a positional parameter.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
