### PR TITLE
DM-54024: Add "unsafe_direct" transer mode to Butler.transfer_from

### DIFF
--- a/python/lsst/daf/butler/_location.py
+++ b/python/lsst/daf/butler/_location.py
@@ -215,6 +215,18 @@ class Location:
         """
         return self.uri.getExtension()
 
+    def toAbsolute(self) -> Location:
+        """Return this location as an absolute URI, detached from the
+        datastore root.
+
+        Returns
+        -------
+        location
+            `Location` with ``datastoreRootUri`` = `None`, and an absolute
+            path.
+        """
+        return Location(None, self.uri)
+
 
 class LocationFactory:
     """Factory for `Location` instances.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -2846,7 +2846,15 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                 info = transfer_info.file_info
                 source_location = transfer_info.location
                 target_location = info.file_location(self.locationFactory)
-                if source_location == target_location and not source_location.pathInStore.isabs():
+                if transfer == "unsafe_direct":
+                    # Use the existing file from the source location in place,
+                    # by recording the absolute URI in the target DB.  This is
+                    # "unsafe" because the file could be deleted from the
+                    # source Butler at any time, leaving a dangling reference.
+                    source_location = source_location.toAbsolute()
+                    direct_transfers.append(source_location)
+                    info = info.update(path=str(source_location.uri))
+                elif source_location == target_location and not source_location.pathInStore.isabs():
                     # Artifact is already in the target location.
                     # (which is how execution butler currently runs)
                     pass


### PR DESCRIPTION
Add a `Butler.transfer_from(transfer="unsafe_direct")` mode that operates like `Butler.ingest(transfer="direct")`.  It records the absolute URI of the files from the source repository in the target datastore with no copying.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
