### PR TITLE
DM-41280: Improve handling of obscore configuration when creating new repo

### DIFF
--- a/doc/changes/DM-41280.bugfix.md
+++ b/doc/changes/DM-41280.bugfix.md
@@ -1,0 +1,2 @@
+Fixed handling of inconsistent obscore configuration in a seed file when creating new Butler repo.
+Now if obscore manager is defined but its configration is missing the warning will be issued and obscore will be disabled.


### PR DESCRIPTION

When creating new repos people tend to use existing butler.yaml as a seed config. In cse when old butler has obscore manager, its configuration will be missing from butler.yaml. This patch adds a test that detects such cases, issues a warning and removes obscore manager.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
