### PR TITLE
DM-54067: Fix query concurrency errors in Butler server

### DIFF
--- a/doc/changes/DM-54067.bugfix.md
+++ b/doc/changes/DM-54067.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an intermittent segfault in Butler server caused by a concurrency error related to Postgres cursors. Butler server now requires Python 3.13 or later.

--- a/python/lsst/daf/butler/tests/server_available.py
+++ b/python/lsst/daf/butler/tests/server_available.py
@@ -32,6 +32,8 @@ __all__ = (
     "butler_server_is_available",
 )
 
+import sys
+
 butler_server_is_available = True
 """`True` if all dependencies required to use Butler server and RemoteButler
 are installed.
@@ -51,3 +53,7 @@ try:
 except ImportError as e:
     butler_server_is_available = False
     butler_server_import_error = f"Server libraries could not be loaded: {str(e)}"
+
+if sys.version_info.major == 3 and sys.version_info.minor < 13:
+    butler_server_is_available = False
+    butler_server_import_error = "Butler server requires Python 3.13 or later."


### PR DESCRIPTION
Fix an issue where cursors were being accessed from multiple threads, and could be closed while they were still being used if cancellation occurred in the query result handler.  This was leading to intermittent segfaults in Butler server, as well as miscellaneous cursor-related exceptions.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
