### PR TITLE
DM-52892: Add option to save metadata to pngs.

### DIFF
--- a/doc/changes/DM-52892.feature.md
+++ b/doc/changes/DM-52892.feature.md
@@ -1,0 +1,1 @@
+Enable saving metadata to Matplotlib PNGs.

--- a/python/lsst/daf/butler/formatters/matplotlib.py
+++ b/python/lsst/daf/butler/formatters/matplotlib.py
@@ -60,4 +60,9 @@ class MatplotlibFormatter(FormatterV2):
         # The fname for savefig can take a file descriptor. If it works
         # with ResourcePath handles then it may be possible to do direct
         # writes. Alternatively, implement with BytesIO and do direct put.
-        in_memory_dataset.savefig(uri.ospath)
+
+        metadata = {}
+        if hasattr(in_memory_dataset, "metadata"):
+            metadata = in_memory_dataset.metadata
+
+        in_memory_dataset.savefig(uri.ospath, metadata=metadata)


### PR DESCRIPTION
This is used by analysis_tools to store the coordinates of regions on the plots for display in the plot navigator.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
