### PR TITLE
DM-54238: Release notes for v30.0.4

### DIFF
--- a/doc/changes/DM-52892.feature.md
+++ b/doc/changes/DM-52892.feature.md
@@ -1,1 +1,0 @@
-Enable saving metadata to Matplotlib PNGs.

--- a/doc/changes/DM-54067.bugfix.md
+++ b/doc/changes/DM-54067.bugfix.md
@@ -1,1 +1,0 @@
-Fixed an intermittent segfault in Butler server caused by a concurrency error related to Postgres cursors. Butler server now requires Python 3.13 or later.

--- a/doc/lsst.daf.butler/CHANGES.rst
+++ b/doc/lsst.daf.butler/CHANGES.rst
@@ -1,3 +1,18 @@
+Butler v30.0.4 (2026-02-23)
+===========================
+
+New Features
+------------
+
+- Enabled saving metadata to Matplotlib PNGs. (`DM-52892 <https://rubinobs.atlassian.net/browse/DM-52892>`_)
+
+
+Bug Fixes
+---------
+
+- Fixed an intermittent segfault in Butler server caused by a concurrency error related to Postgres cursors. Butler server now requires Python 3.13 or later. (`DM-54067 <https://rubinobs.atlassian.net/browse/DM-54067>`_)
+
+
 Butler v30.0.2 (2026-02-06)
 ===========================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
