### PR TITLE
DM-54220: Add storage class and formatter for ColorImage.

### DIFF
--- a/doc/changes/DM-54220.misc.md
+++ b/doc/changes/DM-54220.misc.md
@@ -1,0 +1,1 @@
+Add storage class and formatter declaration for `lsst.images.ColorImage`.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -107,3 +107,4 @@ ImageV2: lsst.images.fits.formatters.ImageFormatter
 MaskV2: lsst.images.fits.formatters.ImageFormatter
 MaskedImageV2: lsst.images.fits.formatters.MaskedImageFormatter
 VisitImage: lsst.images.fits.formatters.VisitImageFormatter
+ColorImage: lsst.images.fits.formatters.ImageFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -514,3 +514,9 @@ storageClasses:
       psf: PointSpreadFunction
     converters:
       lsst.afw.image.Exposure: lsst.images.VisitImage.from_legacy
+  ColorImage:
+    pytype: lsst.images.ColorImage
+    parameters:
+      - bbox
+    derivedComponents:
+      projection: Projection


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
