### PR TITLE
DM-54083-v30-hotfix: Fix version number for latest release notes.

### DIFF
--- a/doc/lsst.daf.butler/CHANGES.rst
+++ b/doc/lsst.daf.butler/CHANGES.rst
@@ -1,12 +1,3 @@
-Butler v30.0.5 (2026-02-28)
-===========================
-
-Other Changes and Additions
----------------------------
-
-- Add storage class and formatter declarations for the new types in `lsst.images`. (`DM-54083 <https://rubinobs.atlassian.net/browse/DM-54083>`_)
-
-
 Butler v30.0.4 (2026-02-23)
 ===========================
 
@@ -15,11 +6,15 @@ New Features
 
 - Enabled saving metadata to Matplotlib PNGs. (`DM-52892 <https://rubinobs.atlassian.net/browse/DM-52892>`_)
 
-
 Bug Fixes
 ---------
 
 - Fixed an intermittent segfault in Butler server caused by a concurrency error related to Postgres cursors. Butler server now requires Python 3.13 or later. (`DM-54067 <https://rubinobs.atlassian.net/browse/DM-54067>`_)
+
+Other Changes and Additions
+---------------------------
+
+- Add storage class and formatter declarations for the new types in `lsst.images`. (`DM-54083 <https://rubinobs.atlassian.net/browse/DM-54083>`_)
 
 
 Butler v30.0.2 (2026-02-06)


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
