### PR TITLE
DM-54457: Avoid unnecessary file size check on remote storage

### DIFF
--- a/python/lsst/daf/butler/_formatter.py
+++ b/python/lsst/daf/butler/_formatter.py
@@ -44,6 +44,7 @@ import os
 import zipfile
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Iterator, Mapping, Set
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar, TypeAlias, final
 
 from lsst.resources import ResourceHandleProtocol, ResourcePath
@@ -81,6 +82,22 @@ class FormatterNotImplementedError(NotImplementedError):
     """Formatter does not implement the specific read or write method
     that is being requested.
     """
+
+
+@dataclass(frozen=True)
+class FormatterWriteResult:
+    """Information about the write executed by ``FormatterV2.write()``"""
+
+    file_size: int
+    """Size of the file written, in bytes."""
+
+
+@dataclass(frozen=True)
+class _DirectWriteResult:
+    written: bool
+    """`True` if the direct write occurred, `False` if it did not."""
+    file_size: int
+    """Size of the file written, in bytes. -1 if ``written`` is `False`."""
 
 
 class FormatterV2:
@@ -898,7 +915,7 @@ class FormatterV2:
         *,
         cache_manager: AbstractDatastoreCacheManager | None = None,
         provenance: DatasetProvenance | None = None,
-    ) -> None:
+    ) -> FormatterWriteResult:
         """Write a Dataset.
 
         Parameters
@@ -935,16 +952,20 @@ class FormatterV2:
         # a different object.
         in_memory_dataset = self.add_provenance(in_memory_dataset, provenance=provenance)
 
-        written = self._write_direct(in_memory_dataset, uri, cache_manager)
-        if not written:
-            self._write_locally_then_move(in_memory_dataset, uri, cache_manager)
+        direct_result = self._write_direct(in_memory_dataset, uri, cache_manager)
+        if direct_result.written:
+            size = direct_result.file_size
+        else:
+            size = self._write_locally_then_move(in_memory_dataset, uri, cache_manager)
+
+        return FormatterWriteResult(file_size=size)
 
     def _write_direct(
         self,
         in_memory_dataset: Any,
         uri: ResourcePath,
         cache_manager: AbstractDatastoreCacheManager | None = None,
-    ) -> bool:
+    ) -> _DirectWriteResult:
         """Serialize and write directly to final location.
 
         Parameters
@@ -959,8 +980,9 @@ class FormatterV2:
 
         Returns
         -------
-        written : `bool`
-            Flag to indicate whether the direct write did happen.
+        result : ``_DirectWriteResult``
+            Result object with flag to indicate whether the direct write did
+            happen, and the size of the file written.
 
         Raises
         ------
@@ -975,11 +997,12 @@ class FormatterV2:
         directly.
 
         If the dataset should be cached or is local the file will not be
-        written and the method will return `False`. This is because local URIs
-        should be written to a temporary file name and then renamed to allow
-        atomic writes. That path is handled by `_write_locally_then_move`
-        through `write_local_file`) and is preferred over this method being
-        subclassed and the atomic write re-implemented.
+        written and the method will return a result object with
+        ``written=False``.
+        This is because local URIs should be written to a temporary file name
+        and then renamed to allow atomic writes. That path is handled by
+        `_write_locally_then_move` through `write_local_file`) and is preferred
+        over this method being subclassed and the atomic write re-implemented.
         """
         cache_manager = self._ensure_cache(cache_manager)
 
@@ -989,10 +1012,12 @@ class FormatterV2:
         # a file is always written and direct write to the remote
         # datastore is bypassed.
         data_written = False
+        size = -1
         if not uri.isLocal and not cache_manager.should_be_cached(self._get_cache_ref()):
             # Remote URI that is not cached so can write directly.
             try:
                 serialized_dataset = self.to_bytes(in_memory_dataset)
+                size = len(serialized_dataset)
             except FormatterNotImplementedError:
                 # Fallback to the file writing option.
                 pass
@@ -1007,14 +1032,14 @@ class FormatterV2:
                 uri.write(serialized_dataset, overwrite=True)
                 log.debug("Successfully wrote bytes directly to %s", uri)
                 data_written = True
-        return data_written
+        return _DirectWriteResult(written=data_written, file_size=size)
 
     def _write_locally_then_move(
         self,
         in_memory_dataset: Any,
         uri: ResourcePath,
         cache_manager: AbstractDatastoreCacheManager | None = None,
-    ) -> None:
+    ) -> int:
         """Write file to file system and then move to final location.
 
         Parameters
@@ -1034,6 +1059,11 @@ class FormatterV2:
             `write_local_file`.
         Exception
             Raised if there is an error serializing the dataset to disk.
+
+        Returns
+        -------
+        file_size : `int`
+            Size of the file written, in bytes.
         """
         cache_manager = self._ensure_cache(cache_manager)
 
@@ -1046,6 +1076,7 @@ class FormatterV2:
             # to_bytes will be called using the base class definition.
             try:
                 self.write_local_file(in_memory_dataset, temporary_uri)
+                size = temporary_uri.size()
             except Exception as e:
                 e.add_note(
                     f"Failed to serialize dataset {self.dataset_ref} of type"
@@ -1066,6 +1097,7 @@ class FormatterV2:
                 cache_manager.move_to_cache(temporary_uri, self._get_cache_ref())
 
         log.debug("Successfully wrote dataset to %s via a temporary file.", uri)
+        return size
 
     def write_local_file(self, in_memory_dataset: Any, uri: ResourcePath) -> None:
         """Serialize the in-memory dataset to a local file.

--- a/python/lsst/daf/butler/_formatter.py
+++ b/python/lsst/daf/butler/_formatter.py
@@ -935,11 +935,11 @@ class FormatterV2:
         # a different object.
         in_memory_dataset = self.add_provenance(in_memory_dataset, provenance=provenance)
 
-        written = self.write_direct(in_memory_dataset, uri, cache_manager)
+        written = self._write_direct(in_memory_dataset, uri, cache_manager)
         if not written:
-            self.write_locally_then_move(in_memory_dataset, uri, cache_manager)
+            self._write_locally_then_move(in_memory_dataset, uri, cache_manager)
 
-    def write_direct(
+    def _write_direct(
         self,
         in_memory_dataset: Any,
         uri: ResourcePath,
@@ -977,7 +977,7 @@ class FormatterV2:
         If the dataset should be cached or is local the file will not be
         written and the method will return `False`. This is because local URIs
         should be written to a temporary file name and then renamed to allow
-        atomic writes. That path is handled by `write_locally_then_move`
+        atomic writes. That path is handled by `_write_locally_then_move`
         through `write_local_file`) and is preferred over this method being
         subclassed and the atomic write re-implemented.
         """
@@ -1009,7 +1009,7 @@ class FormatterV2:
                 data_written = True
         return data_written
 
-    def write_locally_then_move(
+    def _write_locally_then_move(
         self,
         in_memory_dataset: Any,
         uri: ResourcePath,

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -987,6 +987,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         formatter: Formatter | FormatterV2 | type[Formatter | FormatterV2],
         transfer: str | None = None,
         record_validation_info: bool = True,
+        file_size: int | None = None,
     ) -> StoredFileInfo:
         """Relocate (if necessary) and extract `StoredFileInfo` from a
         to-be-ingested file.
@@ -1010,6 +1011,8 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             or file sizes. This can be useful if such information is tracked
             in an external system or if the file is to be compressed in place.
             It is up to the datastore whether this parameter is relevant.
+        file_size : `int`, optional
+            Size of the file, to be recorded as validation information.
 
         Returns
         -------
@@ -1029,12 +1032,11 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         if self._transaction is None:
             raise RuntimeError("Ingest called without transaction enabled")
 
+        checksum = None
+
         # Create URI of the source path, do not need to force a relative
         # path to absolute.
         srcUri = ResourcePath(path, forceAbsolute=False, forceDirectory=False)
-
-        # Track whether we have read the size of the source yet
-        have_sized = False
 
         tgtLocation: Location | None
         if transfer is None or transfer == "split":
@@ -1073,9 +1075,10 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
             # it may be more efficient to get the size and checksum of the
             # local file rather than the transferred one
             if record_validation_info and srcUri.isLocal:
-                size = srcUri.size()
-                checksum = self.computeChecksum(srcUri) if self.useChecksum else None
-                have_sized = True
+                if file_size is None:
+                    file_size = srcUri.size()
+                if checksum is None:
+                    checksum = self.computeChecksum(srcUri) if self.useChecksum else None
 
             # Transfer the resource to the destination.
             # Allow overwrite of an existing file. This matches the behavior
@@ -1096,20 +1099,17 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         # the file should exist in the datastore now
         if record_validation_info:
-            if not have_sized:
-                size = targetUri.size()
+            if file_size is None:
+                file_size = targetUri.size()
+            if checksum is None:
                 checksum = self.computeChecksum(targetUri) if self.useChecksum else None
-        else:
-            # Not recording any file information.
-            size = -1
-            checksum = None
 
         return StoredFileInfo(
             formatter=formatter,
             path=targetPath,
             storageClass=ref.datasetType.storageClass,
             component=ref.datasetType.component(),
-            file_size=size,
+            file_size=file_size if file_size is not None else -1,
             checksum=checksum,
         )
 
@@ -1343,7 +1343,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
 
         with time_this(log, msg="Writing dataset %s with formatter %s", args=(ref, formatter.name())):
             try:
-                formatter_compat.write(
+                write_result = formatter_compat.write(
                     inMemoryDataset, cache_manager=self.cacheManager, provenance=provenance
                 )
             except Exception as e:
@@ -1353,7 +1353,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                 ) from e
 
         # URI is needed to resolve what ingest case are we dealing with
-        return self._extractIngestInfo(uri, ref, formatter=formatter)
+        return self._extractIngestInfo(uri, ref, formatter=formatter, file_size=write_result.file_size)
 
     def knows(self, ref: DatasetRef) -> bool:
         """Check if the dataset is known to the datastore.

--- a/python/lsst/daf/butler/tests/_datasetsHelper.py
+++ b/python/lsst/daf/butler/tests/_datasetsHelper.py
@@ -46,7 +46,6 @@ from lsst.resources import ResourcePath
 
 if TYPE_CHECKING:
     from lsst.daf.butler import Config, DatasetId
-    from lsst.daf.butler.datastore.cache_manager import AbstractDatastoreCacheManager
 
 
 class DatasetTestHelper:
@@ -190,12 +189,11 @@ class BadWriteFormatter(YamlFormatter):
     def read_from_uri(self, uri: ResourcePath, component: str | None = None, expected_size: int = -1) -> Any:
         return NotImplemented
 
-    def write_direct(
+    def write_local_file(
         self,
         in_memory_dataset: Any,
         uri: ResourcePath,
-        cache_manager: AbstractDatastoreCacheManager | None = None,
-    ) -> bool:
+    ) -> None:
         """Write empty file and immediately fail.
 
         Parameters
@@ -204,8 +202,6 @@ class BadWriteFormatter(YamlFormatter):
             The Python object to serialize.
         uri : `lsst.resources.ResourcePath`
             The location to write the content.
-        cache_manager : `AbstractDatastoreCacheManager`
-            Cache manager. Unused.
 
         Raises
         ------
@@ -219,12 +215,10 @@ class BadWriteFormatter(YamlFormatter):
 class BadNoWriteFormatter(BadWriteFormatter):
     """A formatter that always fails without writing anything."""
 
-    def write_direct(
+    def to_bytes(
         self,
         in_memory_dataset: Any,
-        uri: ResourcePath,
-        cache_manager: AbstractDatastoreCacheManager | None = None,
-    ) -> bool:
+    ) -> bytes:
         raise RuntimeError("Did not writing anything at all")
 
 


### PR DESCRIPTION
When using FormatterV2 to write a file, we now keep track of the file size that it wrote to use when recording validation information in the datastore.  This lets us avoid a call to remote storage to retrieve the size of the file after writing it.  In particular, this extra call was contributing to performance problems during heavy processing workloads with the FrDF WebDAV implementation.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
