### PR TITLE
DM-54225: Add storage class and formatter configs for the new CellCoadd.

### DIFF
--- a/doc/changes/DM-54225.misc.md
+++ b/doc/changes/DM-54225.misc.md
@@ -1,0 +1,1 @@
+Add storage class and formatter declaration for `lsst.images.cells.CellCoadd`.

--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -107,3 +107,4 @@ MaskedImageV2: lsst.images.fits.formatters.MaskedImageFormatter
 VisitImage: lsst.images.fits.formatters.VisitImageFormatter
 ColorImage: lsst.images.fits.formatters.ImageFormatter
 ExtendedPsfCandidates: lsst.images.fits.formatters.GenericFormatter
+CellCoadd: lsst.images.fits.formatters.CellCoaddFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -531,3 +531,16 @@ storageClasses:
     pytype: lsst.pipe.tasks.extended_psf.ExtendedPsfCandidates
     parameters:
       - bbox
+  CellCoaddProvenance:
+    pytype: lsst.images.cells.CoaddProvenance
+  CellCoadd:
+    inheritsFrom: MaskedImageV2
+    pytype: lsst.images.cells.CellCoadd
+    derivedComponents:
+      psf: PointSpreadFunction
+      provenance: CellCoaddProvenance
+    converters:
+      # This converter function doesn't actually work, because it takes an
+      # extra argument.  But we need to declare it anyway to give the
+      # legacy formatter an opportunity to do the conversion on read.
+      lsst.cell_coadds.MultipleCellCoadd: lsst.images.cells.CellCoadd.from_legacy


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
