### PR TITLE
DM-54575: Add ObservationSummaryStats to storage classes definition

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -521,6 +521,7 @@ storageClasses:
     pytype: lsst.images.VisitImage
     derivedComponents:
       psf: PointSpreadFunction
+      summary_stats: ObservationSummaryStats
     converters:
       lsst.afw.image.Exposure: lsst.images.VisitImage.from_legacy
   ColorImage:
@@ -529,3 +530,5 @@ storageClasses:
       - bbox
     derivedComponents:
       projection: Projection
+  ObservationSummaryStats:
+    pytype: lsst.images.ObservationSummaryStats


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
