### PR TITLE
DM-54728: Add helper method to indicate whether a directory has a butler config

### DIFF
--- a/doc/changes/DM-54728.api.rst
+++ b/doc/changes/DM-54728.api.rst
@@ -1,0 +1,1 @@
+Added ``Butler.has_repo_config`` method that can be used to check if a directory URI is configured as a butler repository.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -373,6 +373,24 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
                 raise TypeError(f"Unknown Butler type '{butler_type}'")
 
     @staticmethod
+    def has_repo_config(root: ResourcePathExpression) -> bool:
+        """Check whether the given directory path contains a Butler
+        configuration or not.
+
+        Parameters
+        ----------
+        root : `lsst.resources.ResourcePathExpression`
+            The directory URI to check.
+
+        Returns
+        -------
+        is_root : `bool`
+            `True` if this is a directory containing a butler configuration.
+        """
+        root_uri = ResourcePath(root, forceDirectory=True)
+        return root_uri.join("butler.yaml").exists()
+
+    @staticmethod
     def makeRepo(
         root: ResourcePathExpression,
         config: Config | str | None = None,

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -1439,7 +1439,9 @@ class ButlerTests(ButlerPutGetTests):
         root1 = tempfile.mkdtemp(dir=self.root)
         root2 = tempfile.mkdtemp(dir=self.root)
 
+        self.assertFalse(Butler.has_repo_config(root1))
         butlerConfig = Butler.makeRepo(root1, config=Config(self.configFile))
+        self.assertTrue(Butler.has_repo_config(root1))
         limited = Config(self.configFile)
         butler1 = Butler.from_config(butlerConfig)
         self.enterContext(butler1)


### PR DESCRIPTION
This prevents callers from having to check explicitly for a butler.yaml.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
