### PR TITLE
DM-54834: Add export and import of datastore records in arrow format

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -21,6 +21,13 @@ ignore_missing_imports = True
 [mypy-pyarrow.*]
 ignore_missing_imports = True
 
+[mypy-pyarrow.compute.*]
+ignore_missing_imports = True
+# Pyarrow currently has a py.typed marker, but does not have complete typings.
+# This causes mypy to report an attr-defined error for all pyarrow compute
+# functions.
+follow_imports = skip
+
 [mypy-pandas.*]
 ignore_missing_imports = True
 

--- a/python/lsst/daf/butler/_rubin/datastore_records.py
+++ b/python/lsst/daf/butler/_rubin/datastore_records.py
@@ -1,0 +1,76 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("DatastoreRecordTable", "export_datastore_records_table", "import_datastore_records_table")
+
+from collections.abc import Collection
+
+from .._butler import Butler
+from ..datastore.record_data import DatasetId, DatastoreRecordTable
+
+# These are available for external code to export/import datastore records in
+# bulk.  Initially, these are intended for use by the ``butler_transform``
+# package.
+
+
+def export_datastore_records_table(butler: Butler, datasets: Collection[DatasetId]) -> DatastoreRecordTable:
+    """Export datastore records to an arrow table.
+
+    Parameters
+    ----------
+    butler
+        Butler instance to export data from.
+    datasets
+        Dataset UUIDs for the records to export.
+
+    Returns
+    -------
+    table
+        Datastore records table.
+    """
+    return butler._datastore.export_table(datasets)
+
+
+def import_datastore_records_table(butler: Butler, table: DatastoreRecordTable) -> None:
+    """Import datastore records from an arrow table.
+
+    Parameters
+    ----------
+    butler
+        Butler instance to import data into.
+    table
+        Table containing the datastore records to import.
+
+    Raises
+    ------
+    ValueError
+        If the given table contains entries for a datastore that is not
+        known to the given Butler.
+    """
+    return butler._datastore.import_table(table)

--- a/python/lsst/daf/butler/arrow_utils.py
+++ b/python/lsst/daf/butler/arrow_utils.py
@@ -41,6 +41,7 @@ __all__ = (
 
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import Any, ClassVar, final
 
 import astropy.time
@@ -554,6 +555,63 @@ class DateTimeArrowScalar(pa.ExtensionScalar):
 
     def as_py(self, **_unused: Any) -> astropy.time.Time:
         return TimeConverter().nsec_to_astropy(self.value.as_py())
+
+
+class ArrowTableUtils:
+    """Utility functions for manipulating `pyarrow.Table` instances."""
+
+    @staticmethod
+    def replace_column(table: pa.Table, column_name: str, new_column: pa.Array) -> pa.Table:
+        """Return a new `pyarrow.Table` instance, replacing a given column in
+        the table with a new one.
+
+        Parameters
+        ----------
+        table
+            Original arrow table.
+        column_name
+            Name of the column to be replaced.
+        new_column
+            Replacement arrow column.
+
+        Returns
+        -------
+        table
+            Copy of the given table with the column replaced.
+        """
+        index = table.schema.get_field_index(column_name)
+        if index < 0:
+            raise ValueError(
+                f"Column {column_name} not found in arrow table, or multiple columns have the same name."
+            )
+        return table.set_column(index, column_name, new_column)
+
+    @staticmethod
+    def modify_column(
+        table: pa.Table, column_name: str, function: Callable[[pa.Array], pa.Array]
+    ) -> pa.Table:
+        """Return a new `pyarrow.Table` instance, applying a function to
+        replace one of the columns with a new one.
+
+        Parameters
+        ----------
+        table
+            Original arrow table.
+        column_name
+            Name of the column to be replaced.
+        function
+            Function that takes an arrow array, and returns a modified version
+            of that array.
+
+        Returns
+        -------
+        table
+            Copy of the given table with the column replaced with the value
+            returned from the callback function.
+        """
+        column = table.column(column_name)
+        new_column = function(column)
+        return ArrowTableUtils.replace_column(table, column_name, new_column)
 
 
 pa.register_extension_type(RegionArrowType())

--- a/python/lsst/daf/butler/datastore/_datastore.py
+++ b/python/lsst/daf/butler/datastore/_datastore.py
@@ -29,6 +29,8 @@
 
 from __future__ import annotations
 
+from .record_data import DatastoreRecordTable
+
 __all__ = (
     "DatasetRefURIs",
     "Datastore",
@@ -1401,6 +1403,37 @@ class Datastore(FileTransferSource, metaclass=ABCMeta):
             Exported datastore records indexed by datastore name.
         """
         raise NotImplementedError()
+
+    def export_table(self, datasets: Collection[DatasetId]) -> DatastoreRecordTable:
+        """Export datastore records to an arrow table.
+
+        Parameters
+        ----------
+        datasets
+            Dataset UUIDs for the records to export.
+
+        Returns
+        -------
+        table
+            Datastore records table.
+        """
+        return DatastoreRecordTable.create_empty()
+
+    def import_table(self, table: DatastoreRecordTable) -> None:
+        """Import datastore records from an arrow table.
+
+        Parameters
+        ----------
+        table
+            Table containing the datastore records to import.
+
+        Raises
+        ------
+        ValueError
+            If the given table contains entries for a datastore that is not
+            known to this Butler.
+        """
+        pass
 
     def export_predicted_records(self, refs: Iterable[DatasetRef]) -> dict[str, DatastoreRecordData]:
         """Export predicted datastore records and locations to an in-memory

--- a/python/lsst/daf/butler/datastore/record_data.py
+++ b/python/lsst/daf/butler/datastore/record_data.py
@@ -33,15 +33,18 @@ __all__ = ("DatastoreRecordData", "SerializedDatastoreRecordData")
 
 import dataclasses
 import uuid
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
+from functools import cache
 from typing import TYPE_CHECKING, TypeAlias
 
+import pyarrow as pa
+import pyarrow.compute as pc
 import pydantic
 
 from .._dataset_ref import DatasetId
 from ..dimensions import DimensionUniverse
 from ..persistence_context import PersistenceContextVars
-from .stored_file_info import StoredDatastoreItemInfo
+from .stored_file_info import StoredDatastoreItemInfo, StoredFileInfoTable
 
 if TYPE_CHECKING:
     from ..registry import Registry
@@ -260,3 +263,169 @@ class DatastoreRecordData:
         if cache is not None:
             cache[key] = newRecord
         return newRecord
+
+
+class DatastoreRecordTable:
+    """Arrow table representation of datastore records.  Contains the same
+    information as ``DatastoreRecordData`` in a flat table format.
+
+    Parameters
+    ----------
+    table
+        Arrow table containing the file information records.
+
+    Notes
+    -----
+    Users should not call the constructor directly -- use one of the ``from_*``
+    methods.
+    """
+
+    def __init__(self, table: pa.Table) -> None:
+        self._table = table
+
+    @staticmethod
+    def from_arrow(table: pa.Table) -> DatastoreRecordTable:
+        """Create an instance from an external `pyarrow.Table` object.
+
+        Parameters
+        ----------
+        table
+            `pyarrow.Table` instance with a schema compatible with the one
+            returned by ``DatastoreRecordTable.make_arrow_schema()``.
+
+        Returns
+        -------
+        table
+            New ``DatastoreRecordTable`` instance backed by the given table.
+        """
+        return DatastoreRecordTable(table.cast(DatastoreRecordTable.make_arrow_schema()))
+
+    def to_arrow(self) -> pa.Table:
+        """Convert to a raw `pyarrow.Table`."""
+        return self._table
+
+    def filter_by_datastore_name(self, datastore_name: str) -> DatastoreRecordTable:
+        """Return a table containing only the entries corresponding to the
+        given datastore name.
+
+        Parameters
+        ----------
+        datastore_name
+            Datastore name to filter on.
+
+        Return
+        ------
+        table
+            A copy of this table with only the rows that have a
+            ``datastore_name`` column value matching the given value.
+        """
+        return DatastoreRecordTable(self._table.filter(pc.field("datastore_name") == datastore_name))
+
+    def validate_datastore_names(self, names: Iterable[str]) -> None:
+        """Check that all entries in the ``datastore_name`` column are in the
+        given list of names.
+
+        Parameters
+        ----------
+        names
+            List of allowed datastore names.
+
+        Raises
+        ------
+        ValueError
+            If any of the ``datastore_name`` column entries has a value not in
+            the given list.
+        """
+        column = self._table.column("datastore_name")
+        if len(column) == 0:
+            return
+
+        matches = pc.is_in(column, pa.array(names))
+        if not pc.all(matches).as_py():
+            mismatches = column.filter(pc.invert(matches)).unique().to_pylist()
+            raise ValueError(
+                f"Datastore names '{mismatches}' in table do not match known datastores: '{names}'"
+            )
+
+    @staticmethod
+    def from_stored_file_info_table(datastore_name: str, table: StoredFileInfoTable) -> DatastoreRecordTable:
+        """Create an instance of ``DatastoreRecordTable`` given datastore
+        records as a ``StoredFileInfoTable``.
+
+        Parameters
+        ----------
+        datastore_name
+            Datastore name to assign to the ``datastore_name`` column in all
+            rows of the resulting table.
+        table
+            Table of file information records.
+
+        Returns
+        -------
+        table
+            New ``DatastoreRecordTable`` instance.
+        """
+        column_type = DatastoreRecordTable.make_arrow_schema().field("datastore_name").type
+        datastore_name_column = pa.repeat(pa.scalar(datastore_name, type=column_type), len(table))
+        return DatastoreRecordTable(
+            pa.Table.from_arrays(
+                [datastore_name_column, *table.to_arrow().columns],
+                schema=DatastoreRecordTable.make_arrow_schema(),
+            )
+        )
+
+    def to_stored_file_info_table(self) -> StoredFileInfoTable:
+        """Convert this table to a ``StoredFileInfoTable``.
+
+        Returns
+        -------
+        table
+            ``StoredFileInfoTable`` containing a row corresponding to each row
+            of the original table.
+        """
+        table = self._table.drop_columns("datastore_name")
+        return StoredFileInfoTable.from_arrow(table)
+
+    @cache
+    @staticmethod
+    def make_arrow_schema() -> pa.Schema:
+        """Return the `pyarrow.Schema` for the arrow table."""
+        return StoredFileInfoTable.make_arrow_schema().insert(
+            0, pa.field("datastore_name", pa.dictionary(pa.int8(), pa.string()))
+        )
+
+    @staticmethod
+    def combine(tables: Iterable[DatastoreRecordTable]) -> DatastoreRecordTable:
+        """Concatenate multiple ``DatastoreRecordTable`` instances into a
+        single table.
+
+        Parameters
+        ----------
+        tables
+            Tables to combine.
+
+        Returns
+        -------
+        combined_table
+            ``DatastoreRecordTable`` containing all the rows from all of the
+            given tables.
+        """
+        arrow_tables = [t._table for t in tables]
+        if len(arrow_tables) == 0:
+            return DatastoreRecordTable.create_empty()
+
+        return DatastoreRecordTable(pa.concat_tables(arrow_tables))
+
+    @staticmethod
+    def create_empty() -> DatastoreRecordTable:
+        """Create an empty ``DatastoreRecordTable``.
+
+        Returns
+        -------
+        table
+            New ``DatastoreRecordTable`` instance with no rows.
+        """
+        return DatastoreRecordTable(pa.Table.from_pylist([], schema=DatastoreRecordTable.make_arrow_schema()))
+
+    def __len__(self) -> int:
+        return len(self._table)

--- a/python/lsst/daf/butler/datastore/stored_file_info.py
+++ b/python/lsst/daf/butler/datastore/stored_file_info.py
@@ -32,8 +32,11 @@ __all__ = ("SerializedStoredFileInfo", "StoredDatastoreItemInfo", "StoredFileInf
 import inspect
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
+import pyarrow as pa
+import pyarrow.compute as pc
 import pydantic
 
 from lsst.resources import ResourcePath
@@ -43,6 +46,7 @@ from lsst.utils.introspection import get_full_type_name
 from .._formatter import Formatter, FormatterParameter, FormatterV2
 from .._location import Location, LocationFactory
 from .._storage_class import StorageClass, StorageClassFactory
+from ..arrow_utils import ArrowTableUtils
 
 if TYPE_CHECKING:
     from .._dataset_ref import DatasetRef
@@ -412,6 +416,128 @@ class SerializedStoredFileInfo(pydantic.BaseModel):
 
     file_size: int
     """Size of the serialized dataset in bytes."""
+
+
+class StoredFileInfoTable:
+    """Arrow representation of the database rows from ``StoredFileInfo``.
+
+    Parameters
+    ----------
+    table
+        Arrow table containing the file information records.
+
+    Notes
+    -----
+    Users should not call the constructor directly -- use one of the ``from_*``
+    methods.
+    """
+
+    def __init__(self, table: pa.Table) -> None:
+        self._table = table
+
+    @staticmethod
+    def from_arrow(table: pa.Table) -> StoredFileInfoTable:
+        """Create an instance from an external `pyarrow.Table` object.
+
+        Parameters
+        ----------
+        table
+            `pyarrow.Table` instance with a schema compatible with the one
+            returned by ``StoredFileInfoTable.make_arrow_schema()``.
+
+        Returns
+        -------
+        table
+            New ``StoredFileInfoTable`` instance backed by the given table.
+        """
+        return StoredFileInfoTable(table.cast(StoredFileInfoTable.make_arrow_schema()))
+
+    def to_arrow(self) -> pa.Table:
+        """Convert to a raw `pyarrow.Table`."""
+        return self._table
+
+    @staticmethod
+    def from_records(records: Iterable[Mapping[str, Any]]) -> StoredFileInfoTable:
+        """Convert datastore records from raw database row mappings to an arrow
+        table representation.
+
+        Parameters
+        ----------
+        records
+            List of database records as mappings from database column name to
+            value.
+
+        Returns
+        -------
+        table
+            New ``StoredFileInfoTable`` instance containing the given records.
+
+        Notes
+        -----
+        This is a tabular version of ``StoredFileInfo.from_record()``.
+        """
+        records = [{**row, "dataset_id": row["dataset_id"].bytes} for row in records]
+        table = pa.Table.from_pylist(records, schema=StoredFileInfoTable.make_arrow_schema())
+
+        # The underlying database tables use a magic value "__NULL_STRING__"
+        # instead of SQL NULL for missing component values -- replace
+        # with actual nulls to avoid leaking this implementation detail
+        # to downstream consumers.
+        table = ArrowTableUtils.modify_column(table, "component", _replace_null_placeholder_with_null)
+
+        # Similarly, unknown file size is represented in the DB by a negative
+        # number -- replace with NULL to prevent accidental usage of negative
+        # file sizes downstream.
+        table = ArrowTableUtils.modify_column(table, "file_size", _replace_negative_with_null)
+
+        return StoredFileInfoTable(table)
+
+    def to_records(self) -> list[dict[str, Any]]:
+        """Convert datastore records in this table to dictionary instances in a
+        format suitable for insertion to the database.
+
+        Returns
+        -------
+        records
+            List of dictionaries suitable for insertion into datastore records
+            table.
+        """
+        # Undo the transformations done in ``from_records`` to get the database
+        # representation for component and file_size.
+        table = self._table
+        table = ArrowTableUtils.modify_column(table, "component", lambda c: c.fill_null(NULLSTR))
+        table = ArrowTableUtils.modify_column(table, "file_size", lambda c: c.fill_null(-1))
+        return table.to_pylist()
+
+    @cache
+    @staticmethod
+    def make_arrow_schema() -> pa.Schema:
+        """Return the `pyarrow.Schema` for the arrow table."""
+        string_dict = pa.dictionary(pa.int32(), pa.string())
+        return pa.schema(
+            [
+                pa.field("dataset_id", pa.uuid(), nullable=False),
+                pa.field("path", pa.string(), nullable=False),
+                pa.field("formatter", string_dict, nullable=False),
+                pa.field("storage_class", string_dict, nullable=False),
+                pa.field("component", string_dict, nullable=True),
+                pa.field("checksum", pa.string(), nullable=True),
+                pa.field("file_size", pa.int64(), nullable=True),
+            ]
+        )
+
+    def __len__(self) -> int:
+        return len(self._table)
+
+
+def _replace_null_placeholder_with_null(array: pa.Array) -> pa.Array:
+    mask = pc.equal(array, NULLSTR)
+    return pc.if_else(mask, pa.scalar(None), array)
+
+
+def _replace_negative_with_null(array: pa.Array) -> pa.Array:
+    mask = pc.less(array, 0)
+    return pc.if_else(mask, pa.scalar(None), array)
 
 
 def make_datastore_path_relative(path: str) -> str:

--- a/python/lsst/daf/butler/datastores/chainedDatastore.py
+++ b/python/lsst/daf/butler/datastores/chainedDatastore.py
@@ -46,7 +46,7 @@ from lsst.daf.butler.datastore import (
     DatastoreValidationError,
 )
 from lsst.daf.butler.datastore.constraints import Constraints
-from lsst.daf.butler.datastore.record_data import DatastoreRecordData
+from lsst.daf.butler.datastore.record_data import DatastoreRecordData, DatastoreRecordTable
 from lsst.daf.butler.datastores.file_datastore.get import DatasetLocationInformation
 from lsst.daf.butler.datastores.file_datastore.retrieve_artifacts import ArtifactIndexInfo, ZipIndex
 from lsst.resources import ResourcePath
@@ -1169,6 +1169,20 @@ class ChainedDatastore(Datastore):
                 all_records[name] = record_data
 
         return all_records
+
+    def export_table(self, datasets: Collection[DatasetId]) -> DatastoreRecordTable:
+        # Docstring inherited from the base class.
+
+        return DatastoreRecordTable.combine(
+            [datastore.export_table(datasets) for datastore in self.datastores]
+        )
+
+    def import_table(self, table: DatastoreRecordTable) -> None:
+        # Docstring inherited from the base class.
+
+        table.validate_datastore_names(self.names)
+        for datastore in self.datastores:
+            datastore.import_table(table.filter_by_datastore_name(datastore.name))
 
     def export_predicted_records(self, refs: Iterable[DatasetRef]) -> dict[str, DatastoreRecordData]:
         # Docstring inherited from the base class.

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -3199,8 +3199,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         # Datasets (with or without files existing on disk) can persist in
         # this zombie state indefinitely, until someone manually empties
         # the trash.
-        exported_refs = list(self._bridge.check(refs))
-        ids = {ref.id for ref in exported_refs}
+        ids = self._bridge.check([ref.id for ref in refs])
         records: dict[DatasetId, dict[str, list[StoredDatastoreItemInfo]]] = {id: {} for id in ids}
         for row in self._table.fetch(dataset_id=ids):
             info: StoredDatastoreItemInfo = StoredFileInfo.from_record(row)

--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -36,7 +36,7 @@ import hashlib
 import logging
 import math
 from collections import defaultdict
-from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from sqlalchemy import BigInteger, String
@@ -75,8 +75,12 @@ from lsst.daf.butler.datastore.cache_manager import (
 from lsst.daf.butler.datastore.composites import CompositesMap
 from lsst.daf.butler.datastore.file_templates import FileTemplates, FileTemplateValidationError
 from lsst.daf.butler.datastore.generic_base import GenericBaseDatastore
-from lsst.daf.butler.datastore.record_data import DatastoreRecordData
-from lsst.daf.butler.datastore.stored_file_info import StoredDatastoreItemInfo, StoredFileInfo
+from lsst.daf.butler.datastore.record_data import DatastoreRecordData, DatastoreRecordTable
+from lsst.daf.butler.datastore.stored_file_info import (
+    StoredDatastoreItemInfo,
+    StoredFileInfo,
+    StoredFileInfoTable,
+)
 from lsst.daf.butler.datastores.file_datastore.get import (
     DatasetLocationInformation,
     DatastoreFileGetInformation,
@@ -3186,6 +3190,17 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
     def export_records(self, refs: Iterable[DatasetIdRef]) -> Mapping[str, DatastoreRecordData]:
         # Docstring inherited from the base class.
 
+        records: dict[DatasetId, dict[str, list[StoredDatastoreItemInfo]]] = {}
+        for batch in self._export_rows([ref.id for ref in refs]):
+            for row in batch:
+                info: StoredDatastoreItemInfo = StoredFileInfo.from_record(row)
+                dataset_records = records.setdefault(row["dataset_id"], {})
+                dataset_records.setdefault(self._table.name, []).append(info)
+
+        record_data = DatastoreRecordData(records=records)
+        return {self.name: record_data}
+
+    def _export_rows(self, datasets: Collection[DatasetId]) -> Iterator[Sequence[Mapping[str, Any]]]:
         # This call to 'bridge.check' filters out "partially deleted" datasets.
         # Specifically, ones in the unusual edge state that:
         # 1. They have an entry in the registry dataset tables
@@ -3199,15 +3214,26 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         # Datasets (with or without files existing on disk) can persist in
         # this zombie state indefinitely, until someone manually empties
         # the trash.
-        ids = self._bridge.check([ref.id for ref in refs])
-        records: dict[DatasetId, dict[str, list[StoredDatastoreItemInfo]]] = {id: {} for id in ids}
-        for row in self._table.fetch(dataset_id=ids):
-            info: StoredDatastoreItemInfo = StoredFileInfo.from_record(row)
-            dataset_records = records.setdefault(row["dataset_id"], {})
-            dataset_records.setdefault(self._table.name, []).append(info)
+        found_ids = self._bridge.check(datasets)
+        return self._table.fetch_batches(dataset_id=found_ids)
 
-        record_data = DatastoreRecordData(records=records)
-        return {self.name: record_data}
+    def export_table(self, datasets: Collection[DatasetId]) -> DatastoreRecordTable:
+        # Docstring inherited from the base class.
+
+        tables: list[DatastoreRecordTable] = []
+        for batch in self._export_rows(datasets):
+            file_info = StoredFileInfoTable.from_records(batch)
+            tables.append(DatastoreRecordTable.from_stored_file_info_table(self.name, file_info))
+        return DatastoreRecordTable.combine(tables)
+
+    def import_table(self, table: DatastoreRecordTable) -> None:
+        # Docstring inherited from the base class.
+
+        records = table.to_stored_file_info_table().to_records()
+        dataset_ids = [FakeDatasetRef(record["dataset_id"]) for record in records]
+        if len(records) > 0:
+            self._bridge.insert(dataset_ids)
+            self._table.insert(*records, transaction=self._transaction)
 
     def export_predicted_records(self, refs: Iterable[DatasetRef]) -> dict[str, DatastoreRecordData]:
         # Docstring inherited from the base class.

--- a/python/lsst/daf/butler/registry/bridge/ephemeral.py
+++ b/python/lsst/daf/butler/registry/bridge/ephemeral.py
@@ -87,9 +87,9 @@ class EphemeralDatastoreRegistryBridge(DatastoreRegistryBridge):
         with transaction.undoWith(f"Trash {len(ref_list)} datasets", self._rollbackMoveToTrash, ref_list):
             self._trashedIds.update(ref.id for ref in ref_list)
 
-    def check(self, refs: Iterable[DatasetIdRef]) -> Iterable[DatasetIdRef]:
+    def check(self, datasets: Iterable[DatasetId]) -> set[DatasetId]:
         # Docstring inherited from DatastoreRegistryBridge
-        yield from (ref for ref in refs if ref in self)
+        return {id for id in datasets if FakeDatasetRef(id) in self}
 
     def __contains__(self, ref: DatasetIdRef) -> bool:
         return ref.id in self._datasetIds and ref.id not in self._trashedIds

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -212,12 +212,11 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
 
                 self._db.deleteWhere(location, where)
 
-    def check(self, refs: Iterable[DatasetIdRef]) -> Iterable[DatasetIdRef]:
+    def check(self, datasets: Iterable[DatasetId]) -> set[DatasetId]:
         # Docstring inherited from DatastoreRegistryBridge
-        byId = {ref.id: ref for ref in refs}
-        found: list[DatasetIdRef] = []
+        found: set[DatasetId] = set()
         with self._db.session():
-            for batch in chunk_iterable(byId.keys(), 50000):
+            for batch in chunk_iterable(datasets, 50000):
                 sql = (
                     sqlalchemy.sql.select(self._tables.dataset_location.columns.dataset_id)
                     .select_from(self._tables.dataset_location)
@@ -230,7 +229,7 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
                 )
                 with self._db.query(sql) as sql_result:
                     sql_ids = sql_result.scalars().all()
-                found.extend(byId[id] for id in sql_ids)
+                found.update(sql_ids)
 
         return found
 

--- a/python/lsst/daf/butler/registry/interfaces/_bridge.py
+++ b/python/lsst/daf/butler/registry/interfaces/_bridge.py
@@ -169,18 +169,18 @@ class DatastoreRegistryBridge(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def check(self, refs: Iterable[DatasetIdRef]) -> Iterable[DatasetIdRef]:
-        """Check which refs are listed for this datastore.
+    def check(self, datasets: Iterable[DatasetId]) -> set[DatasetId]:
+        """Check which datasets are present in this datastore.
 
         Parameters
         ----------
-        refs : `~collections.abc.Iterable` of `DatasetIdRef`
-            References to the datasets.
+        datasets : `~collections.abc.Iterable` of `DatasetId`
+            UUIDs of the datasets to check.
 
         Returns
         -------
-        present : `~collections.abc.Iterable` [ `DatasetIdRef` ]
-            Datasets from ``refs`` that are recorded as being in this
+        present : `set` [ `DatasetId` ]
+            Datasets from ``datasets`` that are recorded as being in this
             datastore.
         """
         raise NotImplementedError()

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 __all__ = ["OpaqueTableStorage", "OpaqueTableStorageManager"]
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from ...ddl import TableSpec
@@ -126,6 +126,25 @@ class OpaqueTableStorage(ABC):
         ------
         row : `dict`
             A dictionary representing a single result row.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def fetch_batches(
+        self,
+        **where: Any,
+    ) -> Iterator[Sequence[Mapping]]:
+        """Retrieve records from an opaque table in batches.
+
+        Parameters
+        ----------
+        **where
+            Same as ``OpaqueTableStorage.fetch``.
+
+        Yields
+        ------
+        batch
+            A batch of mappings representing a series of result rows.
         """
         raise NotImplementedError()
 

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 __all__ = ["ByNameOpaqueTableStorage", "ByNameOpaqueTableStorageManager"]
 
 import itertools
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import sqlalchemy
@@ -103,7 +103,13 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         **where: Any,
     ) -> Iterator[sqlalchemy.RowMapping]:
         # Docstring inherited from OpaqueTableStorage.
+        for batch in self.fetch_batches(**where):
+            yield from batch
 
+    def fetch_batches(
+        self,
+        **where: Any,
+    ) -> Iterator[Sequence[sqlalchemy.RowMapping]]:
         def _batch_in_clause(
             column: sqlalchemy.schema.Column, values: Iterable[Any]
         ) -> Iterator[sqlalchemy.sql.expression.ClauseElement]:
@@ -145,7 +151,7 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         for sql_batch in batched_sql:
             with self._db.query(sql_batch) as sql_result:
                 sql_mappings = sql_result.mappings().fetchall()
-            yield from sql_mappings
+            yield sql_mappings
 
     def delete(self, columns: Iterable[str], *rows: dict) -> None:
         # Docstring inherited from OpaqueTableStorage.

--- a/python/lsst/daf/butler/tests/_dummyRegistry.py
+++ b/python/lsst/daf/butler/tests/_dummyRegistry.py
@@ -125,6 +125,10 @@ class DummyOpaqueTableStorage(OpaqueTableStorage):
                 else:
                     yield d
 
+    def fetch_batches(self, **where: Any) -> Iterator[list[dict]]:
+        # Docstring inherited from OpaqueTableStorage.
+        yield list(self.fetch(**where))
+
     def delete(self, columns: Iterable[str], *rows: dict) -> None:
         # Docstring inherited from OpaqueTableStorage.
         kept_rows = []

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -61,8 +61,16 @@ from lsst.daf.butler.datastore.cache_manager import (
     DatastoreCacheManagerConfig,
     DatastoreDisabledCacheManager,
 )
-from lsst.daf.butler.datastore.record_data import DatastoreRecordData, SerializedDatastoreRecordData
-from lsst.daf.butler.datastore.stored_file_info import StoredFileInfo, make_datastore_path_relative
+from lsst.daf.butler.datastore.record_data import (
+    DatastoreRecordData,
+    DatastoreRecordTable,
+    SerializedDatastoreRecordData,
+)
+from lsst.daf.butler.datastore.stored_file_info import (
+    StoredFileInfo,
+    StoredFileInfoTable,
+    make_datastore_path_relative,
+)
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 from lsst.daf.butler.tests import (
     BadNoWriteFormatter,
@@ -992,6 +1000,28 @@ class DatastoreTests(DatastoreTestsBase):
         self.assertIsNotNone(data)
         data = datastore2.get(refs[2])
         self.assertIsNotNone(data)
+
+    def testExportImportTable(self) -> None:
+        datastore, refs = self._populate_export_datastore("test_datastore")
+        table = datastore.export_table([ref.id for ref in refs])
+        datastore2 = self.makeDatastore("test_datastore")
+        datastore2.import_table(table)
+
+        for ref in refs:
+            self.assertIsNotNone(datastore2.get(ref))
+            self.assertEqual(datastore.getURI(ref), datastore2.getURI(ref))
+            original_info = datastore.get_file_info_for_transfer([ref.id])[ref.id][0]
+            imported_info_list = datastore.get_file_info_for_transfer([ref.id]).get(ref.id)
+            self.assertIsNotNone(imported_info_list)
+            self.assertEqual(len(imported_info_list), 1)
+            imported_info = imported_info_list[0]
+            self.assertEqual(imported_info.file_info.formatter, original_info.file_info.formatter)
+            self.assertEqual(
+                imported_info.file_info.storage_class_name, original_info.file_info.storage_class_name
+            )
+            self.assertEqual(imported_info.file_info.file_size, original_info.file_info.file_size)
+            self.assertEqual(imported_info.file_info.checksum, original_info.file_info.checksum)
+            self.assertEqual(imported_info.file_info.component, original_info.file_info.component)
 
     def testExportPredictedRecords(self):
         if self.isEphemeral:
@@ -2294,6 +2324,130 @@ class StoredFileInfoTestCase(DatasetTestHelper, unittest.TestCase):
         d = DatastoreRecordData.from_simple(s)
         self.assertIsInstance(d.records[id]["file_datastore_records"][0], StoredFileInfo)
         self.assertIsInstance(d.records[id]["file_datastore_records"][0].checksum, str)
+
+
+class TestDatastoreRecordTable(unittest.TestCase):
+    """Test DatastoreRecordTable and StoredFileInfoTable."""
+
+    def test_empty_datastore_records_table(self) -> None:
+        file_info_table = StoredFileInfoTable.from_records([])
+        self.assertEqual(0, len(file_info_table))
+
+        self.assertEqual(
+            0, len(DatastoreRecordTable.from_stored_file_info_table("datastore_name", file_info_table))
+        )
+
+        self.assertEqual(0, len(DatastoreRecordTable.create_empty()))
+        self.assertEqual(0, len(DatastoreRecordTable.combine([])))
+        # Doesn't throw because there is no mismatch in datastore names.
+        DatastoreRecordTable.create_empty().validate_datastore_names("arbitrary_name")
+
+    def test_stored_file_info_table_records(self) -> None:
+        uuid1 = uuid.UUID("019e1892-7b9b-736d-8248-0e031723646c")
+        uuid2 = uuid.UUID("019e1895-9ec3-7431-bed9-8ae60096103f")
+        uuid3 = uuid.UUID("13d13272-454c-4bc4-94d5-3e322982eee8")
+        checksum = (
+            "021ced8799518305c451cde3e921515ef315ee7ba8937"
+            "a92697a20c571c776afa4102744bc28d2d99d35f44e073cde80cf96e387f65f3967cca45b0d015f5a6b"
+        )
+        input_records = [
+            {
+                "dataset_id": uuid1,
+                "path": "a/relative/path.fits",
+                "formatter": "lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter",
+                "storage_class": "ExposureF",
+                "component": "__NULL_STRING__",
+                "checksum": None,
+                "file_size": 123,
+            },
+            {
+                "dataset_id": uuid2,
+                "path": "file:///an/absolute/path.fits",
+                "formatter": "lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter",
+                "storage_class": "ExposureF",
+                "component": "comp",
+                "checksum": checksum,
+                "file_size": -1,
+            },
+        ]
+        table = StoredFileInfoTable.from_records(input_records)
+        self.assertEqual(len(table), 2)
+
+        def _check_records(records: list[dict]) -> None:
+            rec0 = records[0]
+            self.assertEqual(rec0["dataset_id"], uuid1)
+            self.assertEqual(rec0["path"], "a/relative/path.fits")
+            self.assertEqual(rec0["formatter"], "lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter")
+            self.assertEqual(rec0["storage_class"], "ExposureF")
+            self.assertIsNone(rec0["component"])
+            self.assertIsNone(rec0["checksum"])
+            self.assertEqual(rec0["file_size"], 123)
+            rec1 = records[1]
+            self.assertEqual(rec1["dataset_id"], uuid2)
+            self.assertEqual(rec1["path"], "file:///an/absolute/path.fits")
+            self.assertEqual(rec1["formatter"], "lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter")
+            self.assertEqual(rec1["storage_class"], "ExposureF")
+            self.assertEqual(rec1["component"], "comp")
+            self.assertEqual(rec1["checksum"], checksum)
+            self.assertIsNone(rec1["file_size"])
+
+        arrow_records = table.to_arrow().to_pylist()
+        self.assertEqual(len(arrow_records), 2)
+        _check_records(arrow_records)
+        self.assertEqual(table.to_records(), input_records)
+
+        datastore_table = DatastoreRecordTable.from_stored_file_info_table("name_of_datastore", table)
+        datastore_arrow_records = datastore_table.to_arrow().to_pylist()
+        self.assertEqual(len(datastore_arrow_records), 2)
+        _check_records(datastore_arrow_records)
+        self.assertEqual(datastore_arrow_records[0]["datastore_name"], "name_of_datastore")
+        self.assertEqual(datastore_arrow_records[1]["datastore_name"], "name_of_datastore")
+        _check_records(datastore_table.to_stored_file_info_table().to_arrow().to_pylist())
+        # Check round-tripping to_arrow() through from_arrow()
+        _check_records(
+            datastore_table.from_arrow(datastore_table.to_arrow())
+            .to_stored_file_info_table()
+            .to_arrow()
+            .to_pylist()
+        )
+
+        with self.assertRaisesRegex(ValueError, "do not match known datastores"):
+            datastore_table.validate_datastore_names(["not_the_same_datastore"])
+        datastore_table.validate_datastore_names(["not_the_same_datastore", "name_of_datastore"])
+
+        second_table = DatastoreRecordTable.from_stored_file_info_table(
+            "other_datastore_name",
+            StoredFileInfoTable.from_records(
+                [
+                    {
+                        "dataset_id": uuid3,
+                        "path": "a/relative/path2.fits",
+                        "formatter": "lsst.obs.lsst.rawFormatter.LsstCamRawFormatter",
+                        "storage_class": "Exposure",
+                        "component": "__NULL_STRING__",
+                        "checksum": None,
+                        "file_size": 1000,
+                    },
+                ]
+            ),
+        )
+        combined_table = DatastoreRecordTable.combine([datastore_table, second_table])
+        combined_records = combined_table.to_arrow().to_pylist()
+        _check_records(combined_records)
+        rec2 = combined_records[2]
+        self.assertEqual(rec2["dataset_id"], uuid3)
+        self.assertEqual(rec2["path"], "a/relative/path2.fits")
+        self.assertEqual(rec2["formatter"], "lsst.obs.lsst.rawFormatter.LsstCamRawFormatter")
+        self.assertEqual(rec2["storage_class"], "Exposure")
+        self.assertIsNone(rec2["component"])
+        self.assertIsNone(rec2["checksum"])
+        self.assertEqual(rec2["file_size"], 1000)
+
+        self.assertEqual(0, len(datastore_table.filter_by_datastore_name("unknown_datastore")))
+        filtered_table = combined_table.filter_by_datastore_name("name_of_datastore")
+        self.assertEqual(len(filtered_table), 2)
+        _check_records(filtered_table.to_arrow().to_pylist())
+        self.assertEqual(filtered_table.to_stored_file_info_table().to_records(), input_records)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Add a class `DatastoreRecordTable` to represent datastore records as an arrow table, as well as `Datastore` methods `export_table` and `import_table` to work with it.  This also adds "rubin-internal" wrapper functions to expose these datastore methods, intended for use to write parquet files from [butler_transform](https://github.com/lsst-dm/butler_transform/).  

This mirrors the functionality from the existing `Datastore.export_records` and `Datastore.import_records` methods, but with a flat table instead of a convoluted multi-level hierarchical data structure.  The existing data structure embeds too many implementation details and is difficult to work with from external code.

Putting this in `daf_butler` makes it easier to add comprehensive tests for the conversion to arrow and keeps it closer to the other code relying on the same implementation details.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of dimensions.yaml in `configs/old_dimensions`
