### PR TITLE
DM-54919: Improve import of DatasetRefs from different universe

### DIFF
--- a/python/lsst/daf/butler/_dataset_ref.py
+++ b/python/lsst/daf/butler/_dataset_ref.py
@@ -63,6 +63,7 @@ from lsst.utils.classes import immutable
 
 from ._config_support import LookupKey
 from ._dataset_type import DatasetType, SerializedDatasetType
+from ._exceptions import InconsistentUniverseError
 from ._named import NamedKeyDict
 from ._uuid import generate_uuidv7
 from .datastore.stored_file_info import StoredDatastoreItemInfo
@@ -1084,7 +1085,7 @@ class SerializedDatasetRefContainerV1(SerializedDatasetRefContainer):
             return []
 
         if universe.namespace != self.universe_namespace:
-            raise RuntimeError(
+            raise InconsistentUniverseError(
                 f"Can not convert to refs in universe {universe.namespace} that were created from "
                 f"universe {self.universe_namespace}"
             )
@@ -1092,16 +1093,36 @@ class SerializedDatasetRefContainerV1(SerializedDatasetRefContainer):
         if universe.version != self.universe_version:
             _LOG.warning(
                 "Universe mismatch when attempting to reconstruct DatasetRef from serialized form. "
-                "Serialized with version %d but asked to use version %d.",
+                "Serialized with version %d but asked to use version %d. "
+                "There could be failures due to different universe versions.",
                 self.universe_version,
                 universe.version,
             )
 
         # Reconstruct the DatasetType objects.
-        dataset_types = {
-            name: DatasetType.from_simple(dtype, universe=universe)
-            for name, dtype in self.dataset_types.items()
-        }
+        dataset_types: dict[str, DatasetType] = {}
+        if universe.version == self.universe_version:
+            dataset_types = {
+                name: DatasetType.from_simple(dtype, universe=universe)
+                for name, dtype in self.dataset_types.items()
+            }
+        else:
+            # When versions are different the dimensions may either disappear
+            # or new dimensions can be aedded to conforming set.
+            for name, dtype in self.dataset_types.items():
+                try:
+                    dataset_type = DatasetType.from_simple(dtype, universe=universe)
+                except KeyError as exc:
+                    raise InconsistentUniverseError(
+                        f"Source dimensions {dtype.dimensions} are not compatible with "
+                        f"target universe dimensions {universe}."
+                    ) from exc
+                if set(dataset_type.dimensions.names) != set(dtype.dimensions or []):
+                    raise InconsistentUniverseError(
+                        f"Source dimensions {dtype.dimensions} are different from a conforming "
+                        f"set of target universe dimensions {dataset_type.dimensions}."
+                    )
+                dataset_types[name] = dataset_type
 
         # Dimension records can be attached if available.
         # We assume that all dimension information was stored.

--- a/python/lsst/daf/butler/_dataset_ref.py
+++ b/python/lsst/daf/butler/_dataset_ref.py
@@ -1117,7 +1117,7 @@ class SerializedDatasetRefContainerV1(SerializedDatasetRefContainer):
                         f"Source dimensions {dtype.dimensions} are not compatible with "
                         f"target universe dimensions {universe}."
                     ) from exc
-                if set(dataset_type.dimensions.names) != set(dtype.dimensions or []):
+                if set(dataset_type.dimensions.required) != set(dtype.dimensions or []):
                     raise InconsistentUniverseError(
                         f"Source dimensions {dtype.dimensions} are different from a conforming "
                         f"set of target universe dimensions {dataset_type.dimensions}."

--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -228,8 +228,6 @@ class InconsistentUniverseError(Exception):
     incompatible with the target butler universe.
     """
 
-    pass
-
 
 _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     CalibrationLookupError,

--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -38,6 +38,7 @@ __all__ = (
     "DimensionNameError",
     "EmptyQueryResultError",
     "InconsistentDataIdError",
+    "InconsistentUniverseError",
     "InvalidQueryError",
     "MissingCollectionError",
     "MissingDatasetTypeError",
@@ -220,6 +221,14 @@ class UnknownButlerUserError(ButlerUserError):
     """
 
     error_type = "unknown"
+
+
+class InconsistentUniverseError(Exception):
+    """Raised when an imported dataset has a dimension universe that is
+    incompatible with the target butler universe.
+    """
+
+    pass
 
 
 _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (

--- a/python/lsst/daf/butler/dimensions/_universe.py
+++ b/python/lsst/daf/butler/dimensions/_universe.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
 from lsst.utils.classes import cached_getter, immutable
 
 from .._config import Config
+from .._exceptions import InconsistentUniverseError
 from .._named import NamedValueAbstractSet, NamedValueSet
 from .._topology import TopologicalFamily, TopologicalSpace
 from .._utilities.thread_safe_cache import ThreadSafeCache
@@ -446,6 +447,11 @@ class DimensionUniverse:  # numpydoc ignore=PR02
         """
         match dimensions:
             case DimensionGroup():
+                if dimensions.universe is not self:
+                    raise InconsistentUniverseError(
+                        f"DimensionGroup {dimensions} belongs to a different universe."
+                        f" Expected universe {self}, but got {dimensions.universe}."
+                    )
                 return dimensions
             case str() as name:
                 return self[name].minimal_group

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -44,7 +44,7 @@ import os
 import uuid
 import warnings
 from collections import Counter, defaultdict
-from collections.abc import Collection, Iterable, Iterator, MutableMapping, Sequence
+from collections.abc import Collection, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from functools import partial
 from types import EllipsisType
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, TextIO, cast
@@ -67,7 +67,13 @@ from .._dataset_existence import DatasetExistence
 from .._dataset_ref import DatasetRef
 from .._dataset_type import DatasetType
 from .._deferredDatasetHandle import DeferredDatasetHandle
-from .._exceptions import DatasetNotFoundError, DimensionValueError, EmptyQueryResultError, ValidationError
+from .._exceptions import (
+    DatasetNotFoundError,
+    DimensionValueError,
+    EmptyQueryResultError,
+    InconsistentUniverseError,
+    ValidationError,
+)
 from .._file_dataset import FileDataset
 from .._limited_butler import LimitedButler
 from .._query_all_datasets import QueryAllDatasetsParameters, query_all_datasets
@@ -2131,6 +2137,84 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         return dimension_records
 
+    def _cast_universe_for_import_refs(
+        self, source_refs: Iterable[DatasetRef]
+    ) -> Mapping[DatasetType, list[DatasetRef]]:
+        """Try to cast imported refs to the target universe if possible.
+
+        Parameters
+        ----------
+        source_refs
+            The refs to be imported.
+
+        Returns
+        -------
+        refs
+            The refs to be imported, grouped by dataset type, with the dataset
+            types cast to the target universe.
+
+        Raises
+        ------
+        InconsistentUniverseError
+            Raised if any reference cannot be converted to target universe.
+
+        Notes
+        -----
+        Potentially this method can perform a non-trivial migrations of the
+        datasets by modifying dimensions and dataIds. Presently though it can
+        only perform a trivial validation of the dataset types compatibility.
+        Returned mapping will contain dataset types in the new universe, but
+        returned references will still have the original dataset types as
+        there is presently no easy way to replace dataset type in a reference.
+        """
+        # In theory input refs could come from multiple universes, but in
+        # practice this will not happen, so just group everything by dataset
+        # type.
+        refs_by_source_type: defaultdict[DatasetType, list[DatasetRef]] = defaultdict(list)
+        for ref in source_refs:
+            refs_by_source_type[ref.datasetType].append(ref)
+
+        refs_by_type: defaultdict[DatasetType, list[DatasetRef]] = defaultdict(list)
+        for source_type, refs in refs_by_source_type.items():
+            source_universe = source_type.dimensions.universe
+            if source_universe is self.dimensions:
+                target_type = source_type
+            else:
+                if source_universe.namespace != self.dimensions.namespace:
+                    raise InconsistentUniverseError(
+                        f"Source refs have universe {source_universe} with different namespace "
+                        f"than target universe {self.dimensions}."
+                    )
+
+                # Try to handle case of different universe versions. For now
+                # we can only do trivial check that dimension groups are
+                # identical.
+                try:
+                    target_dimensions = self.dimensions.conform(source_type.dimensions.names)
+                except Exception as exc:
+                    raise InconsistentUniverseError(
+                        f"Source dimensions {source_type.dimensions} are not compatible with "
+                        f"target universe dimensions {self.dimensions}."
+                    ) from exc
+                if target_dimensions != source_type.dimensions:
+                    raise InconsistentUniverseError(
+                        f"Source dimensions {source_type.dimensions} are different from a conforming "
+                        f"set of target universe dimensions {target_dimensions}."
+                    )
+
+                # Rebuild dataset type in new universe.
+                target_type = DatasetType(
+                    name=source_type.name,
+                    dimensions=target_dimensions,
+                    storageClass=source_type.storageClass,
+                    parentStorageClass=source_type.parentStorageClass,
+                    universe=self.dimensions,
+                    isCalibration=source_type.isCalibration(),
+                )
+            refs_by_type[target_type] = refs
+
+        return refs_by_type
+
     def _prepare_for_import_refs(
         self,
         source_butler: LimitedButler,
@@ -2159,19 +2243,19 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
             str(self),
         )
 
+        refs_by_type = self._cast_universe_for_import_refs(source_refs)
+
         # Importing requires that we group the refs by dimension group and run
         # before doing the import.
-        source_dataset_types = set()
         grouped_refs: defaultdict[_RefGroup, list[DatasetRef]] = defaultdict(list)
         for ref in source_refs:
             grouped_refs[_RefGroup(ref.datasetType.dimensions, ref.run)].append(ref)
-            source_dataset_types.add(ref.datasetType)
 
         # Check to see if the dataset type in the source butler has
         # the same definition in the target butler and register missing
         # ones if requested. Registration must happen outside a transaction.
         newly_registered_dataset_types = set()
-        for datasetType in source_dataset_types:
+        for datasetType in refs_by_type:
             if register_dataset_types:
                 # Let this raise immediately if inconsistent. Continuing
                 # on to find additional inconsistent dataset types

--- a/tests/config/dimensions/dimensions1.yaml
+++ b/tests/config/dimensions/dimensions1.yaml
@@ -1,0 +1,61 @@
+#
+# Test universe version 1, includes instrument, detector and visit only.
+#
+version: 1
+namespace: test
+skypix:
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
+
+elements:
+  instrument:
+    keys:
+      - name: name
+        type: string
+        length: 32
+    metadata:
+      - name: class_name
+        type: string
+        length: 64
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  detector:
+    keys:
+      - name: id
+        type: int
+      - name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      - name: name_in_raft
+        type: string
+        length: 32
+      - name: raft
+        type: string
+        length: 32
+      - name: purpose
+        type: string
+        length: 32
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit:
+    keys:
+      - name: id
+        type: int
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    metadata:
+      - name: seq_num
+        type: int
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage

--- a/tests/config/dimensions/dimensions2.yaml
+++ b/tests/config/dimensions/dimensions2.yaml
@@ -1,0 +1,70 @@
+#
+# Test universe version 2, adds  group.
+#
+version: 2
+namespace: test
+skypix:
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
+
+elements:
+  instrument:
+    keys:
+      - name: name
+        type: string
+        length: 32
+    metadata:
+      - name: class_name
+        type: string
+        length: 64
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  detector:
+    keys:
+      - name: id
+        type: int
+      - name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      - name: name_in_raft
+        type: string
+        length: 32
+      - name: raft
+        type: string
+        length: 32
+      - name: purpose
+        type: string
+        length: 32
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit:
+    keys:
+      - name: id
+        type: int
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    metadata:
+      - name: seq_num
+        type: int
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  group:
+    keys:
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage

--- a/tests/config/dimensions/dimensions3.yaml
+++ b/tests/config/dimensions/dimensions3.yaml
@@ -1,0 +1,78 @@
+#
+# Test universe version 3, adds day_obs as a required key for visit.
+#
+version: 3
+namespace: test
+skypix:
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
+
+elements:
+  instrument:
+    keys:
+      - name: name
+        type: string
+        length: 32
+    metadata:
+      - name: class_name
+        type: string
+        length: 64
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  detector:
+    keys:
+      - name: id
+        type: int
+      - name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      - name: name_in_raft
+        type: string
+        length: 32
+      - name: raft
+        type: string
+        length: 32
+      - name: purpose
+        type: string
+        length: 32
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  day_obs:
+    keys:
+      - name: id
+        type: int
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit:
+    keys:
+      - name: id
+        type: int
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument, day_obs]
+    metadata:
+      - name: seq_num
+        type: int
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  group:
+    keys:
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage

--- a/tests/config/dimensions/dimensions4.yaml
+++ b/tests/config/dimensions/dimensions4.yaml
@@ -1,0 +1,81 @@
+#
+# Test universe version 4, adds observation_reason metadata for visit.
+#
+version: 4
+namespace: test
+skypix:
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
+
+elements:
+  instrument:
+    keys:
+      - name: name
+        type: string
+        length: 32
+    metadata:
+      - name: class_name
+        type: string
+        length: 64
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
+
+  detector:
+    keys:
+      - name: id
+        type: int
+      - name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      - name: name_in_raft
+        type: string
+        length: 32
+      - name: raft
+        type: string
+        length: 32
+      - name: purpose
+        type: string
+        length: 32
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  day_obs:
+    keys:
+      - name: id
+        type: int
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  visit:
+    keys:
+      - name: id
+        type: int
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument, day_obs]
+    metadata:
+      - name: seq_num
+        type: int
+      - name: observation_reason
+        type: string
+        length: 68
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
+
+  group:
+    keys:
+      - name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage

--- a/tests/test_dimensions_versions.py
+++ b/tests/test_dimensions_versions.py
@@ -1,0 +1,277 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from contextlib import closing
+
+from pydantic import ValidationError
+
+from lsst.daf.butler import Butler, Config, InconsistentUniverseError
+from lsst.daf.butler.tests import addDataIdValue, addDatasetType, makeTestRepo
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+_INSTRUMENT = "🔭"
+
+
+def _make_butler(root: str, dimensions_version: int) -> Butler:
+    path = os.path.join(
+        os.path.dirname(__file__), "config", "dimensions", f"dimensions{dimensions_version}.yaml"
+    )
+    config = Config()
+    config["datastore", "cls"] = "lsst.daf.butler.datastores.fileDatastore.FileDatastore"
+    butler = makeTestRepo(root, config=config, dimensionConfig=path)
+
+    return butler
+
+
+def _populate_data_ids(butler: Butler, dimension_version: int) -> None:
+    """Populate the repository with data IDs for the dimensions."""
+    addDataIdValue(butler, "instrument", _INSTRUMENT)
+
+    for detector in range(10):
+        addDataIdValue(butler, "detector", detector, instrument=_INSTRUMENT)
+
+    if dimension_version in (1, 2):
+        for visit in range(10):
+            addDataIdValue(butler, "visit", visit, instrument=_INSTRUMENT)
+
+    if dimension_version in (2, 3):
+        for group in "ABCD":
+            addDataIdValue(butler, "group", group, instrument=_INSTRUMENT)
+
+    if dimension_version in (3, 4):
+        for day_obs in range(2):
+            addDataIdValue(butler, "day_obs", day_obs, instrument=_INSTRUMENT)
+        for visit in range(10):
+            addDataIdValue(butler, "visit", visit, day_obs=visit % 2, instrument=_INSTRUMENT)
+
+
+def _populate_repo(butler: Butler, dimension_version: int) -> None:
+    """Populate the repository with some data."""
+    butler.collections.register("test1")
+    butler.collections.register("test2")
+    butler.collections.register("test3")
+
+    if dimension_version in (1, 2):
+        dataset_type = addDatasetType(butler, "test1", {"instrument", "visit", "detector"}, "int")
+        for data in range(10):
+            butler.put(data, dataset_type, run="test1", instrument=_INSTRUMENT, visit=data, detector=data)
+
+    if dimension_version == 2:
+        dataset_type = addDatasetType(butler, "test2", {"instrument", "visit", "detector", "group"}, "int")
+        for data in range(10):
+            butler.put(
+                data,
+                dataset_type,
+                run="test2",
+                instrument=_INSTRUMENT,
+                visit=data,
+                detector=data,
+                group="ABCD"[data % 4],
+            )
+
+    if dimension_version in (3, 4):
+        dataset_type = addDatasetType(butler, "test3", {"instrument", "visit", "detector"}, "int")
+        for data in range(10):
+            butler.put(
+                data,
+                dataset_type,
+                run="test3",
+                instrument=_INSTRUMENT,
+                visit=data,
+                day_obs=data % 2,
+                detector=data,
+            )
+
+
+class DimensionsVersionsTestCase(unittest.TestCase):
+    """Tests for dimensions version compatibility."""
+
+    def _prep_repo(self, root: str, subdir: str, dimension_version: int, fill: bool = False) -> Butler:
+        butler = _make_butler(os.path.join(root, subdir), dimension_version)
+        self.assertEqual(butler.dimensions.namespace, "test")
+        self.assertEqual(butler.dimensions.version, dimension_version)
+        if fill:
+            _populate_data_ids(butler, dimension_version)
+            _populate_repo(butler, dimension_version)
+        return butler
+
+    def setUp(self) -> None:
+        self.root = makeTestTempDir(TESTDIR)
+
+    def tearDown(self) -> None:
+        removeTestTempDir(self.root)
+
+    def test_v1_v2_transfer(self):
+        # Transfer from v1 to v2 works fine as v2 is a superset of v1.
+        with (
+            closing(self._prep_repo(self.root, "butler1", 1, True)) as butler1,
+            closing(self._prep_repo(self.root, "butler2", 2)) as butler2,
+        ):
+            refs = butler1.query_datasets("test1", collections="test1")
+            self.assertEqual(len(refs), 10)
+            butler2.transfer_from(butler1, refs, register_dataset_types=True, transfer_dimensions=True)
+
+    def test_v1_v2_ingest_zip(self):
+        # Ingest_zip v1 to v2 works fine as v2 is a superset of v1.
+        with (
+            closing(self._prep_repo(self.root, "butler1", 1, True)) as butler1,
+            closing(self._prep_repo(self.root, "butler2", 2)) as butler2,
+        ):
+            refs = butler1.query_datasets("test1", collections="test1", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler1.retrieve_artifacts_zip(refs, os.path.join(self.root, "export"))
+            butler2.ingest_zip(export_path, transfer_dimensions=True)
+
+    def test_v2_v1_transfer(self):
+        # Transfer from v2 to v1 works if using a subset of v2 dimensions.
+        with (
+            closing(self._prep_repo(self.root, "butler1", 1)) as butler1,
+            closing(self._prep_repo(self.root, "butler2", 2, True)) as butler2,
+        ):
+            refs = butler2.query_datasets("test1", collections="test1")
+            self.assertEqual(len(refs), 10)
+            butler1.transfer_from(butler2, refs, register_dataset_types=True, transfer_dimensions=True)
+
+            refs = butler2.query_datasets("test2", collections="test2")
+            self.assertEqual(len(refs), 10)
+            with self.assertRaises(InconsistentUniverseError):
+                butler1.transfer_from(butler2, refs, register_dataset_types=True, transfer_dimensions=True)
+
+    def test_v2_v1_ingest_zip(self):
+        # Ingest_zip from v2 to v1 works if using a subset of v2 dimensions.
+        with (
+            closing(self._prep_repo(self.root, "butler1", 1)) as butler1,
+            closing(self._prep_repo(self.root, "butler2", 2, True)) as butler2,
+        ):
+            refs = butler2.query_datasets("test1", collections="test1", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler2.retrieve_artifacts_zip(refs, os.path.join(self.root, "export"))
+            butler1.ingest_zip(export_path, transfer_dimensions=True)
+
+            refs = butler2.query_datasets("test2", collections="test2", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler2.retrieve_artifacts_zip(refs, os.path.join(self.root, "export2"))
+            with self.assertRaises(InconsistentUniverseError):
+                butler1.ingest_zip(export_path, transfer_dimensions=True)
+
+    def test_v2_v3_transfer(self):
+        # Transfer from v2 to v3 fails because day_obs is required for visit.
+        with (
+            closing(self._prep_repo(self.root, "butler2", 2, True)) as butler2,
+            closing(self._prep_repo(self.root, "butler3", 3)) as butler3,
+        ):
+            refs = butler2.query_datasets("test1", collections="test1")
+            self.assertEqual(len(refs), 10)
+            with self.assertRaises(InconsistentUniverseError):
+                butler3.transfer_from(butler2, refs, register_dataset_types=True, transfer_dimensions=True)
+
+    def test_v2_v3_ingest_zip(self):
+        # Transfer from v2 to v3 fails because day_obs is required for visit.
+        with (
+            closing(self._prep_repo(self.root, "butler2", 2, True)) as butler2,
+            closing(self._prep_repo(self.root, "butler3", 3)) as butler3,
+        ):
+            refs = butler2.query_datasets("test1", collections="test1", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler2.retrieve_artifacts_zip(refs, os.path.join(self.root, "export"))
+            with self.assertRaises(InconsistentUniverseError):
+                butler3.ingest_zip(export_path, transfer_dimensions=True)
+
+    def test_v3_v2_transfer(self):
+        # Transfer from v3 to v2 fails because day_obs is required for visit.
+        with (
+            closing(self._prep_repo(self.root, "butler2", 2)) as butler2,
+            closing(self._prep_repo(self.root, "butler3", 3, True)) as butler3,
+        ):
+            refs = butler3.query_datasets("test3", collections="test3")
+            self.assertEqual(len(refs), 10)
+            with self.assertRaises(InconsistentUniverseError):
+                butler2.transfer_from(butler3, refs, register_dataset_types=True, transfer_dimensions=True)
+
+    def test_v3_v2_ingest_zip(self):
+        # Transfer from v3 to v2 fails because day_obs is required for visit.
+        with (
+            closing(self._prep_repo(self.root, "butler2", 2)) as butler2,
+            closing(self._prep_repo(self.root, "butler3", 3, True)) as butler3,
+        ):
+            refs = butler3.query_datasets("test3", collections="test3", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler3.retrieve_artifacts_zip(refs, os.path.join(self.root, "export"))
+            with self.assertRaises(InconsistentUniverseError):
+                butler2.ingest_zip(export_path, transfer_dimensions=True)
+
+    def test_v3_v4_transfer(self):
+        # Transfer from v3 to v4 works OK.
+        with (
+            closing(self._prep_repo(self.root, "butler3", 3, True)) as butler3,
+            closing(self._prep_repo(self.root, "butler4", 4)) as butler4,
+        ):
+            refs = butler3.query_datasets("test3", collections="test3")
+            self.assertEqual(len(refs), 10)
+            butler4.transfer_from(butler3, refs, register_dataset_types=True, transfer_dimensions=True)
+
+    def test_v3_v4_ingest_zip(self):
+        # Ingest_zip from v3 to v4 fails due to pydantic validation error.
+        with (
+            closing(self._prep_repo(self.root, "butler3", 3, True)) as butler3,
+            closing(self._prep_repo(self.root, "butler4", 4)) as butler4,
+        ):
+            refs = butler3.query_datasets("test3", collections="test3", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler3.retrieve_artifacts_zip(refs, os.path.join(self.root, "export"))
+            with self.assertRaises(ValidationError):
+                butler4.ingest_zip(export_path, transfer_dimensions=True)
+
+    def test_v4_v3_transfer(self):
+        # Transfer from v4 to v3 works OK.
+        with (
+            closing(self._prep_repo(self.root, "butler3", 3)) as butler3,
+            closing(self._prep_repo(self.root, "butler4", 4, True)) as butler4,
+        ):
+            refs = butler4.query_datasets("test3", collections="test3")
+            self.assertEqual(len(refs), 10)
+            butler3.transfer_from(butler4, refs, register_dataset_types=True, transfer_dimensions=True)
+
+    def test_v4_v3_ingest_zip(self):
+        # Ingest_zip from v4 to v3 fails due to pydantic validation error.
+        with (
+            closing(self._prep_repo(self.root, "butler3", 3)) as butler3,
+            closing(self._prep_repo(self.root, "butler4", 4, True)) as butler4,
+        ):
+            refs = butler4.query_datasets("test3", collections="test3", with_dimension_records=True)
+            self.assertEqual(len(refs), 10)
+            export_path = butler4.retrieve_artifacts_zip(refs, os.path.join(self.root, "export"))
+            with self.assertRaises(ValidationError):
+                butler3.ingest_zip(export_path, transfer_dimensions=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A couple of improvements were added:
- In transfer_from() we try to convert DatasetType to a target universe before registering it. If after conversion its dimensions are different it means that dimensions changed in incompatible way and we raise an exception.
- When deserializing DatasetRefs in ingest_zip() we do similar checks and generate a specific exception when things look incompatible.

There is still cases that fail with pydantic ValidationError, e.g. when metadata is different in different universes.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
