### PR TITLE
DM-53032: Add storage class / formatter for ExtendedPsfImage

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -113,4 +113,5 @@ MaskedImageV2: lsst.images.formatters.GenericFormatter
 VisitImage: lsst.images.formatters.GenericFormatter
 ColorImage: lsst.images.formatters.GenericFormatter
 ExtendedPsfCandidates: lsst.images.formatters.GenericFormatter
+ExtendedPsfImage: lsst.images.formatters.GenericFormatter
 CellCoadd: lsst.images.formatters.GenericFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -557,6 +557,10 @@ storageClasses:
     pytype: lsst.pipe.tasks.extended_psf.ExtendedPsfCandidates
     parameters:
       - bbox
+  ExtendedPsfImage:
+    pytype: lsst.pipe.tasks.extended_psf.ExtendedPsfImage
+    parameters:
+      - bbox
   CellCoaddProvenance:
     pytype: lsst.images.cells.CoaddProvenance
   CellCoadd:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
