### PR TITLE
DM-54912: Add photometric_scaling component to VisitImage.

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -527,6 +527,7 @@ storageClasses:
       summary_stats: ObservationSummaryStats
       aperture_corrections: StructuredDataDict
       detector: DetectorV2
+      photometric_scaling: ImageField
     converters:
       lsst.afw.image.Exposure: lsst.images.VisitImage.from_legacy
   ColorImage:
@@ -537,6 +538,8 @@ storageClasses:
       projection: Projection
   ObservationSummaryStats:
     pytype: lsst.images.ObservationSummaryStats
+  ImageField:
+    pytype: lsst.images.fields.BaseField
   ExtendedPsfCandidates:
     pytype: lsst.pipe.tasks.extended_psf.ExtendedPsfCandidates
     parameters:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
