### PR TITLE
DM-54979: Protect against writing : into file templates

### DIFF
--- a/doc/changes/DM-54979.bugfix.rst
+++ b/doc/changes/DM-54979.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed file templates so that characters that may confuse file systems are replaced by underscores.
+For example this include ``:` and ``<``.

--- a/python/lsst/daf/butler/datastore/file_templates.py
+++ b/python/lsst/daf/butler/datastore/file_templates.py
@@ -372,6 +372,11 @@ class FileTemplate:
     """Set of special fields that are available independently of the defined
     Dimensions."""
 
+    _special_fs_chars = str.maketrans({c: "_" for c in ' <>:"\\|?*'})
+    """Characters that can cause trouble if they leak into file names are
+    replaced by '_'.
+    """
+
     def __init__(self, template: str):
         if not isinstance(template, str):
             raise FileTemplateValidationError(
@@ -673,8 +678,9 @@ class FileTemplate:
                 replace_slash = False
 
             if isinstance(value, str):
-                # Replace spaces with underscores for more friendly file paths
-                value = value.replace(" ", "_")
+                # Replace any special characters that can cause difficulties
+                # if they appear in filenames.
+                value = value.translate(self._special_fs_chars)
                 if replace_slash:
                     value = value.replace("/", "_")
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -86,6 +86,7 @@ class TestFileTemplates(unittest.TestCase):
             "visit": 52,
             "physical_filter": "Most Amazing U Filter Ever",
             "day_obs": 20200101,
+            "group": "2025-08-07>08:25:27.100",
         }
 
     def assertTemplate(self, template, answer, ref):
@@ -161,6 +162,13 @@ class TestFileTemplates(unittest.TestCase):
             self.makeDatasetRef("calexp", run="run3", dataId=dataId),
         )
 
+        tmplstr = "{run}/{datasetType}/{group}"
+        self.assertTemplate(
+            tmplstr,
+            "run2/calexp/2025-08-07_08_25_27_100",
+            self.makeDatasetRef("calexp"),
+        )
+
         with self.assertRaises(FileTemplateValidationError):
             FileTemplate("no fields at all")
 
@@ -183,7 +191,7 @@ class TestFileTemplates(unittest.TestCase):
             "run2/calexp/00052/Most_Amazing_U_Filter_Ever_20200101",
             self.makeDatasetRef("calexp"),
         )
-        tmplstr = "{run}/{datasetType}/{exposure|visit:05d}/{physical_filter|day_obs}_{group|exposure:?}"
+        tmplstr = "{run}/{datasetType}/{exposure|visit:05d}/{physical_filter|day_obs}_{tract|exposure:?}"
         self.assertTemplate(
             tmplstr,
             "run2/calexp/00052/Most_Amazing_U_Filter_Ever",


### PR DESCRIPTION
These were turning up in group records. Also add additional special characters that might mess up a file sytem.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
