### PR TITLE
DM-54976: adjust storage class and formatter configurations for lsst.images types

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -99,12 +99,18 @@ VignettingCorrection: lsst.ts.observatory.control.utils.extras.vignetting_storag
 SSPAuxiliaryFile: lsst.pipe.tasks.sspAuxiliaryFile.SSPAuxiliaryFileFormatter
 VisitGeometry: lsst.daf.butler.formatters.json.JsonFormatter
 ProvenanceQuantumGraph: lsst.pipe.base.quantum_graph.formatter.ProvenanceFormatter
-Transform: lsst.images.json.formatters.GenericFormatter
-Projection: lsst.images.json.formatters.GenericFormatter
-ImageV2: lsst.images.fits.formatters.ImageFormatter
-MaskV2: lsst.images.fits.formatters.ImageFormatter
-MaskedImageV2: lsst.images.fits.formatters.MaskedImageFormatter
-VisitImage: lsst.images.fits.formatters.VisitImageFormatter
-ColorImage: lsst.images.fits.formatters.ImageFormatter
-ExtendedPsfCandidates: lsst.images.fits.formatters.GenericFormatter
-CellCoadd: lsst.images.fits.formatters.CellCoaddFormatter
+Transform:
+  formatter: lsst.images.formatters.GenericFormatter
+  parameters:
+    format: json
+Projection:
+  formatter: lsst.images.formatters.GenericFormatter
+  parameters:
+    format: json
+ImageV2: lsst.images.formatters.GenericFormatter
+MaskV2: lsst.images.formatters.GenericFormatter
+MaskedImageV2: lsst.images.formatters.GenericFormatter
+VisitImage: lsst.images.formatters.GenericFormatter
+ColorImage: lsst.images.formatters.GenericFormatter
+ExtendedPsfCandidates: lsst.images.formatters.GenericFormatter
+CellCoadd: lsst.images.formatters.GenericFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -479,7 +479,6 @@ storageClasses:
     derivedComponents:
       projection: Projection
       bbox: BoxV2
-      obs_info: ObservationInfo
     converters:
       lsst.afw.image.Image: lsst.images.Image.from_legacy
   MaskV2:
@@ -489,7 +488,6 @@ storageClasses:
     derivedComponents:
       projection: Projection
       bbox: BoxV2
-      obs_info: ObservationInfo
     converters:
       lsst.afw.image.Mask: lsst.images.Mask.from_legacy
   MaskedImageV2:
@@ -502,7 +500,6 @@ storageClasses:
       image: ImageV2
       mask: MaskV2
       variance: ImageV2
-      obs_info: ObservationInfo
     converters:
       lsst.afw.image.MaskedImage: lsst.images.MaskedImage.from_legacy
   PointSpreadFunction:
@@ -524,6 +521,7 @@ storageClasses:
     pytype: lsst.images.VisitImage
     derivedComponents:
       psf: PointSpreadFunction
+      obs_info: ObservationInfo
       summary_stats: ObservationSummaryStats
       aperture_corrections: StructuredDataDict
       detector: DetectorV2


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
