### PR TITLE
Test larger batches with more efficient queries for datastore export

### DIFF
--- a/python/lsst/daf/butler/datastores/fileDatastore.py
+++ b/python/lsst/daf/butler/datastores/fileDatastore.py
@@ -546,12 +546,11 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
                         records_by_ref[ref.id].append(ref_record)
 
         # If there were any refs without datastore records, check opaque table.
-        records = self._table.fetch(dataset_id=[ref.id for ref in refs_with_no_records])
-
         # Uniqueness is dataset_id + component so can have multiple records
         # per ref.
-        for record in records:
-            records_by_ref[record["dataset_id"]].append(StoredFileInfo.from_record(record))
+        for batch in self._table.fetch_by_dataset_ids([ref.id for ref in refs_with_no_records]):
+            for record in batch:
+                records_by_ref[record["dataset_id"]].append(StoredFileInfo.from_record(record))
         return records_by_ref
 
     def _refs_associated_with_artifacts(
@@ -3215,7 +3214,7 @@ class FileDatastore(GenericBaseDatastore[StoredFileInfo]):
         # this zombie state indefinitely, until someone manually empties
         # the trash.
         found_ids = self._bridge.check(datasets)
-        return self._table.fetch_batches(dataset_id=found_ids)
+        return self._table.fetch_by_dataset_ids(found_ids)
 
     def export_table(self, datasets: Collection[DatasetId]) -> DatastoreRecordTable:
         # Docstring inherited from the base class.

--- a/python/lsst/daf/butler/registry/bridge/monolithic.py
+++ b/python/lsst/daf/butler/registry/bridge/monolithic.py
@@ -223,7 +223,9 @@ class MonolithicDatastoreRegistryBridge(DatastoreRegistryBridge):
                     .where(
                         sqlalchemy.sql.and_(
                             self._tables.dataset_location.columns.datastore_name == self.datastoreName,
-                            self._tables.dataset_location.columns.dataset_id.in_(batch),
+                            self._db.make_in_array_constraint(
+                                self._tables.dataset_location.columns.dataset_id, batch
+                            ),
                         )
                     )
                 )

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -467,8 +467,9 @@ class PostgresqlDatabase(Database):
     def make_in_array_constraint(
         self, column: sqlalchemy.ColumnElement[_T], values: Iterable[_T]
     ) -> sqlalchemy.ColumnElement[bool]:
+        array_type = sqlalchemy.dialects.postgresql.ARRAY(column.type)
         return column == sqlalchemy.any_(
-            sqlalchemy.cast(values, sqlalchemy.dialects.postgresql.ARRAY(column.type))
+            sqlalchemy.cast(sqlalchemy.bindparam(key=None, value=values, type_=array_type), array_type)
         )
 
 

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -35,7 +35,7 @@ __all__ = ["PostgresqlDatabase"]
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import closing, contextmanager
-from typing import Any
+from typing import Any, TypeVar
 
 import psycopg2
 import sqlalchemy
@@ -46,6 +46,8 @@ from ..._named import NamedValueAbstractSet
 from ..._timespan import Timespan
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from ..interfaces import Database, DatabaseMetadata
+
+_T = TypeVar("_T")
 
 
 class PostgresqlDatabase(Database):
@@ -461,6 +463,13 @@ class PostgresqlDatabase(Database):
 
         pattern = _escape(pattern)
         return expression.op("LIKE")(sqlalchemy.literal(pattern))
+
+    def make_in_array_constraint(
+        self, column: sqlalchemy.ColumnElement[_T], values: Iterable[_T]
+    ) -> sqlalchemy.ColumnElement[bool]:
+        return column == sqlalchemy.any_(
+            sqlalchemy.cast(values, sqlalchemy.dialects.postgresql.ARRAY(column.type))
+        )
 
 
 class _RangeTimespanType(sqlalchemy.TypeDecorator):

--- a/python/lsst/daf/butler/registry/databases/postgresql.py
+++ b/python/lsst/daf/butler/registry/databases/postgresql.py
@@ -469,7 +469,7 @@ class PostgresqlDatabase(Database):
     ) -> sqlalchemy.ColumnElement[bool]:
         array_type = sqlalchemy.dialects.postgresql.ARRAY(column.type)
         return column == sqlalchemy.any_(
-            sqlalchemy.cast(sqlalchemy.bindparam(key=None, value=values, type_=array_type), array_type)
+            sqlalchemy.cast(sqlalchemy.literal(list(values), array_type), array_type)
         )
 
 

--- a/python/lsst/daf/butler/registry/interfaces/_database.py
+++ b/python/lsst/daf/butler/registry/interfaces/_database.py
@@ -48,7 +48,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from threading import Lock
-from typing import Any, cast, final
+from typing import Any, TypeVar, cast, final
 
 import astropy.time
 import sqlalchemy
@@ -58,6 +58,8 @@ from ...name_shrinker import NameShrinker
 from ...timespan_database_representation import TimespanDatabaseRepresentation
 from .._exceptions import ConflictingDefinitionError
 from ._database_explain import get_query_plan
+
+_T = TypeVar("_T")
 
 
 class DatabaseInsertMode(enum.Enum):
@@ -2007,6 +2009,11 @@ class Database(ABC):
         `False`; the caller is responsible for checking that property first.
         """
         raise NotImplementedError()
+
+    def make_in_array_constraint(
+        self, column: sqlalchemy.ColumnElement[_T], values: Iterable[_T]
+    ) -> sqlalchemy.ColumnElement[bool]:
+        return column.in_(values)
 
     origin: int
     """An integer ID that should be used as the default for any datasets,

--- a/python/lsst/daf/butler/registry/interfaces/_opaque.py
+++ b/python/lsst/daf/butler/registry/interfaces/_opaque.py
@@ -36,6 +36,7 @@ __all__ = ["OpaqueTableStorage", "OpaqueTableStorageManager"]
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
+from uuid import UUID
 
 from ...ddl import TableSpec
 from ._database import Database, StaticTablesContext
@@ -130,16 +131,14 @@ class OpaqueTableStorage(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def fetch_batches(
-        self,
-        **where: Any,
-    ) -> Iterator[Sequence[Mapping]]:
-        """Retrieve records from an opaque table in batches.
+    def fetch_by_dataset_ids(self, dataset_ids: Iterable[UUID]) -> Iterator[Sequence[Mapping]]:
+        """Retrieve records from an opaque table based on lists of dataset
+        UUIDs.
 
         Parameters
         ----------
-        **where
-            Same as ``OpaqueTableStorage.fetch``.
+        dataset_ids
+            List of dataset IDs for which we will retrieve records.
 
         Yields
         ------

--- a/python/lsst/daf/butler/registry/opaque.py
+++ b/python/lsst/daf/butler/registry/opaque.py
@@ -39,6 +39,9 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import sqlalchemy
 
+from lsst.utils.iteration import chunk_iterable
+
+from .._dataset_ref import DatasetId
 from .._utilities.thread_safe_cache import ThreadSafeCache
 from ..ddl import FieldSpec, TableSpec
 from .interfaces import (
@@ -102,14 +105,6 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
         self,
         **where: Any,
     ) -> Iterator[sqlalchemy.RowMapping]:
-        # Docstring inherited from OpaqueTableStorage.
-        for batch in self.fetch_batches(**where):
-            yield from batch
-
-    def fetch_batches(
-        self,
-        **where: Any,
-    ) -> Iterator[Sequence[sqlalchemy.RowMapping]]:
         def _batch_in_clause(
             column: sqlalchemy.schema.Column, values: Iterable[Any]
         ) -> Iterator[sqlalchemy.sql.expression.ClauseElement]:
@@ -150,6 +145,19 @@ class ByNameOpaqueTableStorage(OpaqueTableStorage):
             batched_sql = [sql]
         for sql_batch in batched_sql:
             with self._db.query(sql_batch) as sql_result:
+                sql_mappings = sql_result.mappings().fetchall()
+            yield from sql_mappings
+
+    def fetch_by_dataset_ids(
+        self, dataset_ids: Iterable[DatasetId]
+    ) -> Iterator[Sequence[sqlalchemy.RowMapping]]:
+        batch_size = 50_000
+        sorted_uniques = sorted(set(dataset_ids))
+        for batch in chunk_iterable(sorted_uniques, batch_size):
+            sql = self._table.select().where(
+                self._db.make_in_array_constraint(self._table.c["dataset_id"], batch)
+            )
+            with self._db.query(sql) as sql_result:
                 sql_mappings = sql_result.mappings().fetchall()
             yield sql_mappings
 

--- a/python/lsst/daf/butler/tests/_dummyRegistry.py
+++ b/python/lsst/daf/butler/tests/_dummyRegistry.py
@@ -30,6 +30,7 @@ __all__ = ("DummyRegistry",)
 
 from collections.abc import Iterable, Iterator
 from typing import Any
+from uuid import UUID
 
 from lsst.daf.butler import DimensionUniverse, ddl
 from lsst.daf.butler.registry.bridge.ephemeral import EphemeralDatastoreRegistryBridge
@@ -125,9 +126,9 @@ class DummyOpaqueTableStorage(OpaqueTableStorage):
                 else:
                     yield d
 
-    def fetch_batches(self, **where: Any) -> Iterator[list[dict]]:
+    def fetch_by_dataset_ids(self, dataset_ids: Iterable[UUID]) -> Iterator[list[dict]]:
         # Docstring inherited from OpaqueTableStorage.
-        yield list(self.fetch(**where))
+        yield list(self.fetch(dataset_id=list(dataset_ids)))
 
     def delete(self, columns: Iterable[str], *rows: dict) -> None:
         # Docstring inherited from OpaqueTableStorage.


### PR DESCRIPTION
This reduces export time for `butler_transform` by about 30-40%, but only when using `psycopg3`.  We're still on `psycopg2`, though `psycopg3` will become the default in the next version of sqlalchemy.  

`psycopg2` never uses bind parameters, so it still generates a large new query for each execution.  With `psycopg3` it uses a single bind parameter for the list of dataset IDs, and it is able to cache and re-use the query, and use a more efficient binary encoding for sending the UUIDs.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
