### PR TITLE
Avoid passing pre-formatted strings to time_this (DM-54999)

### DIFF
--- a/python/lsst/daf/butler/_butler_metrics.py
+++ b/python/lsst/daf/butler/_butler_metrics.py
@@ -29,9 +29,9 @@ from __future__ import annotations
 
 __all__ = ["ButlerMetrics"]
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
-from typing import Concatenate, ParamSpec
+from typing import Any, Concatenate, ParamSpec
 
 from pydantic import BaseModel
 
@@ -112,15 +112,21 @@ class ButlerMetrics(BaseModel):
         handler: Callable[Concatenate[float, P], None],
         log: LsstLoggers | None = None,
         msg: str | None = None,
+        log_args: Iterable[Any] = (),
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> Iterator[None]:
-        with time_this(log=log, msg=msg) as timer:
+        with time_this(log=log, msg=msg, args=log_args) as timer:
             yield
         handler(timer.duration, *args, **kwargs)
 
     @contextmanager
-    def instrument_get(self, log: LsstLoggers | None = None, msg: str | None = None) -> Iterator[None]:
+    def instrument_get(
+        self,
+        log: LsstLoggers | None = None,
+        msg: str | None = None,
+        args: Iterable[Any] = (),
+    ) -> Iterator[None]:
         """Run code and increment get statistics.
 
         Parameters
@@ -129,12 +135,20 @@ class ButlerMetrics(BaseModel):
             Logger to use for any timing information.
         msg : `str` or `None`
             Any message to be included in log output.
+        args : `~collections.abc.Iterable` [`Any`]
+            Additional parameters passed to the log command that should be
+            written to ``msg``.
         """
         with self._timer(self.increment_get, log=log, msg=msg):
             yield
 
     @contextmanager
-    def instrument_put(self, log: LsstLoggers | None = None, msg: str | None = None) -> Iterator[None]:
+    def instrument_put(
+        self,
+        log: LsstLoggers | None = None,
+        msg: str | None = None,
+        args: Iterable[Any] = (),
+    ) -> Iterator[None]:
         """Run code and increment put statistics.
 
         Parameters
@@ -143,13 +157,20 @@ class ButlerMetrics(BaseModel):
             Logger to use for any timing information.
         msg : `str` or `None`
             Any message to be included in log output.
+        args : `~collections.abc.Iterable` [`Any`]
+            Additional parameters passed to the log command that should be
+            written to ``msg``.
         """
         with self._timer(self.increment_put, log=log, msg=msg):
             yield
 
     @contextmanager
     def instrument_ingest(
-        self, n_datasets: int, log: LsstLoggers | None = None, msg: str | None = None
+        self,
+        n_datasets: int,
+        log: LsstLoggers | None = None,
+        msg: str | None = None,
+        args: Iterable[Any] = (),
     ) -> Iterator[None]:
         """Run code and increment ingest statistics.
 
@@ -161,6 +182,9 @@ class ButlerMetrics(BaseModel):
             Logger to use for any timing information.
         msg : `str` or `None`
             Any message to be included in log output.
+        args : `~collections.abc.Iterable` [`Any`]
+            Additional parameters passed to the log command that should be
+            written to ``msg``.
         """
-        with self._timer(self.increment_ingest, n_datasets=n_datasets, log=log, msg=msg):
+        with self._timer(self.increment_ingest, n_datasets=n_datasets, log=log, msg=msg, log_args=args):
             yield

--- a/python/lsst/daf/butler/cli/utils.py
+++ b/python/lsst/daf/butler/cli/utils.py
@@ -70,7 +70,7 @@ from collections import Counter
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import click
@@ -900,7 +900,8 @@ class MWOptionDecorator:
         """Get the name that will be passed to the command function for this
         option.
         """
-        return cast(str, self._name)
+        assert self._name is not None, "keep mypy happy"
+        return self._name
 
     def opts(self) -> list[str]:
         """Get the flags that will be used for this option on the command
@@ -1003,7 +1004,8 @@ class MWCommand(click.Command):
         captured_args = []
         for param in param_order:
             if isinstance(param, click.Option):
-                param_name = cast(str, param.name)
+                param_name = param.name
+                assert param_name is not None, "keep mypy happy"
                 if param.multiple:
                     val = opts[param_name][next_idx[param_name]]
                     next_idx[param_name] += 1
@@ -1021,7 +1023,8 @@ class MWCommand(click.Command):
                     captured_args.append(max(param.opts, key=len))
                     captured_args.append(val)
             elif isinstance(param, click.Argument):
-                param_name = cast(str, param.name)
+                param_name = param.name
+                assert param_name is not None, "keep mypy happy"
                 opt = opts[param_name]
                 if opt is not None and opt != _CLICK_UNSET_SENTINEL:
                     captured_args.append(opt)
@@ -1197,7 +1200,8 @@ def yaml_presets(ctx: click.Context, param: str, value: Any) -> None:
             # Remove leading dashes: they are not used for option names in the
             # yaml file.
             if option in [opt.lstrip("-") for opt in param.opts]:
-                return cast(str, param.name)
+                assert param.name is not None, "keep mypy happy"
+                return param.name
         raise RuntimeError(f"'{option}' is not a valid option for {ctx.info_name}")
 
     ctx.default_map = ctx.default_map or {}

--- a/python/lsst/daf/butler/direct_butler/_direct_butler.py
+++ b/python/lsst/daf/butler/direct_butler/_direct_butler.py
@@ -1741,7 +1741,10 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         with (
             self._metrics.instrument_ingest(
-                n_datasets, _LOG, msg=f"Ingesting zip file {zip_file} with {n_datasets} dataset{srefs}"
+                n_datasets,
+                _LOG,
+                msg="Ingesting zip file %s with %s dataset%s",
+                args=(zip_file, n_datasets, srefs),
             ),
             self.transaction(),
         ):
@@ -1860,7 +1863,10 @@ class DirectButler(Butler):  # numpydoc ignore=PR02
 
         with (
             self._metrics.instrument_ingest(
-                n_datasets, _LOG, msg=f"Ingesting {n_files} file{sfiles} with {n_datasets} dataset{srefs}"
+                n_datasets,
+                _LOG,
+                msg="Ingesting %s file%s with %s dataset%s",
+                args=(n_files, sfiles, n_datasets, srefs),
             ),
             self.transaction(),
         ):


### PR DESCRIPTION
That methods expects message string to be a format string for `logging.log`. When we pre-format that message it could end up with a percent sign in it with causes exceptions in `logging`.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
