### PR TITLE
DM-55036: storage class improvements for VisitImage and DifferenceImage

### DIFF
--- a/python/lsst/daf/butler/configs/datastores/formatters.yaml
+++ b/python/lsst/daf/butler/configs/datastores/formatters.yaml
@@ -111,6 +111,7 @@ ImageV2: lsst.images.formatters.GenericFormatter
 MaskV2: lsst.images.formatters.GenericFormatter
 MaskedImageV2: lsst.images.formatters.GenericFormatter
 VisitImage: lsst.images.formatters.GenericFormatter
+DifferenceImage: lsst.images.formatters.GenericFormatter
 ColorImage: lsst.images.formatters.GenericFormatter
 ExtendedPsfCandidates: lsst.images.formatters.GenericFormatter
 ExtendedPsfImage: lsst.images.formatters.GenericFormatter

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -479,7 +479,7 @@ storageClasses:
       # This converter function doesn't actually work, because it takes an
       # extra argument.  But we need to declare it anyway to give the
       # legacy formatter an opportunity to do the conversion on read.
-      lsst.afw.image.SkyWcs: lsst.images.Projection.from_legacy
+      lsst.afw.geom.SkyWcs: lsst.images.Projection.from_legacy
   ObservationInfo:
     pytype: astro_metadata_translator.ObservationInfo
     converters:

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -11,6 +11,8 @@ storageClasses:
     pytype: lsst.afw.table.io.Persistable
   Wcs:
     pytype: lsst.afw.geom.skyWcs.SkyWcs
+    converters:
+      lsst.images.Projection: lsst.images.Projection.to_legacy
   Psf:
     pytype: lsst.afw.detection.Psf
   CoaddInputs:
@@ -42,6 +44,8 @@ storageClasses:
       lsst.images.cameras.Detector: lsst.images.cameras.Detector.to_legacy
   Box2I:
     pytype: lsst.geom.Box2I
+    converters:
+      lsst.images.Box: lsst.images.Box.to_legacy
   Extent2I:
     pytype: lsst.geom.Extent2I
   Point2I:

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -342,6 +342,9 @@ storageClasses:
       dimensions: Extent2I
       xy0: Point2I
     converters:
+      # Order matters here: DifferenceImage is a subclass of VisitImage, so it
+      # needs to be tried first.
+      lsst.images.DifferenceImage: lsst.images.DifferenceImage.to_legacy
       lsst.images.VisitImage: lsst.images.VisitImage.to_legacy
   ExposureF:
     inheritsFrom: Exposure
@@ -545,6 +548,11 @@ storageClasses:
       backgrounds: BackgroundMap
     converters:
       lsst.afw.image.Exposure: lsst.images.VisitImage.from_legacy
+  DifferenceImage:
+    inheritsFrom: VisitImage
+    pytype: lsst.images.DifferenceImage
+    converters:
+      lsst.afw.image.Exposure: lsst.images.DifferenceImage.from_legacy
   ColorImage:
     pytype: lsst.images.ColorImage
     parameters:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
