### PR TITLE
DM-55210: Add MaskedImage derived component to VisitImage and CellCoadd

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -549,6 +549,7 @@ storageClasses:
       detector: DetectorV2
       photometric_scaling: ImageField
       backgrounds: BackgroundMap
+      masked_image: MaskedImageV2
     converters:
       lsst.afw.image.Exposure: lsst.images.VisitImage.from_legacy
   DifferenceImage:
@@ -586,6 +587,7 @@ storageClasses:
       aperture_corrections: StructuredDataDict
       provenance: CellCoaddProvenance
       backgrounds: BackgroundMap
+      masked_image: MaskedImageV2
     converters:
       # This converter function doesn't actually work, because it takes an
       # extra argument.  But we need to declare it anyway to give the

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -516,12 +516,14 @@ storageClasses:
     pytype: lsst.images.MaskedImage
     parameters:
       - bbox
+      - components
     derivedComponents:
       sky_projection: SkyProjection
       bbox: BoxV2
       image: ImageV2
       mask: MaskV2
       variance: ImageV2
+      components: StructuredDataDict
     converters:
       lsst.afw.image.MaskedImage: lsst.images.MaskedImage.from_legacy
   PointSpreadFunction:

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -533,6 +533,11 @@ storageClasses:
       # extra argument.  But we need to declare it anyway to give the
       # legacy formatter an opportunity to do the conversion on read.
       lsst.afw.detection.Psf: lsst.images.psfs.PointSpreadFunction.from_legacy
+  CellPointSpreadFunction:
+    inheritsFrom: PointSpreadFunction
+    pytype: lsst.images.cells.CellPointSpreadFunction
+    parameters:
+      - bbox
   DetectorV2:
     pytype: lsst.images.cameras.Detector
     converters:
@@ -585,7 +590,7 @@ storageClasses:
     inheritsFrom: MaskedImageV2
     pytype: lsst.images.cells.CellCoadd
     derivedComponents:
-      psf: PointSpreadFunction
+      psf: CellPointSpreadFunction
       aperture_corrections: StructuredDataDict
       provenance: CellCoaddProvenance
       backgrounds: BackgroundMap


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
