### PR TITLE
Remove the ScarletModelData to LsstScarletModelData converter (DM-55150)

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -431,8 +431,6 @@ storageClasses:
     delegate: lsst.meas.extensions.scarlet.io.ScarletModelDelegate
   LsstScarletModelData:
     pytype: lsst.meas.extensions.scarlet.io.LsstScarletModelData
-    converters:
-      lsst.scarlet.lite.io.model_data.ScarletModelData: lsst.meas.extensions.scarlet.io.utils.scarlet_model_to_lsst_scarlet_model
     parameters:
       - blend_id
     delegate: lsst.meas.extensions.scarlet.io.ScarletModelDelegate

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -439,8 +439,6 @@ storageClasses:
       lsst.meas.extensions.scarlet.io.LsstScarletModelData: lsst.meas.extensions.scarlet.io.LsstScarletModelData.to_scarlet_model_data
   LsstScarletModelData:
     pytype: lsst.meas.extensions.scarlet.io.LsstScarletModelData
-    converters:
-      lsst.scarlet.lite.io.model_data.ScarletModelData: lsst.meas.extensions.scarlet.io.utils.scarlet_model_to_lsst_scarlet_model
     parameters:
       - blend_id
     delegate: lsst.meas.extensions.scarlet.io.ScarletModelDelegate


### PR DESCRIPTION
A base ScarletModelData cannot be promoted to an LsstScarletModelData: the latter requires a single catalog-wide observed PSF and band list, while a ScarletModelData carries them per blend. The conversion never produced a usable model in the science pipelines, so drop the storage-class `converters` entry (and the now-removed `scarlet_model_to_lsst_scarlet_model` it referenced, deleted in a companion commit on this ticket).

Old ScarletModelData datasets continue to load at their own storage class.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
