### PR TITLE
DM-55220: add difference kernel and template provenance components to DifferenceImage

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -562,11 +562,15 @@ storageClasses:
       masked_image: MaskedImageV2
     converters:
       lsst.afw.image.Exposure: lsst.images.VisitImage.from_legacy
+  ConvolutionKernel:
+    pytype: lsst.images.convolution_kernels.ConvolutionKernel
   DifferenceImage:
     inheritsFrom: VisitImage
     pytype: lsst.images.DifferenceImage
     converters:
       lsst.afw.image.Exposure: lsst.images.DifferenceImage.from_legacy
+    derivedComponents:
+      kernel: ConvolutionKernel
   ColorImage:
     pytype: lsst.images.ColorImage
     parameters:

--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -571,6 +571,7 @@ storageClasses:
       lsst.afw.image.Exposure: lsst.images.DifferenceImage.from_legacy
     derivedComponents:
       kernel: ConvolutionKernel
+      templates: StructuredDataList
   ColorImage:
     pytype: lsst.images.ColorImage
     parameters:


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
