### PR TITLE
DM-55500: Do not send component names to server with butler get

### DIFF
--- a/doc/changes/DM-55497.bugfix.md
+++ b/doc/changes/DM-55497.bugfix.md
@@ -1,4 +1,4 @@
 Fixed `RemoteButler` so that component dataset access no longer requires the Butler server to know the parent dataset type's storage class.
-`RemoteButler` now sends only the parent dataset type name to the server for `get()`, `getDeferred()`, and `find_dataset()`, re-applying the component on the client side.
+`RemoteButler` now sends only the parent dataset type name to the server for `get()`, `getDeferred()`, `find_dataset()`, and `get_dataset_type()`, re-applying the component on the client side.
 Previously `butler.get("deep_coadd.sky_projection", dataId=...)` failed with a server error if the storage class was defined by a science pipelines package not installed on the server, even though the equivalent `butler.get(ref.makeComponentRef("sky_projection"))` worked.
 Additionally, `getDeferred()` called with a component `DatasetRef` now correctly returns the component instead of the composite dataset.

--- a/doc/changes/DM-55497.bugfix.md
+++ b/doc/changes/DM-55497.bugfix.md
@@ -1,0 +1,4 @@
+Fixed `RemoteButler` so that component dataset access no longer requires the Butler server to know the parent dataset type's storage class.
+`RemoteButler` now sends only the parent dataset type name to the server for `get()`, `getDeferred()`, and `find_dataset()`, re-applying the component on the client side.
+Previously `butler.get("deep_coadd.sky_projection", dataId=...)` failed with a server error if the storage class was defined by a science pipelines package not installed on the server, even though the equivalent `butler.get(ref.makeComponentRef("sky_projection"))` worked.
+Additionally, `getDeferred()` called with a component `DatasetRef` now correctly returns the component instead of the composite dataset.

--- a/python/lsst/daf/butler/remote_butler/_ref_utils.py
+++ b/python/lsst/daf/butler/remote_butler/_ref_utils.py
@@ -29,8 +29,10 @@ from __future__ import annotations
 
 __all__ = (
     "apply_storage_class_override",
+    "get_component_override",
     "normalize_dataset_type_name",
     "simplify_dataId",
+    "split_dataset_type_name",
 )
 
 from pydantic import TypeAdapter
@@ -86,6 +88,51 @@ def normalize_dataset_type_name(datasetTypeOrName: DatasetType | str) -> Dataset
         parameter in many `Butler` methods.
     """
     return DatasetTypeName(get_dataset_type_name(datasetTypeOrName))
+
+
+def split_dataset_type_name(
+    datasetTypeOrName: DatasetType | str,
+) -> tuple[DatasetTypeName, str | None]:
+    """Split a dataset type parameter into a parent dataset type name and an
+    optional component name.
+
+    Component dataset type names must never be sent to the server -- the
+    server cannot construct a component `DatasetType` unless it has the
+    parent's storage class definition available, and storage classes are
+    often defined by science pipelines packages that are only installed on
+    the client.  Callers should request the parent dataset type from the
+    server and re-apply the component on the client side.
+
+    Parameters
+    ----------
+    datasetTypeOrName : `DatasetType` | `str`
+        A DatasetType, or the name of a DatasetType.
+
+    Returns
+    -------
+    parent_name : `DatasetTypeName`
+        Name of the parent dataset type, suitable for sending to the server.
+    component : `str` | `None`
+        Component name, or `None` if this is not a component dataset type.
+    """
+    parent_name, component = DatasetType.splitDatasetTypeName(get_dataset_type_name(datasetTypeOrName))
+    return DatasetTypeName(parent_name), component
+
+
+def get_component_override(datasetRefOrType: DatasetRef | DatasetType | str) -> str | None:
+    """Return the component name from a ref or dataset type provided by the
+    user, or `None` if it does not refer to a component.
+
+    Parameters
+    ----------
+    datasetRefOrType : `DatasetRef` | `DatasetType` | `str`
+        A DatasetRef, DatasetType, or name of a DatasetType.  This union is a
+        common parameter in many `Butler` methods.
+    """
+    if isinstance(datasetRefOrType, DatasetRef):
+        return datasetRefOrType.datasetType.component()
+    _, component = split_dataset_type_name(datasetRefOrType)
+    return component
 
 
 def simplify_dataId(dataId: DataId | None, kwargs: dict[str, DataIdValue]) -> SerializedDataId:

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -405,9 +405,16 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             if (cached_value := cache.dataset_types.get(name)) is not None:
                 return cached_value
 
-        response = self._connection.get(f"dataset_type/{quote_path_variable(name)}")
+        # Only the parent dataset type name is sent to the server -- it may
+        # not have the storage class definitions needed to construct a
+        # component DatasetType, so the component dataset type is constructed
+        # here from the parent definition.
+        parent_name, component = split_dataset_type_name(name)
+        response = self._connection.get(f"dataset_type/{quote_path_variable(parent_name)}")
         model = parse_model(response, GetDatasetTypeResponseModel)
         value = DatasetType.from_simple(model.dataset_type, universe=self.dimensions)
+        if component is not None:
+            value = value.makeComponentDatasetType(component)
         with self._cache.access() as cache:
             return cache.dataset_types.setdefault(name, value)
 

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -72,7 +72,13 @@ from ._get import convert_http_url_to_resource_path, get_dataset_as_python_objec
 from ._http_connection import RemoteButlerHttpConnection, parse_model, quote_path_variable
 from ._query_driver import RemoteQueryDriver
 from ._query_results import convert_dataset_ref_results, read_query_results
-from ._ref_utils import apply_storage_class_override, normalize_dataset_type_name, simplify_dataId
+from ._ref_utils import (
+    apply_storage_class_override,
+    get_component_override,
+    normalize_dataset_type_name,
+    simplify_dataId,
+    split_dataset_type_name,
+)
 from ._registry import RemoteButlerRegistry
 from ._remote_butler_collections import RemoteButlerCollections
 from ._remote_file_transfer_source import RemoteFileTransferSource
@@ -263,7 +269,19 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         response = self._get_file_info(datasetRefOrType, dataId, collections, timespan, kwargs)
         # Check that artifact information is available.
         _to_file_payload(response)
-        ref = DatasetRef.from_simple(response.dataset_ref, universe=self.dimensions)
+        if isinstance(datasetRefOrType, DatasetRef):
+            # Use the ref provided by the caller, which may include component
+            # or storage class overrides that are not known to the server.
+            ref = datasetRefOrType
+        else:
+            ref = DatasetRef.from_simple(response.dataset_ref, universe=self.dimensions)
+            # The server returns the parent dataset type -- component dataset
+            # types are never sent to the server, because it may not have the
+            # storage class definitions needed to construct them.  Re-apply
+            # any component here.
+            component = get_component_override(datasetRefOrType)
+            if component is not None:
+                ref = ref.makeComponentRef(component)
         return DeferredDatasetHandle(butler=self, ref=ref, parameters=parameters, storageClass=storageClass)
 
     def get(
@@ -283,13 +301,13 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
             model = self._get_file_info(datasetRefOrType, dataId, collections, timespan, kwargs)
 
             ref = DatasetRef.from_simple(model.dataset_ref, universe=self.dimensions)
-            # If the caller provided a DatasetRef, they may have overridden the
-            # component on it.  We need to explicitly handle this because we
-            # did not send the DatasetType to the server in this case.
-            if isinstance(datasetRefOrType, DatasetRef):
-                componentOverride = datasetRefOrType.datasetType.component()
-                if componentOverride:
-                    ref = ref.makeComponentRef(componentOverride)
+            # The server returns the parent dataset type -- component dataset
+            # types are never sent to the server, because it may not have the
+            # storage class definitions needed to construct them.  Re-apply
+            # any component here.
+            componentOverride = get_component_override(datasetRefOrType)
+            if componentOverride is not None:
+                ref = ref.makeComponentRef(componentOverride)
             ref = apply_storage_class_override(ref, datasetRefOrType, storageClass)
 
             return self._get_dataset_as_python_object(ref, model, parameters)
@@ -326,8 +344,13 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
                 raise ValueError("DatasetRef given, cannot use dataId as well")
             return self._get_file_info_for_ref(datasetRefOrType)
         else:
+            # Only the parent dataset type is sent to the server -- it may
+            # not have the storage class definitions needed to construct a
+            # component DatasetType.  Callers are responsible for re-applying
+            # any component to the returned ref.
+            dataset_type_name, _ = split_dataset_type_name(datasetRefOrType)
             request = GetFileByDataIdRequestModel(
-                dataset_type=normalize_dataset_type_name(datasetRefOrType),
+                dataset_type=dataset_type_name,
                 collections=self._normalize_collections(collections),
                 data_id=simplify_dataId(dataId, kwargs),
                 default_data_id=self._serialize_default_data_id(),
@@ -433,8 +456,12 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         # datastore_records is intentionally ignored.  It is an optimization
         # flag that only applies to DirectButler.
 
+        # Only the parent dataset type is sent to the server -- it may not
+        # have the storage class definitions needed to construct a component
+        # DatasetType.  The component is re-applied to the returned ref below.
+        dataset_type_name, component = split_dataset_type_name(dataset_type)
         query = FindDatasetRequestModel(
-            dataset_type=normalize_dataset_type_name(dataset_type),
+            dataset_type=dataset_type_name,
             data_id=simplify_dataId(data_id, kwargs),
             default_data_id=self._serialize_default_data_id(),
             collections=self._normalize_collections(collections),
@@ -451,6 +478,8 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         ref = DatasetRef.from_simple(model.dataset_ref, universe=self.dimensions)
         if isinstance(data_id, DataCoordinate) and data_id.hasRecords():
             ref = ref.expanded(data_id)
+        if component is not None:
+            ref = ref.makeComponentRef(component)
         return apply_storage_class_override(ref, dataset_type, storage_class)
 
     def _retrieve_artifacts(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -338,6 +338,63 @@ class ButlerClientServerTestCase(unittest.TestCase):
         )
         self.assertEqual(dataset_type_component_data, MetricTestRepo.METRICS_EXAMPLE_SUMMARY)
 
+    def test_component_access_without_server_storage_class(self):
+        """Test that component dataset access via dataset type name does not
+        require the server to know the parent's storage class.
+
+        Storage classes for many dataset types are defined by science
+        pipelines packages that are only installed on the client, so all
+        component handling must occur on the client.
+        """
+        dataset_type = "test_metric_comp"
+        component_type = "test_metric_comp.summary"
+        data_id = {"instrument": "DummyCamComp", "visit": 423}
+        collections = "ingest/run"
+        parent_ref = self.butler.find_dataset(dataset_type, data_id, collections=collections)
+        component_ref = parent_ref.makeComponentRef("summary")
+
+        # Track the dataset type names sent to the server.  Component names
+        # must never be sent, because converting a component dataset type
+        # name to a DatasetType requires the server to instantiate the
+        # parent's storage class.
+        sent_dataset_types: list[str] = []
+        original_post = self.butler._connection.post
+
+        def tracking_post(path, model):
+            dataset_type_name = getattr(model, "dataset_type", None)
+            if dataset_type_name is not None:
+                sent_dataset_types.append(dataset_type_name)
+            return original_post(path, model)
+
+        with patch.object(self.butler._connection, "post", side_effect=tracking_post):
+            # get() with a component dataset type name.
+            data = self.butler.get(component_type, dataId=data_id, collections=collections)
+            self.assertEqual(data, MetricTestRepo.METRICS_EXAMPLE_SUMMARY)
+
+            # find_dataset() with a component dataset type name.
+            found = self.butler.find_dataset(component_type, data_id, collections=collections)
+            self.assertEqual(found, component_ref)
+            self.assertEqual(found.datasetType, component_ref.datasetType)
+
+            # getDeferred() with a component dataset type name.
+            deferred_data = self.butler.getDeferred(component_type, data_id, collections=collections).get()
+            self.assertEqual(deferred_data, MetricTestRepo.METRICS_EXAMPLE_SUMMARY)
+
+            # getDeferred() with a component DatasetRef.
+            deferred_ref_data = self.butler.getDeferred(component_ref).get()
+            self.assertEqual(deferred_ref_data, MetricTestRepo.METRICS_EXAMPLE_SUMMARY)
+
+            # An empty component name raises rather than silently returning
+            # the composite.
+            with self.assertRaises(KeyError):
+                self.butler.get(f"{dataset_type}.", dataId=data_id, collections=collections)
+            with self.assertRaises(KeyError):
+                self.butler.getDeferred(f"{dataset_type}.", data_id, collections=collections)
+
+        self.assertGreater(len(sent_dataset_types), 0)
+        for name in sent_dataset_types:
+            self.assertNotIn(".", name, f"Component dataset type name {name!r} was sent to the server")
+
     def test_getURIs_no_components(self):
         # This dataset does not have components, and should return one URI.
         def check_uri(uri: ResourcePath):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -153,6 +153,42 @@ class ButlerClientServerTestCase(unittest.TestCase):
         with self.assertRaises(MissingDatasetTypeError):
             self.butler_without_error_propagation.get_dataset_type("not_bias")
 
+    def test_get_component_dataset_type(self):
+        """Test that retrieving a component dataset type does not require the
+        server to know the parent's storage class (DM-55497).
+
+        Component dataset type names must never be sent to the server, so
+        the component dataset type is constructed on the client from the
+        parent definition.
+        """
+        # Track the dataset type names requested from the server.
+        requested_paths: list[str] = []
+        original_get = self.butler._connection.get
+
+        def tracking_get(path, **kwargs):
+            requested_paths.append(path)
+            return original_get(path, **kwargs)
+
+        with patch.object(self.butler._connection, "get", side_effect=tracking_get):
+            component_type = self.butler.get_dataset_type("bias.image")
+
+        parent_type = self.butler.get_dataset_type("bias")
+        self.assertEqual(component_type, parent_type.makeComponentDatasetType("image"))
+        for path in requested_paths:
+            if path.startswith("dataset_type/"):
+                self.assertNotIn(".", path, f"Component dataset type name was sent to the server: {path!r}")
+
+        # A second call should be served from the client-side cache.
+        self.assertEqual(self.butler.get_dataset_type("bias.image"), component_type)
+
+        # An unknown component raises client-side.
+        with self.assertRaises(KeyError):
+            self.butler.get_dataset_type("bias.not_a_component")
+
+        # An unknown parent dataset type still raises the standard error.
+        with self.assertRaises(MissingDatasetTypeError):
+            self.butler_without_error_propagation.get_dataset_type("not_bias.image")
+
     def test_find_dataset(self):
         storage_class = self.storageClassFactory.getStorageClass("Exposure")
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
