### PR TITLE
DM-55548: Add v30.0.10 release notes

### DIFF
--- a/doc/changes/DM-55542.bugfix.md
+++ b/doc/changes/DM-55542.bugfix.md
@@ -1,2 +1,0 @@
-Fixed `DimensionConfig.from_simple` so that the resulting configuration contains only JSON-compatible types.
-Previously set-typed fields survived the Pydantic conversion, causing `Config.dump(format="json")` (and thus `Butler.makeRepo` with a `RemoteButler` dimension configuration) to fail with `TypeError`.

--- a/doc/changes/DM-55542.feature.md
+++ b/doc/changes/DM-55542.feature.md
@@ -1,3 +1,0 @@
-Added `DatasetType.conform_to` and `DatasetRef.conform_to` for rebuilding a dataset type or ref in a different but compatible dimension universe.
-Conforming requires that the universes share a namespace and that the dimension group has the same names and the same required/implied split in both universes; otherwise `InconsistentUniverseError` is raised.
-`Butler.transfer_from` now uses this API when importing refs from another universe.

--- a/doc/lsst.daf.butler/CHANGES.rst
+++ b/doc/lsst.daf.butler/CHANGES.rst
@@ -1,3 +1,20 @@
+Butler v30.0.10 (2026-07-20)
+============================
+
+New Features
+------------
+
+- Added ``DatasetType.conform_to`` and ``DatasetRef.conform_to`` for rebuilding a dataset type or ref in a different but compatible dimension universe.
+  Conforming requires that the universes share a namespace and that the dimension group has the same names and the same required/implied split in both universes; otherwise ``InconsistentUniverseError`` is raised. (`DM-55542 <https://rubinobs.atlassian.net/browse/DM-55542>`_)
+
+
+Bug Fixes
+---------
+
+- Fixed ``DimensionConfig.from_simple`` so that the resulting configuration contains only JSON-compatible types.
+  Previously set-typed fields survived the Pydantic conversion, causing ``Config.dump(format="json")`` to fail with `TypeError`. (`DM-55542 <https://rubinobs.atlassian.net/browse/DM-55542>`_)
+
+
 Butler v30.0.9 (2026-07-14)
 ===========================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
