### PR TITLE
DM-55618: Download remotes to the cache directory directly with formatter

### DIFF
--- a/doc/changes/DM-55618.perf.rst
+++ b/doc/changes/DM-55618.perf.rst
@@ -1,2 +1,0 @@
-When reading a remote dataset that is destined for the local cache, the file is now downloaded directly onto the cache file system.
-Previously it was downloaded to the default temporary directory and then relocated into the cache, which required a full copy whenever the temporary directory and the cache were on different file systems.

--- a/doc/changes/DM-55618.perf.rst
+++ b/doc/changes/DM-55618.perf.rst
@@ -1,0 +1,2 @@
+When reading a remote dataset that is destined for the local cache, the file is now downloaded directly onto the cache file system.
+Previously it was downloaded to the default temporary directory and then relocated into the cache, which required a full copy whenever the temporary directory and the cache were on different file systems.

--- a/doc/lsst.daf.butler/CHANGES.rst
+++ b/doc/lsst.daf.butler/CHANGES.rst
@@ -7,6 +7,11 @@ New Features
 - Added ``DatasetType.conform_to`` and ``DatasetRef.conform_to`` for rebuilding a dataset type or ref in a different but compatible dimension universe.
   Conforming requires that the universes share a namespace and that the dimension group has the same names and the same required/implied split in both universes; otherwise ``InconsistentUniverseError`` is raised. (`DM-55542 <https://rubinobs.atlassian.net/browse/DM-55542>`_)
 
+Performance Enhancement
+-----------------------
+
+- When reading a remote dataset that is destined for the local cache, the file is now downloaded directly onto the cache file system.
+  Previously it was downloaded to the default temporary directory and then relocated into the cache, which required a full copy whenever the temporary directory and the cache were on different file systems. (`DM-55618 <https://rubinobs.atlassian.net/browse/DM-55618>`_)
 
 Bug Fixes
 ---------

--- a/python/lsst/daf/butler/_formatter.py
+++ b/python/lsst/daf/butler/_formatter.py
@@ -713,14 +713,23 @@ class FormatterV2:
             else:
                 msg = ""
 
-            with uri.as_local() as local_uri:
+            # If the file is remote and destined for the cache, download it
+            # directly onto the cache file system. This makes the subsequent
+            # move into the cache an atomic rename rather than a
+            # cross-file-system copy, which is what happens when the default
+            # temporary directory and the cache directory are on different
+            # file systems.
+            should_cache = not uri.isLocal and cache_manager.should_be_cached(cache_ref)
+            download_dir = cache_manager.download_directory if should_cache else None
+
+            with uri.as_local(tmpdir=download_dir) as local_uri:
                 self._check_resource_size(self.file_descriptor.location.uri, expected_size, local_uri.size())
                 can_be_cached = False
                 if uri != local_uri:
                     # URI was remote and file was downloaded
                     cache_msg = ""
 
-                    if cache_manager.should_be_cached(cache_ref):
+                    if should_cache:
                         # In this scenario we want to ask if the downloaded
                         # file should be cached but we should not cache
                         # it until after we've used it (to ensure it can't

--- a/python/lsst/daf/butler/datastore/cache_manager.py
+++ b/python/lsst/daf/butler/datastore/cache_manager.py
@@ -324,6 +324,22 @@ class AbstractDatastoreCacheManager(ABC):
         """Return number of cached files tracked by registry."""
         return 0
 
+    @property
+    def download_directory(self) -> ResourcePath | None:
+        """Local directory into which a remote file destined for the cache
+        may be downloaded (`lsst.resources.ResourcePath` or `None`).
+
+        Notes
+        -----
+        Downloading a soon-to-be-cached remote file into this directory
+        guarantees that the file ends up on the same file system as the cache,
+        so that moving it into the cache is an atomic rename rather than a
+        cross-file-system copy. The base class implementation returns `None`
+        to indicate that no such directory is available and downloads should
+        use the default temporary location.
+        """
+        return None
+
     def __init__(self, config: str | DatastoreCacheManagerConfig, universe: DimensionUniverse):
         if not isinstance(config, DatastoreCacheManagerConfig):
             config = DatastoreCacheManagerConfig(config)
@@ -597,6 +613,17 @@ class DatastoreCacheManager(AbstractDatastoreCacheManager):
         should not be expired.
         """
         return self.cache_directory.join(self._temp_exemption_prefix)
+
+    @property
+    def download_directory(self) -> ResourcePath | None:
+        # Docstring inherited.
+        # Stage downloads in the exemption area: it lives on the same file
+        # system as the cache (so the move into the cache is a rename) and is
+        # ignored by the cache scanner, so a partially-downloaded file is never
+        # mistaken for a cache entry.
+        download_dir = self._temp_exempt_directory
+        download_dir.mkdir()
+        return download_dir
 
     @property
     def cache_size(self) -> int:


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
