### PR TITLE
DM-55626: Make the formatter ref consistent with remote and direct butler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
+  # Each ecosystem batches all its version updates into a single pull request.
+  # Security updates are not grouped and still open immediately.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-batch:
+        patterns:
+          - "*"

--- a/.github/workflows/do_not_merge.yaml
+++ b/.github/workflows/do_not_merge.yaml
@@ -31,11 +31,11 @@ jobs:
       - name: Check requirements.txt for branches
         shell: bash
         run: |
-          FILE="requirements.txt requirements/main.in requirements/test.in"
+          FILES=(requirements.txt requirements/main.in requirements/test.in)
           MATCH=tickets/DM-
-          if grep -q $MATCH $FILE
+          if grep -q "$MATCH" "${FILES[@]}"
           then
-            echo "Ticket branches found in $FILE:"
-            grep -n $MATCH $FILE
+            echo "Ticket branches found in ${FILES[*]}:"
+            grep -n "$MATCH" "${FILES[@]}"
             exit 1
           fi

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Install system dependency to build psycopg on ARM
-        if: ${{ matrix.platform.arch }} == 'arm64'
+        if: ${{ matrix.platform.arch == 'arm64' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libpq-dev

--- a/.github/workflows/docstyle.yaml
+++ b/.github/workflows/docstyle.yaml
@@ -25,4 +25,7 @@ jobs:
           python -m pip install numpydoc
 
       - name: Validate docstrings
-        run: python -m numpydoc.hooks.validate_docstrings $(find python -name "*.py")
+        shell: bash
+        run: |
+          mapfile -t files < <(find python -name "*.py")
+          python -m numpydoc.hooks.validate_docstrings "${files[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         args:
@@ -8,14 +8,19 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
+      - id: check-merge-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.13.0
+    rev: v0.14.5
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/numpy/numpydoc
-    rev: "v1.8.0"
+    rev: "v1.10.0"
     hooks:
       - id: numpydoc-validation
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint

--- a/doc/changes/DM-55626.bugfix.rst
+++ b/doc/changes/DM-55626.bugfix.rst
@@ -1,0 +1,3 @@
+Now force the write storage class ref through to the formatter with RemoteButler.
+
+Previously DirectButler gave a write ref to the Formatter and RemoteButler passed in the read ref. Now they are consistent.

--- a/python/lsst/daf/butler/datastore/record_data.py
+++ b/python/lsst/daf/butler/datastore/record_data.py
@@ -313,8 +313,8 @@ class DatastoreRecordTable:
         datastore_name
             Datastore name to filter on.
 
-        Return
-        ------
+        Returns
+        -------
         table
             A copy of this table with only the rows that have a
             ``datastore_name`` column value matching the given value.

--- a/python/lsst/daf/butler/json.py
+++ b/python/lsst/daf/butler/json.py
@@ -60,6 +60,8 @@ def to_json_pydantic(self: SupportsSimple, minimal: bool = False) -> str:
 
     Parameters
     ----------
+    self : `SupportsSimple`
+        The object being serialized.
     minimal : `bool`
         Return minimal possible representation.
     """
@@ -107,6 +109,8 @@ def to_json_generic(self: SupportsSimple, minimal: bool = False) -> str:
 
     Parameters
     ----------
+    self : `SupportsSimple`
+        The object being serialized.
     minimal : `bool`, optional
         Use minimal serialization. Requires Registry to convert
         back to a full type.
@@ -134,6 +138,8 @@ def from_json_generic(
 
     Parameters
     ----------
+    cls : `type` of `SupportsSimple`
+        The Python type being created.
     json_str : `str`
         Representation of the dimensions in JSON format as created
         by ``to_json()``.

--- a/python/lsst/daf/butler/remote_butler/_get.py
+++ b/python/lsst/daf/butler/remote_butler/_get.py
@@ -20,7 +20,8 @@ from .server_models import FileAuthenticationMode, FileInfoPayload, FileInfoReco
 
 
 def get_dataset_as_python_object(
-    ref: DatasetRef,
+    written_ref: DatasetRef,
+    read_ref: DatasetRef,
     payload: FileInfoPayload,
     *,
     auth: RemoteButlerAuthenticationProvider,
@@ -31,8 +32,19 @@ def get_dataset_as_python_object(
 
     Parameters
     ----------
-    ref : `DatasetRef`
-        Metadata about this artifact.
+    written_ref : `DatasetRef`
+        Metadata about this artifact using the `StorageClass` that the file
+        was written with.  This is the ref given to the `Formatter`, so that
+        it always sees the write `StorageClass` regardless of any read-time
+        override, matching the behavior of `DirectButler`.
+    read_ref : `DatasetRef`
+        Metadata about this artifact using the `StorageClass` that the caller
+        wants returned.  This differs from ``written_ref`` only in its
+        `StorageClass` when a read-time override has been requested.  The two
+        refs always share the same dataset type name, so they either both
+        refer to a component or both refer to a composite; any component
+        override requested by the caller is applied before the read
+        `StorageClass` override is derived.
     payload : `FileInfoPayload`
         Pre-processed information about each file associated with this
         artifact.
@@ -52,15 +64,19 @@ def get_dataset_as_python_object(
     """
     fileLocations = [_to_dataset_location_information(file_info, auth) for file_info in payload.file_info]
 
+    # The Formatter is constructed with the written ref, while the read
+    # StorageClass override travels separately.  DirectButler does the same in
+    # ``FileDatastore._prepare_for_direct_get``.
     datastore_file_info = generate_datastore_get_information(
         fileLocations,
-        ref=ref,
+        ref=written_ref,
+        readStorageClass=read_ref.datasetType.storageClass,
         parameters=parameters,
     )
     if cache_manager is None:
         cache_manager = DatastoreDisabledCacheManager()
     return get_dataset_as_python_object_from_get_info(
-        datastore_file_info, ref=ref, parameters=parameters, cache_manager=cache_manager
+        datastore_file_info, ref=read_ref, parameters=parameters, cache_manager=cache_manager
     )
 
 

--- a/python/lsst/daf/butler/remote_butler/_remote_butler.py
+++ b/python/lsst/daf/butler/remote_butler/_remote_butler.py
@@ -300,28 +300,34 @@ class RemoteButler(Butler):  # numpydoc ignore=PR02
         with self._metrics.instrument_get(log=_LOG, msg="Retrieved remote dataset"):
             model = self._get_file_info(datasetRefOrType, dataId, collections, timespan, kwargs)
 
-            ref = DatasetRef.from_simple(model.dataset_ref, universe=self.dimensions)
+            written_ref = DatasetRef.from_simple(model.dataset_ref, universe=self.dimensions)
             # The server returns the parent dataset type -- component dataset
             # types are never sent to the server, because it may not have the
             # storage class definitions needed to construct them.  Re-apply
             # any component here.
             componentOverride = get_component_override(datasetRefOrType)
             if componentOverride is not None:
-                ref = ref.makeComponentRef(componentOverride)
-            ref = apply_storage_class_override(ref, datasetRefOrType, storageClass)
+                written_ref = written_ref.makeComponentRef(componentOverride)
+            # The written ref carries the storage class the file was written
+            # with; the read ref carries any storage class override requested
+            # by the caller.  Keep them separate so the Formatter always sees
+            # the written ref (as it does with DirectButler).
+            read_ref = apply_storage_class_override(written_ref, datasetRefOrType, storageClass)
 
-            return self._get_dataset_as_python_object(ref, model, parameters)
+            return self._get_dataset_as_python_object(written_ref, read_ref, model, parameters)
 
     def _get_dataset_as_python_object(
         self,
-        ref: DatasetRef,
+        written_ref: DatasetRef,
+        read_ref: DatasetRef,
         model: GetFileResponseModel,
         parameters: dict[str, Any] | None,
     ) -> Any:
         # This thin wrapper method is here to provide a place to hook in a mock
         # mimicking DatastoreMock functionality for use in unit tests.
         return get_dataset_as_python_object(
-            ref,
+            written_ref,
+            read_ref,
             _to_file_payload(model),
             auth=self._connection.auth,
             parameters=parameters,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -64,6 +64,7 @@ if butler_server_is_available:
     import safir.dependencies.logger
     from fastapi.testclient import TestClient
 
+    import lsst.daf.butler.remote_butler._get
     import lsst.daf.butler.remote_butler._query_results
     import lsst.daf.butler.remote_butler.server.handlers._query_limits
     import lsst.daf.butler.remote_butler.server.handlers._query_streaming
@@ -373,6 +374,41 @@ class ButlerClientServerTestCase(unittest.TestCase):
             component_ref.datasetType, component_ref.dataId, collections=collections
         )
         self.assertEqual(dataset_type_component_data, MetricTestRepo.METRICS_EXAMPLE_SUMMARY)
+
+    def test_get_formatter_receives_written_ref(self):
+        """The Formatter must always be given the written `DatasetRef`, so its
+        storage class matches the one the file was written with, regardless of
+        any read-time storage class override.
+
+        Formatters should read the write storage class from the
+        `FileDescriptor`, but some read it from the ref, so `RemoteButler` must
+        hand the Formatter the same written ref that `DirectButler` does.
+        """
+        remote_get = lsst.daf.butler.remote_butler._get
+
+        dataset_type = "test_metric_comp"
+        data_id = {"instrument": "DummyCamComp", "visit": 423}
+        collections = "ingest/run"
+        ref = self.butler.find_dataset(dataset_type, data_id, collections=collections)
+        write_storage_class = ref.datasetType.storageClass
+        override = self.storageClassFactory.getStorageClass("MetricsConversion")
+        self.assertNotEqual(write_storage_class, override)
+
+        captured: dict[str, object] = {}
+        original = remote_get.generate_datastore_get_information
+
+        def capturing(fileLocations, *, ref, parameters, readStorageClass=None):
+            captured["ref_storage_class"] = ref.datasetType.storageClass
+            captured["read_storage_class"] = readStorageClass
+            return original(fileLocations, ref=ref, parameters=parameters, readStorageClass=readStorageClass)
+
+        with patch.object(remote_get, "generate_datastore_get_information", side_effect=capturing):
+            self.butler.get(ref, storageClass=override)
+
+        # The ref given to the Formatter must carry the write storage class,
+        # and the override must instead travel via readStorageClass.
+        self.assertEqual(captured["ref_storage_class"], write_storage_class)
+        self.assertEqual(captured["read_storage_class"], override)
 
     def test_component_access_without_server_storage_class(self):
         """Test that component dataset access via dataset type name does not

--- a/tests/test_simpleButler.py
+++ b/tests/test_simpleButler.py
@@ -1016,12 +1016,13 @@ class RemoteSimpleButlerTestCase(SimpleButlerTests, unittest.TestCase):
 
 
 def _mock_get_dataset_as_python_object(
-    ref: DatasetRef,
+    written_ref: DatasetRef,
+    read_ref: DatasetRef,
     model: Any,
     parameters: dict[str, Any] | None,
 ) -> Any:
     """Mimic the functionality of DatastoreMock's get() mock."""
-    return (ref.id, parameters)
+    return (read_ref.id, parameters)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
