### PR TITLE
DM-55630: Convert an AssertionError to InvalidQueryError

### DIFF
--- a/python/lsst/daf/butler/queries/overlaps.py
+++ b/python/lsst/daf/butler/queries/overlaps.py
@@ -354,10 +354,16 @@ class OverlapsVisitor(SimplePredicateVisitor):
             case region_expression, tree.DimensionFieldReference(element=element):
                 pass
             case _:
-                raise AssertionError(f"Unexpected arguments for spatial overlap: {a}, {b}.")
+                raise InvalidQueryError(
+                    "Spatial overlap comparison requires at least one dimension region column; "
+                    f"got {a} and {b}."
+                )
         if region := region_expression.get_literal_value():
             return self.visit_spatial_constraint(element, region, flags)
-        raise AssertionError(f"Unexpected argument for spatial overlap: {region_expression}.")
+        raise InvalidQueryError(
+            f"Spatial overlap comparison requires its other operand to be a region literal; "
+            f"got {region_expression}."
+        )
 
     def visit_temporal_overlap(
         self,

--- a/python/lsst/daf/butler/queries/tree/_predicate.py
+++ b/python/lsst/daf/butler/queries/tree/_predicate.py
@@ -571,7 +571,12 @@ class Comparison(PredicateLeafBase):
                     pass
                 case ("<" | ">" | ">=" | "<=", "int" | "string" | "float" | "datetime"):
                     pass
-                case ("overlaps", "region" | "timespan"):
+                case ("overlaps", "region"):
+                    if not (self.a.is_column_reference or self.b.is_column_reference):
+                        raise InvalidQueryError(
+                            "Spatial overlap comparison requires at least one dimension region column."
+                        )
+                case ("overlaps", "timespan"):
                     pass
                 case ("glob", "string"):
                     pass

--- a/tests/test_query_direct_sqlite.py
+++ b/tests/test_query_direct_sqlite.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import os
 import unittest
 
-from lsst.daf.butler import Butler
+from lsst.daf.butler import Butler, InvalidQueryError
 from lsst.daf.butler.tests.butler_queries import ButlerQueryTests
 from lsst.daf.butler.tests.utils import create_populated_sqlite_registry
 
@@ -53,6 +53,17 @@ class DirectButlerSQLiteTests(ButlerQueryTests, unittest.TestCase):
         for arg in args:
             self.load_data(butler, arg)
         return butler
+
+    def test_spatial_overlap_between_region_literals(self) -> None:
+        """Test a public query with two region literal operands."""
+        butler = self.make_butler("base.yaml")
+        htm7 = butler.dimensions.skypix_dimensions["htm7"]
+        region = htm7.pixelization.pixel(253954)
+
+        with butler.query() as query:
+            x = query.expression_factory
+            with self.assertRaisesRegex(InvalidQueryError, "requires at least one dimension region column"):
+                query.where(x.literal(region).overlaps(region))
 
 
 if __name__ == "__main__":

--- a/tests/test_query_utilities.py
+++ b/tests/test_query_utilities.py
@@ -219,6 +219,14 @@ class OverlapsVisitorTestCase(unittest.TestCase):
         self.assertFalse(visitor.spatial_constraints)
         self.assertFalse(visitor.temporal_dimension_joins)
 
+    def test_invalid_spatial_overlap_operands(self) -> None:
+        """Test defensive validation of spatial overlap operands."""
+        pixelization = Mq3cPixelization(10)
+        region = qt.make_column_literal(pixelization.quad(12058870))
+        visitor = _RecordingOverlapsVisitor(self.universe.empty)
+        with self.assertRaisesRegex(InvalidQueryError, "requires at least one dimension region column"):
+            visitor.visit_spatial_overlap(region, region, PredicateVisitFlags(0))
+
     def test_one_spatial_family(self) -> None:
         """Test the overlaps visitor when there is one spatial family."""
         x = ExpressionFactory(self.universe)


### PR DESCRIPTION
User generated queries that are testing overlaps between two literal regions were resulting in an AssertionError deep in the query system that the server treats as an internal error that should not be reported to the user. This change fixes the exception and adds two new tests that trigger it.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
