### PR TITLE
DM-55631: Ensure streaming queries close on disconnect

### DIFF
--- a/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
+++ b/python/lsst/daf/butler/remote_butler/server/handlers/_query_streaming.py
@@ -28,10 +28,11 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Iterator
 from contextlib import AbstractContextManager
 from typing import Protocol, TypeVar
 
+from fastapi import BackgroundTasks
 from fastapi.responses import StreamingResponse
 
 from lsst.daf.butler.remote_butler.server_models import (
@@ -112,9 +113,12 @@ async def execute_streaming_query(query: StreamingQuery, user: str | None) -> St
     await _query_limits.enforce_query_limits(user)
 
     output_generator = _stream_query_pages(query, user)
+    background_tasks = BackgroundTasks()
+    background_tasks.add_task(_close_query_stream, output_generator)
     return StreamingResponse(
         output_generator,
         media_type="application/jsonlines",
+        background=background_tasks,
         headers={
             # Instruct the Kubernetes ingress to not buffer the response,
             # so that keep-alives reach the client promptly.
@@ -123,7 +127,12 @@ async def execute_streaming_query(query: StreamingQuery, user: str | None) -> St
     )
 
 
-async def _stream_query_pages(query: StreamingQuery, user: str | None) -> AsyncIterator[str]:
+async def _close_query_stream(output_generator: AsyncGenerator[str, None]) -> None:
+    """Close a query stream after its streaming response has finished."""
+    await output_generator.aclose()
+
+
+async def _stream_query_pages(query: StreamingQuery, user: str | None) -> AsyncGenerator[str, None]:
     """Stream the query output with one page object per line, as
     newline-delimited JSON records in the "JSON Lines" format
     (https://jsonlines.org/).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
+import contextlib
 import os.path
 import tempfile
 import threading
@@ -81,7 +82,7 @@ if butler_server_is_available:
     )
     from lsst.daf.butler.remote_butler.server._gafaelfawr import MockGafaelfawrGroupAuthorizer
     from lsst.daf.butler.remote_butler.server.handlers._utils import generate_file_download_uri
-    from lsst.daf.butler.remote_butler.server_models import QueryCollectionsRequestModel
+    from lsst.daf.butler.remote_butler.server_models import QueryCollectionsRequestModel, QueryKeepAliveModel
     from lsst.daf.butler.tests.server import TEST_REPOSITORY_NAME, UnhandledServerError, create_test_server
 
 
@@ -786,6 +787,49 @@ def _timeout_twice():
         return DEFAULT
 
     return timeout
+
+
+@unittest.skipIf(not butler_server_is_available, butler_server_import_error)
+class QueryStreamingTestCase(unittest.IsolatedAsyncioTestCase):
+    """Test streaming query response lifecycle details."""
+
+    async def test_disconnect_closes_query_stream(self) -> None:
+        """Test that a client disconnect closes the query stream."""
+        query_finished = asyncio.Event()
+        first_body_sent = asyncio.Event()
+        block_send = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        class TwoPageQuery:
+            def setup(self):
+                return contextlib.nullcontext(None)
+
+            def execute(self, context):
+                yield QueryKeepAliveModel()
+                yield QueryKeepAliveModel()
+                loop.call_soon_threadsafe(query_finished.set)
+
+        streaming = lsst.daf.butler.remote_butler.server.handlers._query_streaming
+        active_queries_before = streaming._query_limits._active_queries
+        response = await streaming.execute_streaming_query(TwoPageQuery(), "test-user")
+
+        async def receive():
+            await first_body_sent.wait()
+            await query_finished.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.body" and message.get("more_body"):
+                first_body_sent.set()
+                await block_send.wait()
+
+        scope = {"type": "http", "asgi": {"spec_version": "2.3"}}
+        async with asyncio.timeout(5):
+            await response(scope, receive, send)
+
+        # Retain the response until after this assertion to ensure cleanup did
+        # not depend on garbage collection.
+        self.assertEqual(streaming._query_limits._active_queries, active_queries_before)
 
 
 @unittest.skipIf(not butler_server_is_available, butler_server_import_error)


### PR DESCRIPTION
Starlette can cancel its response task while the query output generator is suspended at a yield. In that state the producer may remain blocked while writing the end-of-stream marker to the one-element queue, retaining the user's query-limit slot until garbage collection and producing pending-task or coroutine-reuse errors.

Attach an asynchronous response background task that explicitly closes the output generator when streaming finishes or the client disconnects. Use a separate async helper because an async generator's built-in aclose method is not recognized as an asynchronous callable.

Add an ASGI 2.3 regression test that coordinates a two-page query with an early disconnect, retains the response object, and verifies that the active-query count is restored without relying on garbage collection.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
