### PR TITLE
DM-55779: Add v30.0.11 release notes

### DIFF
--- a/doc/changes/DM-55436.feature.md
+++ b/doc/changes/DM-55436.feature.md
@@ -1,1 +1,0 @@
-Update parquet code to support both pandas2 and pandas3.

--- a/doc/changes/DM-55626.bugfix.rst
+++ b/doc/changes/DM-55626.bugfix.rst
@@ -1,3 +1,0 @@
-Now force the write storage class ref through to the formatter with RemoteButler.
-
-Previously DirectButler gave a write ref to the Formatter and RemoteButler passed in the read ref. Now they are consistent.

--- a/doc/changes/DM-55656.misc.md
+++ b/doc/changes/DM-55656.misc.md
@@ -1,3 +1,0 @@
-Add a downgrading storage class converter for scarlet models.
-
-This should allow repositories that have the old storage class registered to be used when running new pipelines, at the cost of dropping some information on write.

--- a/doc/changes/DM-55708.bugfix.md
+++ b/doc/changes/DM-55708.bugfix.md
@@ -1,7 +1,0 @@
-Fixed component `get` when a read storage class override defines components that the storage class used to write the dataset does not.
-
-Previously the requested component was always resolved against the write storage class, so a call such as `butler.getDeferred(ref, storageClass="Exposure").get(component="photoCalib")` failed with `UnknownComponentError` when the dataset had been written with a storage class that has no `photoCalib` component.
-The datastore now tracks the repository definition of the dataset and the caller's request as separate `DatasetRef`: the component and any storage class conversion are taken from the read ref, while the `Formatter` continues to be given the composite ref as defined in the repository.
-When the component only exists in the read storage class the composite is read and converted first and the component is then extracted from the converted object.
-This is slower than reading a component directly, so a warning is now issued naming the components that the storage class used to write the dataset does define.
-`InMemoryDatastore` now does the same conversion before extracting the component.

--- a/doc/lsst.daf.butler/CHANGES.rst
+++ b/doc/lsst.daf.butler/CHANGES.rst
@@ -1,3 +1,34 @@
+Butler v30.0.11 (2026-08-13)
+============================
+
+New Features
+------------
+
+- Updated parquet code to support both pandas2 and pandas3. (`DM-55436 <https://rubinobs.atlassian.net/browse/DM-55436>`_)
+
+
+Bug Fixes
+---------
+
+- Forced the write storage class ref through to the formatter with ``RemoteButler``.
+
+  Previously ``DirectButler`` gave a write ref to the formatter and ``RemoteButler`` passed in the read ref. Now they are consistent. (`DM-55626 <https://rubinobs.atlassian.net/browse/DM-55626>`_)
+- Fixed component ``get`` when a read storage class override defines components that the storage class used to write the dataset does not.
+
+  Previously the requested component was always resolved against the write storage class, so a call such as ``butler.getDeferred(ref, storageClass="Exposure").get(component="photoCalib")`` failed with ``UnknownComponentError`` when the dataset had been written with a storage class that has no ``photoCalib`` component.
+  When the component only exists in the read storage class the composite is read and converted first and the component is then extracted from the converted object.
+  This is slower than reading a component directly, so a warning is now issued naming the components that the storage class used to write the dataset does define.
+  ``InMemoryDatastore`` now does the same conversion before extracting the component. (`DM-55708 <https://rubinobs.atlassian.net/browse/DM-55708>`_)
+
+
+Other Changes and Additions
+---------------------------
+
+- Added a downgrading storage class converter for scarlet models.
+
+  This should allow repositories that have the old storage class registered to be used when running new pipelines, at the cost of dropping some information on write. (`DM-55656 <https://rubinobs.atlassian.net/browse/DM-55656>`_)
+
+
 Butler v30.0.10 (2026-07-20)
 ============================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
