### PR TITLE
DM-53347: Report malformed dataset type names as user errors

### DIFF
--- a/doc/changes/DM-53347.bugfix.md
+++ b/doc/changes/DM-53347.bugfix.md
@@ -1,0 +1,4 @@
+Fixed the error reported when a malformed dataset type name is given to a client/server Butler.
+
+Previously a name that is not syntactically valid (for example the string ``"..."`` is not the same as the ``...`` wildcard) either produced an HTTP 404 from the client or an unhandled internal server error.
+``DatasetTypeExpressionError`` is now a user-facing error that the server forwards to its clients, and client/server Butler rejects invalid dataset type names before contacting the server.

--- a/python/lsst/daf/butler/_butler.py
+++ b/python/lsst/daf/butler/_butler.py
@@ -2051,7 +2051,7 @@ class Butler(LimitedButler):  # numpydoc ignore=PR02
 
         Raises
         ------
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when ``dataset_type`` expression is invalid.
         lsst.daf.butler.registry.DataIdError
             Raised when ``data_id`` or keyword arguments specify unknown

--- a/python/lsst/daf/butler/_dataset_type.py
+++ b/python/lsst/daf/butler/_dataset_type.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 from pydantic import BaseModel, StrictBool, StrictStr
 
 from ._config_support import LookupKey
-from ._exceptions import InconsistentUniverseError, UnknownComponentError
+from ._exceptions import DatasetTypeExpressionError, InconsistentUniverseError, UnknownComponentError
 from ._storage_class import StorageClass, StorageClassFactory
 from .dimensions import DimensionGroup
 from .json import from_json_pydantic, to_json_pydantic
@@ -207,7 +207,7 @@ class DatasetType:
         isCalibration: bool = False,
     ):
         if self.VALID_NAME_REGEX.match(name) is None:
-            raise ValueError(f"DatasetType name '{name}' is invalid.")
+            raise ValueError(f"DatasetType '{name}' does not look like a valid dataset type name.")
         self._name = name
         universe = universe or getattr(dimensions, "universe", None)
         if universe is None:
@@ -875,3 +875,22 @@ def get_dataset_type_name(datasetTypeOrName: DatasetType | str) -> str:
         return datasetTypeOrName
     else:
         raise TypeError(f"Expected DatasetType or str, got unexpected object: {datasetTypeOrName}")
+
+
+def validate_dataset_type_name(name: str) -> None:
+    """Check that a string is usable as a dataset type name.
+
+    Parameters
+    ----------
+    name : `str`
+        Name of a dataset type, possibly including a component.
+
+    Raises
+    ------
+    lsst.daf.butler.DatasetTypeExpressionError
+        Raised if ``name`` is not a syntactically valid dataset type name.
+    """
+    if DatasetType.VALID_NAME_REGEX.match(name) is None:
+        raise DatasetTypeExpressionError(
+            f"DatasetType {name!r} does not look like a valid dataset type name."
+        )

--- a/python/lsst/daf/butler/_exceptions.py
+++ b/python/lsst/daf/butler/_exceptions.py
@@ -34,6 +34,7 @@ __all__ = (
     "CollectionTypeError",
     "DataIdValueError",
     "DatasetNotFoundError",
+    "DatasetTypeExpressionError",
     "DatasetTypeNotSupportedError",
     "DimensionNameError",
     "EmptyQueryResultError",
@@ -120,6 +121,12 @@ class DatasetNotFoundError(LookupError, ButlerUserError):
     """The requested dataset could not be found."""
 
     error_type = "dataset_not_found"
+
+
+class DatasetTypeExpressionError(DatasetTypeError, ButlerUserError):
+    """Exception raised for an incorrect dataset type expression."""
+
+    error_type = "dataset_type_expression"
 
 
 class DimensionNameError(KeyError, DataIdError, ButlerUserError):
@@ -237,6 +244,7 @@ _USER_ERROR_TYPES: tuple[type[ButlerUserError], ...] = (
     DimensionValueError,
     DataIdValueError,
     DatasetNotFoundError,
+    DatasetTypeExpressionError,
     InconsistentDataIdError,
     InvalidQueryError,
     MissingCollectionError,

--- a/python/lsst/daf/butler/queries/_query.py
+++ b/python/lsst/daf/butler/queries/_query.py
@@ -291,7 +291,7 @@ class Query(QueryBase):
 
         Raises
         ------
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when the ``dataset_type`` expression is invalid.
         lsst.daf.butler.registry.NoDefaultCollectionError
             Raised when ``collections`` is `None` and default butler

--- a/python/lsst/daf/butler/registry/__init__.py
+++ b/python/lsst/daf/butler/registry/__init__.py
@@ -32,6 +32,7 @@ from .._collection_type import CollectionType
 from .._exceptions import (
     CollectionTypeError,
     DataIdValueError,
+    DatasetTypeExpressionError,
     DimensionNameError,
     InconsistentDataIdError,
     MissingCollectionError,

--- a/python/lsst/daf/butler/registry/_exceptions.py
+++ b/python/lsst/daf/butler/registry/_exceptions.py
@@ -30,7 +30,6 @@ __all__ = (
     "ArgumentError",
     "CollectionExpressionError",
     "ConflictingDefinitionError",
-    "DatasetTypeExpressionError",
     "MissingSpatialOverlapError",
     "NoDefaultCollectionError",
     "OrphanedRecordError",
@@ -45,10 +44,6 @@ from .._exceptions_legacy import CollectionError, RegistryError
 
 class ArgumentError(RegistryError):
     """Exception raised when method arguments are invalid or inconsistent."""
-
-
-class DatasetTypeExpressionError(RegistryError):
-    """Exception raised for an incorrect dataset type expression."""
 
 
 class CollectionExpressionError(CollectionError):

--- a/python/lsst/daf/butler/registry/_registry.py
+++ b/python/lsst/daf/butler/registry/_registry.py
@@ -470,7 +470,7 @@ class Registry(ABC):
 
         Raises
         ------
-        lsst.daf.butler.registry.MissingDatasetTypeError
+        lsst.daf.butler.MissingDatasetTypeError
             Raised if the requested dataset type has not been registered.
 
         Notes
@@ -554,9 +554,9 @@ class Registry(ABC):
             ``self.defaults.collections`` is `None`.
         LookupError
             Raised if one or more data ID keys are missing.
-        lsst.daf.butler.registry.MissingDatasetTypeError
+        lsst.daf.butler.MissingDatasetTypeError
             Raised if the dataset type does not exist.
-        lsst.daf.butler.registry.MissingCollectionError
+        lsst.daf.butler.MissingCollectionError
             Raised if any of ``collections`` does not exist in the registry.
 
         Notes
@@ -1064,7 +1064,7 @@ class Registry(ABC):
 
         Raises
         ------
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when ``expression`` is invalid.
         """
         raise NotImplementedError()
@@ -1207,7 +1207,7 @@ class Registry(ABC):
 
         Raises
         ------
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when ``datasetType`` expression is invalid.
         TypeError
             Raised when the arguments are incompatible, such as when a
@@ -1323,7 +1323,7 @@ class Registry(ABC):
         lsst.daf.butler.registry.DataIdError
             Raised when ``dataId`` or keyword arguments specify unknown
             dimensions or values, or when they contain inconsistent values.
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when ``datasetType`` expression is invalid.
         lsst.daf.butler.registry.UserExpressionError
             Raised when ``where`` expression is invalid.
@@ -1402,7 +1402,7 @@ class Registry(ABC):
         lsst.daf.butler.registry.DataIdError
             Raised when ``dataId`` or keyword arguments specify unknown
             dimensions or values, or when they contain inconsistent values.
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when ``datasetType`` expression is invalid.
         lsst.daf.butler.registry.UserExpressionError
             Raised when ``where`` expression is invalid.

--- a/python/lsst/daf/butler/registry/_registry_base.py
+++ b/python/lsst/daf/butler/registry/_registry_base.py
@@ -38,9 +38,10 @@ from .._butler import Butler
 from .._collection_type import CollectionType
 from .._dataset_association import DatasetAssociation
 from .._dataset_type import DatasetType
+from .._exceptions import DatasetTypeExpressionError
 from ..dimensions import DataId, DimensionElement, DimensionGroup
 from ..registry.wildcards import CollectionWildcard, DatasetTypeWildcard
-from ._exceptions import ArgumentError, DatasetTypeExpressionError, NoDefaultCollectionError
+from ._exceptions import ArgumentError, NoDefaultCollectionError
 from ._registry import CollectionArgType, Registry
 from .queries import (
     ChainedDatasetQueryResults,

--- a/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
+++ b/python/lsst/daf/butler/registry/datasets/byDimensions/_manager.py
@@ -18,8 +18,8 @@ from lsst.utils.iteration import chunk_iterable
 from .... import ddl
 from ...._collection_type import CollectionType
 from ...._dataset_ref import DatasetId, DatasetIdFactory, DatasetIdGenEnum, DatasetRef
-from ...._dataset_type import DatasetType, get_dataset_type_name
-from ...._exceptions import CollectionTypeError, MissingDatasetTypeError
+from ...._dataset_type import DatasetType, get_dataset_type_name, validate_dataset_type_name
+from ...._exceptions import CollectionTypeError, DatasetTypeExpressionError, MissingDatasetTypeError
 from ...._exceptions_legacy import DatasetTypeError
 from ...._timespan import Timespan
 from ....dimensions import DataCoordinate, DimensionGroup, DimensionUniverse
@@ -28,7 +28,7 @@ from ....queries import QueryFactoryFunction
 from ....queries import tree as qt  # new query system, both clients + server
 from ..._caching_context import CachingContext
 from ..._collection_summary import CollectionSummary
-from ..._exceptions import ConflictingDefinitionError, DatasetTypeExpressionError, OrphanedRecordError
+from ..._exceptions import ConflictingDefinitionError, OrphanedRecordError
 from ...interfaces import DatasetRecordStorageManager, RunRecord, VersionTuple
 from ...wildcards import DatasetTypeWildcard
 from ._dataset_type_cache import DatasetTypeCache
@@ -453,7 +453,11 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
         for name, dataset_type in wildcard.values.items():
             parent_name, component_name = DatasetType.splitDatasetTypeName(name)
             if component_name is not None:
-                raise DatasetTypeError(
+                # Distinguish a real component name from a string that is not
+                # a valid dataset type name at all, such as "...", which is
+                # sometimes passed in place of the "..." wildcard.
+                validate_dataset_type_name(name)
+                raise DatasetTypeExpressionError(
                     "Component dataset types are not supported in Registry methods; use DatasetRef or "
                     "DatasetType methods to obtain components from parents instead."
                 )
@@ -469,7 +473,7 @@ class ByDimensionsDatasetRecordStorageManagerUUID(DatasetRecordStorageManager):
                         # conversions.
                         resolved_dataset_type = dataset_type
                     else:
-                        raise DatasetTypeError(
+                        raise DatasetTypeExpressionError(
                             f"Dataset type definition in query expression {dataset_type} is "
                             f"not compatible with the registered type {resolved_dataset_type}."
                         )

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -45,7 +45,7 @@ from lsst.utils.iteration import ensure_iterable
 from .._collection_type import CollectionType
 from .._config import Config
 from .._dataset_ref import DatasetId, DatasetIdGenEnum, DatasetRef
-from .._dataset_type import DatasetType
+from .._dataset_type import DatasetType, validate_dataset_type_name
 from .._exceptions import DataIdValueError, DimensionNameError, InconsistentDataIdError
 from .._storage_class import StorageClassFactory
 from .._timespan import Timespan
@@ -814,7 +814,9 @@ class SqlRegistry:
 
         Raises
         ------
-        lsst.daf.butler.registry.MissingDatasetTypeError
+        lsst.daf.butler.DatasetTypeExpressionError
+            Raised if ``name`` is not a valid dataset type name.
+        lsst.daf.butler.MissingDatasetTypeError
             Raised if the requested dataset type has not been registered.
 
         Notes
@@ -822,6 +824,7 @@ class SqlRegistry:
         This method handles component dataset types automatically, though most
         other registry operations do not.
         """
+        validate_dataset_type_name(name)
         parent_name, component = DatasetType.splitDatasetTypeName(name)
         parent_dataset_type = self._managers.datasets.get_dataset_type(parent_name)
         if component is None:

--- a/python/lsst/daf/butler/registry/sql_registry.py
+++ b/python/lsst/daf/butler/registry/sql_registry.py
@@ -1554,7 +1554,7 @@ class SqlRegistry:
 
         Raises
         ------
-        lsst.daf.butler.registry.DatasetTypeExpressionError
+        lsst.daf.butler.DatasetTypeExpressionError
             Raised when ``expression`` is invalid.
         """
         wildcard = DatasetTypeWildcard.from_expression(expression)

--- a/python/lsst/daf/butler/registry/tests/_registry.py
+++ b/python/lsst/daf/butler/registry/tests/_registry.py
@@ -65,6 +65,7 @@ from ..._exceptions import (
     CalibrationLookupError,
     CollectionTypeError,
     DataIdValueError,
+    DatasetTypeExpressionError,
     InconsistentDataIdError,
     InvalidQueryError,
     MissingCollectionError,
@@ -81,7 +82,6 @@ from .._exceptions import (
     ArgumentError,
     CollectionError,
     ConflictingDefinitionError,
-    DatasetTypeExpressionError,
     NoDefaultCollectionError,
     OrphanedRecordError,
 )
@@ -905,6 +905,31 @@ class RegistryTests(ABC):
         # Search for a single dataset with findDataset.
         with self.assertRaises(DatasetTypeError):
             registry.findDataset("bias.wcs", collections=collection, dataId=parentRefResolved.dataId)
+
+    def testInvalidDatasetTypeName(self):
+        """Test that a syntactically invalid dataset type name is reported as
+        a bad expression rather than as a missing dataset type.
+        """
+        butler = self.make_butler()
+        registry = butler.registry
+        self.load_data(butler, "base.yaml", "datasets.yaml")
+        with self.assertRaisesRegex(DatasetTypeExpressionError, "does not look like a valid"):
+            registry.getDatasetType("...")
+        # A search expression reports the name as invalid rather than
+        # complaining that "." introduces an unsupported component.
+        with self.assertRaisesRegex(DatasetTypeExpressionError, "does not look like a valid"):
+            registry.queryDatasetTypes("...")
+        with self.assertRaisesRegex(DatasetTypeExpressionError, "Component dataset types"):
+            registry.queryDatasetTypes("bias.image")
+        # A well-formed name that is simply not registered is still missing
+        # rather than invalid.
+        with self.assertRaises(MissingDatasetTypeError):
+            registry.getDatasetType("not_bias")
+        # Names that cannot be registered do not prevent a search from
+        # reporting the other names it could not find.
+        missing: list[str] = []
+        registry.queryDatasetTypes(["bias", "not-a-legal-name"], missing=missing)
+        self.assertEqual(missing, ["not-a-legal-name"])
 
     def testCollections(self):
         """Tests for registry methods that manage collections."""

--- a/python/lsst/daf/butler/registry/wildcards.py
+++ b/python/lsst/daf/butler/registry/wildcards.py
@@ -43,8 +43,9 @@ from typing import Any
 from lsst.utils.iteration import ensure_iterable
 
 from .._dataset_type import DatasetType
+from .._exceptions import DatasetTypeExpressionError
 from ..utils import globToRegex
-from ._exceptions import CollectionExpressionError, DatasetTypeExpressionError
+from ._exceptions import CollectionExpressionError
 
 
 @dataclasses.dataclass

--- a/python/lsst/daf/butler/remote_butler/_ref_utils.py
+++ b/python/lsst/daf/butler/remote_butler/_ref_utils.py
@@ -39,7 +39,7 @@ __all__ = (
 from pydantic import TypeAdapter
 
 from .._dataset_ref import DatasetRef
-from .._dataset_type import DatasetType, get_dataset_type_name
+from .._dataset_type import DatasetType, get_dataset_type_name, validate_dataset_type_name
 from .._storage_class import StorageClass
 from ..dimensions import DataCoordinate, DataId, DataIdValue, SerializedDataId
 from .server_models import DatasetTypeName
@@ -170,8 +170,17 @@ def split_dataset_type_name(
         Name of the parent dataset type, suitable for sending to the server.
     component : `str` | `None`
         Component name, or `None` if this is not a component dataset type.
+
+    Raises
+    ------
+    lsst.daf.butler.DatasetTypeExpressionError
+        Raised if the given name is not a syntactically valid dataset type
+        name.  Sending such a name to the server would produce a confusing
+        HTTP error instead of a useful message.
     """
-    parent_name, component = DatasetType.splitDatasetTypeName(get_dataset_type_name(datasetTypeOrName))
+    name = get_dataset_type_name(datasetTypeOrName)
+    validate_dataset_type_name(name)
+    parent_name, component = DatasetType.splitDatasetTypeName(name)
     return DatasetTypeName(parent_name), component
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,7 +55,7 @@ from lsst.daf.butler import (
     UnknownComponentError,
 )
 from lsst.daf.butler.datastore import DatasetRefURIs
-from lsst.daf.butler.registry import RegistryDefaults
+from lsst.daf.butler.registry import DatasetTypeExpressionError, RegistryDefaults
 from lsst.daf.butler.tests import DatastoreMock, addDatasetType
 from lsst.daf.butler.tests.dict_convertible_model import DictConvertibleModel
 from lsst.daf.butler.tests.server_available import butler_server_import_error, butler_server_is_available
@@ -197,6 +197,36 @@ class ButlerClientServerTestCase(unittest.TestCase):
         # An unknown parent dataset type still raises the standard error.
         with self.assertRaises(MissingDatasetTypeError):
             self.butler_without_error_propagation.get_dataset_type("not_bias.image")
+
+    def test_get_dataset_type_with_invalid_name(self):
+        """Test that a syntactically invalid dataset type name is rejected on
+        the client without contacting the server (DM-53347).
+        """
+        requested_paths: list[str] = []
+        original_get = self.butler._connection.get
+
+        def tracking_get(path, **kwargs):
+            requested_paths.append(path)
+            return original_get(path, **kwargs)
+
+        with patch.object(self.butler._connection, "get", side_effect=tracking_get):
+            with self.assertRaises(DatasetTypeExpressionError):
+                self.butler.get_dataset_type("...")
+
+        self.assertEqual(requested_paths, [])
+
+    def test_query_dataset_types_with_invalid_name(self):
+        """Test that a dataset type search expression the server cannot handle
+        is reported to the client as a user error rather than an internal
+        server error (DM-53347).
+        """
+        # "..." is a valid wildcard for the Ellipsis object but not as a
+        # string, where it parses as a component dataset type name.
+        with self.assertRaises(DatasetTypeExpressionError):
+            self.butler.registry.queryDatasetTypes("...")
+
+        with self.assertRaises(DatasetTypeExpressionError):
+            self.butler.registry.queryDatasetTypes("bias.image")
 
     def test_find_dataset(self):
         storage_class = self.storageClassFactory.getStorageClass("Exposure")
@@ -466,11 +496,12 @@ class ButlerClientServerTestCase(unittest.TestCase):
             deferred_ref_data = self.butler.getDeferred(component_ref).get()
             self.assertEqual(deferred_ref_data, MetricTestRepo.METRICS_EXAMPLE_SUMMARY)
 
-            # An empty component name raises rather than silently returning
-            # the composite.
-            with self.assertRaises(KeyError):
+            # A trailing separator with no component name is not a valid
+            # dataset type name and is rejected rather than silently
+            # returning the composite.
+            with self.assertRaises(DatasetTypeExpressionError):
                 self.butler.get(f"{dataset_type}.", dataId=data_id, collections=collections)
-            with self.assertRaises(KeyError):
+            with self.assertRaises(DatasetTypeExpressionError):
                 self.butler.getDeferred(f"{dataset_type}.", data_id, collections=collections)
 
         self.assertGreater(len(sent_dataset_types), 0)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,18 +202,10 @@ class ButlerClientServerTestCase(unittest.TestCase):
         """Test that a syntactically invalid dataset type name is rejected on
         the client without contacting the server (DM-53347).
         """
-        requested_paths: list[str] = []
-        original_get = self.butler._connection.get
-
-        def tracking_get(path, **kwargs):
-            requested_paths.append(path)
-            return original_get(path, **kwargs)
-
-        with patch.object(self.butler._connection, "get", side_effect=tracking_get):
+        with patch.object(self.butler._connection, "get") as mock:
             with self.assertRaises(DatasetTypeExpressionError):
                 self.butler.get_dataset_type("...")
-
-        self.assertEqual(requested_paths, [])
+        mock.assert_not_called()
 
     def test_query_dataset_types_with_invalid_name(self):
         """Test that a dataset type search expression the server cannot handle


### PR DESCRIPTION
DatasetTypeExpressionError is now a ButlerUserError, so Butler server forwards it to its clients instead of raising an internal server error. It moves to the top-level exceptions module and is re-exported from lsst.daf.butler.registry, alongside the other user errors that used to live there.  It inherits from the legacy DatasetTypeError so existing handlers still catch it.

Client/server Butler now validates a dataset type name before putting it on the wire.  A name such as "..." previously split into an empty parent name, producing an HTTP 404 rather than a useful message.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
