### PR TITLE
Include extras by default in dev environment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
         if: matrix.variant.pinned == false
 
       - name: Build and install
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked
 
       - name: List installed packages
         run: uv tree

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -100,7 +100,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --group dockertest
+        run: uv sync --locked --group dockertest
 
       - name: Run smoke test
         run: |

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -23,4 +23,4 @@ jobs:
           enable-cache: true
 
       - name: Run mypy
-        run: uv run --locked --all-extras mypy
+        run: uv run --locked mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,7 @@ exclude = [
 [dependency-groups]
 dev = [
     "cryptography>=49",
+    "lsst-daf-butler[postgres,remote,server,s3,https]",
     "fsspec>=2026.7.0",
     "matplotlib>=3.11.1",
     "moto>=5.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1955,6 +1955,7 @@ test = [
 dev = [
     { name = "cryptography" },
     { name = "fsspec" },
+    { name = "lsst-daf-butler", extra = ["https", "postgres", "remote", "s3", "server"] },
     { name = "matplotlib" },
     { name = "moto" },
     { name = "mypy" },
@@ -2013,6 +2014,7 @@ provides-extras = ["postgres", "remote", "server", "test", "s3", "https", "gs"]
 dev = [
     { name = "cryptography", specifier = ">=49" },
     { name = "fsspec", specifier = ">=2026.7.0" },
+    { name = "lsst-daf-butler", extras = ["postgres", "remote", "server", "s3", "https"] },
     { name = "matplotlib", specifier = ">=3.11.1" },
     { name = "moto", specifier = ">=5.2.2" },
     { name = "mypy", specifier = ">=2.3.1" },


### PR DESCRIPTION
Include all the extras referenced by commonly-used features and tests in the dev environment by default, so that `uv run` works out of the box without needing to specify extras.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
