### PR TITLE
DM-55921: Revert incorrect fix for scarlet model compatibility

### DIFF
--- a/python/lsst/daf/butler/configs/storageClasses.yaml
+++ b/python/lsst/daf/butler/configs/storageClasses.yaml
@@ -435,8 +435,6 @@ storageClasses:
     parameters:
       - blend_id
     delegate: lsst.meas.extensions.scarlet.io.ScarletModelDelegate
-    converters:
-      lsst.meas.extensions.scarlet.io.LsstScarletModelData: lsst.meas.extensions.scarlet.io.LsstScarletModelData.to_scarlet_model_data
   LsstScarletModelData:
     pytype: lsst.meas.extensions.scarlet.io.LsstScarletModelData
     converters:


### PR DESCRIPTION
This reverts commit fb81a152f7e9fbe15846deb73a59409ccf5a28ba, reversing changes made to 379fd9c16be94a680b92b04e0369a8dde26f0aad.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
- [ ] (if changing dimensions.yaml) make a copy of the _updated_ dimensions.yaml in `configs/old_dimensions` and update the list in `doc/lsst.daf.butler/dimensions.rst`
